### PR TITLE
Running docker containers as non-root user

### DIFF
--- a/hack/build/dockerfiles/controller/Dockerfile
+++ b/hack/build/dockerfiles/controller/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.6
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && \
+  addgroup -S certmanager && adduser -S -G certmanager certmanager
 
 ADD cert-manager-controller_linux_amd64 /usr/bin/cert-manager
+
+USER certmanager
 
 ENTRYPOINT ["/usr/bin/cert-manager"]
 ARG VCS_REF

--- a/hack/build/dockerfiles/ingress-shim/Dockerfile
+++ b/hack/build/dockerfiles/ingress-shim/Dockerfile
@@ -1,8 +1,11 @@
 FROM alpine:3.6
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && \
+  addgroup -S certmanager && adduser -S -G certmanager certmanager
 
 ADD cert-manager-ingress-shim_linux_amd64 /usr/bin/ingress-shim
+
+USER certmanager
 
 ENTRYPOINT ["/usr/bin/ingress-shim"]
 ARG VCS_REF


### PR DESCRIPTION
**What this PR does / why we need it**:
I've added a user to the controller and ingress-shim Dockerfiles. The processes don't need root access so I figured I might as well limit it.

```release-note
Run cert-manager container as a non root user
```