### PR TITLE
Add leaderElection.namespace option to helm chart

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.3.0-alpha.5
+version: v0.3.0-alpha.6
 appVersion: v0.3.0-alpha.2
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -59,6 +59,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
+| `leaderElection.Namespace` | Override the namespace used to store the ConfigMap for leader election | Same namespace as cert-manager pod
 | `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
 | `rbac.create` | If `true`, create and use RBAC resources | `true`

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -35,6 +35,11 @@ spec:
         {{- else }}
           - --cluster-resource-namespace=$(POD_NAMESPACE)
         {{- end }}
+        {{- if .Values.leaderElection.namespace }}
+          - --leader-election-namespace={{ .Values.leaderElection.namespace }}
+        {{- else }}
+          - --leader-election-namespace=$(POD_NAMESPACE)
+        {{- end }}
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -15,6 +15,10 @@ createCustomResource: true
 # used. This namespace will not be automatically created by the Helm chart.
 clusterResourceNamespace: ""
 
+leaderElection:
+  # Override the namespace used to store the ConfigMap for leader election
+  namespace: ""
+
 certificateResourceShortNames: ["cert", "certs"]
 
 rbac:

--- a/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -30,6 +30,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=$(POD_NAMESPACE)
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/rbac/rbac.yaml
+++ b/contrib/manifests/cert-manager/rbac/rbac.yaml
@@ -6,7 +6,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 rules:
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 roleRef:

--- a/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
+++ b/contrib/manifests/cert-manager/rbac/serviceaccount.yaml
@@ -7,6 +7,6 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller

--- a/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/certificate-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/clusterissuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac/deployment.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -30,6 +30,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
+          - --leader-election-namespace=$(POD_NAMESPACE)
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
+++ b/contrib/manifests/cert-manager/without-rbac/issuer-crd.yaml
@@ -6,7 +6,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.5
+    chart: cert-manager-v0.3.0-alpha.6
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, a ConfigMap in the kube-system namespace was used to perform leader election. This updates the chart to use the same namespace as cert-manager is deployed into for leader election.

**Release note**:
```release-note
Use cert-manager deployment namespace by default for leader election
```
