### PR TITLE
Allow add custom annotations when using ingressClass

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -285,8 +285,9 @@ type ACMECertificateDomainConfig struct {
 }
 
 type ACMECertificateHTTP01Config struct {
-	Ingress      string  `json:"ingress"`
-	IngressClass *string `json:"ingressClass,omitempty"`
+	Ingress      string            `json:"ingress"`
+	IngressClass *string           `json:"ingressClass,omitempty"`
+	Annotations  map[string]string `json:"annotations,omitempty"`
 }
 
 type ACMECertificateDNS01Config struct {

--- a/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
@@ -114,6 +114,13 @@ func (in *ACMECertificateHTTP01Config) DeepCopyInto(out *ACMECertificateHTTP01Co
 			**out = **in
 		}
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -244,6 +244,9 @@ func (s *Solver) ensureIngressHasRule(ingName string, crt *v1alpha1.Certificate,
 	}
 	if domainCfg.HTTP01.IngressClass != nil {
 		ing.Annotations[class.IngressKey] = *domainCfg.HTTP01.IngressClass
+		for k, v := range domainCfg.HTTP01.Annotations {
+			ing.Annotations[k] = v
+		}
 	}
 	if ing.Labels == nil {
 		ing.Labels = make(map[string]string)


### PR DESCRIPTION
**What this PR does / why we need it**:
The main purpose of this PR is to allow us to add custom annotations when using ingressClass. For example after the change we can add annotations for whitelists like:

```
apiVersion: certmanager.k8s.io/v1alpha1
kind: Certificate
metadata:
  name: testcertificate
spec:
  acme:
    config:
    - domains:
      - my.host.com
      http01:
        ingressClass: nginx
        annotations:
          nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0
  dnsNames:
  - my.host.com
  issuerRef:
    kind: ClusterIssuer
    name: letsencrypt-staging
  secretName: testcertificate
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #374

**Special notes for your reviewer**: Please let me know if you think I should do it in a different way and I'll update the PR as soon as possible.

**Release note**:
```NONE
```
