### PR TITLE
 Add ingress-shim controller to create Certificates based on annotations on ingress resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,8 @@ e2e_test:
 		./e2e-tests \
 			-cert-manager-image-pull-policy=Never \
 			-cert-manager-image=$(REGISTRY)/$(APP_NAME)-controller:$(BUILD_TAG) \
+			-ingress-shim-image-pull-policy=Never \
+			-ingress-shim-image=$(REGISTRY)/$(APP_NAME)-ingress-shim:$(BUILD_TAG) \
 			-acme-nginx-certificate-domain=$(E2E_NGINX_CERTIFICATE_DOMAIN)
 
 # Docker targets

--- a/cmd/ingress-shim/README.md
+++ b/cmd/ingress-shim/README.md
@@ -1,0 +1,19 @@
+# ingress-shim
+
+This is a small binary that can be run alongside any cert-manager deployment
+in order to automatically create Certificate resources for Ingresses when a
+particular annotation is found on an ingress resource.
+
+This allows users to consume certificates from cert-manager without having to
+manually create Certificate resources, i.e. in a similar fashion to [kube-lego](https://github.com/jetstack/kube-lego).
+
+It has been developed outside of the core of cert-manager as it is an
+experiment to assess the best way to implement this sort of functionality.
+
+## Project status
+
+This project is experimental, and thus should not be relied upon in a
+production environment. This tool may change in backwards incompatible ways.
+
+In the future, the functionality of this tool may be merged into cert-manager
+itself to provide a more seamless experience for users.

--- a/cmd/ingress-shim/controller/checks.go
+++ b/cmd/ingress-shim/controller/checks.go
@@ -1,0 +1,32 @@
+package controller
+
+import (
+	"fmt"
+
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+func (c *Controller) ingressesForCertificate(crt *v1alpha1.Certificate) ([]*extv1beta1.Ingress, error) {
+	ings, err := c.ingressLister.List(labels.NewSelector())
+
+	if err != nil {
+		return nil, fmt.Errorf("error listing certificiates: %s", err.Error())
+	}
+
+	var affected []*extv1beta1.Ingress
+	for _, ing := range ings {
+		if crt.Namespace != ing.Namespace {
+			continue
+		}
+
+		if metav1.IsControlledBy(crt, ing) {
+			affected = append(affected, ing)
+		}
+	}
+
+	return affected, nil
+}

--- a/cmd/ingress-shim/controller/controller.go
+++ b/cmd/ingress-shim/controller/controller.go
@@ -1,0 +1,185 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
+	extlisters "k8s.io/client-go/listers/extensions/v1beta1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/jetstack/cert-manager/cmd/ingress-shim/options"
+	cmv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/util"
+	extinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/extensions/v1beta1"
+)
+
+const (
+	ControllerName = "ingress-shim"
+)
+
+type Controller struct {
+	Client   kubernetes.Interface
+	CMClient clientset.Interface
+	Recorder record.EventRecorder
+
+	// To allow injection for testing.
+	syncHandler func(ctx context.Context, key string) error
+
+	ingressLister       extlisters.IngressLister
+	certificateLister   cmlisters.CertificateLister
+	issuerLister        cmlisters.IssuerLister
+	clusterIssuerLister cmlisters.ClusterIssuerLister
+
+	queue       workqueue.RateLimitingInterface
+	workerWg    sync.WaitGroup
+	syncedFuncs []cache.InformerSynced
+	options     *options.ControllerOptions
+}
+
+// New returns a new Certificates controller. It sets up the informer handler
+// functions for all the types it watches.
+func New(
+	certificatesInformer cminformers.CertificateInformer,
+	ingressInformer extinformers.IngressInformer,
+	issuerInformer cminformers.IssuerInformer,
+	clusterIssuerInformer cminformers.ClusterIssuerInformer,
+	client kubernetes.Interface,
+	cmClient clientset.Interface,
+	recorder record.EventRecorder,
+	options *options.ControllerOptions,
+) *Controller {
+	ctrl := &Controller{Client: client, CMClient: cmClient, Recorder: recorder, options: options}
+	ctrl.syncHandler = ctrl.processNextWorkItem
+	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ingresses")
+
+	ingressInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})
+	ctrl.ingressLister = ingressInformer.Lister()
+	ctrl.syncedFuncs = append(ctrl.syncedFuncs, ingressInformer.Informer().HasSynced)
+
+	certificatesInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.certificateDeleted})
+	ctrl.certificateLister = certificatesInformer.Lister()
+	ctrl.syncedFuncs = append(ctrl.syncedFuncs, certificatesInformer.Informer().HasSynced)
+
+	ctrl.issuerLister = issuerInformer.Lister()
+	ctrl.syncedFuncs = append(ctrl.syncedFuncs, issuerInformer.Informer().HasSynced)
+	ctrl.clusterIssuerLister = clusterIssuerInformer.Lister()
+	ctrl.syncedFuncs = append(ctrl.syncedFuncs, clusterIssuerInformer.Informer().HasSynced)
+
+	return ctrl
+}
+
+func (c *Controller) certificateDeleted(obj interface{}) {
+	crt, ok := obj.(*cmv1alpha1.Certificate)
+	if !ok {
+		runtime.HandleError(fmt.Errorf("Object is not a certificate object %#v", obj))
+		return
+	}
+	ings, err := c.ingressesForCertificate(crt)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("Error looking up ingress observing certificate: %s/%s", crt.Namespace, crt.Name))
+		return
+	}
+	for _, crt := range ings {
+		key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(crt)
+		if err != nil {
+			runtime.HandleError(err)
+			continue
+		}
+		c.queue.Add(key)
+	}
+}
+
+func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
+	glog.V(4).Infof("Starting %s control loop", ControllerName)
+	// wait for all the informer caches we depend to sync
+	if !cache.WaitForCacheSync(stopCh, c.syncedFuncs...) {
+		return fmt.Errorf("error waiting for informer caches to sync")
+	}
+
+	glog.V(4).Infof("Synced all caches for %s control loop", ControllerName)
+
+	for i := 0; i < workers; i++ {
+		c.workerWg.Add(1)
+		// TODO (@munnerz): make time.Second duration configurable
+		go wait.Until(func() { c.worker(stopCh) }, time.Second, stopCh)
+	}
+	<-stopCh
+	glog.V(4).Infof("Shutting down queue as workqueue signaled shutdown")
+	c.queue.ShutDown()
+	glog.V(4).Infof("Waiting for workers to exit...")
+	c.workerWg.Wait()
+	glog.V(4).Infof("Workers exited.")
+	return nil
+}
+
+func (c *Controller) worker(stopCh <-chan struct{}) {
+	defer c.workerWg.Done()
+	glog.V(4).Infof("Starting %q worker", ControllerName)
+	for {
+		obj, shutdown := c.queue.Get()
+		if shutdown {
+			break
+		}
+
+		var key string
+		err := func(obj interface{}) error {
+			defer c.queue.Done(obj)
+			var ok bool
+			if key, ok = obj.(string); !ok {
+				return nil
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = util.ContextWithStopCh(ctx, stopCh)
+			glog.Infof("%s controller: syncing item '%s'", ControllerName, key)
+			if err := c.syncHandler(ctx, key); err != nil {
+				return err
+			}
+			c.queue.Forget(obj)
+			return nil
+		}(obj)
+
+		if err != nil {
+			glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
+			c.queue.AddRateLimited(obj)
+			continue
+		}
+
+		glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
+	}
+	glog.V(4).Infof("Exiting %q worker loop", ControllerName)
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context, key string) error {
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
+		return nil
+	}
+
+	crt, err := c.ingressLister.Ingresses(namespace).Get(name)
+
+	if err != nil {
+		if k8sErrors.IsNotFound(err) {
+			runtime.HandleError(fmt.Errorf("ingress '%s' in work queue no longer exists", key))
+			return nil
+		}
+
+		return err
+	}
+
+	return c.Sync(ctx, crt)
+}

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -121,9 +121,6 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 		if !ok {
 			challengeType = c.options.DefaultACMEIssuerChallengeType
 		}
