### PR TITLE
Fix .gitlab-ci.yml build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ before_script:
   - mv "${CI_PROJECT_DIR}" "${GOPATH}/src/${PKG_PATH}"
   - cd "${GOPATH}/src/${PKG_PATH}"
   - mkdir -p "${CI_PROJECT_DIR}"
+  - export PULL_BASE_SHA=${CI_COMMIT_SHA}
 
 after_script:
   - cd "/"


### PR DESCRIPTION
Since #372 merged, builds of master (which lead to releases) have been failing.

Technically, the PULL_BASE_SHA should be set to the SHA value of the branch this PR is being *merged into*. Because we don't actually test these on GitLab, this workaround is okay (setting it to the value of the current commit).


**Release note**:
```release-note
NONE
```
