### PR TITLE
Feature/configurable keysize

### DIFF
--- a/docs/reference/certificates.rst
+++ b/docs/reference/certificates.rst
@@ -27,6 +27,7 @@ A simple Certificate could be defined as:
          domains:
          - foo.example.com
          - bar.example.com
+     keysize: 2048
      issuerRef:
        name: letsencrypt-prod
        # We can reference ClusterIssuers by changing the kind here.

--- a/docs/reference/issuers/acme/dns01.rst
+++ b/docs/reference/issuers/acme/dns01.rst
@@ -18,6 +18,7 @@ requests:
      acme:
        email: user@example.com
        server: https://acme-staging-v02.api.letsencrypt.org/directory
+       keysize: 2048
        privateKeySecretRef:
          name: example-issuer-account-key
        dns01:

--- a/docs/reference/issuers/acme/http01.rst
+++ b/docs/reference/issuers/acme/http01.rst
@@ -21,6 +21,7 @@ using Ingress resources
      acme:
        email: user@example.com
        server: https://acme-staging-v02.api.letsencrypt.org/directory
+       keysize: 2048
        privateKeySecretRef:
          name: example-issuer-account-key
        http01: {}

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -132,6 +132,8 @@ type ACMEIssuer struct {
 	HTTP01 *ACMEIssuerHTTP01Config `json:"http01,omitempty"`
 	// DNS-01 config
 	DNS01 *ACMEIssuerDNS01Config `json:"dns01,omitempty"`
+	// KeySize in bits for account rsa key
+	KeySize int `json:"keysize,omitempty"`
 }
 
 type ACMEIssuerHTTP01Config struct {
@@ -297,6 +299,8 @@ type CertificateSpec struct {
 	// a ClusterIssuer of the given name will be used. Any other value is
 	// invalid.
 	IssuerRef ObjectReference `json:"issuerRef"`
+	// KeySize in bits for certificate private key
+	KeySize int `json:"keysize,omitempty"`
 
 	ACME *ACMECertificateConfig `json:"acme,omitempty"`
 }

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -50,7 +50,7 @@ func (a *Acme) obtainCertificate(ctx context.Context, crt *v1alpha1.Certificate)
 	// get existing certificate private key
 	key, err := kube.SecretTLSKey(a.secretsLister, crt.Namespace, crt.Spec.SecretName)
 	if k8sErrors.IsNotFound(err) || errors.IsInvalidData(err) {
-		key, err = pki.GenerateRSAPrivateKey(2048)
+		key, err = pki.GenerateRSAPrivateKey(getKeysize(crt.Spec.KeySize, 2048))
 		if err != nil {
 			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to generate certificate private key: %v", err), false)
 			return nil, nil, fmt.Errorf("error generating private key: %s", err.Error())

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -111,7 +111,7 @@ func (a *Acme) registerAccount(ctx context.Context, cl client.Interface) (*acme.
 
 func (a *Acme) createAccountPrivateKey() (*rsa.PrivateKey, error) {
 	secretName, secretKey := a.acmeAccountPrivateKeyMeta()
-	accountPrivKey, err := pki.GenerateRSAPrivateKey(2048)
+	accountPrivKey, err := pki.GenerateRSAPrivateKey(getKeysize(a.issuer.GetSpec().IssuerConfig.ACME.KeySize, 2048))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/issuer/acme/util.go
+++ b/pkg/issuer/acme/util.go
@@ -44,3 +44,19 @@ var acmev1ToV2Mappings = map[string]string{
 	"https://acme-v01.api.letsencrypt.org/directory/":     "https://acme-v02.api.letsencrypt.org/directory",
 	"https://acme-staging.api.letsencrypt.org/directory/": "https://acme-staging-v02.api.letsencrypt.org/directory",
 }
+
+// the minimum keysize should be 2048 bits
+const ACME_MINIMUM_KEYSIZE = 2048
+
+// return the number of bits for ACME account key or for private keys
+// returned value should never be lower than ACME_MINIMUM_KEYSIZE
+func getKeysize(configuredValue, defaultValue int) (keysize int) {
+	if defaultValue < ACME_MINIMUM_KEYSIZE {
+		defaultValue = ACME_MINIMUM_KEYSIZE
+	}
+	if configuredValue < defaultValue {
+		return defaultValue
+	} else {
+		return configuredValue
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adding fields to ACMEIssuer and CertificateSpec to make the private key size configurable.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Configurable Keysizes for ACME-Accounts and ACME-issued certificates.
```
