### PR TITLE
Remove 'latest' docker image tag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,6 +50,6 @@ release_push:
   - docker
   script:
   - mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json
-  - APP_VERSION=${CI_COMMIT_TAG} make verify build push IMAGE_TAGS="${CI_COMMIT_TAG} latest"
+  - APP_VERSION=${CI_COMMIT_TAG} make verify build push IMAGE_TAGS="${CI_COMMIT_TAG}"
   only:
   - tags


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the 'latest' image tag from the push_release step. This tag doesn't currently behave properly, and isn't referenced anywhere.

We have :canary which tracks master as well as release tags, I don't think we need anything more for now.

**Release note**:
```release-note
NONE
```

/assign