-		if challengeType == "" {
-			return fmt.Errorf("no acme issuer challenge type specified")
-		}
 		domainCfg := v1alpha1.ACMECertificateDomainConfig{
 			Domains: tls.Hosts,
 		}
@@ -139,6 +136,8 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 				return fmt.Errorf("no acme issuer dns01 challenge provider specified")
 			}
 			domainCfg.DNS01 = &v1alpha1.ACMECertificateDNS01Config{Provider: dnsProvider}
+		default:
+			return fmt.Errorf("invalid acme issuer challenge type specified %q", challengeType)
 		}
 		crt.Spec.ACME = &v1alpha1.ACMECertificateConfig{Config: []v1alpha1.ACMECertificateDomainConfig{domainCfg}}
 	}

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -1,0 +1,216 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+const (
+	// tlsACMEAnnotation is here for compatibility with kube-lego style
+	// ingress resources. When set to "true", a Certificate resource with
+	// the default configuration provided to ingress-annotation should be
+	// created.
+	tlsACMEAnnotation = "kubernetes.io/tls-acme"
+	// issuerNameAnnotation can be used to override the issuer specified on the
+	// created Certificate resource.
+	issuerNameAnnotation = "certmanager.k8s.io/issuer"
+	// clusterIssuerNameAnnotation can be used to override the issuer specified on the
+	// created Certificate resource. The Certificate will reference the
+	// specified *ClusterIssuer* instead of normal issuer.
+	clusterIssuerNameAnnotation = "certmanager.k8s.io/cluster-issuer"
+	// acmeIssuerChallengeTypeAnnotation can be used to override the default ACME challenge
+	// type to be used when the specified issuer is an ACME issuer
+	acmeIssuerChallengeTypeAnnotation = "certmanager.k8s.io/acme-challenge-type"
+	// acmeIssuerDNS01ProviderNameAnnotation can be used to override the default dns01 provider
+	// configured on the issuer if the challenge type is set to dns01
+	acmeIssuerDNS01ProviderNameAnnotation = "certmanager.k8s.io/acme-dns01-provider"
+)
+
+var ingressGVK = extv1beta1.SchemeGroupVersion.WithKind("Ingress")
+
+func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
+	if !shouldSync(ing) {
+		glog.Infof("Not syncing ingress %s/%s as it does not contain necessary annotations")
+		return nil
+	}
+
+	// get the existing Certificate resource with the same name as the ingress resource
+	existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(ing.Name)
+	if !apierrors.IsNotFound(err) && err != nil {
+		return err
+	}
+	if existingCrt != nil {
+		glog.Infof("Certificate %q for ingress %q already exists, skipping processing", existingCrt.Name, ing.Name)
+		return nil
+	}
+
+	crts, err := c.buildCertificates(ing)
+	if err != nil {
+		return err
+	}
+
+	for _, crt := range crts {
+		_, err := c.CMClient.CertmanagerV1alpha1().Certificates(crt.Namespace).Create(crt)
+		if err != nil {
+			return err
+		}
+		c.Recorder.Eventf(ing, corev1.EventTypeNormal, "CreateCertificate", "Successfully created Certificate %q", crt.Name)
+	}
+
+	return nil
+}
+
+func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) ([]*v1alpha1.Certificate, error) {
+	issuerName, issuerKind := c.issuerForIngress(ing)
+	issuer, err := c.getGenericIssuer(ing.Namespace, issuerName, issuerKind)
+	if err != nil {
+		return nil, err
+	}
+
+	var crts []*v1alpha1.Certificate
+	for i, tls := range ing.Spec.TLS {
+		// validate the ingress TLS block
+		if len(tls.Hosts) == 0 {
+			return nil, fmt.Errorf("secret %q for ingress %q has no hosts specified", tls.SecretName, ing.Name)
+		}
+		if tls.SecretName == "" {
+			return nil, fmt.Errorf("TLS entry %d for ingress %q must specify a secretName", i, ing.Name)
+		}
+
+		// check if a Certificate for this TLS entry already exists, and if it
+		// does then skip this entry
+		existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(tls.SecretName)
+		if !apierrors.IsNotFound(err) && err != nil {
+			return nil, err
+		}
+		if existingCrt != nil {
+			glog.Infof("Certificate %q for ingress %q already exists, not re-creating", tls.SecretName, ing.Name)
+			continue
+		}
+
+		crt := &v1alpha1.Certificate{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            tls.SecretName,
+				Namespace:       ing.Namespace,
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ing, ingressGVK)},
+			},
+			Spec: v1alpha1.CertificateSpec{
+				DNSNames:   tls.Hosts,
+				SecretName: tls.SecretName,
+				IssuerRef: v1alpha1.ObjectReference{
+					Name: issuerName,
+					Kind: issuerKind,
+				},
+			},
+		}
+		err = c.setIssuerSpecificConfig(crt, issuer, ing, tls)
+		if err != nil {
+			return nil, err
+		}
+		crts = append(crts, crt)
+	}
+	return crts, nil
+}
+
+func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v1alpha1.GenericIssuer, ing *extv1beta1.Ingress, tls extv1beta1.IngressTLS) error {
+	ingAnnotations := ing.Annotations
+	if ingAnnotations == nil {
+		ingAnnotations = map[string]string{}
+	}
+	// for ACME issuers
+	if issuer.GetSpec().ACME != nil {
+		challengeType, ok := ingAnnotations[acmeIssuerChallengeTypeAnnotation]
+		if !ok {
+			challengeType = c.options.DefaultACMEIssuerChallengeType
+		}
+		if challengeType == "" {
+			return fmt.Errorf("no acme issuer challenge type specified")
+		}
+		domainCfg := v1alpha1.ACMECertificateDomainConfig{
+			Domains: tls.Hosts,
+		}
+		switch challengeType {
+		case "http01":
+			domainCfg.HTTP01 = &v1alpha1.ACMECertificateHTTP01Config{Ingress: ing.Name}
+		case "dns01":
+			dnsProvider, ok := ingAnnotations[acmeIssuerDNS01ProviderNameAnnotation]
+			if !ok {
+				dnsProvider = c.options.DefaultACMEIssuerDNS01ProviderName
+			}
+			if dnsProvider == "" {
+				return fmt.Errorf("no acme issuer dns01 challenge provider specified")
+			}
+			domainCfg.DNS01 = &v1alpha1.ACMECertificateDNS01Config{Provider: dnsProvider}
+		}
+		crt.Spec.ACME = &v1alpha1.ACMECertificateConfig{Config: []v1alpha1.ACMECertificateDomainConfig{domainCfg}}
+	}
+	return nil
+}
+
+// shouldSync returns true if this ingress should have a Certificate resource
+// created for it
+func shouldSync(ing *extv1beta1.Ingress) bool {
+	annotations := ing.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if _, ok := annotations[issuerNameAnnotation]; ok {
+		return true
+	}
+	if _, ok := annotations[clusterIssuerNameAnnotation]; ok {
+		return true
+	}
+	if _, ok := annotations[tlsACMEAnnotation]; ok {
+		return true
+	}
+	if _, ok := annotations[acmeIssuerChallengeTypeAnnotation]; ok {
+		return true
+	}
+	if _, ok := annotations[acmeIssuerDNS01ProviderNameAnnotation]; ok {
+		return true
+	}
+	return false
+}
+
+// issuerForIngress will determine the issuer that should be specified on a
+// Certificate created for the given Ingress resource. If one is not set, the
+// default issuer given to the controller will be used.
+func (c *Controller) issuerForIngress(ing *extv1beta1.Ingress) (name string, kind string) {
+	name = c.options.DefaultIssuerName
+	kind = c.options.DefaultIssuerKind
+	annotations := ing.Annotations
+	if annotations == nil {
+		annotations = map[string]string{}
+	}
+	if issuerName, ok := annotations[issuerNameAnnotation]; ok {
+		name = issuerName
+		kind = v1alpha1.IssuerKind
+	}
+	if issuerName, ok := annotations[clusterIssuerNameAnnotation]; ok {
+		name = issuerName
+		kind = v1alpha1.ClusterIssuerKind
+	}
+	return name, kind
+}
+
+func (c *Controller) getGenericIssuer(namespace, name, kind string) (v1alpha1.GenericIssuer, error) {
+	switch kind {
+	case v1alpha1.IssuerKind:
+		return c.issuerLister.Issuers(namespace).Get(name)
+	case v1alpha1.ClusterIssuerKind:
+		if c.clusterIssuerLister == nil {
+			return nil, fmt.Errorf("cannot get ClusterIssuer for %q as ingress-shim is scoped to a single namespace", name)
+		}
+		return c.clusterIssuerLister.Get(name)
+	default:
+		return nil, fmt.Errorf(`invalid value %q for issuer kind. Must be empty, %q or %q`, kind, v1alpha1.IssuerKind, v1alpha1.ClusterIssuerKind)
+	}
+}

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -38,17 +38,7 @@ var ingressGVK = extv1beta1.SchemeGroupVersion.WithKind("Ingress")
 
 func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
 	if !shouldSync(ing) {
-		glog.Infof("Not syncing ingress %s/%s as it does not contain necessary annotations")
-		return nil
-	}
-
-	// get the existing Certificate resource with the same name as the ingress resource
-	existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(ing.Name)
-	if !apierrors.IsNotFound(err) && err != nil {
-		return err
-	}
-	if existingCrt != nil {
-		glog.Infof("Certificate %q for ingress %q already exists, skipping processing", existingCrt.Name, ing.Name)
+		glog.Infof("Not syncing ingress %s/%s as it does not contain necessary annotations", ing.Namespace, ing.Name)
 		return nil
 	}
 

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -1,0 +1,422 @@
+package controller
+
+import (
+	"reflect"
+	"testing"
+
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/cert-manager/cmd/ingress-shim/options"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	cmfake "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+)
+
+func TestShouldSync(t *testing.T) {
+	type testT struct {
+		Annotations map[string]string
+		ShouldSync  bool
+	}
+	tests := []testT{
+		{
+			Annotations: map[string]string{issuerNameAnnotation: ""},
+			ShouldSync:  true,
+		},
+		{
+			Annotations: map[string]string{clusterIssuerNameAnnotation: ""},
+			ShouldSync:  true,
+		},
+		{
+			Annotations: map[string]string{tlsACMEAnnotation: ""},
+			ShouldSync:  true,
+		},
+		{
+			Annotations: map[string]string{acmeIssuerChallengeTypeAnnotation: ""},
+			ShouldSync:  true,
+		},
+		{
+			Annotations: map[string]string{acmeIssuerDNS01ProviderNameAnnotation: ""},
+			ShouldSync:  true,
+		},
+		{
+			ShouldSync: false,
+		},
+	}
+	for _, test := range tests {
+		shouldSync := shouldSync(buildIngress("", "", test.Annotations))
+		if shouldSync != test.ShouldSync {
+			t.Errorf("Expected shouldSync=%v for annotations %#v", test.ShouldSync, test.Annotations)
+		}
+	}
+}
+
+func TestBuildCertificates(t *testing.T) {
+	type testT struct {
+		Name                string
+		Ingress             *extv1beta1.Ingress
+		IssuerLister        []*v1alpha1.Issuer
+		ClusterIssuerLister []*v1alpha1.ClusterIssuer
+		CertificateLister   []*v1alpha1.Certificate
+		Err                 bool
+		Expected            []*v1alpha1.Certificate
+	}
+	tests := []testT{
+		{
+			Name: "return a single Certificate for an ingress with a single valid TLS entry and appropriate annotations",
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						clusterIssuerNameAnnotation:       "issuer-name",
+						acmeIssuerChallengeTypeAnnotation: "http01",
+					},
+				},
+				Spec: extv1beta1.IngressSpec{
+					TLS: []extv1beta1.IngressTLS{
+						{
+							Hosts:      []string{"example.com", "www.example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			ClusterIssuerLister: []*v1alpha1.ClusterIssuer{buildACMEClusterIssuer("issuer-name")},
+			Expected: []*v1alpha1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       "ingress-namespace",
+						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", "ingress-namespace", nil), ingressGVK)},
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com", "www.example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "ClusterIssuer",
+						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.ACMECertificateDomainConfig{
+								{
+									Domains: []string{"example.com", "www.example.com"},
+									HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
+										Ingress: "ingress-name",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "should return an error when no TLS hosts are specified",
+			Err:  true,
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						issuerNameAnnotation: "issuer-name",
+					},
+				},
+				Spec: extv1beta1.IngressSpec{
+					TLS: []extv1beta1.IngressTLS{
+						{
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			IssuerLister: []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
+		},
+		{
+			Name: "should return an error when no TLS secret name is specified",
+			Err:  true,
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						issuerNameAnnotation: "issuer-name",
+					},
+				},
+				Spec: extv1beta1.IngressSpec{
+					TLS: []extv1beta1.IngressTLS{
+						{
+							Hosts: []string{"example.com"},
+						},
+					},
+				},
+			},
+			IssuerLister: []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
+		},
+		{
+			Name: "should error if the specified issuer is not found",
+			Err:  true,
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						issuerNameAnnotation: "invalid-issuer-name",
+					},
+				},
+			},
+		},
+		{
+			Name: "should not return any certificates if a Certificate already exists",
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						issuerNameAnnotation: "issuer-name",
+					},
+				},
+				Spec: extv1beta1.IngressSpec{
+					TLS: []extv1beta1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			IssuerLister:      []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
+			CertificateLister: []*v1alpha1.Certificate{buildCertificate("existing-crt", "ingress-namespace")},
+		},
+	}
+	testFn := func(test testT) func(t *testing.T) {
+		return func(t *testing.T) {
+			cmClient := cmfake.NewSimpleClientset()
+			factory := cminformers.NewSharedInformerFactory(cmClient, 0)
+			issuerInformer := factory.Certmanager().V1alpha1().Issuers()
+			clusterIssuerInformer := factory.Certmanager().V1alpha1().ClusterIssuers()
+			certificatesInformer := factory.Certmanager().V1alpha1().Certificates()
+			for _, i := range test.IssuerLister {
+				issuerInformer.Informer().GetIndexer().Add(i)
+			}
+			for _, i := range test.ClusterIssuerLister {
+				clusterIssuerInformer.Informer().GetIndexer().Add(i)
+			}
+			for _, i := range test.CertificateLister {
+				certificatesInformer.Informer().GetIndexer().Add(i)
+			}
+			c := &Controller{
+				issuerLister:        issuerInformer.Lister(),
+				clusterIssuerLister: clusterIssuerInformer.Lister(),
+				certificateLister:   certificatesInformer.Lister(),
+				options:             &options.ControllerOptions{},
+			}
+			crts, err := c.buildCertificates(test.Ingress)
+			if err != nil && !test.Err {
+				t.Errorf("Expected no error, but got: %s", err)
+			}
+			if !reflect.DeepEqual(crts, test.Expected) {
+				t.Errorf("Expected %+v but got %+v", test.Expected, crts)
+			}
+		}
+	}
+	for _, test := range tests {
+		t.Run(test.Name, testFn(test))
+	}
+}
+
+func TestIssuerForIngress(t *testing.T) {
+	type testT struct {
+		Ingress      *extv1beta1.Ingress
+		DefaultName  string
+		DefaultKind  string
+		ExpectedName string
+		ExpectedKind string
+	}
+	tests := []testT{
+		{
+			Ingress: buildIngress("name", "namespace", map[string]string{
+				issuerNameAnnotation: "issuer",
+			}),
+			ExpectedName: "issuer",
+			ExpectedKind: "Issuer",
+		},
+		{
+			Ingress: buildIngress("name", "namespace", map[string]string{
+				clusterIssuerNameAnnotation: "clusterissuer",
+			}),
+			ExpectedName: "clusterissuer",
+			ExpectedKind: "ClusterIssuer",
+		},
+		{
+			Ingress: buildIngress("name", "namespace", map[string]string{
+				tlsACMEAnnotation: "true",
+			}),
+			DefaultName:  "default-name",
+			DefaultKind:  "ClusterIssuer",
+			ExpectedName: "default-name",
+			ExpectedKind: "ClusterIssuer",
+		},
+		{
+			Ingress: buildIngress("name", "namespace", nil),
+		},
+	}
+	for _, test := range tests {
+		c := &Controller{
+			options: &options.ControllerOptions{
+				DefaultIssuerKind: test.DefaultKind,
+				DefaultIssuerName: test.DefaultName,
+			},
+		}
+		name, kind := c.issuerForIngress(test.Ingress)
+		if name != test.ExpectedName {
+			t.Errorf("expected name to be %q but got %q", test.ExpectedName, name)
+		}
+		if kind != test.ExpectedKind {
+			t.Errorf("expected kind to be %q but got %q", test.ExpectedKind, kind)
+		}
+	}
+}
+
+func TestGetGenericIssuer(t *testing.T) {
+	var nilIssuer *v1alpha1.Issuer
+	var nilClusterIssuer *v1alpha1.ClusterIssuer
+	type testT struct {
+		Name                   string
+		Kind                   string
+		Namespace              string
+		IssuerLister           []*v1alpha1.Issuer
+		ClusterIssuerLister    []*v1alpha1.ClusterIssuer
+		NilClusterIssuerLister bool
+		Err                    bool
+		Expected               v1alpha1.GenericIssuer
+	}
+	tests := []testT{
+		{
+			Name:         "name",
+			Kind:         "Issuer",
+			Namespace:    "namespace",
+			IssuerLister: []*v1alpha1.Issuer{buildIssuer("name", "namespace")},
+			Expected:     buildIssuer("name", "namespace"),
+		},
+		{
+			Name:                "name",
+			Kind:                "ClusterIssuer",
+			ClusterIssuerLister: []*v1alpha1.ClusterIssuer{buildClusterIssuer("name")},
+			Expected:            buildClusterIssuer("name"),
+		},
+		{
+			Name:     "name",
+			Kind:     "Issuer",
+			Err:      true,
+			Expected: nilIssuer,
+		},
+		{
+			Name:     "name",
+			Kind:     "ClusterIssuer",
+			Err:      true,
+			Expected: nilClusterIssuer,
+		},
+		{
+			Name: "name",
+			Err:  true,
+		},
+		{
+			Name: "name",
+			Kind: "ClusterIssuer",
+			NilClusterIssuerLister: true,
+			Err: true,
+		},
+	}
+
+	for _, test := range tests {
+		cmClient := cmfake.NewSimpleClientset()
+		factory := cminformers.NewSharedInformerFactory(cmClient, 0)
+		issuerInformer := factory.Certmanager().V1alpha1().Issuers()
+		clusterIssuerInformer := factory.Certmanager().V1alpha1().ClusterIssuers()
+		for _, i := range test.IssuerLister {
+			issuerInformer.Informer().GetIndexer().Add(i)
+		}
+		for _, i := range test.ClusterIssuerLister {
+			clusterIssuerInformer.Informer().GetIndexer().Add(i)
+		}
+		c := &Controller{
+			issuerLister:        issuerInformer.Lister(),
+			clusterIssuerLister: clusterIssuerInformer.Lister(),
+		}
+		if test.NilClusterIssuerLister {
+			c.clusterIssuerLister = nil
+		}
+		actual, err := c.getGenericIssuer(test.Namespace, test.Name, test.Kind)
+		if err != nil && !test.Err {
+			t.Errorf("Expected no error, but got: %s", err)
+			continue
+		}
+		if !reflect.DeepEqual(actual, test.Expected) {
+			t.Errorf("Expected %#v but got %#v", test.Expected, actual)
+		}
+	}
+}
+
+func buildIssuer(name, namespace string) *v1alpha1.Issuer {
+	return &v1alpha1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func buildCertificate(name, namespace string) *v1alpha1.Certificate {
+	return &v1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
+func buildACMEIssuer(name, namespace string) *v1alpha1.Issuer {
+	return &v1alpha1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1alpha1.IssuerSpec{
+			IssuerConfig: v1alpha1.IssuerConfig{
+				ACME: &v1alpha1.ACMEIssuer{},
+			},
+		},
+	}
+}
+
+func buildACMEClusterIssuer(name string) *v1alpha1.ClusterIssuer {
+	return &v1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1alpha1.IssuerSpec{
+			IssuerConfig: v1alpha1.IssuerConfig{
+				ACME: &v1alpha1.ACMEIssuer{},
+			},
+		},
+	}
+}
+
+func buildClusterIssuer(name string) *v1alpha1.ClusterIssuer {
+	return &v1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func buildIngress(name, namespace string, annotations map[string]string) *extv1beta1.Ingress {
+	return &extv1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+	}
+}

