### PR TITLE
Allow non-static AWS credentials for Route 53.

### DIFF
--- a/docs/api-types/issuer/spec.md
+++ b/docs/api-types/issuer/spec.md
@@ -125,8 +125,13 @@ clouddns:
 
 ```yaml
 route53:
-  accessKeyID: AKIAIOSFODNN7EXAMPLE
   region: eu-west-1
+
+  # optional -- if not specified, load credentials from from standard AWS
+  # environment variables or from EC2 instance metadata
+  accessKeyID: AKIAIOSFODNN7EXAMPLE
+
+  # also optional
   secretAccessKeySecretRef:
     name: prod-route53-credentials-secret
     key: secret-access-key

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -136,19 +136,23 @@ func (s *Solver) solverFor(crt *v1alpha1.Certificate, domain string) (solver, er
 			return nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err.Error())
 		}
 	case providerConfig.Route53 != nil:
-		secretAccessKeySecret, err := s.secretLister.Secrets(s.resourceNamespace).Get(providerConfig.Route53.SecretAccessKey.Name)
-		if err != nil {
-			return nil, fmt.Errorf("error getting route53 secret access key: %s", err.Error())
-		}
+		secretAccessKey := ""
+		if providerConfig.Route53.SecretAccessKey.Name != "" {
+			secretAccessKeySecret, err := s.secretLister.Secrets(s.resourceNamespace).Get(providerConfig.Route53.SecretAccessKey.Name)
+			if err != nil {
+				return nil, fmt.Errorf("error getting route53 secret access key: %s", err.Error())
+			}
 
-		secretAccessKeyBytes, ok := secretAccessKeySecret.Data[providerConfig.Route53.SecretAccessKey.Key]
-		if !ok {
-			return nil, fmt.Errorf("error getting route53 secret access key: key '%s' not found in secret", providerConfig.Route53.SecretAccessKey.Key)
+			secretAccessKeyBytes, ok := secretAccessKeySecret.Data[providerConfig.Route53.SecretAccessKey.Key]
+			if !ok {
+				return nil, fmt.Errorf("error getting route53 secret access key: key '%s' not found in secret", providerConfig.Route53.SecretAccessKey.Key)
+			}
+			secretAccessKey = string(secretAccessKeyBytes)
 		}
 
 		impl, err = route53.NewDNSProviderAccessKey(
 			providerConfig.Route53.AccessKeyID,
-			string(secretAccessKeyBytes),
+			secretAccessKey,
 			providerConfig.Route53.HostedZoneID,
 			providerConfig.Route53.Region,
 		)

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -5,7 +5,6 @@ package route53
 import (
 	"fmt"
 	"math/rand"
-	"os"
 	"strings"
 	"time"
 
@@ -50,34 +49,6 @@ func (d customRetryer) RetryRules(r *request.Request) time.Duration {
 
 	delay := (1 << uint(retryCount)) * (rand.Intn(50) + 200)
 	return time.Duration(delay) * time.Millisecond
-}
-
-// NewDNSProvider returns a DNSProvider instance configured for the AWS
-// Route 53 service.
-//
-// AWS Credentials are automatically detected in the following locations
-// and prioritized in the following order:
-// 1. Environment variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
-//    AWS_REGION, [AWS_SESSION_TOKEN]
-// 2. Shared credentials file (defaults to ~/.aws/credentials)
-// 3. Amazon EC2 IAM role
-//
-// If AWS_HOSTED_ZONE_ID is not set, Lego tries to determine the correct
-// public hosted zone via the FQDN.
-//
-// See also: https://github.com/aws/aws-sdk-go/wiki/configuring-sdk
-func NewDNSProvider() (*DNSProvider, error) {
-	hostedZoneID := os.Getenv("AWS_HOSTED_ZONE_ID")
-
-	r := customRetryer{}
-	r.NumMaxRetries = maxRetries
-	config := request.WithRetryer(aws.NewConfig(), r)
-	client := route53.New(session.New(config))
-
-	return &DNSProvider{
-		client:       client,
-		hostedZoneID: hostedZoneID,
-	}, nil
 }
 
 // NewDNSProviderAccessKey returns a DNSProvider instance configured for the AWS

--- a/pkg/issuer/acme/dns/route53/route53_integration_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_integration_test.go
@@ -17,7 +17,7 @@ func TestRoute53TTL(t *testing.T) {
 		t.Skip(err.Error())
 	}
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProviderAccessKey("", "", "", "")
 	if err != nil {
 		t.Fatalf("Fatal: %s", err.Error())
 	}

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -76,7 +76,7 @@ func TestHostedZoneIDFromEnv(t *testing.T) {
 	defer restoreRoute53Env()
 	os.Setenv("AWS_HOSTED_ZONE_ID", testZoneID)
 
-	provider, err := NewDNSProvider()
+	provider, err := NewDNSProviderAccessKey("", "", "", "")
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")
 
 	fqdn, err := provider.getHostedZoneID("whatever")


### PR DESCRIPTION
**What this PR does / why we need it**:
This change maintains backwards compatibility, but makes the `accessKeyID` and `secretAccessKeySecretRef` fields of the `route53` DNS provider optional.

If not provided, AWS credentials will be loaded from `AWS_*` environment variables or the EC2 metadata service. This should also work for things that impersonate the EC2 metadata service, such as [kube2iam](https://github.com/jtblin/kube2iam) and [kail](https://github.com/uswitch/kiam).

**Which issue this PR fixes**: fixes #195

**Special notes for your reviewer**:
This change will need some manual merging with https://github.com/jetstack/cert-manager/pull/197 since we both modified the same code.

**Release note**:
```release-note
Add support for AWS credentials loaded from environment variables or the EC2 metadata service.
```
