### PR TITLE
Allow setting http_proxy and https_proxy in cert-manager deployment

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.4.0-dev.1
+version: v0.4.0-dev.2
 appVersion: v0.4.0-dev.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -78,6 +78,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |
 | `podDnsConfig` | Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config) |  |
 | `podLabels` | Labels to add to the cert-manager pod | `{}` |
+| `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
+| `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
+| `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -68,6 +68,18 @@ spec:
         {{- if .Values.extraEnv }}
 {{ toYaml .Values.extraEnv | indent 10 }}
         {{- end }}
+          {{- if .Values.http_proxy }}
+          - name: HTTP_PROXY
+            value: {{ .Values.http_proxy }}
+          {{- end }}
+          {{- if .Values.https_proxy }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.https_proxy }}
+          {{- end }}
+          {{- if .Values.no_proxy }}
+          - name: NO_PROXY
+            value: {{ .Values.no_proxy }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -73,3 +73,8 @@ ingressShim: {}
 # namespace manifest for the namespace that cert-manager is being installed
 # within. It should **not** be used if you are using Helm for deployment.
 createNamespaceResource: false
+
+# Use these variables to configure the HTTP_PROXY environment variables
+# http_proxy: "http://proxy:8080"
+# http_proxy: "http://proxy:8080"
+# no_proxy: 127.0.0.1,localhost

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -26,7 +26,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -48,7 +48,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -66,7 +66,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -84,7 +84,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -109,7 +109,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -129,7 +129,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -36,7 +36,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -54,7 +54,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +73,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.1
+    chart: cert-manager-v0.4.0-dev.2
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Solves #310 Allow setting http_proxy environment variables

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #310

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added configuration variables to set http_proxy, https_proxy and no_proxy environment variables in Helm chart.
```
