### PR TITLE
Sync helm chart from kubernetes/charts back to release-0.2

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,4 +1,15 @@
-apiVersion: v1
-description: A Helm chart for Kubernetes
 name: cert-manager
-version: 0.1.0
+version: 0.2.9
+appVersion: 0.2.4
+description: A Helm chart for cert-manager
+home: https://github.com/jetstack/cert-manager
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+sources:
+  - https://github.com/jetstack/cert-manager
+maintainers:
+  - name: munnerz
+    email: james@jetstack.io

--- a/contrib/charts/cert-manager/OWNERS
+++ b/contrib/charts/cert-manager/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- munnerz
+- simonswine
+- kragniz
+reviewers:
+- munnerz
+- unguiculus
+- simonswine
+- kragniz

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -6,27 +6,34 @@ TLS certificates from various issuing sources.
 It will ensure certificates are valid and up to date periodically, and attempt
 to renew certificates at an appropriate time before expiry.
 
-## TL;DR;
-
-```console
-$ helm install .
-```
-
-## Introduction
-
-This chart creates a cert-manager deployment on a Kubernetes cluster using the Helm package manager.
-
 ## Prerequisites
 
-- Kubernetes cluster with support for CustomResourceDefinition or ThirdPartyResource
+- Kubernetes 1.7+
 
 ## Installing the Chart
+
+Full installation instructions, including details on how to configure extra
+functionality in cert-manager can be found in the [getting started docs](https://cert-manager.readthedocs.io/en/latest/getting-started/).
 
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release .
+$ helm install --name my-release stable/cert-manager
 ```
+
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
+
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
 
 > **Tip**: List all releases using `helm list`
 
@@ -42,17 +49,31 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following tables lists the configurable parameters of the cert-manager chart and their default values.
+The following table lists the configurable parameters of the cert-manager chart and their default values.
 
-| Parameter              | Description                             | Default                                        |
-| ---------------------- | --------------------------------------- | ---------------------------------------------- |
-| `image.repository`     | Image repository                        | `quay.io/jetstack/cert-manager-controller`     |
-| `image.tag`            | Image tag                               | `v0.2.3`                                       |
-| `image.pullPolicy`     | Image pull policy                       | `Always`                                       |
-| `replicaCount`         | Number of cert-manager replicas         | `1`                                            |
-| `createCustomResource` | Create CRD/TPR with this release        | `true`                                         |
-| `rbac.enabled`         | Create RBAC resources with this release | `true`                                         |
-| `resources`            | CPU/Memory resource requests/limits     | `None`                                         |
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
+| `image.tag` | Image tag | `v0.2.3` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `replicaCount`  | Number of cert-manager replicas  | `1` |
+| `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
+| `extraArgs` | Optional flags for cert-manager | `[]` |
+| `rbac.create` | If `true`, create and use RBAC resources | `true`
+| `serviceAccount.create` | If `true`, create a new service account | `true`
+| `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template | ``
+| `resources` | CPU/memory resource requests/limits | `requests: {cpu: 10m, memory: 32Mi}` |
+| `nodeSelector` | Node labels for pod assignment | `{}` |
+| `affinity` | Node affinity for pod assignment | `{}` |
+| `tolerations` | Node tolerations for pod assignment | `[]` |
+| `ingressShim.enabled` | Enable ingress-shim for automatic ingress integration | `true`|
+| `ingressShim.extraArgs` | Optional flags for ingress-shim | `[]` |
+| `ingressShim.resources` | CPU/memory resource requests/limits for ingress-shim | `requests: {cpu: 10m, memory: 32Mi}` |
+| `ingressShim.image.repository` | Image repository for ingress-shim | `quay.io/jetstack/cert-manager-ingress-shim` |
+| `ingressShim.image.tag` | Image tag for ingress-shim. Defaults to `image.tag` if empty | `` |
+| `ingressShim.image.pullPolicy` | Image pull policy for ingress-shim | `IfNotPresent` |
+| `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/contrib/charts/cert-manager/templates/NOTES.txt
+++ b/contrib/charts/cert-manager/templates/NOTES.txt
@@ -1,0 +1,15 @@
+cert-manager has been deployed successfully!
+
+In order to begin issuing certificates, you will need to set up a ClusterIssuer
+or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
+
+More information on the different types of issuers and how to configure them
+can be found in our documentation:
+
+https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+
+For information on how to configure cert-manager to automatically provision
+Certificates for Ingress resources, take a look at the `ingress-shim`
+documentation:
+
+https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html

--- a/contrib/charts/cert-manager/templates/_helpers.tpl
+++ b/contrib/charts/cert-manager/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "name" -}}
+{{- define "cert-manager.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -10,7 +10,26 @@ Expand the name of the chart.
 Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "fullname" -}}
