### PR TITLE
Create chart OWNERS

### DIFF
--- a/contrib/charts/cert-manager/OWNERS
+++ b/contrib/charts/cert-manager/OWNERS
@@ -1,0 +1,9 @@
+approvers:
+- munnerz
+- simonswine
+- kragniz
+reviewers:
+- munnerz
+- unguiculus
+- simonswine
+- kragniz


### PR DESCRIPTION
This is syncing the OWNERS chart back from the upstream repo. This should have already been done, but wasn't when I copied k/charts back to release-0.2

**Release note**:
```release-note
NONE
```
