### PR TITLE
Update develop-with-minikube.rst

### DIFF
--- a/docs/devel/develop-with-minikube.rst
+++ b/docs/devel/develop-with-minikube.rst
@@ -18,7 +18,7 @@ First, run minikube, and configure your local kubectl command to work with minik
    minikube version: v0.25.0
 
    # Start a local cluster
-   $ minikube start --extra-config=apiserver.Authorization.Mode=RBAC
+   $ minikube start --extra-config=apiserver.authorization-mode=RBAC
 
    # Verify it works. This should output a local apiserver IP
    $ kubectl cluster-info


### PR DESCRIPTION
**What this PR does / why we need it**:
Minikube will fail to start if the documented option is used for enabling RBAC. This corrects the developer documentation to use `apiserver.authorization-mode`.

**Release note**:
```release-note
NONE
```
