### PR TITLE
Reconfigure certs when ingress config changes

### DIFF
--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -116,7 +116,7 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*
 		if existingCrt != nil {
 			glog.Infof("Certificate %q for ingress %q already exists", tls.SecretName, ing.Name)
 
-			if crtEqual(existingCrt, crt) {
+			if !certNeedsUpdate(existingCrt, crt) {
 				glog.Infof("Certificate %q for ingress %q is up to date", tls.SecretName, ing.Name)
 				continue
 			}
@@ -135,35 +135,35 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*
 	return newCrts, updateCrts, nil
 }
 
-// crtEqual checks and returns true if two Certificates are equal
-func crtEqual(a, b *v1alpha1.Certificate) bool {
+// certNeedsUpdate checks and returns true if two Certificates are equal
+func certNeedsUpdate(a, b *v1alpha1.Certificate) bool {
 	if a.Name != b.Name {
-		return false
+		return true
 	}
 
 	if len(a.Spec.DNSNames) != len(b.Spec.DNSNames) {
-		return false
+		return true
 	}
 
 	for i := range a.Spec.DNSNames {
 		if a.Spec.DNSNames[i] != b.Spec.DNSNames[i] {
-			return false
+			return true
 		}
 	}
 
 	if a.Spec.SecretName != b.Spec.SecretName {
-		return false
+		return true
 	}
 
 	if a.Spec.IssuerRef.Name != b.Spec.IssuerRef.Name {
-		return false
+		return true
 	}
 
 	if a.Spec.IssuerRef.Kind != b.Spec.IssuerRef.Kind {
-		return false
+		return true
 	}
 
-	return true
+	return false
 }
 
 func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v1alpha1.GenericIssuer, ing *extv1beta1.Ingress, tls extv1beta1.IngressTLS) error {

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -69,7 +69,8 @@ func TestBuildCertificates(t *testing.T) {
 		DefaultIssuerName   string
 		DefaultIssuerKind   string
 		Err                 bool
-		Expected            []*v1alpha1.Certificate
+		ExpectedCreate      []*v1alpha1.Certificate
+		ExpectedUpdate      []*v1alpha1.Certificate
 	}
 	tests := []testT{
 		{
@@ -93,7 +94,7 @@ func TestBuildCertificates(t *testing.T) {
 				},
 			},
 			ClusterIssuerLister: []*v1alpha1.ClusterIssuer{buildACMEClusterIssuer("issuer-name")},
-			Expected: []*v1alpha1.Certificate{
+			ExpectedCreate: []*v1alpha1.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
@@ -190,7 +191,7 @@ func TestBuildCertificates(t *testing.T) {
 				},
 			},
 			ClusterIssuerLister: []*v1alpha1.ClusterIssuer{buildACMEClusterIssuer("issuer-name")},
-			Expected: []*v1alpha1.Certificate{
+			ExpectedCreate: []*v1alpha1.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
@@ -259,7 +260,7 @@ func TestBuildCertificates(t *testing.T) {
 				},
 			},
 			ClusterIssuerLister: []*v1alpha1.ClusterIssuer{buildClusterIssuer("issuer-name")},
-			Expected: []*v1alpha1.Certificate{
+			ExpectedCreate: []*v1alpha1.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
@@ -385,8 +386,8 @@ func TestBuildCertificates(t *testing.T) {
 			if err != nil && !test.Err {
 				t.Errorf("Expected no error, but got: %s", err)
 			}
-			if !reflect.DeepEqual(crts, test.Expected) {
-				t.Errorf("Expected %+v but got %+v", test.Expected, crts)
+			if !reflect.DeepEqual(crts, test.ExpectedCreate) {
+				t.Errorf("Expected %+v but got %+v", test.ExpectedCreate, crts)
 			}
 		}
 	}

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -339,7 +339,8 @@ func TestBuildCertificates(t *testing.T) {
 					Name:      "ingress-name",
 					Namespace: "ingress-namespace",
 					Annotations: map[string]string{
-						issuerNameAnnotation: "issuer-name",
+						issuerNameAnnotation:              "issuer-name",
+						acmeIssuerChallengeTypeAnnotation: "http01",
 					},
 				},
 				Spec: extv1beta1.IngressSpec{

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -380,7 +380,7 @@ func TestBuildCertificates(t *testing.T) {
 					DefaultIssuerKind: test.DefaultIssuerKind,
 				},
 			}
-			crts, err := c.buildCertificates(test.Ingress)
+			crts, _, err := c.buildCertificates(test.Ingress)
 			if err != nil && !test.Err {
 				t.Errorf("Expected no error, but got: %s", err)
 			}

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -382,12 +382,16 @@ func TestBuildCertificates(t *testing.T) {
 					DefaultIssuerKind: test.DefaultIssuerKind,
 				},
 			}
-			crts, _, err := c.buildCertificates(test.Ingress)
+			createCrts, updateCrts, err := c.buildCertificates(test.Ingress)
 			if err != nil && !test.Err {
 				t.Errorf("Expected no error, but got: %s", err)
 			}
-			if !reflect.DeepEqual(crts, test.ExpectedCreate) {
-				t.Errorf("Expected %+v but got %+v", test.ExpectedCreate, crts)
+			if !reflect.DeepEqual(createCrts, test.ExpectedCreate) {
+				t.Errorf("Expected to create %+v but got %+v", test.ExpectedCreate, createCrts)
+			}
+
+			if !reflect.DeepEqual(updateCrts, test.ExpectedUpdate) {
+				t.Errorf("Expected to update %+v but got %+v", test.ExpectedUpdate, updateCrts)
 			}
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**: Previously ingress-shim did not reconfigure certificates when the ingress config changed.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #288 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
ingress-shim now reconfigures certificates
```
