### PR TITLE
Bump chart version after changes in previous PRs

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.2
+version: 0.3.0
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

In #330, #340 and #343 the Helm chart was changed, but the version number was not bumped.

This PR bumps the version number of the chart in order to reflect these changes.

In a future PR we should add some automated check to ensure the version number is bumped if files in the `contrib/chart` directory have changed to prevent this happening again.

**Release note**:
```release-note
NONE
```
