### PR TITLE
Check the acme issuer has the challenge type configured.

### DIFF
--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -309,16 +309,16 @@ func (a *Acme) selectChallengesForAuthorizations(ctx context.Context, cl client.
 		var challenge *acme.Challenge
 		for _, ch := range authz.Challenges {
 			switch {
-			case ch.Type == "http-01" && cfg.HTTP01 != nil:
+			case ch.Type == "http-01" && cfg.HTTP01 != nil && a.issuer.GetSpec().ACME.HTTP01 != nil:
 				challenge = ch
-			case ch.Type == "dns-01" && cfg.DNS01 != nil:
+			case ch.Type == "dns-01" && cfg.DNS01 != nil && a.issuer.GetSpec().ACME.DNS01 != nil:
 				challenge = ch
 			}
 		}
 
 		domain := authz.Identifier.Value
 		if challenge == nil {
-			errs = append(errs, fmt.Errorf("ACME server does not allow selected challenge type for domain %q", domain))
+			errs = append(errs, fmt.Errorf("ACME server does not allow selected challenge type or no provider is configured for domain %q", domain))
 			continue
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The ACME issuer will check that a given challenge type is configured on the issuer being used.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

fixes #607

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
action required: ACME http01 validation is no longer attempted using an
Issuer/ClusterIssuer with no ACME http01 config.  Note that the minimal
`http01: {}` config IS sufficient.

If you rely on ACME http01 validation, you should check your issuers to make
sure http01 validation is explicitly enabled.
```
