### PR TITLE
add selector, as otherwise it fails on GKE k8s v1.9.x

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.5
+version: 0.2.6
 appVersion: 0.2.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -10,6 +10,10 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "cert-manager.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cert-manager
+      release: cert-manager
   template:
     metadata:
       labels:

--- a/docs/deploy/rbac/issuer-crd.yaml
+++ b/docs/deploy/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -7,11 +7,15 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: cert-manager
+      release: cert-manager
   template:
     metadata:
       labels:

--- a/docs/deploy/without-rbac/issuer-crd.yaml
+++ b/docs/deploy/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.5
+    chart: cert-manager-0.2.6
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
add `selector` to deployment as otherwise it fails on GKE k8s v1.9.x

```release-note
NONE
```