### PR TITLE
Update Slack channel name

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ project.
 Please take a look at our [issue tracker](https://github.com/jetstack/cert-manager/issues)
 if you are unsure where to start with getting involved!
 
-We also use the #kube-lego channel on kubernetes.slack.com for chat relating to
+We also use the #cert-manager channel on kubernetes.slack.com for chat relating to
 the project.
 
 Developer documentation should be available soon at [docs/devel](docs/devel).


### PR DESCRIPTION
**What this PR does / why we need it**:
Update old `#kube-lego` Slack channel name to `#cert-manager`

**Which issue this PR fixes**
No issue filed.

**Special notes for your reviewer**:
None.

**Release note**:
```release-note
NONE
```
