### PR TITLE
Add localmanifests controller to perform bootstrapping for cert-manager certs

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -129,6 +129,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 		DefaultIssuerKind:                  opts.DefaultIssuerKind,
 		DefaultACMEIssuerChallengeType:     opts.DefaultACMEIssuerChallengeType,
 		DefaultACMEIssuerDNS01ProviderName: opts.DefaultACMEIssuerDNS01ProviderName,
+		LocalManifestsDir:                  opts.LocalManifestsDir,
 	}, kubeCfg, nil
 }
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -29,6 +29,8 @@ type ControllerOptions struct {
 	DefaultIssuerKind                  string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
+
+	LocalManifestsDir string
 }
 
 const (
@@ -48,6 +50,8 @@ const (
 	defaultTLSACMEIssuerKind           = "Issuer"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
+
+	defaultLocalManifestsDir = "/etc/cert-manager/manifests"
 )
 
 var (
@@ -69,6 +73,7 @@ func NewControllerOptions() *ControllerOptions {
 		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
 		DefaultACMEIssuerDNS01ProviderName: defaultACMEIssuerDNS01ProviderName,
+		LocalManifestsDir:                  defaultLocalManifestsDir,
 	}
 }
 
@@ -120,6 +125,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.DefaultACMEIssuerDNS01ProviderName, "default-acme-issuer-dns01-provider-name", defaultACMEIssuerDNS01ProviderName, ""+
 		"Required if --default-acme-issuer-challenge-type is set to dns01. The DNS01 provider to use for ingresses using ACME dns01 "+
 		"validation that do not explicitly state a dns provider.")
