### PR TITLE
Enable go race detector and fix race in scheduler

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,7 @@ $(CMDS):
 
 go_test:
 	go test -v \
+	    -race \
 		$$(go list ./... | \
 			grep -v '/vendor/' | \
 			grep -v '/test/e2e' | \


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a race condition in the scheduler package and enables the race detector in tests

**Release note**:
```release-note
Fix a race condition in the package responsible for scheduling renewals
```
