### PR TITLE
make: split 'verify_pr' out 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,4 +23,4 @@ jobs:
       language: go
       go: 1.9
       script:
-      - make verify test
+      - make verify verify_pr test

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,16 @@ GOOS := linux
 GOARCH := amd64
 GOLDFLAGS := -ldflags "-X $(PACKAGE_NAME)/pkg/util.AppGitState=${GIT_STATE} -X $(PACKAGE_NAME)/pkg/util.AppGitCommit=${GIT_COMMIT} -X $(PACKAGE_NAME)/pkg/util.AppVersion=${APP_VERSION}"
 
-.PHONY: verify build docker_build push generate generate_verify $(CMDS) go_test go_fmt $(DOCKER_BUILD_TARGETS) $(DOCKER_PUSH_TARGETS)
+.PHONY: verify build docker_build push generate generate_verify deploy_verify \
+	$(CMDS) go_test go_fmt e2e_test go_verify hack_verify hack_verify_pr \
+	$(DOCKER_BUILD_TARGETS) $(DOCKER_PUSH_TARGETS)
 
 # Alias targets
 ###############
 
 build: $(CMDS) docker_build
 verify: generate_verify deploy_verify hack_verify go_verify
+verify_pr: hack_verify_pr
 docker_build: $(DOCKER_BUILD_TARGETS)
 docker_push: $(DOCKER_PUSH_TARGETS)
 push: build docker_push
@@ -64,6 +67,8 @@ hack_verify:
 	$(HACK_DIR)/verify-links.sh
 	@echo Running errexit checker
 	$(HACK_DIR)/verify-errexit.sh
+
+hack_verify_pr:
 	@echo Running helm chart version checker
 	$(HACK_DIR)/verify-chart-version.sh
 

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ GOLDFLAGS := -ldflags "-X $(PACKAGE_NAME)/pkg/util.AppGitState=${GIT_STATE} -X $
 # Alias targets
 ###############
 
-verify: generate_verify deploy_verify hack_verify go_verify
 build: $(CMDS) docker_build
+verify: generate_verify deploy_verify hack_verify go_verify
 docker_build: $(DOCKER_BUILD_TARGETS)
 docker_push: $(DOCKER_PUSH_TARGETS)
 push: build docker_push

--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -20,7 +20,7 @@ set -o pipefail
 semvercompareOldVer=""
 semvercompareNewVer=""
 
-if [ "${PULL_BASE_SHA}" == "" ]; then
+if [ -z "${PULL_BASE_SHA+a}" ]; then
     echo "PULL_BASE_SHA must be set"
     exit 1
 fi
@@ -31,7 +31,7 @@ fi
 
 git fetch jetstack "${PULL_BASE_SHA}:refs/remotes/jetstack/pull-base"
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT="$(dirname "${BASH_SOURCE}")/.."
 
 CHANGED_FOLDERS=`git diff --find-renames --name-only $(git merge-base jetstack/pull-base HEAD) "${SCRIPT_ROOT}/contrib/charts/" | awk -F/ '{print $1"/"$2"/"$3}' | uniq`
 


### PR DESCRIPTION
This is a followup/fixup for #372 

The changes in 372 broke break running `make verify` locally, which I think is a somewhat useful developer command.

While I was at it, I also changed the default target to build since I think that's more likely what someone wants. I don't think that breaks anything since I think other places have explicitly been calling out which targets to call.

This also requires https://github.com/jetstack/test-infra/pull/158 to not lose that new coverage