### PR TITLE
enable clouddns meta auth

### DIFF
--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -31,26 +31,27 @@ type DNSProvider struct {
 	client           *dns.Service
 }
 
-func NewDNSProvider(project string, saFile string, saBytes []byte, dns01Nameservers []string, ambient bool) (*DNSProvider, error) {
+func NewDNSProvider(project string, saBytes []byte, dns01Nameservers []string, ambient bool) (*DNSProvider, error) {
+	// project is a required field
 	if project == "" {
 		return nil, fmt.Errorf("Google Cloud project name missing")
 	}
-	if saFile == "" && len(saBytes) == 0 {
+	// if the service account bytes are not provided, we will attempt to instantiate
+	// with 'ambient credentials' (if they are allowed/enabled)
+	if len(saBytes) == 0 {
 		if !ambient {
 			return nil, fmt.Errorf("unable to construct clouddns provider: empty credentials; perhaps you meant to enable ambient credentials?")
 		}
 		return NewDNSProviderCredentials(project, dns01Nameservers)
 	}
-	if saFile != "" {
-		return NewDNSProviderServiceAccount(project, saFile, dns01Nameservers)
-	}
+	// if service account data is provided, we instantiate using that
 	if len(saBytes) != 0 {
 		return NewDNSProviderServiceAccountBytes(project, saBytes, dns01Nameservers)
 	}
-	return nil, fmt.Errorf("Google Cloud project name missing")
+	return nil, fmt.Errorf("missing Google Cloud DNS provider credentials")
 }
 
-// NewDNSProvider returns a DNSProvider instance configured for Google Cloud
+// NewDNSProviderEnvironment returns a DNSProvider instance configured for Google Cloud
 // DNS. Project name must be passed in the environment variable: GCE_PROJECT.
 // A Service Account file can be passed in the environment variable:
 // GCE_SERVICE_ACCOUNT_FILE

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -31,11 +31,30 @@ type DNSProvider struct {
 	client           *dns.Service
 }
 
+func NewDNSProvider(project string, saFile string, saBytes []byte, dns01Nameservers []string, ambient bool) (*DNSProvider, error) {
+	if project == "" {
+		return nil, fmt.Errorf("Google Cloud project name missing")
+	}
+	if saFile == "" && len(saBytes) == 0 {
+		if !ambient {
+			return nil, fmt.Errorf("unable to construct clouddns provider: empty credentials; perhaps you meant to enable ambient credentials?")
+		}
+		return NewDNSProviderCredentials(project, dns01Nameservers)
+	}
+	if saFile != "" {
+		return NewDNSProviderServiceAccount(project, saFile, dns01Nameservers)
+	}
+	if len(saBytes) != 0 {
+		return NewDNSProviderServiceAccountBytes(project, saBytes, dns01Nameservers)
+	}
+	return nil, fmt.Errorf("Google Cloud project name missing")
+}
+
 // NewDNSProvider returns a DNSProvider instance configured for Google Cloud
 // DNS. Project name must be passed in the environment variable: GCE_PROJECT.
 // A Service Account file can be passed in the environment variable:
 // GCE_SERVICE_ACCOUNT_FILE
-func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
+func NewDNSProviderEnvironment(dns01Nameservers []string) (*DNSProvider, error) {
 	project := os.Getenv("GCE_PROJECT")
 	if saFile, ok := os.LookupEnv("GCE_SERVICE_ACCOUNT_FILE"); ok {
 		return NewDNSProviderServiceAccount(project, saFile, dns01Nameservers)

--- a/pkg/issuer/acme/dns/clouddns/clouddns_test.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns_test.go
@@ -55,14 +55,14 @@ func TestNewDNSProviderValidEnv(t *testing.T) {
 		t.Skip("skipping live test (requires credentials)")
 	}
 	os.Setenv("GCE_PROJECT", "my-project")
-	_, err := NewDNSProvider(util.RecursiveNameservers)
+	_, err := NewDNSProviderEnvironment(util.RecursiveNameservers)
 	assert.NoError(t, err)
 	restoreGCloudEnv()
 }
 
 func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("GCE_PROJECT", "")
-	_, err := NewDNSProvider(util.RecursiveNameservers)
+	_, err := NewDNSProviderEnvironment(util.RecursiveNameservers)
 	assert.EqualError(t, err, "Google Cloud project name missing")
 	restoreGCloudEnv()
 }

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -51,7 +51,7 @@ type solver interface {
 // It is useful for mocking out a given provider since an alternate set of
 // constructors may be set.
 type dnsProviderConstructors struct {
-	cloudDNS   func(project string, serviceAccountFile string, serviceAccount []byte, dns01Nameservers []string, ambient bool) (*clouddns.DNSProvider, error)
+	cloudDNS   func(project string, serviceAccount []byte, dns01Nameservers []string, ambient bool) (*clouddns.DNSProvider, error)
 	cloudFlare func(email, apikey string, dns01Nameservers []string) (*cloudflare.DNSProvider, error)
 	route53    func(accessKey, secretKey, hostedZoneID, region string, ambient bool, dns01Nameservers []string) (*route53.DNSProvider, error)
 	azureDNS   func(clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName string, dns01Nameservers []string) (*azuredns.DNSProvider, error)
@@ -171,21 +171,27 @@ func (s *Solver) solverForIssuerProvider(issuer v1alpha1.GenericIssuer, provider
 			return nil, errors.Wrap(err, "error instantiating akamai challenge solver")
 		}
 	case providerConfig.CloudDNS != nil:
+		var keyData []byte
 
-		var key []byte
+		// if the serviceAccount.name field is set, we will load credentials from
+		// that secret.
+		// If it is not set, we will attempt to instantiate the provider using
+		// ambient credentials (if enabled).
 		if providerConfig.CloudDNS.ServiceAccount.Name != "" {
 			saSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.CloudDNS.ServiceAccount.Name)
 			if err != nil {
 				return nil, fmt.Errorf("error getting clouddns service account: %s", err)
 			}
-			saKey := providerConfig.CloudDNS.ServiceAccount.Key
-			saBytes := saSecret.Data[saKey]
 
-			if len(saBytes) == 0 {
+			saKey := providerConfig.CloudDNS.ServiceAccount.Key
+			keyData = saSecret.Data[saKey]
+			if len(keyData) == 0 {
 				return nil, fmt.Errorf("specfied key %q not found in secret %s/%s", saKey, saSecret.Namespace, saSecret.Name)
 			}
 		}
-		impl, err = s.dnsProviderConstructors.cloudDNS(providerConfig.CloudDNS.Project, "", key, s.DNS01Nameservers, s.CanUseAmbientCredentials(issuer))
+
+		// attempt to construct the cloud dns provider
+		impl, err = s.dnsProviderConstructors.cloudDNS(providerConfig.CloudDNS.Project, keyData, s.DNS01Nameservers, s.CanUseAmbientCredentials(issuer))
 		if err != nil {
 			return nil, fmt.Errorf("error instantiating google clouddns challenge solver: %s", err)
 		}

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -136,8 +136,8 @@ func newFakeDNSProviders() *fakeDNSProviders {
 		calls: []fakeDNSProviderCall{},
 	}
 	f.constructors = dnsProviderConstructors{
-		cloudDNS: func(project string, serviceAccount []byte, dns01Nameservers []string) (*clouddns.DNSProvider, error) {
-			f.call("clouddns", project, serviceAccount, util.RecursiveNameservers)
+		cloudDNS: func(project string, serviceAccountFile string, serviceAccount []byte, dns01Nameservers []string, ambient bool) (*clouddns.DNSProvider, error) {
+			f.call("clouddns", project, serviceAccountFile, serviceAccount, util.RecursiveNameservers, ambient)
 			return nil, nil
 		},
 		cloudFlare: func(email, apikey string, dns01Nameservers []string) (*cloudflare.DNSProvider, error) {

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -136,8 +136,8 @@ func newFakeDNSProviders() *fakeDNSProviders {
 		calls: []fakeDNSProviderCall{},
 	}
 	f.constructors = dnsProviderConstructors{
-		cloudDNS: func(project string, serviceAccountFile string, serviceAccount []byte, dns01Nameservers []string, ambient bool) (*clouddns.DNSProvider, error) {
-			f.call("clouddns", project, serviceAccountFile, serviceAccount, util.RecursiveNameservers, ambient)
+		cloudDNS: func(project string, serviceAccount []byte, dns01Nameservers []string, ambient bool) (*clouddns.DNSProvider, error) {
+			f.call("clouddns", project, serviceAccount, util.RecursiveNameservers, ambient)
 			return nil, nil
 		},
 		cloudFlare: func(email, apikey string, dns01Nameservers []string) (*cloudflare.DNSProvider, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
this PR enables gcloud authentication via meta authentication api

**Which issue this PR fixes** 
fixes #241

```release-note
enable metadata server authentication for cloudDNS
```