### PR TITLE
Set Issuer ready condition to false if ACMEv1 endpoints are used

### DIFF
--- a/pkg/issuer/acme/util.go
+++ b/pkg/issuer/acme/util.go
@@ -37,3 +37,10 @@ func authzIDListToStrings(auths []acme.AuthzID) []string {
 	}
 	return ret
 }
+
+var acmev1ToV2Mappings = map[string]string{
+	"https://acme-v01.api.letsencrypt.org/directory":      "https://acme-v02.api.letsencrypt.org/directory",
+	"https://acme-staging.api.letsencrypt.org/directory":  "https://acme-staging-v02.api.letsencrypt.org/directory",
+	"https://acme-v01.api.letsencrypt.org/directory/":     "https://acme-v02.api.letsencrypt.org/directory",
+	"https://acme-staging.api.letsencrypt.org/directory/": "https://acme-staging-v02.api.letsencrypt.org/directory",
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When users upgrade from cert-manager v0.2 to v0.3, any existing Let's Encrypt Issuers they have will break with strange errors (see #491).

This PR causes cert-manager to set the Issuer Ready condition to false with a helpful informational message to advise users how to fix their Issuer resources.

**Which issue this PR fixes**: fixes #491

**Release note**:
```release-note
NONE
```