--- a/cmd/ingress-shim/main.go
+++ b/cmd/ingress-shim/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"flag"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/golang/glog"
+
+	"github.com/jetstack/cert-manager/pkg/logs"
+)
+
+func main() {
+	logs.InitLogs()
+	defer logs.FlushLogs()
+	stopCh := SetupSignalHandler()
+
+	cmd := NewCommandStartController(stopCh)
+	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	flag.CommandLine.Parse([]string{})
+	if err := cmd.Execute(); err != nil {
+		glog.Fatal(err)
+	}
+}
+
+var shutdownSignals = []os.Signal{os.Interrupt, syscall.SIGTERM}
+var onlyOneSignalHandler = make(chan struct{})
+
+// SetupSignalHandler registered for SIGTERM and SIGINT. A stop channel is returned
+// which is closed on one of these signals. If a second signal is caught, the program
+// is terminated with exit code 1.
+func SetupSignalHandler() (stopCh <-chan struct{}) {
+	close(onlyOneSignalHandler) // panics when called twice
+
+	stop := make(chan struct{})
+	c := make(chan os.Signal, 2)
+	signal.Notify(c, shutdownSignals...)
+	go func() {
+		<-c
+		close(stop)
+		<-c
+		os.Exit(1) // second signal. Exit directly.
+	}()
+
+	return stop
+}

