### PR TITLE
fix for long domain names

### DIFF
--- a/Makefile-Docker
+++ b/Makefile-Docker
@@ -1,0 +1,34 @@
+# 1. Create docker image:
+# docker build -t build-cert-manager -f Makefile-Docker .
+
+# 2. Run make
+# docker run -it --privileged -v /var/run/docker.sock:/var/run/docker.sock build-cert-manager
+
+# You should end up with Docker images tagged as:
+# quay.io/jetstack/cert-manager-ingress-shim:build
+# quay.io/jetstack/cert-manager-acmesolver:build
+# quay.io/jetstack/cert-manager-controller:build
+
+# 3. Push these somewhere if you want to use them yourself:
+# docker tag quay.io/jetstack/cert-manager-ingress-shim:build prlx/cert-manager-ingress-shim:build 
+# docker tag quay.io/jetstack/cert-manager-acmesolver:build prlx/cert-manager-acmesolver:build
+# docker tag quay.io/jetstack/cert-manager-controller:build prlx/cert-manager-controller:build
+# docker push prlx/cert-manager-ingress-shim:build 
+# docker push prlx/cert-manager-acmesolver:build
+# docker push prlx/cert-manager-controller:build
+
+FROM golang:1.10.1-stretch
+
+RUN apt-get update && apt-get install -y git make bash curl gcc build-essential apt-transport-https ca-certificates gnupg2 software-properties-common
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+
+RUN add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(lsb_release -cs) stable"
+
+RUN apt-get update && apt-get install -y docker-ce
+
+ADD / /go/src/github.com/jetstack/cert-manager
+
+WORKDIR /go/src/github.com/jetstack/cert-manager
+
+CMD make verify build

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -39,16 +39,16 @@ const (
 
 // svcNameFunc returns the name for the service to solve the challenge
 func svcNameFunc(crtName, domain string) string {
-	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, util.RandStringRunes(5)))
+	return dns1035(fmt.Sprintf("cm-%.54s-%s", crtName, util.RandStringRunes(5)))
 }
 
 // ingNameFunc returns the name for the ingress to solve the challenge
 func ingNameFunc(crtName, domain string) string {
-	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, util.RandStringRunes(5)))
+	return dns1035(fmt.Sprintf("cm-%.54s-%s", crtName, util.RandStringRunes(5)))
 }
 
 func podNameFunc(crtName, domain string) string {
-	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, util.RandStringRunes(5)))
+	return dns1035(fmt.Sprintf("cm-%.54s-%s", crtName, util.RandStringRunes(5)))
 }
 
 // Solver is an implementation of the acme http-01 challenge solver protocol
@@ -96,7 +96,6 @@ func NewSolver(issuer v1alpha1.GenericIssuer, client kubernetes.Interface, secre
 func labelsForCert(crt *v1alpha1.Certificate, domain string) map[string]string {
 	return map[string]string{
 		"certmanager.k8s.io/managed":     "true",
-		"certmanager.k8s.io/domain":      domain,
 		"certmanager.k8s.io/certificate": crt.Name,
 		"certmanager.k8s.io/id":          util.RandStringRunes(5),
 	}


### PR DESCRIPTION
fixes #425, allowing long domain names to be used for http01 auth

**Special notes for your reviewer**:

- Adds a dockerfile to aid in running Make
- Limits lengths of service, ingress and pod names
- Eliminates domain from label map for http01 auth - I think that certName and RandStringRunes(5) will provide adequate collision protection

```release-notes
none
```