### PR TITLE
Absorb HTTP client errors in acme http self check

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -113,7 +113,8 @@ func testReachability(ctx context.Context, domain, path, key string) (bool, erro
 
 	response, err := http.Get(url.String())
 	if err != nil {
-		return false, err
+		// absorb http client errors
+		return false, nil
 	}
 
 	if response.StatusCode != http.StatusOK {


### PR DESCRIPTION
**What this PR does / why we need it**:

As an alternative to #458, this change absorbs HTTP client errors in the ACME http self check.

Previously we would fail if connection to the server failed, which caused Prepare to not be called. This absorbs all errors, returning 'false' for the self check.

**Release note**:
```release-note
NONE
```

/assign
