### PR TITLE
Improve validation of certificates. Fix bug in checking certificate validity

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -91,6 +91,15 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 		return err
 	}
 
+	expectedCN, err := pki.CommonNameForCertificate(crt)
+	if err != nil {
+		return err
+	}
+	expectedDNSNames, err := pki.DNSNamesForCertificate(crt)
+	if err != nil {
+		return err
+	}
+
 	// grab existing certificate and validate private key
 	cert, err := kube.SecretTLSCert(c.secretLister, crt.Namespace, crt.Spec.SecretName)
 	if err != nil {
@@ -111,14 +120,6 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 	defer c.scheduleRenewal(crt)
 
 	crtCopy := crt.DeepCopy()
-	expectedCN, err := pki.CommonNameForCertificate(crtCopy)
-	if err != nil {
-		return err
-	}
-	expectedDNSNames, err := pki.DNSNamesForCertificate(crtCopy)
-	if err != nil {
-		return err
-	}
 
 	// if the certificate was not found, or the certificate data is invalid, we
 	// should issue a new certificate.

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -111,8 +111,14 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 	defer c.scheduleRenewal(crt)
 
 	crtCopy := crt.DeepCopy()
-	expectedCN := pki.CommonNameForCertificate(crtCopy)
-	expectedDNSNames := pki.DNSNamesForCertificate(crtCopy)
+	expectedCN, err := pki.CommonNameForCertificate(crtCopy)
+	if err != nil {
+		return err
+	}
+	expectedDNSNames, err := pki.DNSNamesForCertificate(crtCopy)
+	if err != nil {
+		return err
+	}
 
 	// if the certificate was not found, or the certificate data is invalid, we
 	// should issue a new certificate.

--- a/pkg/issuer/ca/issue.go
+++ b/pkg/issuer/ca/issue.go
@@ -121,7 +121,15 @@ func createCertificateTemplate(publicKey interface{}, commonName string, altName
 // publicKey is the public key of the signee, and signerKey is the private
 // key of the signer.
 func signCertificate(crt *v1alpha1.Certificate, issuerCert *x509.Certificate, publicKey interface{}, signerKey interface{}) ([]byte, *x509.Certificate, error) {
-	template, err := createCertificateTemplate(publicKey, pki.CommonNameForCertificate(crt), pki.DNSNamesForCertificate(crt)...)
+	cn, err := pki.CommonNameForCertificate(crt)
+	if err != nil {
+		return nil, nil, err
+	}
+	dnsNames, err := pki.DNSNamesForCertificate(crt)
+	if err != nil {
+		return nil, nil, err
+	}
+	template, err := createCertificateTemplate(publicKey, cn, dnsNames...)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error creating x509 certificate template: %s", err.Error())
 	}

--- a/pkg/util/filter.go
+++ b/pkg/util/filter.go
@@ -57,15 +57,15 @@ func StringFilter(fn FilterFn, in ...string) StringFilterWrapper {
 }
 
 func RemoveDuplicates(in []string) []string {
-	dedupMap := make(map[string]struct{})
+	var found []string
+Outer:
 	for _, i := range in {
-		dedupMap[i] = struct{}{}
+		for _, i2 := range found {
+			if i2 == i {
+				continue Outer
+			}
+		}
+		found = append(found, i)
 	}
-	out := make([]string, len(dedupMap))
-	i := 0
-	for s := range dedupMap {
-		out[i] = s
-		i++
-	}
-	return out
+	return found
 }

--- a/pkg/util/filter.go
+++ b/pkg/util/filter.go
@@ -55,3 +55,17 @@ func StringFilter(fn FilterFn, in ...string) StringFilterWrapper {
 	}
 	return res
 }
+
+func RemoveDuplicates(in []string) []string {
+	dedupMap := make(map[string]struct{})
+	for _, i := range in {
+		dedupMap[i] = struct{}{}
+	}
+	out := make([]string, len(dedupMap))
+	i := 0
+	for s := range dedupMap {
+		out[i] = s
+		i++
+	}
+	return out
+}

--- a/pkg/util/filter_test.go
+++ b/pkg/util/filter_test.go
@@ -1,0 +1,36 @@
+package util
+
+import "testing"
+
+func TestRemoveDuplicates(t *testing.T) {
+	type testT struct {
+		input  []string
+		output []string
+	}
+	tests := []testT{
+		{
+			input:  []string{"a"},
+			output: []string{"a"},
+		},
+		{
+			input:  []string{"a", "b"},
+			output: []string{"a", "b"},
+		},
+		{
+			input:  []string{"a", "a"},
+			output: []string{"a"},
+		},
+		{
+			input:  []string{"a", "b", "a", "a", "c"},
+			output: []string{"a", "b", "c"},
+		},
+	}
+	for _, test := range tests {
+		actualOutput := RemoveDuplicates(test.input)
+		if len(actualOutput) != len(test.output) ||
+			!EqualUnsorted(test.output, actualOutput) {
+			t.Errorf("returned %q for %q but expected %q", actualOutput, test.input, test.output)
+			continue
+		}
+	}
+}

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -3,28 +3,36 @@ package pki
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"fmt"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util"
 )
 
 // The provided Certificate *must* specify either a DNS name or a
 // CommonName else this function will panic.
