### PR TITLE
WIP: Switching e2e tests to Prow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ jobs:
       # Install CLI dependencies
       - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.6.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && sudo mv linux-amd64/helm /usr/local/bin
       - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/$KUBERNETES_VERSION/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.21.0/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
+      - curl -Lo minikube https://storage.googleapis.com/minikube/releases/v0.24.1/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
       # Install nsenter
       - docker run -v /usr/local/bin:/hostbin munnerz/ubuntu-nsenter cp /nsenter /hostbin/nsenter
       script:
@@ -26,7 +26,7 @@ jobs:
       - ./hack/test/wait-minikube.sh
       # Setup service for nginx ingress controller. A DNS entry for *.certmanager.kubernetes.network has been setup to point to 10.0.0.15 for e2e tests
       - while true; do if kubectl get rc nginx-ingress-controller -n kube-system; then break; fi; echo "Waiting 5s for nginx-ingress-controller rc to be installed..."; sleep 5; done
-      - kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.0.0.15
+      - kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.96.0.132
       - make e2e_test E2E_NGINX_CERTIFICATE_DOMAIN=certmanager.kubernetes.network
     - stage: test
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
       # Setup service for nginx ingress controller. A DNS entry for *.certmanager.kubernetes.network has been setup to point to 10.0.0.15 for e2e tests
       - while true; do if kubectl get rc nginx-ingress-controller -n kube-system; then break; fi; echo "Waiting 5s for nginx-ingress-controller rc to be installed..."; sleep 5; done
       - kubectl expose -n kube-system --port 80 --target-port 80 --type ClusterIP rc nginx-ingress-controller --cluster-ip 10.96.0.132
-      - make e2e_test E2E_NGINX_CERTIFICATE_DOMAIN=certmanager.kubernetes.network
+      - make e2e_test E2E_NGINX_CERTIFICATE_DOMAIN=prowcm.kubernetes.network
     - stage: test
       dist: trusty
       language: go

--- a/hack/test/setup-boulder.sh
+++ b/hack/test/setup-boulder.sh
@@ -13,8 +13,8 @@ echo "Retrieved boulder repository"
 cd "${GOPATH}/src/${BOULDER_REPO}"
 
 # Modify boulder configuration
-sed -i 's/FAKE_DNS: 127.0.0.1/FAKE_DNS: 10.0.0.10/' docker-compose.yml
-sed -i 's/127.0.0.1:8053/10.0.0.10:53/' test/config/va.json
+sed -i 's/FAKE_DNS: 127.0.0.1/FAKE_DNS: 10.96.0.10/' docker-compose.yml
+sed -i 's/127.0.0.1:8053/10.96.0.10:53/' test/config/va.json
 sed -i 's/5002/80/' test/config/va.json
 sed -i 's/good-caa-reserved.com/kubernetes.network/' test/rate-limit-policies.yml
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a WIP PR to replace #216.

**Release note**:
```release-note
Run e2e tests using Prow against Kubernetes 1.7-1.9
```
