### PR TITLE
Optionally write junit reports into artifacts during e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,12 +98,14 @@ go_fmt:
 e2e_test:
 	# Build the e2e tests
 	go test -o e2e-tests -c ./test/e2e
+	mkdir -p "$$(pwd)/_artifacts"
 	# TODO: make these paths configurable
 	# Run e2e tests
 	KUBECONFIG=$$HOME/.kube/config CERTMANAGERCONFIG=$$HOME/.kube/config \
 		./e2e-tests \
 			-acme-nginx-certificate-domain=$(E2E_NGINX_CERTIFICATE_DOMAIN) \
-			-boulder-image-repo=$(BOULDER_IMAGE_REPO)
+			-boulder-image-repo=$(BOULDER_IMAGE_REPO) \
+			-report-dir=./_artifacts
 
 # Docker targets
 ################

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -16,11 +16,13 @@ package e2e
 import (
 	"os"
 	"os/exec"
+	"path"
 	"testing"
 
 	"github.com/golang/glog"
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/config"
+	"github.com/onsi/ginkgo/reporters"
 	"github.com/onsi/gomega"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
@@ -59,7 +61,11 @@ func RunE2ETests(t *testing.T) {
 	InstallHelmChart(t, "boulder", "./contrib/charts/boulder", "boulder", "./test/fixtures/boulder-values.yaml", extraArgs...)
 	glog.Infof("Starting e2e run %q on Ginkgo node %d", framework.RunId, config.GinkgoConfig.ParallelNode)
 
-	if !ginkgo.RunSpecs(t, "cert-manager e2e suite") {
+	var r []ginkgo.Reporter
+	if framework.TestContext.ReportDir != "" {
+		r = append(r, reporters.NewJUnitReporter(path.Join(framework.TestContext.ReportDir, "junit_00.xml")))
+	}
+	if !ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "cert-manager e2e suite", r) {
 		PrintPodLogs(t)
 	}
 }

--- a/test/e2e/framework/test_context.go
+++ b/test/e2e/framework/test_context.go
@@ -38,6 +38,8 @@ type TestContextType struct {
 	BoulderImageRepo string
 	BoulderImageTag  string
 	ACMEURL          string
+
+	ReportDir string
 }
 
 var TestContext TestContextType
@@ -62,6 +64,7 @@ func RegisterCommonFlags() {
 	flag.StringVar(&TestContext.BoulderImageRepo, "boulder-image-repo", "", "The container image repository for boulder to use in e2e tests")
 	flag.StringVar(&TestContext.BoulderImageTag, "boulder-image-tag", "", "The container image tag for boulder to use in e2e tests")
 	flag.StringVar(&TestContext.ACMEURL, "acme-url", "http://boulder.boulder.svc.cluster.local:4000/directory", "The ACME test server to use in e2e tests")
+	flag.StringVar(&TestContext.ReportDir, "report-dir", "", "Optional directory to store junit output in. If not specified, no junit file will be output")
 }
 
 func RegisterParseFlags() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Output junit reports during e2e tests for gubernator to display test details more clearly.

/release-note-none
/assign