### PR TITLE
Ingress shim fixes

### DIFF
--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -27,6 +27,10 @@ spec:
         - name: ingress-shim
           image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag | default .Values.image.tag }}"
           imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
+          args:
+{{- range .Values.ingressShim.extraArgs }}
+          - {{ . }}
+{{- end }}
           resources:
 {{ toYaml .Values.ingressShim.resources | indent 12 }}
 {{- end }}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -20,6 +20,8 @@ resources:
 
 ingressShim:
   enabled: true
+  # Optional additional arguments for ingress-shim
+  extraArgs: []
   resources:
     requests:
       cpu: 10m

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -25,7 +25,7 @@ ingressShim:
       cpu: 10m
       memory: 32Mi
   image:
-    repository: quay.io/jetstack/cert-manager-controller
+    repository: quay.io/jetstack/cert-manager-ingress-shim
     # Defaults to image.tag.
     # You should only change this if you know what you are doing!
     # tag: v0.2.1


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes ingress-shim image name in helm chart
Allow specifying extraArgs to ingress-shim in helm chart

**Release note**:
```release-note
NONE
```

/assign