### PR TITLE
Remove .spec.strategy.type: Recreate

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.0
+version: 0.2.1
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -9,8 +9,6 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
-  strategy:
-    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
**What this PR does / why we need it**:

We changed this in the most recent release, which caused upgrades from prior versions to fail. This removes the strategy from the chart in a backwards compatible way for those that have started on v0.2.3.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #268 

**Release note**:
```release-note
Revert change to Helm chart deployment update strategy that'd cause upgrades from previous versions to fail
```