--- a/cmd/ingress-shim/options/options.go
+++ b/cmd/ingress-shim/options/options.go
@@ -1,0 +1,113 @@
+package options
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/pflag"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+)
+
+type ControllerOptions struct {
+	APIServerHost string
+	Namespace     string
+
+	LeaderElect                 bool
+	LeaderElectionNamespace     string
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
+
+	DefaultIssuerName                  string
+	DefaultIssuerKind                  string
+	DefaultACMEIssuerChallengeType     string
+	DefaultACMEIssuerDNS01ProviderName string
+}
+
+const (
+	defaultAPIServerHost = ""
+	defaultNamespace     = ""
+
+	defaultLeaderElect                 = true
+	defaultLeaderElectionNamespace     = "kube-system"
+	defaultLeaderElectionLeaseDuration = 15 * time.Second
+	defaultLeaderElectionRenewDeadline = 10 * time.Second
+	defaultLeaderElectionRetryPeriod   = 2 * time.Second
+
+	defaultTLSACMEIssuerName           = ""
+	defaultTLSACMEIssuerKind           = "Issuer"
+	defaultACMEIssuerChallengeType     = "http01"
+	defaultACMEIssuerDNS01ProviderName = ""
+)
+
+func NewControllerOptions() *ControllerOptions {
+	return &ControllerOptions{
+		APIServerHost:                      defaultAPIServerHost,
+		Namespace:                          defaultNamespace,
+		LeaderElect:                        defaultLeaderElect,
+		LeaderElectionNamespace:            defaultLeaderElectionNamespace,
+		LeaderElectionLeaseDuration:        defaultLeaderElectionLeaseDuration,
+		LeaderElectionRenewDeadline:        defaultLeaderElectionRenewDeadline,
+		LeaderElectionRetryPeriod:          defaultLeaderElectionRetryPeriod,
+		DefaultIssuerName:                  defaultTLSACMEIssuerName,
+		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
+		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
+		DefaultACMEIssuerDNS01ProviderName: defaultACMEIssuerDNS01ProviderName,
+	}
+}
+
+func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
+	fs.StringVar(&s.APIServerHost, "master", defaultAPIServerHost, ""+
+		"Optional apiserver host address to connect to. If not specified, autoconfiguration "+
+		"will be attempted.")
+	fs.StringVar(&s.Namespace, "namespace", defaultNamespace, ""+
+		"Optional namespace to monitor resources within. This can be used to limit the scope "+
+		"of ingress-annotation-controller to a single namespace. If not specified, all namespaces will be watched.")
+
+	fs.BoolVar(&s.LeaderElect, "leader-elect", true, ""+
+		"If true, ingress-annotation-controller will perform leader election between instances to ensure no more "+
+		"than one instance of cert-manager operates at a time.")
+	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", defaultLeaderElectionNamespace, ""+
+		"Namespace used to perform leader election. Only used if leader election is enabled.")
+	fs.DurationVar(&s.LeaderElectionLeaseDuration, "leader-election-lease-duration", defaultLeaderElectionLeaseDuration, ""+
+		"The duration that non-leader candidates will wait after observing a leadership "+
+		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
+		"slot. This is effectively the maximum duration that a leader can be stopped "+
+		"before it is replaced by another candidate. This is only applicable if leader "+
+		"election is enabled.")
+	fs.DurationVar(&s.LeaderElectionRenewDeadline, "leader-election-renew-deadline", defaultLeaderElectionRenewDeadline, ""+
+		"The interval between attempts by the acting master to renew a leadership slot "+
+		"before it stops leading. This must be less than or equal to the lease duration. "+
+		"This is only applicable if leader election is enabled.")
+	fs.DurationVar(&s.LeaderElectionRetryPeriod, "leader-election-retry-period", defaultLeaderElectionRetryPeriod, ""+
+		"The duration the clients should wait between attempting acquisition and renewal "+
+		"of a leadership. This is only applicable if leader election is enabled.")
+
+	fs.StringVar(&s.DefaultIssuerName, "default-issuer-name", defaultTLSACMEIssuerName, ""+
+		"Name of the Issuer to use when the tls is requested but issuer name is not specified on the ingress resource.")
+	fs.StringVar(&s.DefaultIssuerKind, "default-issuer-kind", defaultTLSACMEIssuerKind, ""+
+		"Kind of the Issuer to use when the tls is requested but issuer kind is not specified on the ingress resource.")
+	fs.StringVar(&s.DefaultACMEIssuerChallengeType, "default-acme-issuer-challenge-type", defaultACMEIssuerChallengeType, ""+
+		"The ACME challenge type to use when tls is requested for an ACME Issuer but is not specified on the ingress resource.")
+	fs.StringVar(&s.DefaultACMEIssuerDNS01ProviderName, "default-acme-issuer-dns01-provider-name", defaultACMEIssuerDNS01ProviderName, ""+
+		"Required if --default-acme-issuer-challenge-type is set to dns01. The DNS01 provider to use for ingresses using ACME dns01 "+
+		"validation that do not explicitly state a dns provider.")
+}
+
+func (o *ControllerOptions) Validate() error {
+	var errs []error
+
+	switch o.DefaultACMEIssuerChallengeType {
+	case "dns01", "http01", "":
+	default:
+		errs = append(errs, fmt.Errorf("--default-acme-issuer-challenge-type must be one of 'http01', 'dns01' or not set"))
+	}
+
+	if o.DefaultACMEIssuerChallengeType == "dns01" {
+		if o.DefaultACMEIssuerDNS01ProviderName == "" {
+			errs = append(errs, fmt.Errorf("--default-acme-issuer-dns01-provider-name must be set when --default-acme-issuer-challenge-type is set to dns01"))
+		}
+	}
+
+	return utilerrors.NewAggregate(errs)
+}

