### PR TITLE
Certificate controller logging & self subject access reviews

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
+	"sort"
 	"time"
 
+	"github.com/golang/glog"
 	api "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
-	"github.com/golang/glog"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/issuer"
 	"github.com/jetstack/cert-manager/pkg/util"
@@ -62,9 +64,9 @@ const (
 )
 
 func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err error) {
-	// step zero: check if the referenced issuer exists and is ready
+	// get an issuer resource. we get a generic issuer here so we can support
+	// ClusterIssuers as well as Issuers without forking the code
 	issuerObj, err := c.getGenericIssuer(crt)
-
 	if err != nil {
 		s := fmt.Sprintf(messageIssuerNotFound, err.Error())
 		glog.Info(s)
@@ -72,10 +74,13 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 		return err
 	}
 
+	// check if the issuer is ready
 	issuerReady := issuerObj.HasCondition(v1alpha1.IssuerCondition{
 		Type:   v1alpha1.IssuerConditionReady,
 		Status: v1alpha1.ConditionTrue,
 	})
+	// if the issuer is not ready, we throw an error so the certificate can be
+	// processed again later
 	if !issuerReady {
 		s := fmt.Sprintf(messageIssuerNotReady, issuerObj.GetObjectMeta().Name)
 		glog.Info(s)
@@ -83,6 +88,7 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 		return fmt.Errorf(s)
 	}
 
+	// get an issuer implementation for the issuer specified on the certificate
 	i, err := c.issuerFactory.IssuerFor(issuerObj)
 	if err != nil {
 		s := messageIssuerErrorInit + err.Error()
@@ -91,12 +97,12 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 		return err
 	}
 
-	// grab existing certificate and validate private key
+	// attempt to get a copy of the existing certificate
 	cert, err := kube.SecretTLSCert(c.secretLister, crt.Namespace, crt.Spec.SecretName)
 	if err != nil {
 		s := messageErrorCheckCertificate + err.Error()
 		glog.Info(s)
-		c.recorder.Event(crt, api.EventTypeWarning, errorCheckCertificate, s)
+		c.recorder.Event(crt, api.EventTypeNormal, errorCheckCertificate, s)
 	}
 
 	// if an error is returned, and that error is something other than
@@ -105,47 +111,51 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 		return err
 	}
 
-	// as there is an existing certificate, or we may create one below, we will
-	// run scheduleRenewal to schedule a renewal if required at the end of
-	// execution.
-	defer c.scheduleRenewal(crt)
-
+	// make a copy of the Certificate from the cache, so we can modify it
 	crtCopy := crt.DeepCopy()
 	expectedCN := pki.CommonNameForCertificate(crtCopy)
 	expectedDNSNames := pki.DNSNamesForCertificate(crtCopy)
 