+
+	fs.StringVar(&s.LocalManifestsDir, "local-manifests-dir", defaultLocalManifestsDir, ""+
+		"Directory containing resources to be synced and mirrored back to the Kubernetes API. "+
+		"Similar to 'mirror pods' in Kubernetes.")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/cmd/controller/start.go
+++ b/cmd/controller/start.go
@@ -15,6 +15,7 @@ import (
 	_ "github.com/jetstack/cert-manager/pkg/controller/clusterissuers"
 	_ "github.com/jetstack/cert-manager/pkg/controller/ingress-shim"
 	_ "github.com/jetstack/cert-manager/pkg/controller/issuers"
+	_ "github.com/jetstack/cert-manager/pkg/controller/localmanifests"
 	_ "github.com/jetstack/cert-manager/pkg/issuer/acme"
 	_ "github.com/jetstack/cert-manager/pkg/issuer/ca"
 	_ "github.com/jetstack/cert-manager/pkg/issuer/selfsigned"

--- a/hack/build/dockerfiles/controller/Dockerfile
+++ b/hack/build/dockerfiles/controller/Dockerfile
@@ -7,6 +7,8 @@ ADD cert-manager-controller_linux_amd64 /usr/bin/cert-manager
 
 USER certmanager
 
+VOLUME ["/etc/cert-manager/manifests"]
+
 ENTRYPOINT ["/usr/bin/cert-manager"]
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -426,6 +426,7 @@ type ObjectReference struct {
 }
 
 const (
+	CertificateKind   = "Certificate"
 	ClusterIssuerKind = "ClusterIssuer"
 	IssuerKind        = "Issuer"
 )

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -41,4 +41,8 @@ type Context struct {
 	DefaultIssuerKind                  string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
+
+	// LocalManifestsDir is the directory containing local manifests that
+	// should be processed and eventually persisted to the API server.
+	LocalManifestsDir string
 }

--- a/pkg/controller/localmanifests/controller.go
+++ b/pkg/controller/localmanifests/controller.go
@@ -1,0 +1,295 @@
+// Package localmanifests implements a control loop that watches manifest files
+// on disk and manually forces them through their respective control loops.
+//
+// Similar to the kubelet's 'static manifests' concept, it allows cert-manager
+// to process resources before it is able to interact with its own API.
+// This is especially useful, and originally designed for, bootstrapping the
+// Validating/Mutating webhook components of cert-manager to solve the
+// chicken-egg problem.
+package localmanifests
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/golang/glog"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/jetstack/cert-manager/pkg/api"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/util"
+)
+
+// Controller is the localmanifest controller
+type Controller struct {
+	cmClient clientset.Interface
+
+	issuerInformer        cminformers.IssuerInformer
+	clusterIssuerInformer cminformers.ClusterIssuerInformer
+	certificateInformer   cminformers.CertificateInformer
+
+	// path to the directory containing the static manifests
+	manifestsPath string
+
+	// queue is a queue of filepaths to process
+	queue workqueue.RateLimitingInterface
+}
+
+// Run will start the local manifest controller.
+// When run, the 'manifestsPath' will be read. Each file in the directory will
+// be queued to be processed, and will keep being requeued until it has been
+// successfully synced.
+// In future, we may use something like inotify to watch for changes on disk to
+// these resources.
+//
+// The 'workers' parameter is ignored, and only one manifest will be processed
+// at a time.
+func (c *Controller) Run(_ int, stopCh <-chan struct{}) error {
+	c.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*2, time.Minute*1), "localmanifests")
+
+	// wait for all the informer caches we depend to sync
+	if !cache.WaitForCacheSync(stopCh,
+		c.certificateInformer.Informer().HasSynced,
+		c.clusterIssuerInformer.Informer().HasSynced,
+		c.issuerInformer.Informer().HasSynced,
+	) {
+		return fmt.Errorf("error waiting for informer caches to sync")
+	}
+
+	files, err := ioutil.ReadDir(c.manifestsPath)
+	if err != nil {
+		return err
+	}
+
+	for _, f := range files {
+		if f.IsDir() {
+			continue
+		}
+
+		// load each file into the workqueue
+		fp := filepath.Join(c.manifestsPath, f.Name())
+		c.queue.Add(fp)
+	}
+
+	workers := 1
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go wait.Until(func() { defer wg.Done(); c.work(stopCh) }, time.Second, stopCh)
+	}
+
+	<-stopCh
+	glog.V(4).Infof("Shutting down queue as workqueue signaled shutdown")
+	c.queue.ShutDown()
+	glog.V(4).Infof("Waiting for workers to exit...")
+	wg.Wait()
+	glog.V(4).Infof("Workers exited.")
+
+	return nil
+}
+
+// work will read paths of the queue and run processNextWorkItem.
+// If processing fails, the item will be re-queued with the rate limit applied.
+func (c *Controller) work(stopCh <-chan struct{}) {
+	glog.V(4).Infof("Starting %q worker", controllerName)
+	for {
+		obj, shutdown := c.queue.Get()
+		if shutdown {
+			break
+		}
+
+		var key string
+		err := func(obj interface{}) error {
+			defer c.queue.Done(obj)
+			var ok bool
+			if key, ok = obj.(string); !ok {
+				return nil
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			ctx = util.ContextWithStopCh(ctx, stopCh)
+			glog.Infof("%s controller: syncing item '%s'", controllerName, key)
+			if err := c.processNextWorkItem(ctx, key); err != nil {
+				return err
+			}
+			c.queue.Forget(obj)
+			return nil
+		}(obj)
+
+		if err != nil {
+			glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", controllerName, key, err.Error())
+			c.queue.AddRateLimited(obj)
+			continue
+		}
+
+		glog.Infof("%s controller: Finished processing work item %q", controllerName, key)
+	}
+	glog.V(4).Infof("Exiting %q worker loop", controllerName)
+}
+
+func (c *Controller) processNextWorkItem(ctx context.Context, path string) error {
+	glog.Infof("Processing local manifest %q", path)
+
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		glog.Infof("Error reading local manifest %q: %v", path, err)
+		return err
+	}
+
+	decoder := api.Codecs.UniversalDeserializer()
+	obj, gvk, err := decoder.Decode(data, nil, nil)
+	if err != nil {
+		glog.Infof("Error decoding manifest %q: %v", path, err)
+		return err
+	}
+
+	glog.V(4).Infof("Read GVK: %v, obj: %v", gvk, obj)
+	return c.runController(gvk, obj)
+}
+
+func (c *Controller) runController(gvk *schema.GroupVersionKind, obj runtime.Object) error {
+	if gvk.Group != "certmanager.k8s.io" {
+		glog.Errorf("Invalid group for local manifest resource: %q", gvk.Group)
+		return nil
+	}
+	if gvk.Version != "v1alpha1" {
+		glog.Errorf("Invalid version for local manifest resource: %q", gvk.Version)
+		return nil
+	}
+
+	var err error
+	var addFn func(interface{}) error
+	switch gvk.Kind {
+	case v1alpha1.CertificateKind:
+		err = c.persistCertificate(obj)
+		addFn = c.certificateInformer.Informer().GetIndexer().Add
+	case v1alpha1.IssuerKind:
+		err = c.persistIssuer(obj)
+		addFn = c.issuerInformer.Informer().GetIndexer().Add
+	case v1alpha1.ClusterIssuerKind:
+		err = c.persistClusterIssuer(obj)
+		addFn = c.clusterIssuerInformer.Informer().GetIndexer().Add
+	default:
+		glog.Errorf("Invalid kind for local manifest resource: %q", gvk.Kind)
+		return nil
+	}
+	// if persisting the object to the API is successful, we return as everything
+	// is already bootstrapped.
+	if err == nil {
+		return nil
+	}
+
+	// otherwise, manually add the resource to the lister so it will be processed
+	// and return an error
+	err = addFn(obj)
+	if err != nil {
+		return err
+	}
+
+	return fmt.Errorf("failed to persist resource to API - retrying")
+}
+
+func (c *Controller) persistCertificate(obj runtime.Object) error {
+	crt, ok := obj.(*v1alpha1.Certificate)
+	if !ok {
+		return fmt.Errorf("resource is not a Certificate")
+	}
+
+	existingCrt, err := c.certificateInformer.Lister().Certificates(crt.Namespace).Get(crt.Name)
+	if err == nil && existingCrt.ResourceVersion != "" {
+		// we want to overwrite the contents of the Certificate, and this is a
+		// required field on update
+		crt.ResourceVersion = existingCrt.ResourceVersion
+		_, err := c.cmClient.CertmanagerV1alpha1().Certificates(crt.Namespace).Update(crt)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, err = c.cmClient.CertmanagerV1alpha1().Certificates(crt.Namespace).Create(crt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) persistIssuer(obj runtime.Object) error {
+	iss, ok := obj.(*v1alpha1.Issuer)
+	if !ok {
+		return fmt.Errorf("resource is not an Issuer")
+	}
+
+	existingIss, err := c.issuerInformer.Lister().Issuers(iss.Namespace).Get(iss.Name)
+	if err == nil && existingIss.ResourceVersion != "" {
+		// we want to overwrite the contents of the Issuer, and this is a
+		// required field on update
+		iss.ResourceVersion = existingIss.ResourceVersion
+		_, err := c.cmClient.CertmanagerV1alpha1().Issuers(iss.Namespace).Update(iss)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, err = c.cmClient.CertmanagerV1alpha1().Issuers(iss.Namespace).Create(iss)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *Controller) persistClusterIssuer(obj runtime.Object) error {
+	iss, ok := obj.(*v1alpha1.ClusterIssuer)
+	if !ok {
+		return fmt.Errorf("resource is not a ClusterIssuer")
+	}
+
+	existingIss, err := c.clusterIssuerInformer.Lister().Get(iss.Name)
+	if err == nil && existingIss.ResourceVersion != "" {
+		// we want to overwrite the contents of the ClusterIssuer, and this is a
+		// required field on update
+		iss.ResourceVersion = existingIss.ResourceVersion
+		_, err := c.cmClient.CertmanagerV1alpha1().ClusterIssuers().Update(iss)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	_, err = c.cmClient.CertmanagerV1alpha1().ClusterIssuers().Create(iss)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+const (
+	controllerName = "localmanifests"
+)
+
+func init() {
+	controllerpkg.Register(controllerName, func(ctx *controllerpkg.Context) controllerpkg.Interface {
+		return (&Controller{
+			cmClient:              ctx.CMClient,
+			certificateInformer:   ctx.SharedInformerFactory.Certmanager().V1alpha1().Certificates(),
+			issuerInformer:        ctx.SharedInformerFactory.Certmanager().V1alpha1().Issuers(),
+			clusterIssuerInformer: ctx.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers(),
+			manifestsPath:         ctx.LocalManifestsDir,
+		}).Run
+	})
+}

--- a/pkg/controller/localmanifests/controller_test.go
+++ b/pkg/controller/localmanifests/controller_test.go
@@ -1,0 +1,804 @@
+package localmanifests
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	cltesting "k8s.io/client-go/testing"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
+	informers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+)
+
+const (
+	noResync = time.Duration(0)
+)
+
+type fixture struct {
+	cl *fake.Clientset
+	// if cl is nil, a new client will be created with these objects
+	clientObjects []runtime.Object
+	// reactors is an optional set of custom client reactors
+	reactors []reactor
+
+	// optional manifests path. If not set, a temporary directory will be
+	// created and used.
+	manifestsPath        string
+	cleanupManifestsPath bool
+
+	// optional custom workqueue. If not set, a default rate limiting workqueue
+	// will be used
+	workqueue workqueue.RateLimitingInterface
+
+	// optional custom SharedInformerFactory. If not set, an informer based on
+	// the fake client will be used.
+	factory informers.SharedInformerFactory
+	stopCh  chan struct{}
+
+	// this will be set after a call to controller()
+	c *Controller
+}
+
+func (f *fixture) controller() *Controller {
+	if f.c != nil {
+		return f.c
+	}
+
+	f.c = &Controller{
+		cmClient:              f.cl,
+		issuerInformer:        f.factory.Certmanager().V1alpha1().Issuers(),
+		clusterIssuerInformer: f.factory.Certmanager().V1alpha1().ClusterIssuers(),
+		certificateInformer:   f.factory.Certmanager().V1alpha1().Certificates(),
+		manifestsPath:         f.manifestsPath,
+		queue:                 f.workqueue,
+	}
+	// we call these informers so that WaitForCacheSync will ensure the listers
+	// are synced.
+	f.c.issuerInformer.Informer()
+	f.c.clusterIssuerInformer.Informer()
+	f.c.certificateInformer.Informer()
+
+	f.factory.Start(f.stopCh)
+	f.factory.WaitForCacheSync(f.stopCh)
+	return f.c
+}
+
+func (f *fixture) init(t *testing.T) {
+	if f.cl == nil {
+		f.cl = fake.NewSimpleClientset(f.clientObjects...)
+	}
+	for _, r := range f.reactors {
+		f.cl.PrependReactor(r.verb, r.resource, r.fn)
+	}
+	if f.workqueue == nil {
+		f.workqueue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*2, time.Minute*1), "localmanifests")
+	}
+	if f.factory == nil {
+		f.factory = informers.NewSharedInformerFactory(f.cl, noResync)
+	}
+	if f.manifestsPath == "" {
+		var err error
+		f.manifestsPath, err = ioutil.TempDir("", "cert-manager-unit")
+		if err != nil {
+			t.Errorf("error creating temporary manifest directory: %v", err)
+			t.FailNow()
+			return
+		}
+		f.cleanupManifestsPath = true
+	}
+	f.stopCh = make(chan struct{})
+}
+
+func (f *fixture) cleanup(t *testing.T) {
+	if f.cleanupManifestsPath {
+		err := os.RemoveAll(f.manifestsPath)
+		if err != nil {
+			t.Errorf("error cleaning up temporary manifests directory: %v", err)
+		}
+	}
+	close(f.stopCh)
+}
+
+func (f *fixture) filterActions(actions []cltesting.Action) []cltesting.Action {
+	var out []cltesting.Action
+	for _, a := range actions {
+		switch a.GetVerb() {
+		case "list", "watch":
+			continue
+		default:
+			out = append(out, a)
+		}
+	}
+	return out
+}
+
+// This is a special test to ensure the 'e2e' functionality of this controller.
+// It will perform a test where 'create' requests to the API server are failing,
+// and ensure that:
+//
+// 1) the object is instead directly added to a lister
+// 2) an informer that is watching for resources of that type has its OnAdd fn fired
+//
+// This is effectively a verification that this control loop does what is was
+// originally designed to do.
+func TestRunControllerTriggersInformers(t *testing.T) {
+	clusterIssuerGVK := v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.ClusterIssuerKind)
+	basicClusterIssuer := &v1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+
+	// create/init fixture
+	f := &fixture{
+		reactors: []reactor{
+			{"create", "clusterissuers",
+				func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+					return true, nil, fmt.Errorf("unknown failure")
+				}},
+		},
+	}
+	f.init(t)
+	defer f.cleanup(t)
+
+	addFnCalledCh := make(chan struct{})
+	defer close(addFnCalledCh)
+	// use the informer to add an AddFunc which verifies that the informer calls
+	// its handlers when we manually add items to a lister
+	f.factory.Certmanager().V1alpha1().ClusterIssuers().Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc: func(obj interface{}) {
+			// signal that the AddFunc has been called
+			close(addFnCalledCh)
+		},
+	})
+
+	c := f.controller()
+	// run test
+	err := c.runController(&clusterIssuerGVK, basicClusterIssuer)
+	// check basic err status
+	if err == nil {
+		t.Errorf("expected an error, but got none")
+	}
+
+	// ++++++++++++
+	// this block of checks is copied from the 'TestRunController' test below
+	// ++++++++++++
+
+	// first we verify that the 'create' endpoint was called.
+	// this request will have failed, but we check it anyway to ensure
+	// behaviour stays consistent
+	actions := f.filterActions(f.cl.Actions())
+	if len(actions) != 1 {
+		t.Errorf("expected 1 action but got: %v", actions)
+		return
+	}
+	a := actions[0]
+	if !a.Matches("create", "clusterissuers") {
+		t.Errorf("expected 'create clusterissuers' action but got: %v", a)
+		return
+	}
+	createAction := a.(cltesting.CreateAction)
+	obj := createAction.GetObject().(*v1alpha1.ClusterIssuer)
+	if !reflect.DeepEqual(basicClusterIssuer, obj) {
+		t.Errorf("expected %v to equal %v", obj, basicClusterIssuer)
+		return
+	}
+
+	// then check to make sure the clientset does not have a copy of
+	// the expected resource (as the create should have failed)
+	_, err = f.cl.CertmanagerV1alpha1().ClusterIssuers().Get(obj.Name, metav1.GetOptions{})
+	if !apierrors.IsNotFound(err) {
+		t.Errorf("expected not found error, but got: %v", err)
+		return
+	}
+
+	// now ensure that the Lister *does* contain a copy of the resource
+	listerObj, err := f.controller().clusterIssuerInformer.Lister().Get(obj.Name)
+	if err != nil {
+		t.Errorf("expected no error, but got: %v", err)
+		return
+	}
+	if !reflect.DeepEqual(basicClusterIssuer, listerObj) {
+		t.Errorf("expected %v to equal %v", listerObj, basicClusterIssuer)
+		return
+	}
+
+	// verify that the AddFunc has been called as a result of the item being added
+	// to the lister
+	waitDuration := time.Second * 2
+	waitForAddFunc, cancel := context.WithTimeout(context.Background(), waitDuration)
+	defer cancel()
+	select {
+	case <-addFnCalledCh:
+		break
+	case <-waitForAddFunc.Done():
+		t.Errorf("expected informer AddFunc to be called, but it was not after %v", waitDuration)
+	}
+}
+
+func TestRunController(t *testing.T) {
+	certGVK := v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CertificateKind)
+	basicCertificate := &v1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "abc",
+		},
+	}
+
+	issuerGVK := v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.IssuerKind)
+	basicIssuer := &v1alpha1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "abc",
+		},
+	}
+
+	clusterIssuerGVK := v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.ClusterIssuerKind)
+	basicClusterIssuer := &v1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+
+	type testT struct {
+		// test function args
+		gvk schema.GroupVersionKind
+		obj runtime.Object
+		// whether to expect an error
+		expectedErr bool
+		// set of objects to load into the fake clientset
+		clientObjects []runtime.Object
+		// function to verify the state of the fixture after test
+		verify func(t *testing.T, test testT, f *fixture)
+		// custom clientset reaction funcs
+		reactors []reactor
+	}
+
+	tests := map[string]testT{
+		"should create certificate without touching lister if possible": {
+			gvk:         certGVK,
+			obj:         basicCertificate.DeepCopy(),
+			expectedErr: false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "certificates") {
+					t.Errorf("expected 'create certificates' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.Certificate)
+				if !reflect.DeepEqual(test.obj, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.obj)
+					return
+				}
+			},
+		},
+		"should create issuer without touching lister if possible": {
+			gvk:         issuerGVK,
+			obj:         basicIssuer.DeepCopy(),
+			expectedErr: false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "issuers") {
+					t.Errorf("expected 'create issuers' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.Issuer)
+				if !reflect.DeepEqual(test.obj, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.obj)
+					return
+				}
+			},
+		},
+		"should create clusterissuer without touching lister if possible": {
+			gvk:         clusterIssuerGVK,
+			obj:         basicClusterIssuer.DeepCopy(),
+			expectedErr: false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "clusterissuers") {
+					t.Errorf("expected 'create clusterissuers' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.ClusterIssuer)
+				if !reflect.DeepEqual(test.obj, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.obj)
+					return
+				}
+			},
+		},
+		"should manually add resource to indexer if persisting fails & return an error": {
+			gvk:         clusterIssuerGVK,
+			obj:         basicClusterIssuer.DeepCopy(),
+			expectedErr: true,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				// first we verify that the 'create' endpoint was called.
+				// this request will have failed, but we check it anyway to ensure
+				// behaviour stays consistent
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "clusterissuers") {
+					t.Errorf("expected 'create clusterissuers' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.ClusterIssuer)
+				if !reflect.DeepEqual(test.obj, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.obj)
+					return
+				}
+
+				// then check to make sure the clientset does not have a copy of
+				// the expected resource (as the create should have failed)
+				_, err := f.cl.CertmanagerV1alpha1().ClusterIssuers().Get(obj.Name, metav1.GetOptions{})
+				if !apierrors.IsNotFound(err) {
+					t.Errorf("expected not found error, but got: %v", err)
+					return
+				}
+
+				// now ensure that the Lister *does* contain a copy of the resource
+				listerObj, err := f.controller().clusterIssuerInformer.Lister().Get(obj.Name)
+				if err != nil {
+					t.Errorf("expected no error, but got: %v", err)
+					return
+				}
+				if !reflect.DeepEqual(test.obj, listerObj) {
+					t.Errorf("expected %v to equal %v", listerObj, test.obj)
+					return
+				}
+			},
+			reactors: []reactor{
+				{"create", "clusterissuers",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			// create/init fixture
+			f := &fixture{
+				clientObjects: test.clientObjects,
+				reactors:      test.reactors,
+			}
+			f.init(t)
+			defer f.cleanup(t)
+			c := f.controller()
+			// run test
+			err := c.runController(&test.gvk, test.obj)
+			// check basic err status
+			if err != nil && !test.expectedErr {
+				t.Errorf("expected no error, but got: %v", err)
+			} else if err == nil && test.expectedErr {
+				t.Errorf("expected an error, but got none")
+			}
+
+			// verify expected actions/state
+			if test.verify != nil {
+				test.verify(t, test, f)
+			}
+		})
+	}
+}
+
+func TestPersistCertificate(t *testing.T) {
+	basicCertificate := &v1alpha1.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "abc",
+		},
+	}
+	basicCertificateWithRV := basicCertificate.DeepCopy()
+	basicCertificateWithRV.ResourceVersion = "10"
+
+	type testT struct {
+		toPersist     runtime.Object
+		clientObjects []runtime.Object
+		expectedErr   bool
+		verify        func(t *testing.T, test testT, f *fixture)
+		reactors      []reactor
+	}
+	tests := map[string]testT{
+		"should create a Certificate if it does not exist": {
+			// define test vars
+			toPersist:     basicCertificate.DeepCopy(),
+			clientObjects: []runtime.Object{},
+			expectedErr:   false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "certificates") {
+					t.Errorf("expected 'create certificates' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.Certificate)
+				if !reflect.DeepEqual(test.toPersist, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.toPersist)
+					return
+				}
+			},
+		},
+		"should update a Certificate if one already exists": {
+			// define test vars
+			toPersist:     basicCertificate.DeepCopy(),
+			clientObjects: []runtime.Object{basicCertificateWithRV.DeepCopy()},
+			expectedErr:   false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("update", "certificates") {
+					t.Errorf("expected 'update certificates' action but got: %v", a)
+					return
+				}
+				updateAction := a.(cltesting.UpdateAction)
+				obj := updateAction.GetObject().(*v1alpha1.Certificate)
+				metaToPersist := test.toPersist.(metav1.Object)
+				metaToPersist.SetResourceVersion(obj.ResourceVersion)
+				if !reflect.DeepEqual(test.toPersist, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.toPersist)
+					return
+				}
+			},
+		},
+		"should error on failure to create": {
+			// define test vars
+			toPersist:     basicCertificate.DeepCopy(),
+			clientObjects: []runtime.Object{},
+			expectedErr:   true,
+			reactors: []reactor{
+				{"create", "certificates",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+		"should error on failure to update": {
+			// define test vars
+			toPersist:     basicCertificate.DeepCopy(),
+			clientObjects: []runtime.Object{basicCertificateWithRV},
+			expectedErr:   true,
+			reactors: []reactor{
+				{"update", "certificates",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+		"should error with invalid resource": {
+			toPersist:   &v1alpha1.Issuer{},
+			expectedErr: true,
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			// create/init fixture
+			f := &fixture{
+				clientObjects: test.clientObjects,
+				reactors:      test.reactors,
+			}
+			f.init(t)
+			defer f.cleanup(t)
+			c := f.controller()
+			// run test
+			err := c.persistCertificate(test.toPersist)
+			// check basic err status
+			if err != nil && !test.expectedErr {
+				t.Errorf("expected no error, but got: %v", err)
+			} else if err == nil && test.expectedErr {
+				t.Errorf("expected an error, but got none")
+			}
+
+			// verify expected actions/state
+			if test.verify != nil {
+				test.verify(t, test, f)
+			}
+		})
+	}
+}
+
+func TestPersistIssuer(t *testing.T) {
+	basicIssuer := &v1alpha1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "abc",
+		},
+	}
+	basicIssuerWithRV := &v1alpha1.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			Namespace:       "abc",
+			ResourceVersion: "10",
+		},
+	}
+	type testT struct {
+		toPersist     runtime.Object
+		clientObjects []runtime.Object
+		expectedErr   bool
+		verify        func(t *testing.T, test testT, f *fixture)
+		reactors      []reactor
+	}
+	tests := map[string]testT{
+		"should create a Issuer if it does not exist": {
+			// define test vars
+			toPersist:     basicIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{},
+			expectedErr:   false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "issuers") {
+					t.Errorf("expected 'create issuers' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.Issuer)
+				if !reflect.DeepEqual(test.toPersist, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.toPersist)
+					return
+				}
+			},
+		},
+		"should update a Issuer if one already exists": {
+			// define test vars
+			toPersist:     basicIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{basicIssuerWithRV.DeepCopy()},
+			expectedErr:   false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("update", "issuers") {
+					t.Errorf("expected 'update issuers' action but got: %v", a)
+					return
+				}
+				updateAction := a.(cltesting.UpdateAction)
+				obj := updateAction.GetObject().(*v1alpha1.Issuer)
+				metaToPersist := test.toPersist.(metav1.Object)
+				metaToPersist.SetResourceVersion(obj.ResourceVersion)
+				if !reflect.DeepEqual(test.toPersist, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.toPersist)
+					return
+				}
+			},
+		},
+		"should error on failure to create": {
+			// define test vars
+			toPersist:     basicIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{},
+			expectedErr:   true,
+			reactors: []reactor{
+				{"create", "issuers",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+		"should error on failure to update": {
+			// define test vars
+			toPersist:     basicIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{basicIssuerWithRV},
+			expectedErr:   true,
+			reactors: []reactor{
+				{"update", "issuers",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+		"should error with invalid resource": {
+			toPersist:   &v1alpha1.Certificate{},
+			expectedErr: true,
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			// create/init fixture
+			f := &fixture{
+				clientObjects: test.clientObjects,
+				reactors:      test.reactors,
+			}
+			f.init(t)
+			defer f.cleanup(t)
+			c := f.controller()
+			// run test
+			err := c.persistIssuer(test.toPersist)
+			// check basic err status
+			if err != nil && !test.expectedErr {
+				t.Errorf("expected no error, but got: %v", err)
+			} else if err == nil && test.expectedErr {
+				t.Errorf("expected an error, but got none")
+			}
+
+			// verify expected actions/state
+			if test.verify != nil {
+				test.verify(t, test, f)
+			}
+		})
+	}
+}
+
+func TestPersistClusterIssuer(t *testing.T) {
+	basicClusterIssuer := &v1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+	}
+	basicClusterIssuerWithRV := &v1alpha1.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "test",
+			ResourceVersion: "10",
+		},
+	}
+	type testT struct {
+		toPersist     runtime.Object
+		clientObjects []runtime.Object
+		expectedErr   bool
+		verify        func(t *testing.T, test testT, f *fixture)
+		reactors      []reactor
+	}
+	tests := map[string]testT{
+		"should create a ClusterIssuer if it does not exist": {
+			// define test vars
+			toPersist:     basicClusterIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{},
+			expectedErr:   false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("create", "clusterissuers") {
+					t.Errorf("expected 'create clusterissuers' action but got: %v", a)
+					return
+				}
+				createAction := a.(cltesting.CreateAction)
+				obj := createAction.GetObject().(*v1alpha1.ClusterIssuer)
+				if !reflect.DeepEqual(test.toPersist, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.toPersist)
+					return
+				}
+			},
+		},
+		"should update a ClusterIssuer if one already exists": {
+			// define test vars
+			toPersist:     basicClusterIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{basicClusterIssuerWithRV.DeepCopy()},
+			expectedErr:   false,
+			verify: func(t *testing.T, test testT, f *fixture) {
+				actions := f.filterActions(f.cl.Actions())
+				if len(actions) != 1 {
+					t.Errorf("expected 1 action but got: %v", actions)
+					return
+				}
+				a := actions[0]
+				if !a.Matches("update", "clusterissuers") {
+					t.Errorf("expected 'update clusterissuers' action but got: %v", a)
+					return
+				}
+				updateAction := a.(cltesting.UpdateAction)
+				obj := updateAction.GetObject().(*v1alpha1.ClusterIssuer)
+				metaToPersist := test.toPersist.(metav1.Object)
+				metaToPersist.SetResourceVersion(obj.ResourceVersion)
+				if !reflect.DeepEqual(test.toPersist, obj) {
+					t.Errorf("expected %v to equal %v", obj, test.toPersist)
+					return
+				}
+			},
+		},
+		"should error on failure to create": {
+			// define test vars
+			toPersist:     basicClusterIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{},
+			expectedErr:   true,
+			reactors: []reactor{
+				{"create", "clusterissuers",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+		"should error on failure to update": {
+			// define test vars
+			toPersist:     basicClusterIssuer.DeepCopy(),
+			clientObjects: []runtime.Object{basicClusterIssuerWithRV},
+			expectedErr:   true,
+			reactors: []reactor{
+				{"update", "clusterissuers",
+					func(action cltesting.Action) (handled bool, ret runtime.Object, err error) {
+						return true, nil, fmt.Errorf("unknown failure")
+					}},
+			},
+		},
+		"should error with invalid resource": {
+			toPersist:   &v1alpha1.Certificate{},
+			expectedErr: true,
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			// create/init fixture
+			f := &fixture{
+				clientObjects: test.clientObjects,
+				reactors:      test.reactors,
+			}
+			f.init(t)
+			defer f.cleanup(t)
+			c := f.controller()
+			// run test
+			err := c.persistClusterIssuer(test.toPersist)
+			// check basic err status
+			if err != nil && !test.expectedErr {
+				t.Errorf("expected no error, but got: %v", err)
+			} else if err == nil && test.expectedErr {
+				t.Errorf("expected an error, but got none")
+			}
+
+			// verify expected actions/state
+			if test.verify != nil {
+				test.verify(t, test, f)
+			}
+		})
+	}
+}
+
+// todo: probably move this structure out of this package into some kind of testutils
+type reactor struct {
+	verb, resource string
+	fn             cltesting.ReactionFunc
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a 'localmanifests' controller, which can be used similar to the kubelet's 'mirror pods' directory.

It will allow us to process Certificates/Issuers/ClusterIssuers before we are able to persist those resources to the API.

This is useful because when we add the validating admission webhook, we'll need to provide a way to secure it with up to date TLS certificates. We also want the `failurePolicy` of this webhook to be `Fail` (else users may be able to create invalid resources whilst the API is down). This will allow us to generate certificates for the webhook whilst we are unable to persist their appropriate resources, thus breaking the chicken-egg problem 😄 

/cc @kragniz 

**Release note**:
```release-note
Add 'local manifests' support to allow bootstrapping TLS certificates for use by cert-manager's validating admission webhooks
```