-func CommonNameForCertificate(crt *v1alpha1.Certificate) string {
-	if crt.Spec.CommonName == "" {
-		return crt.Spec.DNSNames[0]
+func CommonNameForCertificate(crt *v1alpha1.Certificate) (string, error) {
+	if crt.Spec.CommonName != "" {
+		return crt.Spec.CommonName, nil
 	}
-	return crt.Spec.CommonName
+	if len(crt.Spec.DNSNames) == 0 {
+		return "", fmt.Errorf("certificate must specify at least one of dnsNames or commonName")
+	}
+	return crt.Spec.DNSNames[0], nil
 }
 
 // The provided Certificate *must* specify either a DNS name or a
 // CommonName else this function will panic.
-func DNSNamesForCertificate(crt *v1alpha1.Certificate) []string {
+func DNSNamesForCertificate(crt *v1alpha1.Certificate) ([]string, error) {
 	if len(crt.Spec.DNSNames) == 0 {
-		return []string{crt.Spec.CommonName}
+		if crt.Spec.CommonName == "" {
+			return nil, fmt.Errorf("certificate must specify at least one of dnsNames or commonName")
+		}
+		return []string{crt.Spec.CommonName}, nil
 	}
 	if crt.Spec.CommonName != "" {
-		return append([]string{crt.Spec.CommonName}, crt.Spec.DNSNames...)
+		return util.RemoveDuplicates(append([]string{crt.Spec.CommonName}, crt.Spec.DNSNames...)), nil
 	}
-	return crt.Spec.DNSNames
+	return crt.Spec.DNSNames, nil
 }
 
 func GenerateCSR(commonName string, altNames ...string) *x509.CertificateRequest {

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -1,0 +1,128 @@
+package pki
+
+import (
+	"testing"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+func buildCertificate(cn string, dnsNames ...string) *v1alpha1.Certificate {
+	return &v1alpha1.Certificate{
+		Spec: v1alpha1.CertificateSpec{
+			CommonName: cn,
+			DNSNames:   dnsNames,
+		},
+	}
+}
+
+func TestCommonNameForCertificate(t *testing.T) {
+	type testT struct {
+		name        string
+		crtCN       string
+		crtDNSNames []string
+		expectedCN  string
+		expectErr   bool
+	}
+	tests := []testT{
+		{
+			name:       "certificate with CommonName set",
+			crtCN:      "test",
+			expectedCN: "test",
+		},
+		{
+			name:        "certificate with one DNS name set",
+			crtDNSNames: []string{"dnsname"},
+			expectedCN:  "dnsname",
+		},
+		{
+			name:      "certificate with neither common name or dnsNames set",
+			expectErr: true,
+		},
+		{
+			name:        "certificate with both common name and dnsName set",
+			crtCN:       "cn",
+			crtDNSNames: []string{"dnsname"},
+			expectedCN:  "cn",
+		},
+		{
+			name:        "certificate with multiple dns names set",
+			crtDNSNames: []string{"dnsname1", "dnsname2"},
+			expectedCN:  "dnsname1",
+		},
+	}
+	testFn := func(test testT) func(*testing.T) {
+		return func(t *testing.T) {
+			actualCN, err := CommonNameForCertificate(buildCertificate(test.crtCN, test.crtDNSNames...))
+			if err != nil && !test.expectErr {
+				t.Errorf("did not expect error from CommonNameForCertificate: %s", err.Error())
+				return
+			}
+			if actualCN != test.expectedCN {
+				t.Errorf("expected %q but got %q", test.expectedCN, actualCN)
+				return
+			}
+		}
+	}
+	for _, test := range tests {
+		t.Run(test.name, testFn(test))
+	}
+}
+
+func TestDNSNamesForCertificate(t *testing.T) {
+	type testT struct {
+		name           string
+		crtCN          string
+		crtDNSNames    []string
+		expectDNSNames []string
+		expectErr      bool
+	}
+	tests := []testT{
+		{
+			name:           "certificate with CommonName set",
+			crtCN:          "test",
+			expectDNSNames: []string{"test"},
+		},
+		{
+			name:           "certificate with one DNS name set",
+			crtDNSNames:    []string{"dnsname"},
+			expectDNSNames: []string{"dnsname"},
+		},
+		{
+			name:      "certificate with neither common name or dnsNames set",
+			expectErr: true,
+		},
+		{
+			name:           "certificate with both common name and dnsName set",
+			crtCN:          "cn",
+			crtDNSNames:    []string{"dnsname"},
+			expectDNSNames: []string{"cn", "dnsname"},
+		},
+		{
+			name:           "certificate with multiple dns names set",
+			crtDNSNames:    []string{"dnsname1", "dnsname2"},
+			expectDNSNames: []string{"dnsname1", "dnsname2"},
+		},
+	}
+	testFn := func(test testT) func(*testing.T) {
+		return func(t *testing.T) {
+			actualDNSNames, err := DNSNamesForCertificate(buildCertificate(test.crtCN, test.crtDNSNames...))
+			if err != nil && !test.expectErr {
+				t.Errorf("did not expect error from CommonNameForCertificate: %s", err.Error())
+				return
+			}
+			if len(actualDNSNames) != len(test.expectDNSNames) {
+				t.Errorf("expected %q but got %q", test.expectDNSNames, actualDNSNames)
+				return
+			}
+			for i, actual := range actualDNSNames {
+				if test.expectDNSNames[i] != actual {
+					t.Errorf("expected %q but got %q", test.expectDNSNames, actualDNSNames)
+					return
+				}
+			}
+		}
+	}
+	for _, test := range tests {
+		t.Run(test.name, testFn(test))
+	}
+}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -102,6 +102,18 @@ func TestDNSNamesForCertificate(t *testing.T) {
 			crtDNSNames:    []string{"dnsname1", "dnsname2"},
 			expectDNSNames: []string{"dnsname1", "dnsname2"},
 		},
+		{
+			name:           "certificate with dnsName[0] set to equal common name",
+			crtCN:          "cn",
+			crtDNSNames:    []string{"cn", "dnsname"},
+			expectDNSNames: []string{"cn", "dnsname"},
+		},
+		{
+			name:           "certificate with a dnsName equal to cn",
+			crtCN:          "cn",
+			crtDNSNames:    []string{"dnsname", "cn"},
+			expectDNSNames: []string{"cn", "dnsname"},
+		},
 	}
 	testFn := func(test testT) func(*testing.T) {
 		return func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Improves the validation of dnsNames and commonNames on certificate resources.
Fixes a bug in checking certificate validity.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #176, fixes #175

**Release note**:
```release-note
Fix a bug in checking certificate validity and improve validation of dnsNames and commonName
```
