### PR TITLE
Add default shortNames to certificates CRD

### DIFF
--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -58,6 +58,7 @@ The following tables lists the configurable parameters of the cert-manager chart
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
 | `rbac.create` | If `true`, create and use RBAC resources | `true`
 | `serviceAccount.create` | If `true`, create a new service account | `true`

--- a/contrib/charts/cert-manager/templates/certificate-crd.yaml
+++ b/contrib/charts/cert-manager/templates/certificate-crd.yaml
@@ -11,8 +11,12 @@ metadata:
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
+    {{- if .Values.certificateResourceShortNames }}
+    shortNames:
+{{ toYaml .Values.certificateResourceShortNames | indent 6 }}
+    {{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -10,6 +10,8 @@ image:
 
 createCustomResource: true
 
+certificateResourceShortNames: ["cert", "certs"]
+
 rbac:
   # Specifies whether RBAC resources should be created
   create: true

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -12,7 +12,11 @@ metadata:
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
+    shortNames:
+      - cert
+      - certs
+      

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -12,7 +12,11 @@ metadata:
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
+    shortNames:
+      - cert
+      - certs
+      


### PR DESCRIPTION
Defaults to `[cert, certs]` and is configurable with `certificateCRDShortNames` parameter.

**What this PR does / why we need it**:

Simplifies manual certificate management with kubectl.

Fixes #311

<div name="review-notes" />

**Special notes for your reviewer**:

Instead of a boolean switch do/dont include the shortNames, the value defines the aliases. This may be handy if anybody prefers `[crt, crts]` instead.

I'm not too keen on the `certificateCRDShortNames` variable name. It might be better to use `Resource` instead of `CRD` to be consistent with the `createCustomResource` var.

Other CRDs are probably ok without an alias, but other people workflows may differ. Should these also be configurable? In that case, the variables could be `shortNames: {certificates: [], …}`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Certificate CRD shortnames `cert` and `certs`. This is configurable in the Helm Chart with `certificateResourceShortNames`.
```
