### PR TITLE
WIP: Add CRD validation support

### DIFF
--- a/contrib/charts/cert-manager/templates/certificate-crd.yaml
+++ b/contrib/charts/cert-manager/templates/certificate-crd.yaml
@@ -11,6 +11,57 @@ spec:
     kind: Certificate
     plural: certificates
   scope: Namespaced
+  validation:
+    # openAPIV3Schema is the schema for validating custom objects.
+    openAPIV3Schema:
+      properties:
+        spec:
+          required:
+          - secretName
+          properties:
+            issuerRef:
+              type: object
+              required:
+              - name
+              properties:
+                name:
+                  type: string
+                kind:
+                  type: string
+                  pattern: '^(((Cluster)?Issuer)|)$'
+            commonName:
+              type: string
+            dnsNames:
+              type: array
+              items:
+                type: string
+            secretName:
+              type: string
+            acme:
+              type: object
+              properties:
+                config:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      domains:
+                        type: array
+                        items:
+                          type: string
+                      http01:
+                        type: object
+                        properties:
+                          ingress:
+                            type: string
+                          ingressClass:
+                            type: string
+                      dns01:
+                        type: object
+                        properties:
+                          provider:
+                            type: string
+
 {{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
 apiVersion: extensions/v1beta1
 kind: ThirdPartyResource

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -1,4 +1,4 @@
-/*
+/*https://github.com/munnerz/cert-manager/edit/crd-validation/pkg/apis/certmanager/v1alpha1/types.go
 Copyright 2017 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
@@ -229,7 +229,7 @@ type CertificateSpec struct {
 	// CommonName is a common name to be used on the Certificate
 	CommonName string `json:"commonName"`
 	// DNSNames is a list of subject alt names to be used on the Certificate
-	DNSNames []string `json:"dnsNames"`
+	DNSNames []string `json:"dnsNames,omitempty"`
 	// SecretName is the name of the secret resource to store this secret in
 	SecretName string `json:"secretName"`
 	// IssuerRef is a reference to the issuer for this certificate. If the


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for Custom Resource validation for our CRD types (as per https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#validation)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #132 

**Release note**:
```release-note
Add optional CRD validation spec to the helm chart to validate certmanager resources
```