--- a/cmd/ingress-shim/start.go
+++ b/cmd/ingress-shim/start.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/golang/glog"
+	"github.com/spf13/cobra"
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+
+	"github.com/jetstack/cert-manager/cmd/ingress-shim/options"
+	"github.com/jetstack/cert-manager/pkg/util"
+)
+
+// NewCommandStartController is a CLI handler for starting ingress-shim-controller
+func NewCommandStartController(stopCh <-chan struct{}) *cobra.Command {
+	o := options.NewControllerOptions()
+
+	cmd := &cobra.Command{
+		Use:   "ingress-shim-controller",
+		Short: fmt.Sprintf("Automate creation of Certificate resources for Ingress (%s) (%s)", util.AppVersion, util.AppGitCommit),
+		Long: `
+This is a small binary that can be run alongside any cert-manager deployment
+in order to automatically create Certificate resources for Ingresses when a
+particular annotation is found on an ingress resource.
+
+This allows users to consume certificates from cert-manager without having to
+manually create Certificate resources`,
+
+		// TODO: Refactor this function from this package
+		Run: func(cmd *cobra.Command, args []string) {
+			if err := o.Validate(); err != nil {
+				glog.Fatalf("error validating options: %s", err.Error())
+			}
+			Run(o, stopCh)
+		},
+	}
+
+	flags := cmd.Flags()
+	o.AddFlags(flags)
+
+	return cmd
+}

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -23,7 +23,14 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-    {{- if .Values.nodeSelector }}
+{{- if .Values.ingressShim.enabled }}
+        - name: ingress-shim
+          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag | default .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
+          resources:
+{{ toYaml .Values.ingressShim.resources | indent 12 }}
+{{- end }}
+{{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
-    {{- end }}
+{{- end }}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -13,4 +13,20 @@ createCustomResource: true
 rbac:
   enabled: true
 
-resources: {}
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+ingressShim:
+  enabled: true
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi
+  image:
+    repository: quay.io/jetstack/cert-manager-controller
+    # Defaults to image.tag.
+    # You should only change this if you know what you are doing!
+    # tag: v0.2.1
+    pullPolicy: Always

--- a/hack/build/dockerfiles/ingress-shim/Dockerfile
+++ b/hack/build/dockerfiles/ingress-shim/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:3.6
+
+RUN apk add --no-cache ca-certificates
+
+ADD cert-manager-ingress-shim_linux_amd64 /usr/bin/ingress-shim
+
+ENTRYPOINT ["/usr/bin/ingress-shim"]
+ARG VCS_REF
+LABEL org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/jetstack/cert-manager" \
+      org.label-schema.license="Apache-2.0"

--- a/hack/test/setup-boulder.sh
+++ b/hack/test/setup-boulder.sh
@@ -16,7 +16,7 @@ cd "${GOPATH}/src/${BOULDER_REPO}"
 sed -i 's/FAKE_DNS: 127.0.0.1/FAKE_DNS: 10.0.0.10/' docker-compose.yml
 sed -i 's/127.0.0.1:8053/10.0.0.10:53/' test/config/va.json
 sed -i 's/5002/80/' test/config/va.json
-# TODO: set ratelimits
+sed -i 's/good-caa-reserved.com/kubernetes.network/' test/rate-limit-policies.yml
 
 function start {
     if ! docker-compose up; then

--- a/pkg/util/kube/config.go
+++ b/pkg/util/kube/config.go
@@ -1,0 +1,36 @@
+package kube
+
+import (
+	"fmt"
+
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// KubeConfig will return a rest.Config for communicating with the Kubernetes API server.
+// If apiServerHost is specified, a config without authentication that is configured
+// to talk to the apiServerHost URL will be returned. Else, the in-cluster config will be loaded,
+// and failing this, the config will be loaded from the users local kubeconfig directory
+func KubeConfig(apiServerHost string) (*rest.Config, error) {
+	var err error
+	var cfg *rest.Config
+
+	if len(apiServerHost) > 0 {
+		cfg = new(rest.Config)
+		cfg.Host = apiServerHost
+	} else if cfg, err = rest.InClusterConfig(); err != nil {
+		apiCfg, err := clientcmd.NewDefaultClientConfigLoadingRules().Load()
+
+		if err != nil {
+			return nil, fmt.Errorf("error loading cluster config: %s", err.Error())
+		}
+
+		cfg, err = clientcmd.NewDefaultClientConfig(*apiCfg, &clientcmd.ConfigOverrides{}).ClientConfig()
+
+		if err != nil {
+			return nil, fmt.Errorf("error loading cluster client config: %s", err.Error())
+		}
+	}
+
+	return cfg, nil
+}

--- a/test/e2e/certificate/certificate_acme.go
+++ b/test/e2e/certificate/certificate_acme.go
@@ -36,12 +36,9 @@ const testingACMEEmail = "test@example.com"
 const testingACMEPrivateKey = "test-acme-private-key"
 const foreverTestTimeout = time.Second * 60
 
-var acmeCertificateDomain string
 var acmeIngressClass string
 
 func init() {
-	flag.StringVar(&acmeCertificateDomain, "acme-nginx-certificate-domain", "",
-		"The provided domain and all sub-domains should resolve to the nginx ingress controller")
 	flag.StringVar(&acmeIngressClass, "acme-nginx-ingress-class", "nginx", ""+
 		"The ingress class for the nginx ingress controller")
 }
@@ -97,7 +94,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 	It("should obtain a signed certificate with a single CN from the ACME server", func() {
 		By("Creating a Certificate")
-		_, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, acmeIngressClass, acmeCertificateDomain))
+		_, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, acmeIngressClass, util.ACMECertificateDomain))
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Certificate to become Ready")
 		err = util.WaitForCertificateCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name),
@@ -117,7 +114,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 	It("should obtain a signed certificate with a CN and single subdomain as dns name from the ACME server", func() {
 		By("Creating a Certificate")
-		_, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, acmeIngressClass, acmeCertificateDomain, fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeCertificateDomain)))
+		_, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, acmeIngressClass, util.ACMECertificateDomain, fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), util.ACMECertificateDomain)))
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Certificate to become Ready")
 		err = util.WaitForCertificateCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name),

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -26,6 +26,7 @@ import (
 	_ "github.com/jetstack/cert-manager/test/e2e/certificate"
 	_ "github.com/jetstack/cert-manager/test/e2e/clusterissuer"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
+	_ "github.com/jetstack/cert-manager/test/e2e/ingress"
 	_ "github.com/jetstack/cert-manager/test/e2e/issuer"
 )
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -28,7 +28,7 @@ import (
 
 const (
 	certManagerPodName = "test-cert-manager"
-	ingressShimPodName = "test-cert-manager"
+	ingressShimPodName = "test-ingress-shim"
 )
 
 // Framework supports common operations used by e2e tests; it will keep a client & a namespace for you.

--- a/test/e2e/ingress/certificate_acme.go
+++ b/test/e2e/ingress/certificate_acme.go
@@ -94,17 +94,17 @@ var _ = framework.CertManagerDescribe("ACME Certificate with Ingress (HTTP01)", 
 
 	It("should obtain a signed certificate with a single CN from the ACME server when putting an annotation on an ingress resource", func() {
 		By("Creating an Ingress with the issuer name annotation set")
-		_, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace.Name).Create(util.NewIngress(certificateName, certificateSecretName, map[string]string{
+		_, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace.Name).Create(util.NewIngress(certificateSecretName, certificateSecretName, map[string]string{
 			"certmanager.k8s.io/issuer":                  issuerName,
 			"certmanager.k8s.io/acme-challenge-provider": "http01",
 		}, acmeCertificateDomain))
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Certificate to exist")
-		err = util.WaitForCertificateToExist(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name), certificateName, foreverTestTimeout)
+		err = util.WaitForCertificateToExist(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name), certificateSecretName, foreverTestTimeout)
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Certificate to become Ready")
 		err = util.WaitForCertificateCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name),
-			certificateName,
+			certificateSecretName,
 			v1alpha1.CertificateCondition{
 				Type:   v1alpha1.CertificateConditionReady,
 				Status: v1alpha1.ConditionTrue,

--- a/test/e2e/ingress/certificate_acme.go
+++ b/test/e2e/ingress/certificate_acme.go
@@ -14,7 +14,6 @@ limitations under the License.
 package ingress
 
 import (
-	"flag"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -32,16 +31,6 @@ const testingACMEURL = "http://127.0.0.1:4000/directory"
 const testingACMEEmail = "test@example.com"
 const testingACMEPrivateKey = "test-acme-private-key"
 const foreverTestTimeout = time.Second * 60
-
-var acmeCertificateDomain string
-var acmeIngressClass string
-
-func init() {
-	flag.StringVar(&acmeCertificateDomain, "acme-nginx-certificate-domain", "",
-		"The provided domain and all sub-domains should resolve to the nginx ingress controller")
-	flag.StringVar(&acmeIngressClass, "acme-nginx-ingress-class", "nginx", ""+
-		"The ingress class for the nginx ingress controller")
-}
 
 var _ = framework.CertManagerDescribe("ACME Certificate with Ingress (HTTP01)", func() {
 	f := framework.NewDefaultFramework("create-acme-certificate-http01-ingress")
@@ -96,7 +85,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate with Ingress (HTTP01)", 
 		_, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace.Name).Create(util.NewIngress(certificateSecretName, certificateSecretName, map[string]string{
 			"certmanager.k8s.io/issuer":                  issuerName,
 			"certmanager.k8s.io/acme-challenge-provider": "http01",
-		}, acmeCertificateDomain))
+		}, util.ACMECertificateDomain))
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Certificate to exist")
 		err = util.WaitForCertificateToExist(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name), certificateSecretName, foreverTestTimeout)

--- a/test/e2e/ingress/certificate_acme.go
+++ b/test/e2e/ingress/certificate_acme.go
@@ -47,7 +47,6 @@ var _ = framework.CertManagerDescribe("ACME Certificate with Ingress (HTTP01)", 
 	f := framework.NewDefaultFramework("create-acme-certificate-http01-ingress")
 
 	issuerName := "test-acme-issuer"
-	certificateName := "test-acme-certificate"
 	certificateSecretName := "test-acme-certificate"
 
 	BeforeEach(func() {

--- a/test/e2e/ingress/certificate_acme.go
+++ b/test/e2e/ingress/certificate_acme.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2017 Jetstack Ltd.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ingress
+
+import (
+	"flag"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/util"
+)
+
+const testingACMEURL = "http://127.0.0.1:4000/directory"
+const testingACMEEmail = "test@example.com"
+const testingACMEPrivateKey = "test-acme-private-key"
+const foreverTestTimeout = time.Second * 60
+
+var acmeCertificateDomain string
+var acmeIngressClass string
+
+func init() {
+	flag.StringVar(&acmeCertificateDomain, "acme-nginx-certificate-domain", "",
+		"The provided domain and all sub-domains should resolve to the nginx ingress controller")
+	flag.StringVar(&acmeIngressClass, "acme-nginx-ingress-class", "nginx", ""+
+		"The ingress class for the nginx ingress controller")
+}
+
+var _ = framework.CertManagerDescribe("ACME Certificate with Ingress (HTTP01)", func() {
+	f := framework.NewDefaultFramework("create-acme-certificate-http01-ingress")
+
+	issuerName := "test-acme-issuer"
+	certificateName := "test-acme-certificate"
+	certificateSecretName := "test-acme-certificate"
+
+	BeforeEach(func() {
+		By("Verifying there is no existing ACME private key")
+		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(testingACMEPrivateKey, metav1.GetOptions{})
+		Expect(err).To(MatchError(apierrors.NewNotFound(corev1.Resource("secrets"), testingACMEPrivateKey)))
+		By("Verifying there is no existing TLS certificate secret")
+		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(certificateSecretName, metav1.GetOptions{})
+		Expect(err).To(MatchError(apierrors.NewNotFound(corev1.Resource("secrets"), certificateSecretName)))
+		By("Creating an Issuer")
+		_, err = f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Create(util.NewCertManagerACMEIssuer(issuerName, testingACMEURL, testingACMEEmail, testingACMEPrivateKey))
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1alpha1.IssuerCondition{
+				Type:   v1alpha1.IssuerConditionReady,
+				Status: v1alpha1.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying the ACME account URI is set")
+		err = util.WaitForIssuerStatusFunc(f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name),
+			issuerName,
+			func(i *v1alpha1.Issuer) (bool, error) {
+				if i.GetStatus().ACMEStatus().URI == "" {
+					return false, nil
+				}
+				return true, nil
+			})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying ACME account private key exists")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(testingACMEPrivateKey, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if len(secret.Data) != 1 {
+			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
+		}
+	})
+
+	AfterEach(func() {
+		By("Cleaning up")
+		f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Delete(issuerName, nil)
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(testingACMEPrivateKey, nil)
+	})
+
+	It("should obtain a signed certificate with a single CN from the ACME server when putting an annotation on an ingress resource", func() {
+		By("Creating an Ingress with the issuer name annotation set")
+		_, err := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace.Name).Create(util.NewIngress(certificateName, certificateSecretName, map[string]string{
+			"certmanager.k8s.io/issuer":                  issuerName,
+			"certmanager.k8s.io/acme-challenge-provider": "http01",
+		}, acmeCertificateDomain))
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Certificate to exist")
+		err = util.WaitForCertificateToExist(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name), certificateName, foreverTestTimeout)
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Certificate to become Ready")
+		err = util.WaitForCertificateCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name),
+			certificateName,
+			v1alpha1.CertificateCondition{
+				Type:   v1alpha1.CertificateConditionReady,
+				Status: v1alpha1.ConditionTrue,
+			}, foreverTestTimeout)
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying TLS certificate exists")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(certificateSecretName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if len(secret.Data) != 2 {
+			Fail("Expected 2 keys in ACME certificate secret, but there was %d", len(secret.Data))
+		}
+	})
+
+})

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -23,6 +23,7 @@ var certManagerImageFlag string
 var certManagerImagePullPolicy string
 var ingressShimImageFlag string
 var ingressShimImagePullPolicy string
