### PR TITLE
Use https docs URL in chart NOTES.txt

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.3.0
+version: v0.3.1
 appVersion: v0.3.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/templates/NOTES.txt
+++ b/contrib/charts/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-http://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-http://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -26,7 +26,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -48,7 +48,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -66,7 +66,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -84,7 +84,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -109,7 +109,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -129,7 +129,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -36,7 +36,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +73,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.3.0
+    chart: cert-manager-v0.3.1
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

When syncing changes page from the k/charts repo in the past, this was switched to plain http.

**Release note**:
```release-note
NONE
```
