### PR TITLE
Install Helm during .gitlab-ci.yml release build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,7 +11,7 @@ before_script:
   # Install docker
   # Note: 1.11+ changes the tarball format
   - curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
-  - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.8.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && mv linux-amd64/helm /usr/local/bin
+  - curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.8.1-linux-amd64.tar.gz | tar -C /tmp -xvzf- && mv /tmp/linux-amd64/helm /usr/local/bin
   - apt-get update
   - apt-get install -y make curl
   - export DOCKER_HOST=${DOCKER_PORT}

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,6 +11,7 @@ before_script:
   # Install docker
   # Note: 1.11+ changes the tarball format
   - curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
+  - curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.8.1-linux-amd64.tar.gz && tar xvf helm.tar.gz && mv linux-amd64/helm /usr/local/bin
   - apt-get update
   - apt-get install -y make curl
   - export DOCKER_HOST=${DOCKER_PORT}


### PR DESCRIPTION
Install Helm during .gitlab-ci.yml script

(in future, this file will go away altogether once we have set up a 'trusted' build cluster to push releases)

**Release note**:
```release-note
NONE
```

/assign