+{{- define "cert-manager.fullname" -}}
 {{- $name := default .Chart.Name .Values.nameOverride -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- $fullname := printf "%s-%s" $name .Release.Name -}}
+{{- default $fullname .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cert-manager.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cert-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cert-manager.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/certificate-crd.yaml
+++ b/contrib/charts/cert-manager/templates/certificate-crd.yaml
@@ -1,23 +1,22 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
+  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
-  scope: Namespaced
-{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: certificate.certmanager.k8s.io
-description: "A specification for a cert-manager certificate"
-versions:
-- name: v1alpha1
-{{- end -}}
+    {{- if .Values.certificateResourceShortNames }}
+    shortNames:
+{{ toYaml .Values.certificateResourceShortNames | indent 6 }}
+    {{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
@@ -11,5 +15,4 @@ spec:
     kind: ClusterIssuer
     plural: clusterissuers
   scope: Cluster
-{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -1,44 +1,70 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "cert-manager.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "name" . }}
+        app: {{ template "cert-manager.name" . }}
         release: {{ .Release.Name }}
+      annotations:
+      {{- if .Values.podAnnotations }}
+{{ toYaml .Values.podAnnotations | indent 8 }}
+      {{- end }}
     spec:
-      serviceAccount: {{ template "fullname" . }}
-      serviceAccountName: {{ template "fullname" . }}
+      serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-{{- range .Values.extraArgs }}
-          - {{ . }}
-{{- end }}
+          # This is currently commented out until the 0.3 release of
+          # cert-manager, as it results in a breaking change (users will need
+          # to move credentials/acme private keys from kube-system into the
+          # same namespace cert-manager is deployed into.
+          # - --cluster-resource-namespace=$(POD_NAMESPACE)
+        {{- if .Values.extraArgs }}
+{{ toYaml .Values.extraArgs | indent 10 }}
+        {{- end }}
+          env:
+          - name: POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
           resources:
 {{ toYaml .Values.resources | indent 12 }}
 {{- if .Values.ingressShim.enabled }}
         - name: ingress-shim
-          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag | default .Values.image.tag }}"
+          image: "{{ .Values.ingressShim.image.repository }}:{{ default .Values.ingressShim.image.tag .Values.image.tag }}"
           imagePullPolicy: {{ .Values.ingressShim.image.pullPolicy }}
+        {{- if .Values.ingressShim.extraArgs }}
           args:
-{{- range .Values.ingressShim.extraArgs }}
-          - {{ . }}
-{{- end }}
+{{ toYaml .Values.ingressShim.extraArgs | indent 10 }}
+        {{- end }}
           resources:
 {{ toYaml .Values.ingressShim.resources | indent 12 }}
 {{- end }}
-{{- if .Values.nodeSelector }}
+    {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml .Values.nodeSelector | indent 8 }}
-{{- end }}
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/contrib/charts/cert-manager/templates/issuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/issuer-crd.yaml
@@ -1,9 +1,13 @@
 {{- if .Values.createCustomResource -}}
-{{- if .Capabilities.APIVersions.Has "apiextensions.k8s.io/v1beta1" -}}
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
 spec:
   group: certmanager.k8s.io
   version: v1alpha1
@@ -11,13 +15,4 @@ spec:
     kind: Issuer
     plural: issuers
   scope: Namespaced
-{{ else if .Capabilities.APIVersions.Has "extensions/v1beta1"  }}
-apiVersion: extensions/v1beta1
-kind: ThirdPartyResource
-metadata:
-  name: issuer.certmanager.k8s.io
-description: "A specification for a cert-manager issuer"
-versions:
-- name: v1alpha1
-{{- end -}}
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/rbac.yaml
+++ b/contrib/charts/cert-manager/templates/rbac.yaml
@@ -1,39 +1,44 @@
-{{- if .Values.rbac.enabled -}}
+{{- if .Values.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 rules:
-- apiGroups: ["certmanager.k8s.io"]
-  resources: ["certificates", "issuers", "clusterissuers"]
-  verbs: ["*"]
-- apiGroups: [""]
-  resources: ["secrets", "events", "endpoints", "services", "pods"]
-  verbs: ["*"]
-- apiGroups: ["extensions"]
-  resources: ["ingresses"]
-  verbs: ["*"]
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers", "clusterissuers"]
+    verbs: ["*"]
+  - apiGroups: [""]
+    # TODO: remove endpoints once 0.4 is released. We include it here in case
+    # users use the 'master' version of the Helm chart with a 0.2.x release of
+    # cert-manager that still performs leader election with Endpoint resources.
+    # We advise users don't do this, but some will anyway and this will reduce
+    # friction.
+    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
+    verbs: ["*"]
+  - apiGroups: ["extensions"]
+    resources: ["ingresses"]
+    verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.fullname" . }}
 subjects:
-- name: {{ template "fullname" . }}
-  namespace: {{ .Release.Namespace | quote }}
-  kind: ServiceAccount
+  - name: {{ template "cert-manager.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace | quote }}
+    kind: ServiceAccount
 {{- end -}}

--- a/contrib/charts/cert-manager/templates/serviceaccount.yaml
+++ b/contrib/charts/cert-manager/templates/serviceaccount.yaml
@@ -1,9 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "fullname" . }}
+  name: {{ template "cert-manager.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
   labels:
-    app: {{ template "name" . }}
-    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- end -}}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -10,28 +10,59 @@ image:
 
 createCustomResource: true
 
+certificateResourceShortNames: ["cert", "certs"]
+
 rbac:
-  enabled: true
+  # Specifies whether RBAC resources should be created
+  create: true
 
-resources:
-  requests:
-    cpu: 10m
-    memory: 32Mi
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:
 
-# Optional additional arguments for cert-manager
+# Optional additional arguments
 extraArgs: []
+  # Use this flag to set a namespace that cert-manager will use to store
+  # supporting resources required for each ClusterIssuer (default is kube-system)
+  # - --cluster-resource-namespace=kube-system
+
+resources: {}
+  # requests:
+  #   cpu: 10m
+  #   memory: 32Mi
+
+podAnnotations: {}
+
+nodeSelector: {}
 
 ingressShim:
   enabled: true
+
   # Optional additional arguments for ingress-shim
   extraArgs: []
-  resources:
-    requests:
-      cpu: 10m
-      memory: 32Mi
+    # Use these flags to specify the default Issuer/ClusterIssuer
+    # (IMPORTANT: You need to create this Issuer/ClusterIssuer resource yourself)
+    # - --default-issuer-name=letsencrypt-prod
+    # - --default-issuer-kind=ClusterIssuer
+
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
   image:
     repository: quay.io/jetstack/cert-manager-ingress-shim
+
     # Defaults to image.tag.
     # You should only change this if you know what you are doing!
-    # tag: v0.2.4
+    # tag: v0.2.3
+
     pullPolicy: IfNotPresent
+
+# This is used by the static manifest generator in order to create a static
+# namespace manifest for the namespace that cert-manager is being installed
+# within. It should **not** be used if you are using Helm for deployment.
+createNamespaceResource: false


### PR DESCRIPTION
**What this PR does / why we need it**:

As per https://github.com/jetstack/cert-manager/issues/489#issue-315504968, this PR syncs the chart in kubernetes/charts back to the release-0.2 branch.

From now on, we will publish changes to the chart from the latest stable release branch to kubernetes/charts periodically.

In future, we may set up a bot to automate this process, or at least remind us to do it ourselves.

**Which issue this PR fixes**: fixes #489

**Release note**:
```release-note
NONE
```
