### PR TITLE
Update to go 1.9

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.8-alpine
+image: golang:1.9-alpine
 
 variables:
   DOCKER_DRIVER: overlay

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
     - stage: test
       dist: trusty
       language: go
-      go: 1.8
+      go: 1.9
       env:
       - KUBERNETES_VERSION=v1.7.0
       before_script:
@@ -31,6 +31,6 @@ jobs:
     - stage: test
       dist: trusty
       language: go
-      go: 1.8
+      go: 1.9
       script:
       - make verify test


### PR DESCRIPTION
1.10 isn't too far off, at which point 1.8 will no longer receive security updates. It seems simple enough to bump sooner rather than wait until the last second.

**Release note**:
```release-note
NONE
```
