### PR TITLE
Annotate created secrets with cert information

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -20,6 +20,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	AltNamesAnnotationKey   = "certmanager.k8s.io/alt-names"
+	CommonNameAnnotationKey = "certmanager.k8s.io/common-name"
+	IssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
+	IssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
+)
+
 // +genclient
 // +genclient:nonNamespaced
 // +k8s:openapi-gen=true

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -239,6 +239,9 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 	}
 	secret.Annotations[v1alpha1.AltNamesAnnotationKey] = strings.Join(dnsnames, ",")
 
+	// Note: since this sets annotations based on certificate resource, incorrect
+	// annotations will be set if resource and actual certificate somehow get out
+	// of sync
 	cn, err := pki.CommonNameForCertificate(crt)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**: Previously, it was hard to inspect why a secret was created. This adds additional information in the form of annotations which should help keep track of created secrets.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #262 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
TLS secrets are now annotated with information about the certificate
```
