### PR TITLE
Automated cherry pick of #628 #655 #662 #674

### DIFF
--- a/docs/tutorials/vault/creating-vault-issuers.rst
+++ b/docs/tutorials/vault/creating-vault-issuers.rst
@@ -62,7 +62,8 @@ We can now create a cluster issuer referencing this secret:
               key: secretId
 
 Where *path* is the Vault role path of the PKI backend and *server* is
-the Vault server base URL. The Vault appRole credentials are supplied as the
+the Vault server base URL. The *path* MUST USE the vault ``sign`` endpoint.
+The Vault appRole credentials are supplied as the
 Vault authentication method using the appRole created in Vault. The secretRef
 references the Kubernetes secret created previously. More specifically, the field
 *name* is the Kubernetes secret name and *key* is the name given as the

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -2,6 +2,7 @@ package clusterissuers
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
@@ -26,6 +27,10 @@ func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.ClusterIssuer) (err
 
 	err = i.Setup(ctx)
 	defer func() {
+		// TODO: replace this with more efficient comparison?
+		if reflect.DeepEqual(issuerCopy.Status, iss.Status) {
+			return
+		}
 		if saveErr := c.updateIssuerStatus(issuerCopy); saveErr != nil {
 			errs := []error{saveErr}
 			if err != nil {

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -2,6 +2,7 @@ package issuers
 
 import (
 	"context"
+	"reflect"
 
 	"github.com/golang/glog"
 	"k8s.io/api/core/v1"
@@ -26,6 +27,10 @@ func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.Issuer) (err error)
 
 	err = i.Setup(ctx)
 	defer func() {
+		// TODO: replace this with more efficient comparison?
+		if reflect.DeepEqual(issuerCopy.Status, iss.Status) {
+			return
+		}
 		if saveErr := c.updateIssuerStatus(issuerCopy); saveErr != nil {
 			errs := []error{saveErr}
 			if err != nil {

--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -462,7 +462,7 @@ func (a *Acme) shouldAttemptValidation(ctx context.Context, cl client.Interface,
 			}
 		}
 
-		return prepareAttemptWaitPeriod - (time.Now().Sub(condition.LastTransitionTime.Time)), order, nil
+		return prepareAttemptWaitPeriod - (time.Now().Sub(condition.LastTransitionTime.Time)), nil, nil
 	}
 
 	return 0, nil, fmt.Errorf("unrecognised existing acme order status: %q", order.Status)

--- a/test/e2e/certificate/certificate_acme.go
+++ b/test/e2e/certificate/certificate_acme.go
@@ -31,7 +31,7 @@ import (
 )
 
 const invalidACMEURL = "http://not-a-real-acme-url.com"
-const testingACMEEmail = "test@example.com"
+const testingACMEEmail = "e2e@cert-manager.io"
 const testingACMEPrivateKey = "test-acme-private-key"
 const foreverTestTimeout = time.Second * 60
 


### PR DESCRIPTION
Cherry pick of #628 #655 #662 #674 on release-0.3.

#628: Vault issuer MUST USE the vault 'sign' endpoint
#655: Update e2e test ACME email
#662: issuers: Skip triggering API update if status has not changed
#674: Don't return invalid/expired orders in shouldAttemptValidation