### PR TITLE
Make existing TLS certificate check emit a Normal event instead of Warning when the existing certificate is invalid

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -45,7 +45,7 @@ const (
 	messageIssuerNotFound            = "Issuer %s does not exist"
 	messageIssuerNotReady            = "Issuer %s not ready"
 	messageIssuerErrorInit           = "Error initializing issuer: "
-	messageErrorCheckCertificate     = "Error checking existing TLS certificate: "
+	messageErrorCheckCertificate     = "Error checking existing TLS certificate, will re-issue: "
 	messageErrorGetCertificate       = "Error getting TLS certificate: "
 	messageErrorPreparingCertificate = "Error preparing issuer for certificate: "
 	messageErrorIssuingCertificate   = "Error issuing certificate: "
@@ -105,7 +105,7 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 	if err != nil {
 		s := messageErrorCheckCertificate + err.Error()
 		glog.Info(s)
-		c.recorder.Event(crt, api.EventTypeWarning, errorCheckCertificate, s)
+		c.recorder.Event(crt, api.EventTypeNormal, errorCheckCertificate, s)
 	}
 
 	// if an error is returned, and that error is something other than


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, when requesting a certificate for the first time, the following events are logged:

```
  Warning  ErrorCheckCertificate  1m                 cert-manager-controller  Error checking existing TLS certificate: secret "httpbin" not found
  Normal   PrepareCertificate     1m                 cert-manager-controller  Preparing certificate with issuer
```

This has caused confusion for users when they see a Warning/Error being logged. This PR changes that to be:

```
  Normal   ErrorCheckCertificate  1m                 cert-manager-controller  Error checking existing TLS certificate, will re-issue: secret "httpbin" not found
  Normal   PrepareCertificate     1m                 cert-manager-controller  Preparing certificate with issuer
```

**Release note**:
```release-note
Clearer event logging when issuing a certificate for the first time
```
