### PR TITLE
charts/cert-manager: add extraEnv

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.4.0-dev.0
+version: v0.4.0-dev.1
 appVersion: v0.4.0-dev.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -62,6 +62,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `leaderElection.Namespace` | Override the namespace used to store the ConfigMap for leader election | Same namespace as cert-manager pod
 | `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |
 | `extraArgs` | Optional flags for cert-manager | `[]` |
+| `extraEnv` | Optional environment variables for cert-manager | `[]` |
 | `rbac.create` | If `true`, create and use RBAC resources | `true` |
 | `serviceAccount.create` | If `true`, create a new service account | `true` |
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -65,6 +65,9 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+        {{- if .Values.extraEnv }}
+{{ toYaml .Values.extraEnv | indent 10 }}
+        {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -38,6 +38,10 @@ extraArgs: []
   # supporting resources required for each ClusterIssuer (default is kube-system)
   # - --cluster-resource-namespace=kube-system
 
+extraEnv: []
+# - name: SOME_VAR
+#   value: 'some value'
+
 resources: {}
   # requests:
   #   cpu: 10m

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -26,7 +26,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -48,7 +48,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -66,7 +66,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -84,7 +84,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -109,7 +109,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -129,7 +129,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -36,7 +36,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +73,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.0
+    chart: cert-manager-v0.4.0-dev.1
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:
This allows configuring environment variables for the `cert-manager`.
For example it enables configuring `Vault` client to accept connections with kubernetes Certificate Authority:
```yaml
extraEnv:
- name: VAULT_CAPATH
  value: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
```
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
added option to set additional environment variable values to the helm chart
```
