### PR TITLE
Restructure makefile for running e2e tests with prow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,7 @@ jobs:
       # Wait for e2e service dependencies
       - ./hack/test/wait-boulder.sh
       - ./hack/test/wait-minikube.sh
-      # Setup service for nginx ingress controller. A DNS entry for *.certmanager.kubernetes.network has been setup to point to 10.0.0.15 for e2e tests
-      - while true; do if kubectl get rc nginx-ingress-controller -n kube-system; then break; fi; echo "Waiting 5s for nginx-ingress-controller rc to be installed..."; sleep 5; done
-      - kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.0.0.15
-      - make e2e_test E2E_NGINX_CERTIFICATE_DOMAIN=certmanager.kubernetes.network
+      - make e2e_test
     - stage: test
       dist: trusty
       language: go

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ BUILD_TAG := build
 # Domain name to use in e2e tests. This is important for ACME HTTP01 e2e tests,
 # which require a domain that resolves to the ingress controller to be used for
 # e2e tests.
-E2E_NGINX_CERTIFICATE_DOMAIN=
+E2E_NGINX_CERTIFICATE_DOMAIN ?= certmanager.kubernetes.network
 
 # AppVersion is set as the AppVersion to be compiled into the controller binary.
 # It's used as the default version of the 'acmesolver' image to use for ACME
@@ -92,7 +92,10 @@ go_fmt:
 		exit 1; \
 	fi
 
-e2e_test:
+.e2e_configure_ingress:
+	kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.0.0.15
+
+e2e_test: .e2e_configure_ingress
 	# Build the e2e tests
 	go test -o e2e-tests -c ./test/e2e
 	# TODO: make these paths configurable

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ go_fmt:
 	fi
 
 .e2e_configure_ingress:
+	while true; do if kubectl get rc nginx-ingress-controller -n kube-system; then break; fi; echo "Waiting 5s for nginx-ingress-controller rc to be installed..."; sleep 5; done
 	kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.0.0.15
 
 e2e_test: .e2e_configure_ingress


### PR DESCRIPTION
**What this PR does / why we need it**:

Move some logic into the Makefile to make running e2e tests on prow easier

**Release note**:
```release-note
NONE
```

/assign