### PR TITLE
Vault issuer MUST USE the vault 'sign' endpoint

### DIFF
--- a/docs/tutorials/vault/creating-vault-issuers.rst
+++ b/docs/tutorials/vault/creating-vault-issuers.rst
@@ -62,7 +62,8 @@ We can now create a cluster issuer referencing this secret:
               key: secretId
 
 Where *path* is the Vault role path of the PKI backend and *server* is
-the Vault server base URL. The Vault appRole credentials are supplied as the
+the Vault server base URL. The *path* MUST USE the vault ``sign`` endpoint.
+The Vault appRole credentials are supplied as the
 Vault authentication method using the appRole created in Vault. The secretRef
 references the Kubernetes secret created previously. More specifically, the field
 *name* is the Kubernetes secret name and *key* is the name given as the


### PR DESCRIPTION
**What this PR does / why we need it**:
Update the documentation to avoid errors using vault issuer

**Release note**:
```NONE
```
