### PR TITLE
add support CNAME for dns-01 challenge

### DIFF
--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -1,9 +1,20 @@
 package util
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/miekg/dns"
+)
 
 // DNS01Record returns a DNS record which will fulfill the `dns-01` challenge
 // TODO: move this into a non-generic place by resolving import cycle in dns package
 func DNS01Record(domain, value string) (string, string, int) {
-	return fmt.Sprintf("_acme-challenge.%s.", domain), value, 60
+	fqdn := fmt.Sprintf("_acme-challenge.%s.", domain)
+
+	// Check if the domain has CNAME then return that
+	r, err := dnsQuery(fqdn, dns.TypeCNAME, RecursiveNameservers, true)
+	if err == nil && r.Rcode == dns.RcodeSuccess {
+		fqdn = updateDomainWithCName(r, fqdn)
+	}
+	return fqdn, value, 60
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Domain for which certificate is asked for can have a `CNAME`, so we should check it.
If domain has a `CNAME`, create the challenge `TXT` record in the alias domain.

This is useful in the scenario where a company like us is using some DNS provider
which is not supported dynamically. We can then create a CNAME for records like

`_acme-challenge.example.com -> example.aws.hosted.com`

So this will allow us getting cert for `*.example.com` with creating a `TXT` record in route53 hosted zone for above example.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Add support for delegating DNS-01 challenges using CNAME records.
```
