### PR TITLE
Enable e2e tests on Kubernetes 1.8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
 # Install CLI dependencies
 - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
 - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.23.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
 # Install nsenter
 - docker run -v /usr/local/bin:/hostbin munnerz/ubuntu-nsenter cp /nsenter /hostbin/nsenter
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ jobs:
       go: 1.8
       env:
       - KUBERNETES_VERSION=v1.7.0
+      - KUBERNETES_VERSION=v1.8.0
       before_script:
       # Install CLI dependencies
       - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       # Install CLI dependencies
       - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
       - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.21.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       # Install nsenter
       - docker run -v /usr/local/bin:/hostbin munnerz/ubuntu-nsenter cp /nsenter /hostbin/nsenter
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,37 +1,39 @@
 go_import_path: github.com/jetstack/cert-manager
 
+dist: trusty
+language: go
+go: 1.8
+
+env:
+- KUBERNETES_VERSION=v1.7.0
+- KUBERNETES_VERSION=v1.8.0
+
+before_script:
+# Install CLI dependencies
+- curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
+- curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+- curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+# Install nsenter
+- docker run -v /usr/local/bin:/hostbin munnerz/ubuntu-nsenter cp /nsenter /hostbin/nsenter
+
+script:
+# Setup e2e service dependencies
+- ./hack/test/setup-boulder.sh
+- ./hack/test/setup-minikube.sh
+# Build images while we wait for services to start
+- make build image APP_VERSION=build
+# Wait for e2e service dependencies
+- ./hack/test/wait-boulder.sh
+- ./hack/test/wait-minikube.sh
+# Setup service for nginx ingress controller. A DNS entry for *.certmanager.kubernetes.network has been setup to point to 10.0.0.15 for e2e tests
+- while true; do if kubectl get rc nginx-ingress-controller -n kube-system; then break; fi; echo "Waiting 5s for nginx-ingress-controller rc to be installed..."; sleep 5; done
+- kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.0.0.15
+- make e2e_test E2E_NGINX_CERTIFICATE_DOMAIN=certmanager.kubernetes.network
+
+
 jobs:
   include:
     - stage: test
-      dist: trusty
-      language: go
-      go: 1.8
-      env:
-      - KUBERNETES_VERSION=v1.7.0
-      - KUBERNETES_VERSION=v1.8.0
       before_script:
-      # Install CLI dependencies
-      - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
-      - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.22.3/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-      # Install nsenter
-      - docker run -v /usr/local/bin:/hostbin munnerz/ubuntu-nsenter cp /nsenter /hostbin/nsenter
-      script:
-      # Setup e2e service dependencies
-      - ./hack/test/setup-boulder.sh
-      - ./hack/test/setup-minikube.sh
-      # Build images while we wait for services to start
-      - make build image APP_VERSION=build
-      # Wait for e2e service dependencies
-      - ./hack/test/wait-boulder.sh
-      - ./hack/test/wait-minikube.sh
-      # Setup service for nginx ingress controller. A DNS entry for *.certmanager.kubernetes.network has been setup to point to 10.0.0.15 for e2e tests
-      - while true; do if kubectl get rc nginx-ingress-controller -n kube-system; then break; fi; echo "Waiting 5s for nginx-ingress-controller rc to be installed..."; sleep 5; done
-      - kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.0.0.15
-      - make e2e_test E2E_NGINX_CERTIFICATE_DOMAIN=certmanager.kubernetes.network
-    - stage: test
-      dist: trusty
-      language: go
-      go: 1.8
       script:
       - make verify test

--- a/hack/test/setup-boulder.sh
+++ b/hack/test/setup-boulder.sh
@@ -19,7 +19,10 @@ sed -i 's/5002/80/' test/config/va.json
 # TODO: set ratelimits
 
 function start {
-    if ! docker-compose up; then
+    # Read the log from a file to stop docker-compose abusing the terminal
+    touch /tmp/boulder.log
+    tail -f /tmp/boulder.log &
+    if ! docker-compose up > /tmp/boulder.log 2>&1; then
         echo "Error running boulder"
         exit 1
     fi


### PR DESCRIPTION
Closes #108 
/area test-infra

**Release note:**
```release-note
Enable e2e tests on Kubernetes 1.8.0
```