### PR TITLE
Sync cert-manager chart with kubernetes/charts

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: 0.2.8
+version: 0.2.9
 appVersion: 0.2.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -49,7 +49,7 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the cert-manager chart and their default values.
+The following table lists the configurable parameters of the cert-manager chart and their default values.
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |

--- a/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/rbac.yaml
+++ b/contrib/manifests/cert-manager/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
+++ b/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller

--- a/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.8
+    chart: cert-manager-0.2.9
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
Includes a typo fix from @AdamDang.

```release-note
none
```
