### PR TITLE
 Improve logs for CloudDNS service account errors

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -169,7 +169,13 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 		if err != nil {
 			return nil, fmt.Errorf("error getting clouddns service account: %s", err.Error())
 		}
-		saBytes := saSecret.Data[providerConfig.CloudDNS.ServiceAccount.Key]
+
+		saKey := providerConfig.CloudDNS.ServiceAccount.Key
+		saBytes := saSecret.Data[saKey]
+
+		if len(saBytes) == 0 {
+			return nil, fmt.Errorf("specfied key %q not found in secret %s/%s", saKey, saSecret.Namespace, saSecret.Name)
+		}
 
 		impl, err = s.dnsProviderConstructors.cloudDNS(providerConfig.CloudDNS.Project, saBytes)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Improve logging for Google CloudSQL configuration errors around misconfigured ServiceAccounts.

In my case, there happened to be two Secrets with the same name and different keys, and it was impossible to determine which Secret the cert-manager was trying to load.
**Which issue this PR fixes** 

/fixes 539

