### PR TITLE
Fix verify-chart-version script when running more than once

### DIFF
--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -25,7 +25,10 @@ if [ "${PULL_BASE_SHA}" == "" ]; then
     exit 1
 fi
 
-git remote add jetstack https://github.com/jetstack/cert-manager
+if ! git remote get-url jetstack; then
+  git remote add jetstack https://github.com/jetstack/cert-manager
+fi
+
 git fetch jetstack "${PULL_BASE_SHA}:refs/remotes/jetstack/pull-base"
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously when the verify-chart-version script was run more than once, it would fail.

**Release note**:
```release-note
NONE
```
