### PR TITLE
Update default deployment namespace to be 'cert-manager'

### DIFF
--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: {{ template "cert-manager.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/serviceaccount.yaml
+++ b/contrib/charts/cert-manager/templates/serviceaccount.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "cert-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cert-manager
+  namespace: "cert-manager"
   labels:
     app: cert-manager
     chart: cert-manager-0.2.2

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -35,5 +35,5 @@ roleRef:
   name: cert-manager
 subjects:
   - name: cert-manager
-    namespace: "default"
+    namespace: "cert-manager"
     kind: ServiceAccount

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -4,6 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cert-manager
+  namespace: "cert-manager"
   labels:
     app: cert-manager
     chart: cert-manager-0.2.2

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   name: cert-manager
+  namespace: "cert-manager"
   labels:
     app: cert-manager
     chart: cert-manager-0.2.2

--- a/hack/update-deploy-gen.sh
+++ b/hack/update-deploy-gen.sh
@@ -18,7 +18,7 @@ gen() {
 		"${REPO_ROOT}/contrib/charts/cert-manager" \
 		--values "${SCRIPT_ROOT}/deploy/${VALUES}.yaml" \
 		--kube-version "${KUBE_VERSION}" \
-		--namespace "default" \
+		--namespace "cert-manager" \
 		--name "cert-manager" \
 		--set "fullnameOverride=cert-manager" \
 		--output-dir "${TMP_OUTPUT}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, our deployment manifests deployed into the 'default' namespace. This changes them to deploy into 'cert-manager' instead.

**Release note**:
```release-note
The static deployment manifests now automatically deploy into the 'cert-manager' namespace by default
```
