### PR TITLE
issuers: Skip triggering API update if status has not changed

### DIFF
--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -2,6 +2,7 @@ package clusterissuers
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
@@ -26,6 +27,10 @@ func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.ClusterIssuer) (err
 
 	err = i.Setup(ctx)
 	defer func() {
+		// TODO: replace this with more efficient comparison?
+		if reflect.DeepEqual(issuerCopy.Status, iss.Status) {
+			return
+		}
 		if saveErr := c.updateIssuerStatus(issuerCopy); saveErr != nil {
 			errs := []error{saveErr}
 			if err != nil {

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -2,6 +2,7 @@ package issuers
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
@@ -26,6 +27,10 @@ func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.Issuer) (err error)
 
 	err = i.Setup(ctx)
 	defer func() {
+		// TODO: replace this with more efficient comparison?
+		if reflect.DeepEqual(issuerCopy.Status, iss.Status) {
+			return
+		}
 		if saveErr := c.updateIssuerStatus(issuerCopy); saveErr != nil {
 			errs := []error{saveErr}
 			if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes a bug that could cause ACME issuers to spin, re-checking their account validation status every few seconds.

**Release note**:
```release-note
Fix a bug that could cause ACME Issuers to re-check Account validation status every few seconds
```
