### PR TITLE
Add podAnnotations

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.4
+version: 0.2.5
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -73,6 +73,7 @@ The following tables lists the configurable parameters of the cert-manager chart
 | `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
 | `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
 | `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+| `podAnnotations` | Annotations to add to each pod | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -73,7 +73,7 @@ The following tables lists the configurable parameters of the cert-manager chart
 | `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
 | `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
 | `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
-| `podAnnotations` | Annotations to add to each pod | `{}` |
+| `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -15,6 +15,10 @@ spec:
       labels:
         app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       containers:

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -34,6 +34,8 @@ resources: {}
   #   cpu: 10m
   #   memory: 32Mi
 
+podAnnotations: {}
+
 nodeSelector: {}
 
 ingressShim:

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: cert-manager
         release: cert-manager
+      annotations:
     spec:
       serviceAccountName: cert-manager
       containers:

--- a/docs/deploy/rbac/issuer-crd.yaml
+++ b/docs/deploy/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -17,6 +17,7 @@ spec:
       labels:
         app: cert-manager
         release: cert-manager
+      annotations:
     spec:
       serviceAccountName: default
       containers:

--- a/docs/deploy/without-rbac/issuer-crd.yaml
+++ b/docs/deploy/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.4
+    chart: cert-manager-0.2.5
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR add podAnnotations value to the deployment resource.

This is useful if you want to use the Route53 provider together with Kube2Iam to allocate AWS role to a pod.

```
annotations:
   "iam.amazonaws.com/role":"arn:aws:iam::<project id>:role/CertManagerRole"
```

**Which issue this PR fixes**

https://github.com/jetstack/cert-manager/issues/195

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add podAnnotations to Helm chart
```