### PR TITLE
Fast forward release-0.2 helm chart to latest master

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,4 +1,15 @@
-apiVersion: v1
-description: A Helm chart for Kubernetes
 name: cert-manager
-version: 0.1.0
+version: 0.2.2
+appVersion: 0.2.3
+description: A Helm chart for cert-manager
+home: https://github.com/jetstack/cert-manager
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+sources:
+  - https://github.com/jetstack/cert-manager
+maintainers:
+  - name: munnerz
+    email: james@jetstack.io

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -6,27 +6,34 @@ TLS certificates from various issuing sources.
 It will ensure certificates are valid and up to date periodically, and attempt
 to renew certificates at an appropriate time before expiry.
 
-## TL;DR;
-
-```console
-$ helm install .
-```
-
-## Introduction
-
-This chart creates a cert-manager deployment on a Kubernetes cluster using the Helm package manager.
-
 ## Prerequisites
 
-- Kubernetes cluster with support for CustomResourceDefinition or ThirdPartyResource
+- Kubernetes 1.7+
 
 ## Installing the Chart
+
+Full installation instructions, including details on how to configure extra
+functionality in cert-manager can be found in the [official deploying docs](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/deploying.md#addendum).
 
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release .
+$ helm install --name my-release stable/cert-manager
 ```
+
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
+
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://github.com/jetstack/cert-manager/tree/master/docs/api-types/issuer
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/ingress-shim.md
 
 > **Tip**: List all releases using `helm list`
 
@@ -44,15 +51,26 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following tables lists the configurable parameters of the cert-manager chart and their default values.
 
-| Parameter              | Description                             | Default                                        |
-| ---------------------- | --------------------------------------- | ---------------------------------------------- |
-| `image.repository`     | Image repository                        | `quay.io/jetstack/cert-manager-controller`     |
-| `image.tag`            | Image tag                               | `v0.2.3`                                       |
-| `image.pullPolicy`     | Image pull policy                       | `Always`                                       |
-| `replicaCount`         | Number of cert-manager replicas         | `1`                                            |
-| `createCustomResource` | Create CRD/TPR with this release        | `true`                                         |
-| `rbac.enabled`         | Create RBAC resources with this release | `true`                                         |
-| `resources`            | CPU/Memory resource requests/limits     | `None`                                         |
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
+| `image.tag` | Image tag | `v0.2.3` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `replicaCount`  | Number of cert-manager replicas  | `1` |
+| `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
+| `extraArgs` | Optional flags for cert-manager | `[]` |
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
+| `resources` | CPU/memory resource requests/limits | `requests: {cpu: 10m, memory: 32Mi}` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `ingressShim.enabled` | Enable ingress-shim for automatic ingress integration | `true`|
+| `ingressShim.extraArgs` | Optional flags for ingress-shim | `[]` |
+| `ingressShim.resources` | CPU/memory resource requests/limits for ingress-shim | `requests: {cpu: 10m, memory: 32Mi}` |
+| `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
+| `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
+| `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/contrib/charts/cert-manager/templates/00-namespace.yaml
+++ b/contrib/charts/cert-manager/templates/00-namespace.yaml
@@ -1,0 +1,6 @@
+{{ if .Values.createNamespaceResource }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace | quote }}
+{{- end }}

--- a/contrib/charts/cert-manager/templates/NOTES.txt
+++ b/contrib/charts/cert-manager/templates/NOTES.txt
@@ -1,0 +1,15 @@
+cert-manager has been deployed successfully!
+
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
+
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://github.com/jetstack/cert-manager/tree/v0.2.3/docs/api-types/issuer
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/user-guides/ingress-shim.md

--- a/contrib/charts/cert-manager/templates/_helpers.tpl
+++ b/contrib/charts/cert-manager/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "cert-manager.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,26 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "cert-manager.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- $fullname := printf "%s-%s" $name .Release.Name -}}
+{{- default $fullname .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cert-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cert-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cert-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/certificate-crd.yaml
+++ b/contrib/charts/cert-manager/templates/certificate-crd.yaml
@@ -1,23 +1,22 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
-{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: certificate.certmanager.k8s.io
-description: "A specification for a cert-manager certificate"
-versions:
-- name: v1alpha1
-{{- end -}}
+    {{- if .Values.certificateResourceShortNames }}
+    shortNames:
+{{ toYaml .Values.certificateResourceShortNames | indent 6 }}
+    {{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
@@ -11,5 +15,4 @@ spec:
     kind: ClusterIssuer
     plural: clusterissuers
   scope: Cluster
-{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -1,10 +1,11 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -12,29 +13,34 @@ spec:
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
     spec:
-      serviceAccount: {{ template "fullname" . }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-{{- range .Values.extraArgs }}
-          - {{ . }}
-{{- end }}
+          - --cluster-resource-namespace=$(POD_NAMESPACE)
+        {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 10 }}
+        {{- end }}
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.ingressShim.enabled }}
         - name: ingress-shim
-          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag | default .Values.image.tag }}"
+          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
+        {{- if .Values.ingressShim.extraArgs }}
           args:
-{{- range .Values.ingressShim.extraArgs }}
-          - {{ . }}
-{{- end }}
+{{ toYaml .Values.ingressShim.extraArgs | indent 10 }}
+        {{- end }}
           resources:
 {{ toYaml .Values.ingressShim.resources | indent 12 }}
 {{- end }}

--- a/contrib/charts/cert-manager/templates/issuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/issuer-crd.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
@@ -11,13 +15,4 @@ spec:
     kind: Issuer
     plural: issuers
   scope: Namespaced
-{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: issuer.certmanager.k8s.io
-description: "A specification for a cert-manager issuer"
-versions:
-- name: v1alpha1
-{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/rbac.yaml
+++ b/contrib/charts/cert-manager/templates/rbac.yaml
@@ -1,39 +1,44 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-- apiGroups: ["certmanager.k8s.io"]
-  resources: ["certificates", "issuers", "clusterissuers"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["secrets", "events", "endpoints", "services", "pods"]
-  verbs: ["*"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses"]
-  verbs: ["*"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers", "clusterissuers"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    # TODO: remove endpoints once 0.4 is released. We include it here in case
+    # users use the 'master' version of the Helm chart with a 0.2.x release of
+    # cert-manager that still performs leader election with Endpoint resources.
+    # We advise users don't do this, but some will anyway and this will reduce
+    # friction.
+    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
 subjects:
-- name: {{ template "fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  kind: ServiceAccount
+  - name: {{ template "cert-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/serviceaccount.yaml
+++ b/contrib/charts/cert-manager/templates/serviceaccount.yaml
@@ -1,9 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- end -}}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -6,32 +6,57 @@ replicaCount: 1
 image:
   repository: quay.io/jetstack/cert-manager-controller
   tag: v0.2.3
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
 
 createCustomResource: true
 
+certificateResourceShortNames: ["cert", "certs"]
+
 rbac:
-  enabled: true
+  # Specifies whether RBAC resources should be created
+  create: true
 
-resources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
-# Optional additional arguments for cert-manager
+# Optional additional arguments
 extraArgs: []
+  # Use this flag to set a namespace that cert-manager will use to store
+  # supporting resources required for each ClusterIssuer (default is kube-system)
+  # - --cluster-resource-namespace=kube-system
+
+resources: {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
+
+nodeSelector: {}
 
 ingressShim:
   enabled: true
+
   # Optional additional arguments for ingress-shim
   extraArgs: []
-  resources:
-    requests:
-      cpu: 10m
-      memory: 32Mi
+
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
   image:
     repository: quay.io/jetstack/cert-manager-ingress-shim
+
     # Defaults to image.tag.
     # You should only change this if you know what you are doing!
     # tag: v0.2.3
-    pullPolicy: Always
+
+    pullPolicy: IfNotPresent
+
+# This is used by the static manifest generator in order to create a static
+# namespace manifest for the namespace that cert-manager is being installed
+# within. It should **not** be used if you are using Helm for deployment.
+createNamespaceResource: false

--- a/test/e2e/clusterissuer/clusterissuer_ca.go
+++ b/test/e2e/clusterissuer/clusterissuer_ca.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jetstack/cert-manager/test/util"
 )
 
-const clusterResourceNamespace = "kube-system"
+const clusterResourceNamespace = "cert-manager"
 
 var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {
 	f := framework.NewDefaultFramework("create-ca-clusterissuer")

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -32,6 +32,8 @@ import (
 	_ "github.com/jetstack/cert-manager/test/e2e/issuer"
 )
 
+const certManagerDeploymentNamespace = "cert-manager"
+
 // TestE2E checks configuration parameters (specified through flags) and then runs
 // E2E tests using the Ginkgo runner.
 func RunE2ETests(t *testing.T) {
@@ -45,7 +47,7 @@ func RunE2ETests(t *testing.T) {
 	}
 
 	glog.Infof("Installing cert-manager helm chart")
-	InstallHelmChart(t, releaseName, "./contrib/charts/cert-manager", "cert-manager", "./test/fixtures/cert-manager-values.yaml")
+	InstallHelmChart(t, releaseName, "./contrib/charts/cert-manager", certManagerDeploymentNamespace, "./test/fixtures/cert-manager-values.yaml")
 
 	glog.Infof("Installing boulder chart")
 	// 10 minute timeout for boulder install due to large images


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the Helm chart on the release-0.2 branch to be up to date with master. We won't normally do this, but given the big divergence between master and release-0.2 and the mismatch of documentation, I think it's easiest we make this change now.

Technically this is breaking, but only within the realms of the chart itself.

**Release note**:
```release-note
Update Helm chart to follow the chart best practices
```
