### PR TITLE
Set default cluster resource namespace to current pod namespace

### DIFF
--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -20,10 +20,16 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- if .Values.extraArgs }}
           args:
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+        {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 12 }}
         {{- end }}
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.ingressShim.enabled }}

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
         {{- if .Values.extraArgs }}
-{{ toYaml .Values.extraArgs | indent 12 }}
+{{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}
           env:
           - name: POD_NAMESPACE
@@ -38,7 +38,7 @@ spec:
           imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
         {{- if .Values.ingressShim.extraArgs }}
           args:
-{{ toYaml .Values.ingressShim.extraArgs | indent 12 }}
+{{ toYaml .Values.ingressShim.extraArgs | indent 10 }}
         {{- end }}
           resources:
 {{ toYaml .Values.ingressShim.resources | indent 12 }}

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -22,6 +22,13 @@ spec:
         - name: cert-manager
           image: "quay.io/jetstack/cert-manager-controller:v0.2.3"
           imagePullPolicy: IfNotPresent
+          args:
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           resources:
             requests:
               cpu: 10m

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -22,6 +22,13 @@ spec:
         - name: cert-manager
           image: "quay.io/jetstack/cert-manager-controller:v0.2.3"
           imagePullPolicy: IfNotPresent
+          args:
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           resources:
             requests:
               cpu: 10m

--- a/test/e2e/clusterissuer/clusterissuer_ca.go
+++ b/test/e2e/clusterissuer/clusterissuer_ca.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jetstack/cert-manager/test/util"
 )
 
-const clusterResourceNamespace = "kube-system"
+const clusterResourceNamespace = "cert-manager"
 
 var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {
 	f := framework.NewDefaultFramework("create-ca-clusterissuer")

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -34,6 +34,8 @@ import (
 	_ "github.com/jetstack/cert-manager/test/e2e/issuer"
 )
 
+const certManagerDeploymentNamespace = "cert-manager"
+
 // TestE2E checks configuration parameters (specified through flags) and then runs
 // E2E tests using the Ginkgo runner.
 func RunE2ETests(t *testing.T) {
@@ -47,7 +49,7 @@ func RunE2ETests(t *testing.T) {
 	}
 
 	glog.Infof("Installing cert-manager helm chart")
-	InstallHelmChart(t, releaseName, "./contrib/charts/cert-manager", "cert-manager", "./test/fixtures/cert-manager-values.yaml")
+	InstallHelmChart(t, releaseName, "./contrib/charts/cert-manager", certManagerDeploymentNamespace, "./test/fixtures/cert-manager-values.yaml")
 
 	glog.Infof("Installing boulder chart")
 	// 10 minute timeout for boulder install due to large images


### PR DESCRIPTION
**What this PR does / why we need it**:

Changes the default cluster resource namespace from kube-system to the current namespace of the cert-manager deployment.

**Which issue this PR fixes**: fixes #103 

**Release note**:
```release-note
Supporting resources for ClusterIssuer's (e.g. signing CA certificates, or ACME account private keys) will now be stored in the same namespace as cert-manager, instead of kube-system in previous versions. Action required: you will need to ensure to properly manually migrate these referenced resources across into the deployment namespace of cert-manager, else cert-manager may not be able to find account private keys or signing CA certificates.
```

/cc @mikebryant 