### PR TITLE
Document common ingressShim.extraArgs use case in chart

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.3
+version: 0.2.4
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.2
+version: 0.2.3
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -41,6 +41,10 @@ ingressShim:
 
   # Optional additional arguments for ingress-shim
   extraArgs: []
+    # Use these flags to specify the default Issuer/ClusterIssuer
+    # (IMPORTANT: You need to create this Issuer/ClusterIssuer resource yourself)
+    # - --default-issuer-name=letsencrypt-prod
+    # - --default-issuer-kind=ClusterIssuer
 
   resources: {}
     # requests:

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/issuer-crd.yaml
+++ b/docs/deploy/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/issuer-crd.yaml
+++ b/docs/deploy/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/issuer-crd.yaml
+++ b/docs/deploy/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.2
+    chart: cert-manager-0.2.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/issuer-crd.yaml
+++ b/docs/deploy/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.3
+    chart: cert-manager-0.2.4
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Lots of new users don't realize:
(a) They need to create a Issuer/ClusterIssuer themselves
(b) They need to tell `ingress-shim` the name via `extra-args`
This PR adds a comment to the helm chart `values.yaml` to address these issues.

(Ideally the `helm` would create an ClusterIssuer for you by default, and set these options, if you specify and email address to use with LE.)

Release note:
```release-note
NONE
```