### PR TITLE
Add quick-start guide for nginx ingress controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,15 @@ and has borrowed some wisdom from other similar projects e.g.
 
 ![cert-manager high level overview diagram](/docs/high-level-overview.png)
 
+## Quickstart
+
+> Prebuilt images for cert-manager are made available on Dockerhub.
+
+For the common use-case of automatically issuing TLS certificates to
+Ingress resources, aka a [kube-lego](https://github.com/jetstack/kube-lego)
+replacement, see the [cert-manager nginx ingress quick start
+guide](docs/quick-start/nginx-ingress/).
+
 ## Current status
 
 This project is not yet ready to be a component in a critical production stack,
@@ -25,14 +34,7 @@ there may be breaking changes that will require changes to *all*
 `Issuer`/`Certificate` resources you have already created. We aim to provide a
 stable API after a 1.0 release.
 
-## Quickstart
-
-> Prebuilt images for cert-manager are made available on Dockerhub.
-
-### Pre-requisites
-
-* Kubernetes cluster with `CustomResourceDefinition` or `ThirdPartyResource`
-support
+## Using cert-manager
 
 ### Deploying cert-manager
 
@@ -53,7 +55,7 @@ validation](docs/user-guides/acme-http-validation.md)
 * [Issuing an ACME certificate using DNS
 validation](docs/user-guides/acme-dns-validation.md)
 
-## Further documentation
+### Further Documentation
 
 For further documentation, please check the [/docs](/docs) directory in this
 repository.