+var ACMECertificateDomain string
 
 func init() {
 	flag.StringVar(&certManagerImageFlag, "cert-manager-image", "quay.io/jetstack/cert-manager-controller:canary",
@@ -33,6 +34,8 @@ func init() {
 		"The container image for ingress-shim to test against")
 	flag.StringVar(&ingressShimImagePullPolicy, "ingress-shim-image-pull-policy", "Never",
 		"The image pull policy to use for ingress-shim when running tests")
+	flag.StringVar(&ACMECertificateDomain, "acme-nginx-certificate-domain", "",
+		"The provided domain and all sub-domains should resolve to the nginx ingress controller")
 }
 
 func CertificateOnlyValidForDomains(cert *x509.Certificate, commonName string, dnsNames ...string) bool {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -12,6 +12,7 @@ import (
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -261,7 +262,17 @@ func NewIngress(name, secretName string, annotations map[string]string, dnsNames
 				{
 					Host: dnsNames[0],
 					IngressRuleValue: extv1beta1.IngressRuleValue{
-						HTTP: &extv1beta1.HTTPIngressRuleValue{},
+						HTTP: &extv1beta1.HTTPIngressRuleValue{
+							Paths: []extv1beta1.HTTPIngressPath{
+								{
+									Path: "/",
+									Backend: extv1beta1.IngressBackend{
+										ServiceName: "dummy-service",
+										ServicePort: intstr.FromInt(80),
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -1,18 +1,19 @@
 package util
 
 import (
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"time"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
+	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"crypto/x509"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/util"
@@ -20,12 +21,18 @@ import (
 
 var certManagerImageFlag string
 var certManagerImagePullPolicy string
+var ingressShimImageFlag string
+var ingressShimImagePullPolicy string
 
 func init() {
 	flag.StringVar(&certManagerImageFlag, "cert-manager-image", "quay.io/jetstack/cert-manager-controller:canary",
 		"The container image for cert-manager to test against")
 	flag.StringVar(&certManagerImagePullPolicy, "cert-manager-image-pull-policy", "Never",
 		"The image pull policy to use for cert-manager when running tests")
+	flag.StringVar(&ingressShimImageFlag, "ingress-shim-image", "quay.io/jetstack/cert-manager-ingress-shim:canary",
+		"The container image for ingress-shim to test against")
+	flag.StringVar(&ingressShimImagePullPolicy, "ingress-shim-image-pull-policy", "Never",
+		"The image pull policy to use for ingress-shim when running tests")
 }
 
 func CertificateOnlyValidForDomains(cert *x509.Certificate, commonName string, dnsNames ...string) bool {
@@ -94,6 +101,24 @@ func WaitForCertificateCondition(client clientset.CertificateInterface, name str
 	)
 }
 
+// WaitForCertificateToExist waits for the named certificate to exist
+func WaitForCertificateToExist(client clientset.CertificateInterface, name string, timeout time.Duration) error {
+	return wait.PollImmediate(500*time.Millisecond, timeout,
+		func() (bool, error) {
+			glog.V(5).Infof("Waiting for Certificate %v to exist", name)
+			_, err := client.Get(name, metav1.GetOptions{})
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+			if err != nil {
+				return false, fmt.Errorf("error getting Certificate %v: %v", name, err)
+			}
+
+			return true, nil
+		},
+	)
+}
+
 // WaitForCRDToNotExist waits for the CRD with the given name to no
 // longer exist.
 func WaitForCRDToNotExist(client apiextcs.CustomResourceDefinitionInterface, name string) error {
@@ -130,6 +155,28 @@ func NewCertManagerControllerPod(name string, args ...string) *v1.Pod {
 					Image:           certManagerImageFlag,
 					Args:            args,
 					ImagePullPolicy: v1.PullPolicy(certManagerImagePullPolicy),
+				},
+			},
+		},
+	}
+}
+
+func NewIngressShimControllerPod(name string, args ...string) *v1.Pod {
+	return &v1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				"app": name,
+			},
+		},
+		Spec: v1.PodSpec{
+			HostNetwork: true,
+			Containers: []v1.Container{
+				{
+					Name:            name,
+					Image:           ingressShimImageFlag,
+					Args:            args,
+					ImagePullPolicy: v1.PullPolicy(ingressShimImagePullPolicy),
 				},
 			},
 		},
@@ -187,6 +234,31 @@ func NewCertManagerACMECertificate(name, secretName, issuerName string, issuerKi
 						HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
 							IngressClass: &ingressClass,
 						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func NewIngress(name, secretName string, annotations map[string]string, dnsNames ...string) *extv1beta1.Ingress {
+	return &extv1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Annotations: annotations,
+		},
+		Spec: extv1beta1.IngressSpec{
+			TLS: []extv1beta1.IngressTLS{
+				{
+					Hosts:      dnsNames,
+					SecretName: secretName,
+				},
+			},
+			Rules: []extv1beta1.IngressRule{
+				{
+					Host: dnsNames[0],
+					IngressRuleValue: extv1beta1.IngressRuleValue{
+						HTTP: &extv1beta1.HTTPIngressRuleValue{},
 					},
 				},
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a new controller, ingress-shim, that will automatically create Certificate resources for ingress resources with annotations on them.

By setting defaults on the ingress-shim CLI, it's possible to re-implement the `kubernetes.io/tls-acme` behavior of kube-lego.

There also needs to be some documentation written about this, as well as a user guide. This can be our migration story for users coming from kube-lego as well. It'd be interesting to know how easily it'd be to support a seamless migration from [kube-cert-manager](https://github.com/PalmStoneGames/kube-cert-manager) through this tool too.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #19 

**Special notes for your reviewer**:

This includes unit tests for sync.go in the new controller, as well as a basic e2e test that ensures an ACME certificate is obtained correctly when an annotation is set on an ingress.

**Release note**:
```release-note
Add ingress-shim controller to automatically create Certificate resources based on annotations on ingresses. This allows for easy creation of Certificate resources when using ingress.
```

Slightly related to #97 
