### PR TITLE
Add custom resolver configuration per DNS provider

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -144,7 +144,8 @@ type ACMEIssuerDNS01Config struct {
 }
 
 type ACMEIssuerDNS01Provider struct {
-	Name string `json:"name"`
+	Name        string   `json:"name"`
+	Nameservers []string `json:"nameservers,omitempty"`
 
 	Akamai     *ACMEIssuerDNS01ProviderAkamai     `json:"akamai,omitempty"`
 	CloudDNS   *ACMEIssuerDNS01ProviderCloudDNS   `json:"clouddns,omitempty"`

--- a/pkg/issuer/acme/dns/akamai/akamai_test.go
+++ b/pkg/issuer/acme/dns/akamai/akamai_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -88,7 +89,7 @@ func (r httpResponder) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func TestPresent(t *testing.T) {
-	akamai, err := NewDNSProvider("akamai.example.com", "token", "secret", "access-token")
+	akamai, err := NewDNSProvider(util.RecursiveNameservers, "akamai.example.com", "token", "secret", "access-token")
 	assert.NoError(t, err)
 
 	var response []byte
@@ -103,7 +104,7 @@ func TestPresent(t *testing.T) {
 }
 
 func TestCleanUp(t *testing.T) {
-	akamai, err := NewDNSProvider("akamai.example.com", "token", "secret", "access-token")
+	akamai, err := NewDNSProvider(util.RecursiveNameservers, "akamai.example.com", "token", "secret", "access-token")
 	assert.NoError(t, err)
 
 	var response []byte
@@ -154,7 +155,7 @@ func mockTransport(t *testing.T, akamai *DNSProvider, domain, data string, respo
 		t.Fatalf("unexpected method: %v", req.Method)
 		return nil, nil
 	})
-	akamai.findHostedDomainByFqdn = func(fqdn string) (string, error) {
+	akamai.findHostedDomainByFqdn = func(fqdn string, nameservers []string) (string, error) {
 		if !strings.HasSuffix(fqdn, domain+".") {
 			t.Fatalf("unexpected fqdn: %s", fqdn)
 		}

--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +37,7 @@ func TestLiveAzureDnsPresent(t *testing.T) {
 	if !azureLiveTest {
 		t.Skip("skipping live test")
 	}
-	provider, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName)
 	assert.NoError(t, err)
 
 	err = provider.Present(azureDomain, "", "123d==")
@@ -50,7 +51,7 @@ func TestLiveAzureDnsCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 5)
 
-	provider, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(azureDomain, "", "123d==")

--- a/pkg/issuer/acme/dns/clouddns/clouddns_test.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns_test.go
@@ -9,6 +9,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
 
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -36,7 +37,7 @@ func TestNewDNSProviderValid(t *testing.T) {
 		t.Skip("skipping live test (requires credentials)")
 	}
 	os.Setenv("GCE_PROJECT", "")
-	_, err := NewDNSProviderCredentials("my-project")
+	_, err := NewDNSProviderCredentials(util.RecursiveNameservers, "my-project")
 	assert.NoError(t, err)
 	restoreGCloudEnv()
 }
@@ -63,7 +64,7 @@ func TestLiveGoogleCloudPresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(gcloudProject)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, gcloudProject)
 	assert.NoError(t, err)
 
 	err = provider.Present(gcloudDomain, "", "123d==")
@@ -75,7 +76,7 @@ func TestLiveGoogleCloudPresentMultiple(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(gcloudProject)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, gcloudProject)
 	assert.NoError(t, err)
 
 	// Check that we're able to create multiple entries
@@ -91,7 +92,7 @@ func TestLiveGoogleCloudCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	provider, err := NewDNSProviderCredentials(gcloudProject)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, gcloudProject)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(gcloudDomain, "", "123d==")

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,7 +33,7 @@ func restoreCloudFlareEnv() {
 func TestNewDNSProviderValid(t *testing.T) {
 	os.Setenv("CLOUDFLARE_EMAIL", "")
 	os.Setenv("CLOUDFLARE_API_KEY", "")
-	_, err := NewDNSProviderCredentials("123", "123")
+	_, err := NewDNSProviderCredentials(util.RecursiveNameservers, "123", "123")
 	assert.NoError(t, err)
 	restoreCloudFlareEnv()
 }
@@ -58,7 +59,7 @@ func TestCloudFlarePresent(t *testing.T) {
 		t.Skip("skipping live test")
 	}
 
-	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, cflareEmail, cflareAPIKey)
 	assert.NoError(t, err)
 
 	err = provider.Present(cflareDomain, "", "123d==")
@@ -72,7 +73,7 @@ func TestCloudFlareCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 2)
 
