### PR TITLE
 Require asterisk denoted wildcard in acme solver config for wildcard certificates

### DIFF
--- a/pkg/issuer/acme/prepare_test.go
+++ b/pkg/issuer/acme/prepare_test.go
@@ -1,5 +1,177 @@
 package acme
 
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/diff"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/third_party/crypto/acme"
+)
+
 const (
 	defaultTestNamespace = "default"
 )
+
+func TestACMESolverConfigurationForAuthorization(t *testing.T) {
+	type testT struct {
+		cfg         *v1alpha1.ACMECertificateConfig
+		authz       *acme.Authorization
+		expectedCfg *v1alpha1.ACMESolverConfig
+		expectedErr bool
+	}
+	tests := map[string]testT{
+		"correctly selects normal domain": testT{
+			cfg: &v1alpha1.ACMECertificateConfig{
+				Config: []v1alpha1.ACMECertificateDomainConfig{
+					{
+						Domains: []string{"example.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "correctdns",
+							},
+						},
+					},
+				},
+			},
+			authz: &acme.Authorization{
+				Identifier: acme.AuthzID{
+					Value: "example.com",
+				},
+			},
+			expectedCfg: &v1alpha1.ACMESolverConfig{
+				DNS01: &v1alpha1.ACMECertificateDNS01Config{
+					Provider: "correctdns",
+				},
+			},
+		},
+		"correctly selects normal domain with multiple domains configured": testT{
+			cfg: &v1alpha1.ACMECertificateConfig{
+				Config: []v1alpha1.ACMECertificateDomainConfig{
+					{
+						Domains: []string{"notexample.com", "example.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "correctdns",
+							},
+						},
+					},
+				},
+			},
+			authz: &acme.Authorization{
+				Identifier: acme.AuthzID{
+					Value: "example.com",
+				},
+			},
+			expectedCfg: &v1alpha1.ACMESolverConfig{
+				DNS01: &v1alpha1.ACMECertificateDNS01Config{
+					Provider: "correctdns",
+				},
+			},
+		},
+		"correctly selects normal domain with multiple domains configured separately": testT{
+			cfg: &v1alpha1.ACMECertificateConfig{
+				Config: []v1alpha1.ACMECertificateDomainConfig{
+					{
+						Domains: []string{"example.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "correctdns",
+							},
+						},
+					},
+					{
+						Domains: []string{"notexample.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "incorrectdns",
+							},
+						},
+					},
+				},
+			},
+			authz: &acme.Authorization{
+				Identifier: acme.AuthzID{
+					Value: "example.com",
+				},
+			},
+			expectedCfg: &v1alpha1.ACMESolverConfig{
+				DNS01: &v1alpha1.ACMECertificateDNS01Config{
+					Provider: "correctdns",
+				},
+			},
+		},
+		"correctly selects configuration for wildcard domain": testT{
+			cfg: &v1alpha1.ACMECertificateConfig{
+				Config: []v1alpha1.ACMECertificateDomainConfig{
+					{
+						Domains: []string{"example.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "incorrectdns",
+							},
+						},
+					},
+					{
+						Domains: []string{"*.example.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "correctdns",
+							},
+						},
+					},
+				},
+			},
+			authz: &acme.Authorization{
+				Wildcard: true,
+				Identifier: acme.AuthzID{
+					// identifiers for wildcards do not include the *. prefix and
+					// instead set the Wildcard field on the Authz object
+					Value: "example.com",
+				},
+			},
+			expectedCfg: &v1alpha1.ACMESolverConfig{
+				DNS01: &v1alpha1.ACMECertificateDNS01Config{
+					Provider: "correctdns",
+				},
+			},
+		},
+		"returns an error when configuration for the domain is not found": testT{
+			cfg: &v1alpha1.ACMECertificateConfig{
+				Config: []v1alpha1.ACMECertificateDomainConfig{
+					{
+						Domains: []string{"notexample.com"},
+						ACMESolverConfig: v1alpha1.ACMESolverConfig{
+							DNS01: &v1alpha1.ACMECertificateDNS01Config{
+								Provider: "incorrectdns",
+							},
+						},
+					},
+				},
+			},
+			authz: &acme.Authorization{
+				Identifier: acme.AuthzID{
+					Value: "example.com",
+				},
+			},
+			expectedErr: true,
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			actualCfg, err := acmeSolverConfigurationForAuthorization(test.cfg, test.authz)
+			if err != nil && !test.expectedErr {
+				t.Errorf("Expected to return non-nil error, but got %v", err)
+				return
+			}
+			if err == nil && test.expectedErr {
+				t.Errorf("Expected error, but got none")
+				return
+			}
+			if !reflect.DeepEqual(test.expectedCfg, actualCfg) {
+				t.Errorf("Expected did not equal actual: %v", diff.ObjectDiff(test.expectedCfg, actualCfg))
+			}
+		})
+	}
+}

--- a/test/e2e/certificate/certificate_acme_dns01.go
+++ b/test/e2e/certificate/certificate_acme_dns01.go
@@ -172,8 +172,6 @@ var _ = framework.CertManagerDescribe("ACME Certificate (DNS01)", func() {
 				},
 			},
 		})
-		// temporary hack whilst cert-manager does not understand wildcard domains in config
-		cert.Spec.ACME.Config[0].Domains = []string{dnsName}
 		cert, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(cert)
 		Expect(err).NotTo(HaveOccurred())
 		f.WaitCertificateIssuedValid(cert)

--- a/third_party/crypto/acme/types.go
+++ b/third_party/crypto/acme/types.go
@@ -293,6 +293,9 @@ type Authorization struct {
 	// to prove posession of the identifier. For valid/invalid authorizations,
 	// this is the list of challenges that were used.
 	Challenges []*Challenge
+
+	// Wildcard is set to true if this authorization is for a 'wildcard' dnsName.
+	Wildcard bool
 }
 
 // AuthzID is an identifier that an account is authorized to represent.
@@ -315,6 +318,7 @@ type wireAuthz struct {
 		Type  string
 		Value string
 	}
+	Wildcard bool
 }
 
 func (z *wireAuthz) authorization(url string) *Authorization {
@@ -324,6 +328,7 @@ func (z *wireAuthz) authorization(url string) *Authorization {
 		Expires:    z.Expires,
 		Identifier: AuthzID{Type: z.Identifier.Type, Value: z.Identifier.Value},
 		Challenges: make([]*Challenge, len(z.Challenges)),
+		Wildcard:   z.Wildcard,
 	}
 	for i, v := range z.Challenges {
 		a.Challenges[i] = v.challenge()


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, in order to obtain validations for a wildcard certificate, a user must specify `certificate.spec.{dnsNames,commonName}=*.domain.com` and `certificate.spec.acme.config.domains=domain.com`.

This changes the behaviour, so that `certificate.spec.acme.config.domains=*.domain.com` is now required.

This also makes ingress-shim compatible with wildcard certs.

**Which issue this PR fixes**: fixes #501

**Special notes for your reviewer**:

This is based on #513 and should not be merged until after that.

It incorporates parts of #510.

**Release note**:
```release-note
Fixed bug requiring users to specify the apex domain (e.g. example.com) when attempting to obtain a wildcard certificate from an ACME server
```

/hold
/assign