### PR TITLE
 issuer/acme/*: log namespaces for resources 

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -258,12 +258,12 @@ func NewSolver(issuer v1alpha1.GenericIssuer, client kubernetes.Interface, secre
 func (s *Solver) loadSecretData(selector *v1alpha1.SecretKeySelector) ([]byte, error) {
 	secret, err := s.secretLister.Secrets(s.resourceNamespace).Get(selector.Name)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to load secret with name %q", selector.Name)
+		return nil, errors.Wrapf(err, "failed to load secret %q", s.resourceNamespace+"/"+selector.Name)
 	}
 
 	if data, ok := secret.Data[selector.Key]; ok {
 		return data, nil
 	}
 
-	return nil, errors.Errorf("no key %q in secret %q", selector.Key, selector.Name)
+	return nil, errors.Errorf("no key %q in secret %q", selector.Key, s.resourceNamespace+"/"+selector.Name)
 }

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -167,18 +167,18 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 	case providerConfig.CloudDNS != nil:
 		saSecret, err := s.secretLister.Secrets(s.resourceNamespace).Get(providerConfig.CloudDNS.ServiceAccount.Name)
 		if err != nil {
-			return nil, fmt.Errorf("error getting clouddns service account: %s", err.Error())
+			return nil, fmt.Errorf("error getting clouddns service account: %s", err)
 		}
 		saBytes := saSecret.Data[providerConfig.CloudDNS.ServiceAccount.Key]
 
 		impl, err = s.dnsProviderConstructors.cloudDNS(providerConfig.CloudDNS.Project, saBytes)
 		if err != nil {
-			return nil, fmt.Errorf("error instantiating google clouddns challenge solver: %s", err.Error())
+			return nil, fmt.Errorf("error instantiating google clouddns challenge solver: %s", err)
 		}
 	case providerConfig.Cloudflare != nil:
 		apiKeySecret, err := s.secretLister.Secrets(s.resourceNamespace).Get(providerConfig.Cloudflare.APIKey.Name)
 		if err != nil {
-			return nil, fmt.Errorf("error getting cloudflare service account: %s", err.Error())
+			return nil, fmt.Errorf("error getting cloudflare service account: %s", err)
 		}
 
 		email := providerConfig.Cloudflare.Email
@@ -186,14 +186,14 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 
 		impl, err = s.dnsProviderConstructors.cloudFlare(email, apiKey)
 		if err != nil {
-			return nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err.Error())
+			return nil, fmt.Errorf("error instantiating cloudflare challenge solver: %s", err)
 		}
 	case providerConfig.Route53 != nil:
 		secretAccessKey := ""
 		if providerConfig.Route53.SecretAccessKey.Name != "" {
 			secretAccessKeySecret, err := s.secretLister.Secrets(s.resourceNamespace).Get(providerConfig.Route53.SecretAccessKey.Name)
 			if err != nil {
-				return nil, fmt.Errorf("error getting route53 secret access key: %s", err.Error())
+				return nil, fmt.Errorf("error getting route53 secret access key: %s", err)
 			}
 
 			secretAccessKeyBytes, ok := secretAccessKeySecret.Data[providerConfig.Route53.SecretAccessKey.Key]
@@ -211,12 +211,12 @@ func (s *Solver) solverForIssuerProvider(providerName string) (solver, error) {
 			s.ambientCredentials,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("error instantiating route53 challenge solver: %s", err.Error())
+			return nil, fmt.Errorf("error instantiating route53 challenge solver: %s", err)
 		}
 	case providerConfig.AzureDNS != nil:
 		clientSecret, err := s.secretLister.Secrets(s.resourceNamespace).Get(providerConfig.AzureDNS.ClientSecret.Name)
 		if err != nil {
-			return nil, fmt.Errorf("error getting azuredns client secret: %s", err.Error())
+			return nil, fmt.Errorf("error getting azuredns client secret: %s", err)
 		}
 
 		clientSecretBytes, ok := clientSecret.Data[providerConfig.AzureDNS.ClientSecret.Key]

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -4,16 +4,9 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
-
-// contextWithTimeout calls context.WithTimeout, and throws away the cancel fn
-func contextWithTimeout(t time.Duration) context.Context {
-	c, _ := context.WithTimeout(context.Background(), t)
-	return c
-}
 
 // countReachabilityTestCalls is a wrapper function that allows us to count the number
 // of calls to a reachabilityTest.

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -40,7 +40,7 @@ func (s *Solver) getIngressesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1
 	for _, ingress := range ingressList {
 		if !metav1.IsControlledBy(ingress, crt) {
 			glog.Infof("Found ingress %q with acme-order-url annotation set to that of Certificate %q "+
-				"but it is not owned by the Certificate resource, so skipping it.", ingress.Name, crt.Name)
+				"but it is not owned by the Certificate resource, so skipping it.", ingress.Namespace+"/"+ingress.Name, crt.Namespace+"/"+crt.Name)
 			continue
 		}
 		relevantIngresses = append(relevantIngresses, ingress)
@@ -83,7 +83,7 @@ func (s *Solver) ensureIngress(crt *v1alpha1.Certificate, svcName string, ch v1a
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	glog.Infof("No existing HTTP01 challenge solver ingress found for Certificate %q. One will be created.")
+	glog.Infof("No existing HTTP01 challenge solver ingress found for Certificate %q. One will be created.", crt.Namespace+"/"+crt.Name)
 	return s.createIngress(crt, svcName, ch)
 }
 
@@ -193,7 +193,7 @@ func (s *Solver) cleanupIngresses(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrd
 		if err != nil {
 			return err
 		}
-		glog.V(4).Infof("Found %d ingresses to clean up for certificate %q", len(ingresses), crt.Name)
+		glog.V(4).Infof("Found %d ingresses to clean up for certificate %q", len(ingresses), crt.Namespace+"/"+crt.Name)
 		var errs []error
 		for _, ingress := range ingresses {
 			// TODO: should we call DeleteCollection here? We'd need to somehow
@@ -209,7 +209,7 @@ func (s *Solver) cleanupIngresses(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrd
 	// otherwise, we need to remove any cert-manager added rules from the ingress resource
 	ing, err := s.client.ExtensionsV1beta1().Ingresses(crt.Namespace).Get(existingIngressName, metav1.GetOptions{})
 	if k8sErrors.IsNotFound(err) {
-		glog.Infof("attempt to cleanup Ingress %q of ACME challenge path failed: %v", existingIngressName, err)
+		glog.Infof("attempt to cleanup Ingress %q of ACME challenge path failed: %v", crt.Namespace+"/"+existingIngressName, err)
 		return nil
 	}
 	if err != nil {

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -46,7 +46,7 @@ func (s *Solver) ensurePod(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChall
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	glog.Infof("No existing HTTP01 challenge solver pod found for Certificate %q. One will be created.", crt.Name)
+	glog.Infof("No existing HTTP01 challenge solver pod found for Certificate %q. One will be created.", crt.Namespace+"/"+crt.Name)
 	return s.createPod(crt, ch)
 }
 
@@ -72,7 +72,7 @@ func (s *Solver) getPodsForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.ACME
 	for _, pod := range podList {
 		if !metav1.IsControlledBy(pod, crt) {
 			glog.Infof("Found pod %q with acme-order-url annotation set to that of Certificate %q"+
-				"but it is not owned by the Certificate resource, so skipping it.", pod.Name, crt.Name)
+				"but it is not owned by the Certificate resource, so skipping it.", pod.Namespace+"/"+pod.Name, crt.Namespace+"/"+crt.Name)
 			continue
 		}
 		relevantPods = append(relevantPods, pod)

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -32,7 +32,7 @@ func (s *Solver) ensureService(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderC
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	glog.Infof("No existing HTTP01 challenge solver service found for Certificate %q. One will be created.")
+	glog.Infof("No existing HTTP01 challenge solver service found for Certificate %q. One will be created.", crt.Namespace+"/"+crt.Name)
 	return s.createService(crt, ch)
 }
 
@@ -58,7 +58,7 @@ func (s *Solver) getServicesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.
 	for _, service := range serviceList {
 		if !metav1.IsControlledBy(service, crt) {
 			glog.Infof("Found service %q with acme-order-url annotation set to that of Certificate %q"+
-				"but it is not owned by the Certificate resource, so skipping it.", service.Name, crt.Name)
+				"but it is not owned by the Certificate resource, so skipping it.", service.Namespace+"/"+service.Name, crt.Namespace+"/"+crt.Name)
 			continue
 		}
 		relevantServices = append(relevantServices, service)


### PR DESCRIPTION
It's useful to know what namespace is being operated on, so log
namespaces all over the place!

Specifically, I think this would have helped in #540

**Release note**:
```release-note
NONE
```
