### PR TITLE
Update Helm chart to follow newer best practice for helper functions

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,4 +1,5 @@
 apiVersion: v1
-description: A Helm chart for Kubernetes
+description: A Helm chart for Kubernetes cert-manager
+home: https://github.com/jetstack/cert-manager
 name: cert-manager
-version: 0.1.0
+version: 0.1.1

--- a/contrib/charts/cert-manager/templates/_helpers.tpl
+++ b/contrib/charts/cert-manager/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "cert-manager.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,11 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "cert-manager.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -1,9 +1,9 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "cert-manager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -12,11 +12,11 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccount: {{ template "fullname" . }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccount: {{ template "cert-manager.fullname" . }}
+      serviceAccountName: {{ template "cert-manager.fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/contrib/charts/cert-manager/templates/rbac.yaml
+++ b/contrib/charts/cert-manager/templates/rbac.yaml
@@ -2,9 +2,9 @@
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "cert-manager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -22,18 +22,18 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "cert-manager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
 subjects:
-- name: {{ template "fullname" . }}
+- name: {{ template "cert-manager.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
   kind: ServiceAccount
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/serviceaccount.yaml
+++ b/contrib/charts/cert-manager/templates/serviceaccount.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
+    app: {{ template "cert-manager.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}


### PR DESCRIPTION
This updates the 'contrib' Helm chart to follow newer best practice for helper functions

1) go template names are global and so must be prefixed with the chart name.
https://docs.helm.sh/chart_template_guide/#declaring-and-using-templates-with-define-and-template

2) The fullname template should avoid doubling up on the release/chart name
https://github.com/kubernetes/helm/blob/7c79d1c76534074d5708eae2c5ef88ae044941db/pkg/chartutil/create.go#L237-L249
