### PR TITLE
Fix wildcard certificate e2e test

### DIFF
--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -453,9 +453,14 @@ func (a *Acme) acceptChallenge(ctx context.Context, cl client.Interface, crt *v1
 		URL:   ch.URL,
 		Token: ch.Token,
 	}
-	_, err := cl.AcceptChallenge(ctx, acmeChal)
+	var err error
+	acmeChal, err = cl.AcceptChallenge(ctx, acmeChal)
 	if err != nil {
 		return err
+	}
+	if acmeChal.Error != nil {
+		glog.Infof("Error accepting challenge for domain %q: %v", ch.Domain, err)
+		return acmeChal.Error
 	}
 
 	glog.Infof("Waiting for authorization for domain %q", ch.Domain)

--- a/test/e2e/certificate/certificate_acme_dns01.go
+++ b/test/e2e/certificate/certificate_acme_dns01.go
@@ -132,22 +132,28 @@ var _ = framework.CertManagerDescribe("ACME Certificate (DNS01)", func() {
 		f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Delete(issuerName, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(testingACMEPrivateKey, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(cloudflareSecretName, nil)
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(certificateSecretName, nil)
 	})
 
 	It("should obtain a signed certificate for a wildcard domain", func() {
 		By("Creating a Certificate")
+		dnsName := cmutil.RandStringRunes(5) + "." + util.ACMECloudflareDomain
 		cert := generate.Certificate(generate.CertificateConfig{
 			Name:       certificateName,
 			Namespace:  f.Namespace.Name,
+			SecretName: certificateSecretName,
 			IssuerName: issuerName,
-			DNSNames:   []string{"*." + cmutil.RandStringRunes(5) + "." + util.ACMECloudflareDomain},
+			DNSNames:   []string{"*." + dnsName},
 			ACMESolverConfig: v1alpha1.ACMESolverConfig{
 				DNS01: &v1alpha1.ACMECertificateDNS01Config{
 					Provider: "cloudflare",
 				},
 			},
 		})
-		cert, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, acmeIngressClass, util.ACMECertificateDomain))
+		// patching the domain solver config to drop the *. prefix
+		// TODO: patch up main controller to automatically handle this
+		cert.Spec.ACME.Config[0].Domains = []string{dnsName}
+		cert, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(cert)
 		Expect(err).NotTo(HaveOccurred())
 		f.WaitCertificateIssuedValid(cert)
 	})

--- a/test/util/generate/certificate.go
+++ b/test/util/generate/certificate.go
@@ -12,6 +12,7 @@ type CertificateConfig struct {
 
 	// common parameters
 	IssuerName, IssuerKind string
+	SecretName             string
 	CommonName             string
 	DNSNames               []string
 
@@ -27,6 +28,7 @@ func Certificate(cfg CertificateConfig) *v1alpha1.Certificate {
 			Namespace: cfg.Namespace,
 		},
 		Spec: v1alpha1.CertificateSpec{
+			SecretName: cfg.SecretName,
 			IssuerRef: v1alpha1.ObjectReference{
 				Name: cfg.IssuerName,
 				Kind: cfg.IssuerKind,


### PR DESCRIPTION
**What this PR does / why we need it**:

This wildcard e2e test previously did not actually test wildcards.

**Release note**:
```release-note
NONE
```
