### PR TITLE
Update helm chart to align with k/charts feedback

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.1
+version: 0.2.2
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
@@ -10,3 +10,6 @@ keywords:
   - tls
 sources:
   - https://github.com/jetstack/cert-manager
+maintainers:
+  - name: munnerz
+    email: james@jetstack.io

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -6,27 +6,34 @@ TLS certificates from various issuing sources.
 It will ensure certificates are valid and up to date periodically, and attempt
 to renew certificates at an appropriate time before expiry.
 
-## TL;DR;
-
-```console
-$ helm install .
-```
-
-## Introduction
-
-This chart creates a cert-manager deployment on a Kubernetes cluster using the Helm package manager.
-
 ## Prerequisites
 
-- Kubernetes cluster with support for CustomResourceDefinition or ThirdPartyResource
+- Kubernetes 1.7+
 
 ## Installing the Chart
+
+Full installation instructions, including details on how to configure extra
+functionality in cert-manager can be found in the [official deploying docs](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/deploying.md#addendum).
 
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release .
+$ helm install --name my-release stable/cert-manager
 ```
+
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
+
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://github.com/jetstack/cert-manager/tree/master/docs/api-types/issuer
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/ingress-shim.md
 
 > **Tip**: List all releases using `helm list`
 

--- a/contrib/charts/cert-manager/templates/NOTES.txt
+++ b/contrib/charts/cert-manager/templates/NOTES.txt
@@ -1,5 +1,15 @@
 cert-manager has been deployed successfully!
 
-You may now go ahead and create issuers and certificates.
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 
-See https://github.com/jetstack/cert-manager/blob/master/docs/README.md
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://github.com/jetstack/cert-manager/tree/v0.2.3/docs/api-types/issuer
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/user-guides/ingress-shim.md

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -27,10 +27,10 @@ extraArgs: []
   # supporting resources required for each ClusterIssuer (default is kube-system)
   # - --cluster-resource-namespace=kube-system
 
-resources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
+resources: {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
 
 nodeSelector: {}
 
@@ -40,10 +40,10 @@ ingressShim:
   # Optional additional arguments for ingress-shim
   extraArgs: []
 
-  resources:
-    requests:
-      cpu: 10m
-      memory: 32Mi
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
 
   image:
     repository: quay.io/jetstack/cert-manager-ingress-shim

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/issuer-crd.yaml
+++ b/docs/deploy/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -26,7 +26,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/issuer-crd.yaml
+++ b/docs/deploy/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.1
+    chart: cert-manager-0.2.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/hack/deploy/rbac-values.yaml
+++ b/hack/deploy/rbac-values.yaml
@@ -1,0 +1,10 @@
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+ingressShim:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi

--- a/hack/deploy/without-rbac-values.yaml
+++ b/hack/deploy/without-rbac-values.yaml
@@ -3,3 +3,14 @@ rbac:
 
 serviceAccount:
   create: false
+
+resources:
+  requests:
+    cpu: 10m
+    memory: 32Mi
+
+ingressShim:
+  resources:
+    requests:
+      cpu: 10m
+      memory: 32Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR brings the helm chart in line with what is found in kubernetes/charts (changes contained here: https://github.com/kubernetes/charts/pull/3416/commits/008d52cbc4c2b7d2b4981f53214e15779e085fb7).

It also addresses some feedback (https://github.com/kubernetes/charts/issues/3513) in order to improve our post-installation documentation by providing links to how to configure issuers/ingress-shim.

**Release note**:
```release-note
Remove default resource requests in Helm chart. Improve post-deployment informational messages.
```
