### PR TITLE
Bump chart and manifests for v0.3.0 release

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.3.0-alpha.7
-appVersion: v0.3.0-alpha.2
+version: v0.3.0
+appVersion: v0.3.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.2.3` |
+| `image.tag` | Image tag | `v0.3.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.3.0-alpha.2
+  tag: v0.3.0
   pullPolicy: IfNotPresent
 
 createCustomResource: true

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -26,7 +26,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -48,7 +48,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -66,7 +66,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -84,7 +84,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -109,7 +109,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -129,7 +129,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -148,7 +148,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.3.0-alpha.2"
+          image: "quay.io/jetstack/cert-manager-controller:v0.3.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -36,7 +36,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +73,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0-alpha.7
+    chart: cert-manager-v0.3.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -92,7 +92,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.3.0-alpha.2"
+          image: "quay.io/jetstack/cert-manager-controller:v0.3.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps strings for the v0.3.0 release

Merge after #574 

```release-note
NONE
```
