### PR TITLE
Add Endpoints back into the cert-manager RBAC policy

### DIFF
--- a/contrib/charts/cert-manager/templates/rbac.yaml
+++ b/contrib/charts/cert-manager/templates/rbac.yaml
@@ -13,7 +13,12 @@ rules:
     resources: ["certificates", "issuers", "clusterissuers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "events", "services", "pods"]
+    # TODO: remove endpoints once 0.4 is released. We include it here in case
+    # users use the 'master' version of the Helm chart with a 0.2.x release of
+    # cert-manager that still performs leader election with Endpoint resources.
+    # We advise users don't do this, but some will anyway and this will reduce
+    # friction.
+    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -14,7 +14,12 @@ rules:
     resources: ["certificates", "issuers", "clusterissuers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "events", "services", "pods"]
+    # TODO: remove endpoints once 0.4 is released. We include it here in case
+    # users use the 'master' version of the Helm chart with a 0.2.x release of
+    # cert-manager that still performs leader election with Endpoint resources.
+    # We advise users don't do this, but some will anyway and this will reduce
+    # friction.
+    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds permission to CRUD Endpoints resources back into the cert-manager RBAC role. This is to prevent deployments using the 'master' version of the Helm chart failing when deploying a pre-0.3 (unreleased) release of cert-manager.

We will remove this in 0.4. This is in order to reduce friction for new users if they forget/decide not to use a tagged release of the Helm chart.

**Release note**:
```release-note
NONE
```

/cc @davecheney @mikebryant 
