### PR TITLE
Don't perform ACME validation if user account already holds valid authorization

### DIFF
--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -109,6 +109,15 @@ func (a *Acme) prepare(crt *v1alpha1.Certificate) error {
 	// todo: parallelize this
 	// todo: refactor into own function
 	for _, auth := range auths {
+		if auth.auth.Status == acme.StatusValid {
+			log.Printf("[%s] Skipped authorization for domain we are already validated", auth.domain)
+			crt.Status.ACMEStatus().SaveAuthorization(v1alpha1.ACMEDomainAuthorization{
+				Domain: auth.domain,
+				URI:    auth.auth.URI,
+			})
+			continue
+		}
+
 		log.Printf("picking challenge type for domain '%s'", auth.domain)
 		challengeType, err := pickChallengeType(auth.domain, auth.auth, crt.Spec.ACME.Config)
 		if err != nil {


### PR DESCRIPTION
This implements the functionality described here: https://github.com/jetstack-experimental/cert-manager/issues/16

If the ACME Issuer being used already holds an authorization for the requested domain, we now skip acquiring the authorization. The downside to this, is that users will find out *at renewal time* that a particular authorization mechanism is no longer working, as opposed to at the time of first issue. Grateful for feedback/opinions on this change!

```release-note
Re-use ACME validations previously obtained by an Issuer
```

