### PR TITLE
Update for v0.2.2

### DIFF
--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -47,7 +47,7 @@ The following tables lists the configurable parameters of the cert-manager chart
 | Parameter              | Description                             | Default                                        |
 | ---------------------- | --------------------------------------- | ---------------------------------------------- |
 | `image.repository`     | Image repository                        | `quay.io/jetstack/cert-manager-controller`     |
-| `image.tag`            | Image tag                               | `v0.2.1`                                       |
+| `image.tag`            | Image tag                               | `v0.2.2`                                       |
 | `image.pullPolicy`     | Image pull policy                       | `Always`                                       |
 | `replicaCount`         | Number of cert-manager replicas         | `1`                                            |
 | `createCustomResource` | Create CRD/TPR with this release        | `true`                                         |

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.2.1
+  tag: v0.2.2
   pullPolicy: Always
 
 createCustomResource: true
@@ -30,5 +30,5 @@ ingressShim:
     repository: quay.io/jetstack/cert-manager-ingress-shim
     # Defaults to image.tag.
     # You should only change this if you know what you are doing!
-    # tag: v0.2.1
+    # tag: v0.2.2
     pullPolicy: Always

--- a/docs/examples/cert-manager.yaml
+++ b/docs/examples/cert-manager.yaml
@@ -13,5 +13,8 @@ spec:
     spec:
       containers:
       - name: cert-manager
-        image: quay.io/jetstack/cert-manager-controller:v0.2.1
+        image: quay.io/jetstack/cert-manager-controller:v0.2.2
+        imagePullPolicy: Always
+      - name: ingress-shim
+        image: quay.io/jetstack/cert-manager-ingress-shim:v0.2.2
         imagePullPolicy: Always


### PR DESCRIPTION
**What this PR does / why we need it**:

Version bump for 0.2.2

**Release note**:
```release-note
NONE
```
