### PR TITLE
Rename Event types to be prefixed 'Err' instead of 'Error' for brevity

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -24,15 +24,15 @@ import (
 const renewBefore = time.Hour * 24 * 30
 
 const (
-	errorIssuerNotFound       = "ErrorIssuerNotFound"
-	errorIssuerNotReady       = "ErrorIssuerNotReady"
-	errorIssuerInit           = "ErrorIssuerInitialization"
-	errorCheckCertificate     = "ErrorCheckCertificate"
-	errorGetCertificate       = "ErrorGetCertificate"
-	errorPreparingCertificate = "ErrorPrepareCertificate"
-	errorIssuingCertificate   = "ErrorIssueCertificate"
-	errorRenewingCertificate  = "ErrorRenewCertificate"
-	errorSavingCertificate    = "ErrorSaveCertificate"
+	errorIssuerNotFound       = "ErrIssuerNotFound"
+	errorIssuerNotReady       = "ErrIssuerNotReady"
+	errorIssuerInit           = "ErrIssuerInitialization"
+	errorCheckCertificate     = "ErrCheckCertificate"
+	errorGetCertificate       = "ErrGetCertificate"
+	errorPreparingCertificate = "ErrPrepareCertificate"
+	errorIssuingCertificate   = "ErrIssueCertificate"
+	errorRenewingCertificate  = "ErrRenewCertificate"
+	errorSavingCertificate    = "ErrSaveCertificate"
 
 	reasonPreparingCertificate = "PrepareCertificate"
 	reasonIssuingCertificate   = "IssueCertificate"


### PR DESCRIPTION
**What this PR does / why we need it**:

Shortens the event type names we use to be prefixed 'Err' instead of 'Error'

**Special notes for your reviewer**:

This brings us in-line with the issuer and cluster issuer controllers, and other controllers in Kubernetes.

**Release note**:
```release-note
Rename Event types to be prefixed 'Err' instead of 'Error' for brevity
```
