### PR TITLE
Create a Namespace resource as part of the static manifest bundle

### DIFF
--- a/contrib/charts/cert-manager/templates/00-namespace.yaml
+++ b/contrib/charts/cert-manager/templates/00-namespace.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.createNamespaceResource }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -55,3 +55,8 @@ ingressShim:
     # tag: v0.2.3
 
     pullPolicy: IfNotPresent
+
+# This is used by the static manifest generator in order to create a static
+# namespace manifest for the namespace that cert-manager is being installed
+# within. It should **not** be used if you are using Helm for deployment.
+createNamespaceResource: false

--- a/docs/deploy/rbac/00-namespace.yaml
+++ b/docs/deploy/rbac/00-namespace.yaml
@@ -1,0 +1,7 @@
+##---
+# Source: cert-manager/templates/00-namespace.yaml
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "cert-manager"

--- a/docs/deploy/without-rbac/00-namespace.yaml
+++ b/docs/deploy/without-rbac/00-namespace.yaml
@@ -1,0 +1,7 @@
+##---
+# Source: cert-manager/templates/00-namespace.yaml
+
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "cert-manager"

--- a/hack/update-deploy-gen.sh
+++ b/hack/update-deploy-gen.sh
@@ -21,6 +21,7 @@ gen() {
 		--namespace "cert-manager" \
 		--name "cert-manager" \
 		--set "fullnameOverride=cert-manager" \
+		--set "createNamespaceResource=true" \
 		--output-dir "${TMP_OUTPUT}"
 	mv "${TMP_OUTPUT}"/cert-manager/templates/*.* "${OUTPUT_DIR}/"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Create a Namespace resource as part of the static deployment manifests bundle, to make it easier for users to deploy cert-manager without a Helm chart

**Release note**:
```release-note
NONE
```

/cc @davecheney @wallrj 