### PR TITLE
Fix panic in shouldAttemptValidation

### DIFF
--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -444,7 +444,11 @@ func (a *Acme) shouldAttemptValidation(ctx context.Context, cl client.Interface,
 			Type:   v1alpha1.CertificateConditionValidationFailed,
 			Status: v1alpha1.ConditionTrue,
 		}) {
-			crt.UpdateStatusCondition(v1alpha1.CertificateConditionValidationFailed, v1alpha1.ConditionTrue, "OrderFailed", fmt.Sprintf("Order failed: %v", order.Error.Error()), true)
+			var extraText = ""
+			if order.Error != nil {
+				extraText = fmt.Sprintf(": %v", order.Error.Error())
+			}
+			crt.UpdateStatusCondition(v1alpha1.CertificateConditionValidationFailed, v1alpha1.ConditionTrue, "OrderFailed", "Order status is invalid"+extraText, true)
 		}
 
 		// we know that we'll be able to find the appropriate condition because


### PR DESCRIPTION
**What this PR does / why we need it**:

Check if order.Error != nil before accessing .Error() on it

**Which issue this PR fixes**: fixes #531

**Release note**:
```release-note
NONE
```