-	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey)
+	provider, err := NewDNSProviderCredentials(util.RecursiveNameservers, cflareEmail, cflareAPIKey)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(cflareDomain, "", "123d==")

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -55,16 +55,7 @@ type Solver struct {
 }
 
 func (s *Solver) Present(ctx context.Context, _ *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
-	if ch.ACMESolverConfig.DNS01 == nil {
-		return fmt.Errorf("challenge dns config must be specified")
-	}
-
-	providerName := ch.ACMESolverConfig.DNS01.Provider
-	if providerName == "" {
-		return fmt.Errorf("dns01 challenge provider name must be set")
-	}
-
-	slv, err := s.solverForIssuerProvider(providerName)
+	slv, err := solverForChallenge(ch)
 	if err != nil {
 		return err
 	}
@@ -94,16 +85,7 @@ func (s *Solver) Check(ch v1alpha1.ACMEOrderChallenge) (bool, error) {
 }
 
 func (s *Solver) CleanUp(ctx context.Context, _ *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
-	if ch.ACMESolverConfig.DNS01 == nil {
-		return fmt.Errorf("challenge dns config must be specified")
-	}
-
-	providerName := ch.ACMESolverConfig.DNS01.Provider
-	if providerName == "" {
-		return fmt.Errorf("dns01 challenge provider name must be set")
-	}
-
-	slv, err := s.solverForIssuerProvider(providerName)
+	slv, err := solverForChallenge(ch)
 	if err != nil {
 		return err
 	}
@@ -122,6 +104,21 @@ func (s *Solver) providerForDomain(crt *v1alpha1.Certificate, domain string) (st
 		return "", fmt.Errorf("dns-01 challenge provider for domain %q is not configured. Ensure the Certificate resource configures a dns-01 provider for the domain", domain)
 	}
 	return cfg.Provider, nil
+}
+
+// solverForChallenge returns a Solver for the given
+// ACMEOrderChallenge
+func (s *Solver) solverForChallenge(ch v1alpha1.ACMEOrderChallenge) (solver, error) {
+	if ch.ACMESolverConfig.DNS01 == nil {
+		return fmt.Errorf("challenge dns config must be specified")
+	}
+
+	providerName := ch.ACMESolverConfig.DNS01.Provider
+	if providerName == "" {
+		return fmt.Errorf("dns01 challenge provider name must be set")
+	}
+
+	return s.solverForIssuerProvider(providerName)
 }
 
 // solverForIssuerProvider returns a Solver for the given providerName.

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -30,16 +30,17 @@ type solver interface {
 	Present(domain, token, key string) error
 	CleanUp(domain, token, key string) error
 	Timeout() (timeout, interval time.Duration)
+	GetNameservers() []string
 }
 
 // dnsProviderConstructors defines how each provider may be constructed.
 // It is useful for mocking out a given provider since an alternate set of
 // constructors may be set.
 type dnsProviderConstructors struct {
-	cloudDNS   func(project string, serviceAccount []byte) (*clouddns.DNSProvider, error)
-	cloudFlare func(email, apikey string) (*cloudflare.DNSProvider, error)
-	route53    func(accessKey, secretKey, hostedZoneID, region string, ambient bool) (*route53.DNSProvider, error)
-	azureDNS   func(clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName string) (*azuredns.DNSProvider, error)
+	cloudDNS   func(nameservers []string, project string, serviceAccount []byte) (*clouddns.DNSProvider, error)
+	cloudFlare func(nameservers []string, email, apikey string) (*cloudflare.DNSProvider, error)
+	route53    func(nameservers []string, accessKey, secretKey, hostedZoneID, region string, ambient bool) (*route53.DNSProvider, error)
+	azureDNS   func(nameservers []string, clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName string) (*azuredns.DNSProvider, error)
 }
 
 // Solver is a solver for the acme dns01 challenge.
@@ -55,7 +56,7 @@ type Solver struct {
 }
 
 func (s *Solver) Present(ctx context.Context, _ *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
-	slv, err := solverForChallenge(ch)
+	slv, err := s.solverForChallenge(ch)
 	if err != nil {
 		return err
 	}
@@ -65,10 +66,15 @@ func (s *Solver) Present(ctx context.Context, _ *v1alpha1.Certificate, ch v1alph
 }
 
 func (s *Solver) Check(ch v1alpha1.ACMEOrderChallenge) (bool, error) {
-	fqdn, value, ttl := util.DNS01Record(ch.Domain, ch.Key)
-	glog.Infof("Checking DNS propagation for %q using name servers: %v", ch.Domain, util.RecursiveNameservers)
+	slv, err := s.solverForChallenge(ch)
+	if err != nil {
+		return false, err
+	}
 
-	ok, err := util.PreCheckDNS(fqdn, value)
+	fqdn, value, ttl := util.DNS01Record(ch.Domain, ch.Key)
+	glog.Infof("Checking DNS propagation for %q using name servers: %v", ch.Domain, slv.GetNameservers())
+
+	ok, err := util.PreCheckDNS(fqdn, value, slv.GetNameservers())
 	if err != nil {
 		return false, err
 	}
@@ -85,7 +91,7 @@ func (s *Solver) Check(ch v1alpha1.ACMEOrderChallenge) (bool, error) {
 }
 
 func (s *Solver) CleanUp(ctx context.Context, _ *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
-	slv, err := solverForChallenge(ch)
+	slv, err := s.solverForChallenge(ch)
 	if err != nil {
 		return err
 	}
@@ -110,12 +116,12 @@ func (s *Solver) providerForDomain(crt *v1alpha1.Certificate, domain string) (st
 // ACMEOrderChallenge
 func (s *Solver) solverForChallenge(ch v1alpha1.ACMEOrderChallenge) (solver, error) {
 	if ch.ACMESolverConfig.DNS01 == nil {
-		return fmt.Errorf("challenge dns config must be specified")
+		return nil, fmt.Errorf("challenge dns config must be specified")
 	}
 
 	providerName := ch.ACMESolverConfig.DNS01.Provider
 	if providerName == "" {
-		return fmt.Errorf("dns01 challenge provider name must be set")
+		return nil, fmt.Errorf("dns01 challenge provider name must be set")
 	}
 
 	return s.solverForIssuerProvider(providerName)
@@ -133,6 +139,11 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 	providerConfig, err := s.issuer.GetSpec().ACME.DNS01.Provider(providerName)
 	if err != nil {
 		return nil, err
+	}
+
+	nameservers := providerConfig.Nameservers
+	if len(nameservers) == 0 {
+		nameservers = util.RecursiveNameservers
 	}
 
 	var impl solver
@@ -154,6 +165,7 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 		}
 
 		impl, err = akamai.NewDNSProvider(
+			nameservers,
 			providerConfig.Akamai.ServiceConsumerDomain,
 			string(clientToken),
 			string(clientSecret),
@@ -168,7 +180,7 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 		}
 		saBytes := saSecret.Data[providerConfig.CloudDNS.ServiceAccount.Key]
 
-		impl, err = s.dnsProviderConstructors.cloudDNS(providerConfig.CloudDNS.Project, saBytes)
+		impl, err = s.dnsProviderConstructors.cloudDNS(nameservers, providerConfig.CloudDNS.Project, saBytes)
 		if err != nil {
 			return nil, fmt.Errorf("error instantiating google clouddns challenge solver: %s", err.Error())
 		}
@@ -181,7 +193,7 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 		email := providerConfig.Cloudflare.Email
 		apiKey := string(apiKeySecret.Data[providerConfig.Cloudflare.APIKey.Key])
 
-		impl, err = s.dnsProviderConstructors.cloudFlare(email, apiKey)
+		impl, err = s.dnsProviderConstructors.cloudFlare(nameservers, email, apiKey)
 		if err != nil {
 			return nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err.Error())
 		}
@@ -201,6 +213,7 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 		}
 
 		impl, err = s.dnsProviderConstructors.route53(
+			nameservers,
 			strings.TrimSpace(providerConfig.Route53.AccessKeyID),
 			strings.TrimSpace(secretAccessKey),
 			providerConfig.Route53.HostedZoneID,
@@ -222,6 +235,7 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 		}
 
 		impl, err = s.dnsProviderConstructors.azureDNS(
+			nameservers,
 			providerConfig.AzureDNS.ClientID,
 			string(clientSecretBytes),
 			providerConfig.AzureDNS.SubscriptionID,

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -145,6 +145,7 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 	if len(nameservers) == 0 {
 		nameservers = util.RecursiveNameservers
 	}
+	nameservers = util.AddNameserverPorts(nameservers)
 
 	var impl solver
 	switch {

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -32,6 +32,20 @@ var RecursiveNameservers = getNameservers(defaultResolvConf, defaultNameservers)
 // DNSTimeout is used to override the default DNS timeout of 10 seconds.
 var DNSTimeout = 10 * time.Second
 
+// AddNameserverPorts makes sure all servers have a port number
+func AddNameserverPorts(nameservers []string) []string {
+	nameserversWithPorts := []string{}
+	for _, server := range nameservers {
+		// ensure all servers have a port number
+		if _, _, err := net.SplitHostPort(server); err != nil {
+			nameserversWithPorts = append(nameserversWithPorts, net.JoinHostPort(server, "53"))
+		} else {
+			nameserversWithPorts = append(nameserversWithPorts, server)
+		}
+	}
+	return nameserversWithPorts
+}
+
 // getNameservers attempts to get systems nameservers before falling back to the defaults
 func getNameservers(path string, defaults []string) []string {
 	config, err := dns.ClientConfigFromFile(path)
@@ -39,15 +53,7 @@ func getNameservers(path string, defaults []string) []string {
 		return defaults
 	}
 
-	systemNameservers := []string{}
-	for _, server := range config.Servers {
-		// ensure all servers have a port number
-		if _, _, err := net.SplitHostPort(server); err != nil {
-			systemNameservers = append(systemNameservers, net.JoinHostPort(server, "53"))
-		} else {
-			systemNameservers = append(systemNameservers, server)
-		}
-	}
+	systemNameservers := AddNameserverPorts(config.Servers)
 	return systemNameservers
 }
 

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/publicsuffix"
 )
 
-type preCheckDNSFunc func(fqdn, value string) (bool, error)
+type preCheckDNSFunc func(fqdn, value string, nameservers []string) (bool, error)
 
 var (
 	// PreCheckDNS checks DNS propagation before notifying ACME that
@@ -52,9 +52,9 @@ func getNameservers(path string, defaults []string) []string {
 }
 
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
-func checkDNSPropagation(fqdn, value string) (bool, error) {
+func checkDNSPropagation(fqdn, value string, nameservers []string) (bool, error) {
 	// Initial attempt to resolve at the recursive NS
-	r, err := dnsQuery(fqdn, dns.TypeTXT, RecursiveNameservers, true)
+	r, err := dnsQuery(fqdn, dns.TypeTXT, nameservers, true)
 	if err != nil {
 		return false, err
 	}
@@ -70,7 +70,7 @@ func checkDNSPropagation(fqdn, value string) (bool, error) {
 		}
 	}
 
-	authoritativeNss, err := lookupNameservers(fqdn)
+	authoritativeNss, err := lookupNameservers(fqdn, nameservers)
 	if err != nil {
 		return false, err
 	}
@@ -141,15 +141,15 @@ func dnsQuery(fqdn string, rtype uint16, nameservers []string, recursive bool) (
 }
 
 // lookupNameservers returns the authoritative nameservers for the given fqdn.
-func lookupNameservers(fqdn string) ([]string, error) {
+func lookupNameservers(fqdn string, nameservers []string) ([]string, error) {
 	var authoritativeNss []string
 
-	zone, err := FindZoneByFqdn(fqdn, RecursiveNameservers)
+	zone, err := FindZoneByFqdn(fqdn, nameservers)
 	if err != nil {
 		return nil, fmt.Errorf("Could not determine the zone: %v", err)
 	}
 
-	r, err := dnsQuery(zone, dns.TypeNS, RecursiveNameservers, true)
+	r, err := dnsQuery(zone, dns.TypeNS, nameservers, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -83,7 +83,7 @@ var checkResolvConfServersTests = []struct {
 
 func TestPreCheckDNS(t *testing.T) {
 	// TODO: find a better TXT record to use in tests
-	ok, err := PreCheckDNS("google.com.", "v=spf1 include:_spf.google.com ~all")
+	ok, err := PreCheckDNS("google.com.", "v=spf1 include:_spf.google.com ~all", RecursiveNameservers)
 	if err != nil || !ok {
 		t.Errorf("preCheckDNS failed for acme-staging.api.letsencrypt.org: %s", err.Error())
 	}
@@ -91,7 +91,7 @@ func TestPreCheckDNS(t *testing.T) {
 
 func TestLookupNameserversOK(t *testing.T) {
 	for _, tt := range lookupNameserversTestsOK {
-		nss, err := lookupNameservers(tt.fqdn)
+		nss, err := lookupNameservers(tt.fqdn, RecursiveNameservers)
 		if err != nil {
 			t.Fatalf("#%s: got %q; want nil", tt.fqdn, err)
 		}
@@ -107,7 +107,7 @@ func TestLookupNameserversOK(t *testing.T) {
 
 func TestLookupNameserversErr(t *testing.T) {
 	for _, tt := range lookupNameserversTestsErr {
-		_, err := lookupNameservers(tt.fqdn)
+		_, err := lookupNameservers(tt.fqdn, RecursiveNameservers)
 		if err == nil {
 			t.Fatalf("#%s: expected %q (error); got <nil>", tt.fqdn, tt.error)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows resolver configuration on a per provider basis:
```
---
apiVersion: certmanager.k8s.io/v1alpha1
kind: Issuer
metadata:
  name: letsencrypt-staging
spec:
  acme
    server: https://acme-staging-v02.api.letsencrypt.org/directory
    dns01:
      providers:
      - name: default
        route53:
          region: eu-west-1
        nameServers:
        - 8.8.8.8:53
```

In particular we need this for split-horizon dns. In our environment we need cert-manager to use our internal dns to resolve the http_proxy to get access to the letsencrypt and AWS APIs, while being able to use the external resolvers for the self check.

**Which issue this PR fixes**: fixes #506

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make it possible to use custom resolvers for each DNS provider
```
