### PR TITLE
Fix ingress-shim cli flags

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.3.0-alpha.3
+version: v0.3.0-alpha.4
 appVersion: v0.3.0-alpha.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -42,10 +42,10 @@ spec:
           - --default-issuer-kind={{ .defaultIssuerKind }}
           {{- end }}
           {{- if .defaultACMEChallengeType }}
-          - --default-acme-challenge-type={{ .defaultACMEChallengeType }}
+          - --default-acme-issuer-challenge-type={{ .defaultACMEChallengeType }}
           {{- end }}
           {{- if .defaultACMEDNS01ChallengeProvider }}
-          - --default-acme-dns01-challenge-provider={{ .defaultACMEDNS01ChallengeProvider }}
+          - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
           {{- end }}
           {{- end }}
           env:

--- a/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/rbac.yaml
+++ b/contrib/manifests/cert-manager/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
+++ b/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller

--- a/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.3
+    chart: cert-manager-v0.3.0-alpha.4
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

#502 changed the Helm chart to add the ingress shim flags to the main controller.

The chart was however updated incorrectly, and the previous flag values are invalid.

**Release note**:
```release-note
NONE
```