--- a/docs/quick-start/nginx-ingress/README.md
+++ b/docs/quick-start/nginx-ingress/README.md
@@ -1,0 +1,131 @@
+# Cert-Manager NGINX Ingress Quick-Start Guide
+
+## Step -1 - Install Helm Client
+**Skip this section if you have `helm` installed.**
+
+The easiest way to install `cert-manager` is to use [Helm](https://github.com/kubernetes/helm), a templating and deployment system for Kubernetes resources.
+
+Firstly, ensure you have the Helm client installed by following [its installation instructions](https://github.com/kubernetes/helm/blob/master/docs/install.md).
+
+For example, on Mac OS X:
+```bash
+$ brew install kubernetes-helm
+```
+
+
+## Step 0 - Installer Tiller
+**Skip this section if you have Tiller set-up.**
+
+Tiller is Helm's server-side component, which the `helm` client uses to deploy resources.
+
+Deploying resources is a privileged operation; in the general case requiring arbitrary privileges. As a convenience, we will give Tiller complete control of the cluster. Do not run with this configuration in production.
+
+Create the RBAC resources.
+
+```bash
+$ kubectl create serviceaccount tiller --namespace=kube-system
+$ kubectl create clusterrolebinding tiller-admin --serviceaccount=kube-system:tiller --clusterrole=cluster-admin
+```
+
+Now install the Tiller component.
+
+```bash
+$ helm init --service-account=tiller
+```
+
+*If you'd like to read more, full documentation is available on [installing Tiller](https://github.com/kubernetes/helm/blob/master/docs/install.md) and [RBAC configuration](https://github.com/kubernetes/helm/blob/master/docs/rbac.md).*
+
+
+## Step 1 - Deploy the NGINX Ingress Controller
+### Create a namespace
+```bash
+$ kubectl apply -f nginx/00-namespace.yaml
+```
+
+### Create a default backend
+Used for all requests that don't match any Ingress resource
+
+```bash
+$ kubectl apply -f nginx/default-deployment.yaml
+$ kubectl apply -f nginx/default-service.yaml
+```
+
+### Create the NGINX ingress controller
+```bash
+$ kubectl apply -f nginx/rbac.yaml
+$ kubectl apply -f nginx/configmap.yaml
+$ kubectl apply -f nginx/service.yaml
+$ kubectl apply -f nginx/deployment.yaml
+```
+
+The `nginx` ingress controller service is the only one which is made available outside the cluster, as it handles all incoming traffic. It does this via a load balancer in your cloud provider. A few minutes after you've created the `nginx` Service, get its public IP or domain name via `kubectl`.
+
+```bash
+$ kubectl describe svc nginx --namespace nginx-ingress
+[...]
+LoadBalancer Ingress:   1.2.3.4
+[...]
+```
+
+This is the IP to which all incoming traffic should be routed, so add it to a DNS zone you control, e.g. as `echo.example.com`. AWS will give a domain name instead; in this case CNAME your name to that name.
+
+
+## Step 2 - Deploy an Example Service (Echoserver)
+```bash
+$ kubectl apply -f echoserver/00-namespace.yaml
+$ kubectl apply -f echoserver/deployment.yaml
+$ kubectl apply -f echoserver/service.yaml
+```
+
+We will first create an Ingress resource that listens on plain HTTP.
+
+```bash
+$ kubectl apply -f echoserver/ingress-notls.yaml
+```
+
+Now make sure the echo service is reachable at the domain name you added above, e.g. http://echo.example.com.
+
+
+## Step 3 - Deploy Cert Manager
+```bash
+$ helm install --name cert-manager --namespace kube-system stable/cert-manager
+```
+
+## Step 4 - Configure Letsentrypt Issuer
+
+With cert manager running, we must tell it about a service it can use to issue certificates for us. In this case we will configure letsencrypt. NB: the following code sets up letsencrypt "production". This will issue valid certificates but has a strict rate limit. If you are having difficulty and failing to get certificates, [switch this for letsencrypt's "staging" issuer](https://github.com/jetstack/cert-manager/blob/master/docs/user-guides/acme-http-validation.md) while you debug, otherwise you will hit the rolling 7 day rate limit.
+
+Substitute your own email address in the definition below and apply to your cluster.
+
+```yaml
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v01.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: user@example.com
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod-key
+    # Enable the HTTP-01 challenge provider
+    http01: {}
+```
+
+## Step 5 - Deploy a TLS Ingress Resource for the Echoserver
+We will now update the Ingress resource to listen on HTTPS and use a TLS certificate stored in a named secret. Cert manager will notice this change to the Ingress resource and generate the certificate for us automatically.
+
+Edit `echoserver/ingress-tls.yaml` to replace `echo.example.com` with your DNS name. While the previous, non-TLS, Ingress resource definition was simply configured to accept requests with any `host` header, TLS Ingress resources need to know which SNI header values to match, and `cert-manager` uses the same field as the CN in the issued certificate.
+
+Note how this updated Ingress resource uses an annotation to tell `cert-manager` to use the issuer previously defined to get a TLS certificate for this Ingress resource. The mere presence of this annotation key tells `cert-manager` to generate a certificate for this Ingress. It is generated for the domain name specified in the `tls` part of the Ingress spec, and stored in the secret named there.
+
+```bash
+$ kubectl apply -f echoserver/ingress-tls.yaml
+```
+
+The echo server should now be available over TLS at e.g. https://echo.example.com.
+
+*This example could have been done manually using cert manager's `Issuer` and `Certificate` resources. However, issuing Ingress TLS certificates is such a common use-case that cert manager comes with an "ingress shim" which spots Ingress objects requesting TLS certificates and automatically issues them using the specified provider. The ingress shim is what powered this example. Cert manager is a flexible, general-purpose certificate manager, and this is only a fraction of its potential.*

--- a/docs/quick-start/nginx-ingress/echoserver/00-namespace.yaml
+++ b/docs/quick-start/nginx-ingress/echoserver/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: echoserver

--- a/docs/quick-start/nginx-ingress/echoserver/deployment.yaml
+++ b/docs/quick-start/nginx-ingress/echoserver/deployment.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: echoserver
+  namespace: echoserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: echoserver
+    spec:
+      containers:
+      - image: gcr.io/google_containers/echoserver:1.0
+        imagePullPolicy: Always
+        name: echoserver
+        ports:
+        - containerPort: 8080

--- a/docs/quick-start/nginx-ingress/echoserver/ingress-notls.yaml
+++ b/docs/quick-start/nginx-ingress/echoserver/ingress-notls.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echoserver
+  namespace: echoserver
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    # certmanager.k8s.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  # tls:
+  # - hosts:
+  #   - echo.example.com
+  #   secretName: echoserver-tls
+  rules:
+  - host:
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: echoserver
+          servicePort: 80

--- a/docs/quick-start/nginx-ingress/echoserver/ingress-tls.yaml
+++ b/docs/quick-start/nginx-ingress/echoserver/ingress-tls.yaml
@@ -1,0 +1,21 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: echoserver
+  namespace: echoserver
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    certmanager.k8s.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+  - hosts:
+    - echo.example.com
+    secretName: echoserver-tls
+  rules:
+  - host: echo.example.com
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: echoserver
+          servicePort: 80

--- a/docs/quick-start/nginx-ingress/echoserver/service.yaml
+++ b/docs/quick-start/nginx-ingress/echoserver/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: echoserver
+  namespace: echoserver
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: echoserver

--- a/docs/quick-start/nginx-ingress/nginx/00-namespace.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: nginx-ingress

--- a/docs/quick-start/nginx-ingress/nginx/configmap.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+data:
+  proxy-connect-timeout: "15"
+  proxy-read-timeout: "600"
+  proxy-send-timeout: "600"
+  hsts-include-subdomains: "false"
+  body-size: "64m"
+  server-name-hash-bucket-size: "256"
+kind: ConfigMap
+metadata:
+  namespace: nginx-ingress
+  name: nginx

--- a/docs/quick-start/nginx-ingress/nginx/default-deployment.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/default-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: default-http-backend
+  labels:
+    app: default-http-backend
+  namespace: nginx-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: default-http-backend
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+      - name: default-http-backend
+        # Any image is permissable as long as:
+        # 1. It serves a 404 page at /
+        # 2. It serves 200 on a /healthz endpoint
+        image: gcr.io/google_containers/defaultbackend:1.4
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: 30
+          timeoutSeconds: 5
+        ports:
+        - containerPort: 8080
+        resources:
+          limits:
+            cpu: 10m
+            memory: 20Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi

--- a/docs/quick-start/nginx-ingress/nginx/default-service.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/default-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: default-http-backend
+  namespace: nginx-ingress
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: default-http-backend

--- a/docs/quick-start/nginx-ingress/nginx/deployment.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/deployment.yaml
@@ -1,0 +1,43 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      serviceAccountName: nginx-ingress
+      containers:
+        - name: nginx
+          image: quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.9.0
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --configmap=$(POD_NAMESPACE)/nginx
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+          - name: http
+            containerPort: 80
+          - name: https
+            containerPort: 443
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /healthz
+              port: 10254
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1

--- a/docs/quick-start/nginx-ingress/nginx/rbac.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/rbac.yaml
@@ -1,0 +1,133 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx-ingress
+  namespace: nginx-ingress
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: nginx-ingress-clusterrole
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - endpoints
+      - nodes
+      - pods
+      - secrets
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+        - events
+    verbs:
+        - create
+        - patch
+  - apiGroups:
+      - "extensions"
+    resources:
+      - ingresses/status
+    verbs:
+      - update
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: nginx-ingress-role
+  namespace: nginx-ingress
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - pods
+      - secrets
+      - namespaces
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    resourceNames:
+      # Defaults to "<election-id>-<ingress-class>"
+      # Here: "<ingress-controller-leader>-<nginx>"
+      # This has to be adapted if you change either parameter
+      # when launching the nginx-ingress-controller.
+      - "ingress-controller-leader-nginx"
+    verbs:
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: nginx-ingress-role-nisa-binding
+  namespace: nginx-ingress
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: nginx-ingress-role
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress
+    namespace: nginx-ingress
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: nginx-ingress-clusterrole-nisa-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: nginx-ingress-clusterrole
+subjects:
+  - kind: ServiceAccount
+    name: nginx-ingress
+    namespace: nginx-ingress

--- a/docs/quick-start/nginx-ingress/nginx/service.yaml
+++ b/docs/quick-start/nginx-ingress/nginx/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx
+  namespace: nginx-ingress
+spec:
+  type: LoadBalancer
+  ports:
+  - port: 80
+    name: http
+  - port: 443
+    name: https
+  selector:
+    app: nginx


### PR DESCRIPTION
Example YAMLs from kube-lego. Instructions to take you from new cluster to TLS echoserver with the least typing.