### PR TITLE
Allow ingressClass to be specified for ingress-shim

### DIFF
--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -237,7 +237,7 @@ func shouldSync(ing *extv1beta1.Ingress) bool {
 	if _, ok := annotations[acmeIssuerDNS01ProviderNameAnnotation]; ok {
 		return true
 	}
-	if s, ok := annotations[ingressClassAnnotation]; ok {
+	if s, ok := annotations[editInPlaceAnnotation]; ok {
 		if b, _ := strconv.ParseBool(s); b {
 			return true
 		}

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -187,7 +187,7 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 		case "http01":
 			editInPlace, ok := ingAnnotations[editInPlaceAnnotation]
 			// If annotation isn't present, or it's set to true, edit the existing ingress
-			if !ok || (ok && editInPlace == "true") {
+			if ok && editInPlace == "true" {
 				domainCfg.HTTP01 = &v1alpha1.ACMECertificateHTTP01Config{Ingress: ing.Name}
 			} else {
 				ingressClass, ok := ingAnnotations["kubernetes.io/ingress.class"]

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -22,7 +22,7 @@ const (
 	tlsACMEAnnotation = "kubernetes.io/tls-acme"
 	// editInPlaceAnnotation is used to toggle the use of ingressClass instead
 	// of ingress on the created Certificate resource
-	editInPlaceAnnotation = "certmanager.k8s.io/edit-in-place"
+	editInPlaceAnnotation = "certmanager.k8s.io/acme-http01-edit-in-place"
 	// issuerNameAnnotation can be used to override the issuer specified on the
 	// created Certificate resource.
 	issuerNameAnnotation = "certmanager.k8s.io/issuer"

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -232,8 +232,7 @@ func shouldSync(ing *extv1beta1.Ingress) bool {
 	if _, ok := annotations[acmeIssuerDNS01ProviderNameAnnotation]; ok {
 		return true
 	}
-	if s, ok := annotations[ingressClassAnnotation]; ok {
-		glog.Infof("%s: %s", annotations[ingressClassAnnotation], s)
+	if _, ok := annotations[ingressClassAnnotation]; ok {
 		return true
 	}
 	return false

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -191,10 +191,9 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 				domainCfg.HTTP01 = &v1alpha1.ACMECertificateHTTP01Config{Ingress: ing.Name}
 			} else {
 				ingressClass, ok := ingAnnotations["kubernetes.io/ingress.class"]
-				if !ok {
-					return fmt.Errorf("unable to determine class of ingress %s", ing.Name)
+				if ok {
+					domainCfg.HTTP01 = &v1alpha1.ACMECertificateHTTP01Config{IngressClass: &ingressClass}
 				}
-				domainCfg.HTTP01 = &v1alpha1.ACMECertificateHTTP01Config{IngressClass: &ingressClass}
 			}
 		case "dns01":
 			dnsProvider, ok := ingAnnotations[acmeIssuerDNS01ProviderNameAnnotation]

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -237,11 +237,6 @@ func shouldSync(ing *extv1beta1.Ingress) bool {
 	if _, ok := annotations[acmeIssuerDNS01ProviderNameAnnotation]; ok {
 		return true
 	}
-	if s, ok := annotations[editInPlaceAnnotation]; ok {
-		if b, _ := strconv.ParseBool(s); b {
-			return true
-		}
-	}
 	return false
 }
 

--- a/cmd/ingress-shim/controller/sync.go
+++ b/cmd/ingress-shim/controller/sync.go
@@ -20,7 +20,7 @@ const (
 	// the default configuration provided to ingress-annotation should be
 	// created.
 	tlsACMEAnnotation = "kubernetes.io/tls-acme"
-	// ingressClassAnnotation is used to toggle the use of ingressClass instead
+	// editInPlaceAnnotation is used to toggle the use of ingressClass instead
 	// of ingress on the created Certificate resource
 	editInPlaceAnnotation = "certmanager.k8s.io/edit-in-place"
 	// issuerNameAnnotation can be used to override the issuer specified on the

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -48,6 +48,10 @@ func TestShouldSync(t *testing.T) {
 			ShouldSync:  true,
 		},
 		{
+			Annotations: map[string]string{editInPlaceAnnotation: ""},
+			ShouldSync:  true,
+		},
+		{
 			ShouldSync: false,
 		},
 	}

--- a/cmd/ingress-shim/controller/sync_test.go
+++ b/cmd/ingress-shim/controller/sync_test.go
@@ -48,10 +48,6 @@ func TestShouldSync(t *testing.T) {
 			ShouldSync:  true,
 		},
 		{
-			Annotations: map[string]string{editInPlaceAnnotation: ""},
-			ShouldSync:  true,
-		},
-		{
 			ShouldSync: false,
 		},
 	}

--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -68,5 +68,11 @@ Certificate resources to be automatically created:
   configuration of the ingress-shim (see above). Namely, a default issuer must be
   specified as arguments to the ingress-shim container.
 
+* ``certmanager.k8s.io/ingress-class: ""`` - by default, if the
+'kubernetes.io/tls-acme' annotation is set to "True", the resulting Certificate
+is created with 'ingest: <name>' in the acme spec. If present, this annotation
+will alter this behaviour and supply 'ingestClass: <value>' when creating the
+Certificate.
+
 .. _kube-lego: https://github.com/jetstack/kube-lego
 .. _ingress-shim: https://github.com/jetstack/cert-manager/tree/master/cmd/ingress-shim

--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -69,9 +69,9 @@ Certificate resources to be automatically created:
   specified as arguments to the ingress-shim container.
 
 * ``certmanager.k8s.io/ingress-class: ""`` - by default, if the
-'kubernetes.io/tls-acme' annotation is set to "True", the resulting Certificate
-is created with 'ingest: <name>' in the acme spec. If present, this annotation
-will alter this behaviour and supply 'ingestClass: <value>' when creating the
+'kubernetes.io/tls-acme' annotation is set to "true", the resulting Certificate
+is created with 'ingress: <name>' in the acme spec. If present, this annotation
+will alter this behaviour and supply 'ingressClass: <value>' when creating the
 Certificate.
 
 .. _kube-lego: https://github.com/jetstack/kube-lego

--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -68,11 +68,11 @@ Certificate resources to be automatically created:
   configuration of the ingress-shim (see above). Namely, a default issuer must be
   specified as arguments to the ingress-shim container.
 
-* ``certmanager.k8s.io/ingress-class: ""`` - by default, if the
-'kubernetes.io/tls-acme' annotation is set to "true", the resulting Certificate
-is created with 'ingress: <name>' in the acme spec. If present, this annotation
-will alter this behaviour and supply 'ingressClass: <value>' when creating the
-Certificate.
+* ``certmanager.k8s.io/edit-in-place""`` - if the ACME challenge type has been
+  set to http01, and the ingress has the 'kubernetes.io/tls-acme: true'
+  annotation, this controls whether the ingress is modified 'in-place', or a new
+  one created specifically for the http01 challenge. Must be 'true' or 'false'.
+  Defaults to 'false'
 
 .. _kube-lego: https://github.com/jetstack/kube-lego
 .. _ingress-shim: https://github.com/jetstack/cert-manager/tree/master/cmd/ingress-shim

--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -68,11 +68,12 @@ Certificate resources to be automatically created:
   configuration of the ingress-shim (see above). Namely, a default issuer must be
   specified as arguments to the ingress-shim container.
 
-* ``certmanager.k8s.io/edit-in-place""`` - if the ACME challenge type has been
-  set to http01, and the ingress has the 'kubernetes.io/tls-acme: true'
+* ``certmanager.k8s.io/acme-http01-edit-in-place""`` - if the ACME challenge type
+  has been set to http01, and the ingress has the 'kubernetes.io/tls-acme: true'
   annotation, this controls whether the ingress is modified 'in-place', or a new
-  one created specifically for the http01 challenge. Must be 'true' or 'false'.
-  Defaults to 'false'
+  one created specifically for the http01 challenge. If present, and set to "true"
+  the existing ingress will be modified. Any other value, or the absence of the
+  annotation assumes "false".
 
 .. _kube-lego: https://github.com/jetstack/kube-lego
 .. _ingress-shim: https://github.com/jetstack/cert-manager/tree/master/cmd/ingress-shim


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:
This allows an Ingress to be annotated with 'certmanager.k8s.io/ingress-class: nginx', which signals that any Certificates created for this Ingress resource that use HTTP01 challenges should use ingressClass: <value> instead of ingress: <name>

**Which issue this PR fixes** fixes #235, fixes #454

**Special notes for your reviewer**:

I'm not overly familiar with Go, so I expect there might be some things I need to tidy up. I'm not convinced the presence of the annotation should trigger a sync, either. Please let me know if you'd like something changed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
