### PR TITLE
Only perform one validation per identifier for a single order at a time

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -374,6 +374,9 @@ type ACMEOrderChallenge struct {
 	// Challenge key for this challenge
 	Key string `json:"key"`
 
+	// Set to true if this challenge is for a wildcard domain
+	Wildcard bool `json:"wildcard"`
+
 	// Configuration used to present this challenge
 	ACMESolverConfig `json:",inline"`
 }

--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -150,6 +150,9 @@ Outer:
 		}
 
 	}
+
+	crt.Status.ACMEStatus().Order.Challenges = newChallengeList
+
 	// we aggregate the errors here before beginning to accept challenges.
 	// This will mean we only accept challenges once all self checks are
 	// passing, to save the number of 'accept' operations sent to the acme server.
@@ -161,7 +164,6 @@ Outer:
 		return err
 	}
 
-	crt.Status.ACMEStatus().Order.Challenges = newChallengeList
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionValidationFailed, v1alpha1.ConditionFalse, "OrderValidated", fmt.Sprintf("Order validated"), true)
 
 	return nil

--- a/test/e2e/certificate/certificate_acme_dns01.go
+++ b/test/e2e/certificate/certificate_acme_dns01.go
@@ -176,4 +176,24 @@ var _ = framework.CertManagerDescribe("ACME Certificate (DNS01)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		f.WaitCertificateIssuedValid(cert)
 	})
+
+	It("should obtain a signed certificate for a wildcard and apex domain", func() {
+		By("Creating a Certificate")
+		dnsName := cmutil.RandStringRunes(5) + "." + util.ACMECloudflareDomain
+		cert := generate.Certificate(generate.CertificateConfig{
+			Name:       certificateName,
+			Namespace:  f.Namespace.Name,
+			SecretName: certificateSecretName,
+			IssuerName: issuerName,
+			DNSNames:   []string{"*." + dnsName, dnsName},
+			ACMESolverConfig: v1alpha1.ACMESolverConfig{
+				DNS01: &v1alpha1.ACMECertificateDNS01Config{
+					Provider: "cloudflare",
+				},
+			},
+		})
+		cert, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(cert)
+		Expect(err).NotTo(HaveOccurred())
+		f.WaitCertificateIssuedValid(cert)
+	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, if a user requested a certificate for *.domain.com and domain.com at the same time, cert-manager would constantly update the DNS record with both challenge keys, causing neither to succeed.

This PR changes cert-manager to serialise validations for the same identifier (i.e. domain).

The only caveat, is if a user were to set a dns01 challenge for *.domain.com, and a http01 challenge for domain.com, the validations would still be serialised despite the fact they don't need to be.

I think this is a minor drawback however, and is an edge case.

This shouldn't be merged until after #512 

**Which issue this PR fixes**: fixes #505 

**Release note**:
```release-note
Fix a bug causing certificates for domain.com as well as *.domain.com to fail validation
```
