### PR TITLE
Call Prepare even if Check fails

### DIFF
--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -202,11 +202,8 @@ func (a *Acme) presentChallenge(ctx context.Context, cl client.Interface, crt *v
 		return err
 	}
 
-	ok, err := solver.Check(ch)
-	if err != nil {
-		return err
-	}
-
+	// we defer checking checkErr to ensure that we call Present
+	ok, checkErr := solver.Check(ch)
 	if ok {
 		return nil
 	}
@@ -217,6 +214,9 @@ func (a *Acme) presentChallenge(ctx context.Context, cl client.Interface, crt *v
 	//       as we are just waiting for propagation
 	err = solver.Present(ctx, crt, ch)
 	if err != nil {
+		return err
+	}
+	if checkErr != nil {
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Since #309, if a HTTP endpoint is returning an error, e.g. TLS cert expired, which can often be the case with any old/expired domain, Prepare will never be called.

This changes the behaviour to always call Prepare even if Check returns an error.

**Release note**:
```release-note
NONE
```

/assign