### PR TITLE
acmesolver: Run as non-root

### DIFF
--- a/hack/build/dockerfiles/acmesolver/Dockerfile
+++ b/hack/build/dockerfiles/acmesolver/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:3.6
 
-RUN apk add --no-cache ca-certificates
+RUN apk add --no-cache ca-certificates && \
+    adduser -S -u 100 acmesolver
 
 ADD cert-manager-acmesolver_linux_amd64 /usr/bin/acmesolver
 
+USER 100
 ENTRYPOINT ["/usr/bin/acmesolver"]
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \


### PR DESCRIPTION
acmesolver won't run in a namespace with a restrictive PSP
(Pod Security Policy)[1] without this change.
Note: A numeric user id is required due to [1]

[1] https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups
[2] https://github.com/kubernetes/kubernetes/pull/56503

```release-note
Run acmesolver container as non-root user
```