### PR TITLE
Bump chart version

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: 0.2.6
-appVersion: 0.2.3
+version: 0.2.7
+appVersion: 0.2.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/contrib/charts/cert-manager/templates/NOTES.txt
+++ b/contrib/charts/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://github.com/jetstack/cert-manager/tree/v0.2.3/docs/api-types/issuer
+https://github.com/jetstack/cert-manager/tree/v0.2.4/docs/api-types/issuer
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://github.com/jetstack/cert-manager/blob/v0.2.3/docs/user-guides/ingress-shim.md
+https://github.com/jetstack/cert-manager/blob/v0.2.4/docs/user-guides/ingress-shim.md

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.2.3
+  tag: v0.2.4
   pullPolicy: IfNotPresent
 
 createCustomResource: true

--- a/docs/deploy/rbac/certificate-crd.yaml
+++ b/docs/deploy/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/deployment.yaml
+++ b/docs/deploy/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.2.3"
+          image: "quay.io/jetstack/cert-manager-controller:v0.2.4"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -41,7 +41,7 @@ spec:
               memory: 32Mi
             
         - name: ingress-shim
-          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.3"
+          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.4"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/docs/deploy/rbac/issuer-crd.yaml
+++ b/docs/deploy/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/rbac/rbac.yaml
+++ b/docs/deploy/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/docs/deploy/rbac/serviceaccount.yaml
+++ b/docs/deploy/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller

--- a/docs/deploy/without-rbac/certificate-crd.yaml
+++ b/docs/deploy/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/clusterissuer-crd.yaml
+++ b/docs/deploy/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/deploy/without-rbac/deployment.yaml
+++ b/docs/deploy/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.2.3"
+          image: "quay.io/jetstack/cert-manager-controller:v0.2.4"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -41,7 +41,7 @@ spec:
               memory: 32Mi
             
         - name: ingress-shim
-          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.3"
+          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.4"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/docs/deploy/without-rbac/issuer-crd.yaml
+++ b/docs/deploy/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.6
+    chart: cert-manager-0.2.7
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/examples/cert-manager.yaml
+++ b/docs/examples/cert-manager.yaml
@@ -13,8 +13,8 @@ spec:
     spec:
       containers:
       - name: cert-manager
-        image: quay.io/jetstack/cert-manager-controller:v0.2.3
+        image: quay.io/jetstack/cert-manager-controller:v0.2.4
         imagePullPolicy: Always
       - name: ingress-shim
-        image: quay.io/jetstack/cert-manager-ingress-shim:v0.2.3
+        image: quay.io/jetstack/cert-manager-ingress-shim:v0.2.4
         imagePullPolicy: Always


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the chart version for 0.2.4

This PR should then be cherry picked into release-0.2 and the conflicts resolved.

**Release note**:
```release-note
NONE
```