-	// if the certificate was not found, or the certificate data is invalid, we
-	// should issue a new certificate.
-	// if the certificate is valid for a list of domains other than those
-	// listed in the certificate spec, we should re-issue the certificate.
-	if k8sErrors.IsNotFound(err) || errors.IsInvalidData(err) ||
-		expectedCN != cert.Subject.CommonName || !util.EqualUnsorted(cert.DNSNames, expectedDNSNames) {
-		err := c.issue(ctx, i, crtCopy)
-		updateErr := c.updateCertificateStatus(crtCopy)
-		if err != nil || updateErr != nil {
-			return utilerrors.NewAggregate([]error{err, updateErr})
-		}
-		return nil
+	glog.V(4).Infof("Checking certificate validity. Expect CN %q and dnsNames %q", expectedCN, expectedDNSNames)
+	switch {
+	case k8sErrors.IsNotFound(err):
+		glog.V(4).Infof("Issuing certificate as existing certificate is not found")
+	case errors.IsInvalidData(err):
+		glog.V(4).Infof("Issuing certificate as existing certificate contains invalid data")
+	case expectedCN != cert.Subject.CommonName:
+		glog.V(4).Infof("Issuing certificate as existing certificate has common name %q, but should be %q", cert.Subject.CommonName, expectedCN)
+	case !util.EqualUnsorted(cert.DNSNames, expectedDNSNames):
+		sortedActualNames := cert.DNSNames
+		sortedExpectedNames := expectedDNSNames
+		sort.Strings(sortedActualNames)
+		sort.Strings(sortedExpectedNames)
+		glog.V(4).Infof("Issuing certificate as existing certificate has DNSNames %q, but should be %q", sortedActualNames, sortedExpectedNames)
 	}
-
-	// calculate the amount of time until expiry
-	durationUntilExpiry := cert.NotAfter.Sub(time.Now())
-	// calculate how long until we should start attempting to renew the
-	// certificate
-	renewIn := durationUntilExpiry - renewBefore
-	// if we should being attempting to renew now, then trigger a renewal
-	if renewIn <= 0 {
-		err := c.renew(ctx, i, crtCopy)
-		updateErr := c.updateCertificateStatus(crtCopy)
-		if err != nil || updateErr != nil {
-			return utilerrors.NewAggregate([]error{err, updateErr})
+	if cert == nil {
+		err = c.issue(ctx, i, crtCopy)
+	} else {
+		// calculate the amount of time until expiry
+		durationUntilExpiry := cert.NotAfter.Sub(time.Now())
+		// if we should being attempting to renew now, then trigger a renewal
+		if durationUntilExpiry <= renewBefore {
+			err = c.renew(ctx, i, crtCopy)
 		}
 	}
 
+	updateErr := c.updateCertificateStatus(crtCopy)
+	if err != nil || updateErr != nil {
+		return utilerrors.NewAggregate([]error{err, updateErr})
+	}
+
+	c.scheduleRenewal(crt)
 	return nil
 }
 
 func (c *Controller) getGenericIssuer(crt *v1alpha1.Certificate) (v1alpha1.GenericIssuer, error) {
+	if crt.Spec.IssuerRef.Name == "" {
+		return nil, fmt.Errorf("certificate.spec.issuerRef.name is a required field")
+	}
+
 	switch crt.Spec.IssuerRef.Kind {
 	case "", v1alpha1.IssuerKind:
 		return c.issuerLister.Issuers(crt.Namespace).Get(crt.Spec.IssuerRef.Name)
@@ -194,26 +204,49 @@ func (c *Controller) scheduleRenewal(crt *v1alpha1.Certificate) {
 	c.recorder.Event(crt, api.EventTypeNormal, successRenewalScheduled, s)
 }
 
-// return an error on failure. If retrieval is succesful, the certificate data
-// and private key will be stored in the named secret
-func (c *Controller) issue(ctx context.Context, issuer issuer.Interface, crt *v1alpha1.Certificate) error {
-	var err error
+func (c *Controller) prepare(ctx context.Context, issuer issuer.Interface, crt *v1alpha1.Certificate) error {
+	if crt.Spec.SecretName == "" {
+		return fmt.Errorf("certificate.spec.secretName is a required field")
+	}
+
 	s := messagePreparingCertificate
 	glog.Info(s)
 	c.recorder.Event(crt, api.EventTypeNormal, reasonPreparingCertificate, s)
+	// check we can create and update the certificate secret before we continue
+	allowed, reason, err := kube.CanI(c.client, crt.Namespace, "create,update", certmanager.GroupName, "secrets", crt.Spec.SecretName)
+	if err != nil {
+		s := messageErrorPreparingCertificate + err.Error()
+		glog.Info(s)
+		c.recorder.Event(crt, api.EventTypeWarning, errorPreparingCertificate, s)
+		return err
+	}
+	if !allowed {
+		s := messageErrorPreparingCertificate + reason
+		glog.Info(s)
+		c.recorder.Event(crt, api.EventTypeWarning, errorPreparingCertificate, s)
+		return fmt.Errorf(s)
+	}
 	if err = issuer.Prepare(ctx, crt); err != nil {
 		s := messageErrorPreparingCertificate + err.Error()
 		glog.Info(s)
 		c.recorder.Event(crt, api.EventTypeWarning, errorPreparingCertificate, s)
 		return err
 	}
+	return nil
+}
 
-	s = messageIssuingCertificate
+// return an error on failure. If retrieval is succesful, the certificate data
+// and private key will be stored in the named secret
+func (c *Controller) issue(ctx context.Context, issuer issuer.Interface, crt *v1alpha1.Certificate) error {
+	if err := c.prepare(ctx, issuer, crt); err != nil {
+		return err
+	}
+
+	s := messageIssuingCertificate
 	glog.Info(s)
 	c.recorder.Event(crt, api.EventTypeNormal, reasonIssuingCertificate, s)
 
-	var key, cert []byte
-	key, cert, err = issuer.Issue(ctx, crt)
+	key, cert, err := issuer.Issue(ctx, crt)
 
 	if err != nil {
 		s := messageErrorIssuingCertificate + err.Error()
@@ -252,24 +285,15 @@ func (c *Controller) issue(ctx context.Context, issuer issuer.Interface, crt *v1
 // return an error on failure. If renewal is succesful, the certificate data
 // and private key will be stored in the named secret
 func (c *Controller) renew(ctx context.Context, issuer issuer.Interface, crt *v1alpha1.Certificate) error {
-	var err error
-	s := messagePreparingCertificate
-	glog.Info(s)
-	c.recorder.Event(crt, api.EventTypeNormal, reasonPreparingCertificate, s)
-
-	if err = issuer.Prepare(ctx, crt); err != nil {
-		s := messageErrorPreparingCertificate + err.Error()
-		glog.Info(s)
-		c.recorder.Event(crt, api.EventTypeWarning, errorPreparingCertificate, s)
+	if err := c.prepare(ctx, issuer, crt); err != nil {
 		return err
 	}
 
-	s = messageRenewingCertificate
+	s := messageRenewingCertificate
 	glog.Info(s)
 	c.recorder.Event(crt, api.EventTypeNormal, reasonRenewingCertificate, s)
 
-	var key, cert []byte
-	key, cert, err = issuer.Renew(ctx, crt)
+	key, cert, err := issuer.Renew(ctx, crt)
 
 	if err != nil {
 		s := messageErrorRenewingCertificate + err.Error()

--- a/pkg/util/kube/cani.go
+++ b/pkg/util/kube/cani.go
@@ -1,0 +1,27 @@
+package kube
+
+import (
+	authz "k8s.io/api/authorization/v1beta1"
+	"k8s.io/client-go/kubernetes"
+)
+
+func CanI(cl kubernetes.Interface, namespace, verb, group, resource, name string) (ok bool, reason string, err error) {
+	review := &authz.SelfSubjectAccessReview{
+		Spec: authz.SelfSubjectAccessReviewSpec{
+			ResourceAttributes: &authz.ResourceAttributes{
+				Namespace: namespace,
+				Verb:      verb,
+				Group:     group,
+				Resource:  resource,
+				Name:      name,
+			},
+		},
+	}
+	review, err = cl.AuthorizationV1beta1().SelfSubjectAccessReviews().Create(review)
+	if err != nil {
+		return
+	}
+	ok = review.Status.Allowed
+	reason = review.Status.Reason
+	return
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve logging in Certificate controller, add validation check to ensure we can create/update secret resource

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #135 

**Release note**:
```release-note
Perform SelfSubjectAccessReview on target secret to ensure it can be created/updated by cert-manager before attempting to obtain certificates
```
