### PR TITLE
Check the value of the tls-acme annotation, not just its existence

### DIFF
--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
@@ -157,8 +158,10 @@ func shouldSync(ing *extv1beta1.Ingress) bool {
 	if _, ok := annotations[clusterIssuerNameAnnotation]; ok {
 		return true
 	}
-	if _, ok := annotations[tlsACMEAnnotation]; ok {
-		return true
+	if s, ok := annotations[tlsACMEAnnotation]; ok {
+		if b, _ := strconv.ParseBool(s); b {
+			return true
+		}
 	}
 	if _, ok := annotations[acmeIssuerChallengeTypeAnnotation]; ok {
 		return true

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -28,7 +28,7 @@ func TestShouldSync(t *testing.T) {
 			ShouldSync:  true,
 		},
 		{
-			Annotations: map[string]string{tlsACMEAnnotation: ""},
+			Annotations: map[string]string{tlsACMEAnnotation: "true"},
 			ShouldSync:  true,
 		},
 		{

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -32,6 +32,14 @@ func TestShouldSync(t *testing.T) {
 			ShouldSync:  true,
 		},
 		{
+			Annotations: map[string]string{tlsACMEAnnotation: "false"},
+			ShouldSync:  false,
+		},
+		{
+			Annotations: map[string]string{tlsACMEAnnotation: ""},
+			ShouldSync:  false,
+		},
+		{
 			Annotations: map[string]string{acmeIssuerChallengeTypeAnnotation: ""},
 			ShouldSync:  true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Previously the ingress-shim would sync an Ingress resource if it simply contained the `kubernetes.io/tls-acme` annotation, regardless of the value; now it will only do so if the annotation value is truthy (e.g., "true", "t", "1", so forth).

<!-- **Which issue this PR fixes**: fixes # -->

**Special notes for your reviewer**: This could probably be done in a way that doesn't disrupt the function's aesthetics so much. Open to all suggestions.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
ingress-shim will only sync Ingress resources with `kubernetes.io/tls-acme` annotation if the value of that annotation is true.
```
