### PR TITLE
 docs/devel: add 'deploy to minikube' docs 

### DIFF
--- a/docs/devel/README.md
+++ b/docs/devel/README.md
@@ -1,0 +1,46 @@
+# Develop with minikube
+
+## Start minikube
+
+First, run minikube, and configure your local kubectl command to work with minikube; minikube typically does this automatically.
+
+
+```shell
+$ minikube version
+minikube version: v0.25.0
+
+$ minikube start --extra-config=apiserver.Authorization.Mode=RBAC
+# Verify it works
+$ kubectl cluster-info
+# Should output a local master ip
+
+$ kubectl create clusterrolebinding default-admin --clusterrole=cluster-admin --serviceaccount=kube-system:default
+$ helm init
+```
+
+## Build a dev version of cert-manager for minikube
+
+```shell
+$ eval "$(minikube docker-env)"
+$ make build
+# ....
+Successfully tagged quay.io/jetstack/cert-manager-controller:build
+```
+
+## Deploy that version with helm
+
+```shell
+$ helm install --set image.tag=build --name cert-manager ./contrib/charts/cert-manager
+```
+
+From here, you should be able to do whatever manual testing or development you wish to.
+
+## Deploy a new version
+
+In general, upgrading can be done simply by running `make build`, and then deleting the deployed pod using `kubectl delete pod`.
+
+However, if you make changes to the helm chart or wish to change the controller's arguments, such as to change the logging level, you may also update it with the following:
+
+```shell
+$ helm upgrade  --set extraArgs="{-v=5}" --set image.tag=build cert-manager ./contrib/charts/cert-manager
+```

--- a/docs/examples/acme-cert.yaml
+++ b/docs/examples/acme-cert.yaml
@@ -35,11 +35,11 @@ spec:
         provider: cloudflare
       domains:
       - cm-dns-cloudflare.k8s.group
-    - dns-01:
+    - dns01:
         provider: route53
       domains:
       - cm-dns-route53.k8s.group
-    - dns-01:
+    - dns01:
         provider: azuredns
       domains:
       - cm-dns-azuredns.k8s.group


### PR DESCRIPTION
**What this PR does / why we need it**:

I felt that the steps to deploy/run/test cert-manager in minikube were non-trivial enough that it was worth documenting.

Let me know if this should live somewhere else in the repo or if you have suggestions for how to better document this.

```release-note
NONE
```
