### PR TITLE
Add back the commit sha in the `org.label-schema.vcs-ref` label.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ DOCKER_PUSH_TARGETS := $(addprefix docker_push_, $(CMDS))
 # Go build flags
 GOOS := linux
 GOARCH := amd64
+GIT_COMMIT := $(shell git rev-parse HEAD)
 GOLDFLAGS := -ldflags "-X $(PACKAGE_NAME)/pkg/util.AppGitState=${GIT_STATE} -X $(PACKAGE_NAME)/pkg/util.AppGitCommit=${GIT_COMMIT} -X $(PACKAGE_NAME)/pkg/util.AppVersion=${APP_VERSION}"
 
 .PHONY: verify build docker_build push generate generate_verify deploy_verify \


### PR DESCRIPTION
It looks like it was accidentally removed in commit
8c7eaa1db8e4143254b14711f3fa3fdcaa53e22c

**What this PR does / why we need it**:
Adds back the commit sha label for the docker images

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
None 

**Release note**:

N/A
