### PR TITLE
release-0.2: Add empty 'verify_pr' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ GOLDFLAGS := -ldflags "-X $(PACKAGE_NAME)/pkg/util.AppGitState=${GIT_STATE} -X $
 ###############
 
 verify: generate_verify hack_verify go_verify
+verify_pr:
+	# This target is intentionaly blank. This is to allow the new e2e test
+	# invocation syntax to not fail since #397 merged
+
 build: $(CMDS) docker_build
 docker_build: $(DOCKER_BUILD_TARGETS)
 docker_push: $(DOCKER_PUSH_TARGETS)


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a follow up to #397 where we also switched the Prow scenario spec to run 'verify_pr' as part of the quick-verify test process

**Special notes for your reviewer**:

This is required to fix builds on release-0.2

**Release note**:
```release-note
NONE
```
