### PR TITLE
 Bump chart and appVersion on master branch

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: 0.2.9
-appVersion: 0.2.4
+version: v0.3.0-alpha.1
+appVersion: v0.3.0-alpha.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.2.4
+  tag: v0.3.0-alpha.1
   pullPolicy: IfNotPresent
 
 createCustomResource: true
@@ -58,7 +58,7 @@ ingressShim:
 
     # Defaults to image.tag.
     # You should only change this if you know what you are doing!
-    # tag: v0.2.3
+    # tag: v0.3.0-alpha.1
 
     pullPolicy: IfNotPresent
 

--- a/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.2.4"
+          image: "quay.io/jetstack/cert-manager-controller:v0.3.0-alpha.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -41,7 +41,7 @@ spec:
               memory: 32Mi
             
         - name: ingress-shim
-          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.4"
+          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.3.0-alpha.1"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/rbac.yaml
+++ b/contrib/manifests/cert-manager/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
+++ b/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller

--- a/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -26,7 +26,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.2.4"
+          image: "quay.io/jetstack/cert-manager-controller:v0.3.0-alpha.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -41,7 +41,7 @@ spec:
               memory: 32Mi
             
         - name: ingress-shim
-          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.2.4"
+          image: "quay.io/jetstack/cert-manager-ingress-shim:v0.3.0-alpha.1"
           imagePullPolicy: IfNotPresent
           resources:
             requests:

--- a/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-0.2.9
+    chart: cert-manager-v0.3.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the chart and app version on the master branch to the latest tagged prerelease. This PR will also be on the release-0.3 branch after it's fast-forwarded to the head of master.

Part of #489 

**Release note**:
```release-note
NONE
```

/cc @kragniz 
ref #503 