### PR TITLE
 pkg/controller: log correct renewal time, move pkg/scheduler to k8s fakeclock

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -928,9 +928,18 @@
   ]
   revision = "39a7bf85c140f972372c2a0d1ee40adbf0c8bfe1"
 
+[[projects]]
+  branch = "master"
+  name = "k8s.io/utils"
+  packages = [
+    "clock",
+    "clock/testing"
+  ]
+  revision = "ab9069044f32ba0c6da081bb46bb0b12e3862c21"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d792bbf24d87653ea8f00046b922dca780a50fdd60e8ea9540c9f34c9a28e675"
+  inputs-digest = "18d7042f445f227a674b1a6d9aa75b6f8a54c7c8aef3edba7ca142e659d4cc53"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,6 +20,10 @@ required = [
   version = "kubernetes-1.10.0"
 
 [[constraint]]
+  name = "k8s.io/utils"
+  branch = "master"
+
+[[constraint]]
   name = "k8s.io/code-generator"
   version = "kubernetes-1.10.0"
 

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -67,11 +67,13 @@ func New(
 ) *Controller {
 	ctrl := &Controller{client: client, cmClient: cmClient, issuerFactory: issuerFactory, recorder: recorder}
 	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*2, time.Minute*1), "certificates")
+
+	rateLimiter := workqueue.NewItemExponentialFailureRateLimiter(time.Second*2, time.Minute*1)
+	ctrl.queue = workqueue.NewNamedRateLimitingQueue(rateLimiter, "certificates")
 	// Create a scheduled work queue that calls the ctrl.queue.Add method for
 	// each object in the queue. This is used to schedule re-checks of
 	// Certificate resources when they get near to expiry
-	ctrl.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(ctrl.queue.AddRateLimited)
+	ctrl.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(ctrl.queue.Add, rateLimiter)
 
 	certificatesInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})
 	ctrl.certificateLister = certificatesInformer.Lister()

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -1,24 +1,11 @@
 package scheduler
 
 import (
-	"sync"
 	"time"
 
 	"k8s.io/client-go/util/workqueue"
+	k8sClock "k8s.io/utils/clock"
 )
-
-// For mocking purposes.
-// This little bit of wrapping needs to be done becuase go doesn't do
-// covariance, but it does coerse *time.Timer into stoppable implicitly if we
-// write it out like so.
-var afterFunc = func(d time.Duration, f func()) stoppable {
-	return time.AfterFunc(d, f)
-}
-
-// stoppable is the subset of time.Timer which we use, split out for mocking purposes
-type stoppable interface {
-	Stop() bool
-}
 
 // ProcessFunc is a function to process an item in the work queue.
 type ProcessFunc func(interface{})
@@ -36,61 +23,156 @@ type ScheduledWorkQueue interface {
 	Add(interface{}, time.Duration) time.Duration
 	// Forget will cancel the timer for the given object, if the timer exists.
 	Forget(interface{})
+	// Stop stops processing all items and frees all resources
+	Stop()
+}
+
+type workItem struct {
+	processAt time.Time
+	item      interface{}
 }
 
 type scheduledWorkQueue struct {
+	clock       k8sClock.Clock
 	limiter     workqueue.RateLimiter
 	processFunc ProcessFunc
-	work        map[interface{}]stoppable
-	workLock    sync.Mutex
+
+	// These channels control the work loop
+	// in provides new items to add to processing, forget provides items to
+	// forget, done indicates items that have been procssed and can be removed
+	// from processing, and stop stops the entire loop.
+	in     chan workItem
+	forget chan interface{}
+	done   chan interface{}
+	stop   chan struct{}
+
+	// pending holds items which are waiting for their time to execute
+	// processing holds items that are currently being processed, and thus
+	// shouldn't be re-added to 'pending' yet.
+	// No locks are needed because the workLoop has exclusive ownership of these maps
+	pending    map[interface{}]time.Time
+	processing map[interface{}]struct{}
+	// nextTime holds a timer for the earliest item in 'pending'. It is
+	// recalculated any time 'pending' changes.
+	nextTime  k8sClock.Timer
+	timerRead bool
 }
 
 // NewScheduledWorkQueue will create a new workqueue with the given processFunc
 func NewScheduledWorkQueue(processFunc ProcessFunc, limiter workqueue.RateLimiter) ScheduledWorkQueue {
-	return &scheduledWorkQueue{limiter, processFunc, make(map[interface{}]stoppable), sync.Mutex{}}
+	return newScheduledWorkQueue(k8sClock.RealClock{}, processFunc, limiter)
+}
+
+// newScheduledWorkQueue will create a new workqueue with the given processFunc
+func newScheduledWorkQueue(clock k8sClock.Clock, processFunc ProcessFunc, limiter workqueue.RateLimiter) ScheduledWorkQueue {
+	q := &scheduledWorkQueue{
+		clock:       clock,
+		limiter:     limiter,
+		processFunc: processFunc,
+
+		in:     make(chan workItem),
+		done:   make(chan interface{}),
+		forget: make(chan interface{}),
+		stop:   make(chan struct{}),
+
+		pending:    make(map[interface{}]time.Time),
+		processing: make(map[interface{}]struct{}),
+		// arbitrarily tick in an hour to avoid a nil timer
+		nextTime: clock.NewTimer(1 * time.Hour),
+	}
+	go q.workLoop()
+
+	return q
+}
+
+func (s *scheduledWorkQueue) workLoop() {
+	for {
+		select {
+		case <-s.stop:
+			return
+		case now := <-s.nextTime.C():
+			s.timerRead = true
+			for obj, t := range s.pending {
+				if t.Before(now) || t.Equal(now) {
+					delete(s.pending, obj)
+					s.processing[obj] = struct{}{}
+					go func(obj interface{}) {
+						s.processFunc(obj)
+						s.done <- obj
+					}(obj)
+				}
+			}
+			// reset is only useful if we haven't drained it yet; this case means
+			// it's already drained since we just recv'd on the timer
+			s.setNextTime()
+		case newItem := <-s.in:
+			if _, ok := s.processing[newItem.item]; ok {
+				// already processing this, be stingy rather than overeager
+				continue
+			}
+			// if this one's already pending, override it with the new time
+			// arbitrarily
+			s.pending[newItem.item] = newItem.processAt
+			s.setNextTime()
+		case obj := <-s.forget:
+			delete(s.pending, obj)
+			s.setNextTime()
+		case item := <-s.done:
+			for obj := range s.processing {
+				if obj == item {
+					delete(s.processing, obj)
+					s.limiter.Forget(obj)
+				}
+			}
+		}
+	}
+}
+
+func (s *scheduledWorkQueue) setNextTime() {
+	// See the time.Timer.Reset docs for why we stop + drain
+	// It's only safe to do stop+drain here if the timer has not yet been read,
+	// so use s.timerRead to ensure the timer hasn't been.
+	if !s.timerRead && !s.nextTime.Stop() {
+		<-s.nextTime.C()
+		s.timerRead = true
+	}
+	var min *time.Time
+	for _, t := range s.pending {
+		t := t
+		if min == nil {
+			min = &t
+			continue
+		}
+		if t.Before(*min) {
+			min = &t
+		}
+	}
+	if min == nil {
+		return
+	}
+	nextTick := min.Sub(s.clock.Now())
+	s.nextTime.Reset(nextTick)
+	s.timerRead = false
 }
 
 // Add will add an item to this queue, executing the ProcessFunc after the
 // Duration has come (since the time Add was called). If an existing Timer for
 // obj already exists, the previous timer will be cancelled.
 func (s *scheduledWorkQueue) Add(obj interface{}, duration time.Duration) time.Duration {
-	s.workLock.Lock()
-	defer s.workLock.Unlock()
-	s.forget(obj)
 	delay := s.limiter.When(obj)
-	s.work[obj] = afterFunc(duration+delay, func() {
-		s.processItem(obj)
-	})
-
-	return duration + delay
+	s.in <- workItem{
+		processAt: s.clock.Now().Add(delay + duration),
+		item:      obj,
+	}
+	return delay + duration
 }
 
 // Forget will cancel the timer for the given object, if the timer exists.
 // It will not reset any rate limits for the given object, only a successful completion of that object will.
 func (s *scheduledWorkQueue) Forget(obj interface{}) {
-	s.workLock.Lock()
-	defer s.workLock.Unlock()
-	s.forget(obj)
+	s.forget <- obj
 }
 
-// forget cancels and removes an item. It *must* be called with the lock already held
-func (s *scheduledWorkQueue) forget(obj interface{}) {
-	if timer, ok := s.work[obj]; ok {
-		timer.Stop()
-		delete(s.work, obj)
-	}
-}
-
-// processItem processes the given item, removes it from the queue, and resets
-// its rate limit.
-func (s *scheduledWorkQueue) processItem(obj interface{}) {
-	// since we don't know how long processFunc will run, don't hold the lock during it.
-	// Run it before we've removed the item from the queue so if we race, we race
-	// towards being more stingy.
-	s.processFunc(obj)
-
-	s.workLock.Lock()
-	s.limiter.Forget(obj)
-	s.forget(obj)
-	s.workLock.Unlock()
+func (s *scheduledWorkQueue) Stop() {
+	close(s.stop)
 }

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -31,9 +31,8 @@ type workItem struct {
 	processAt time.Time
 	item      interface{}
 	// itemAdded is used to signal 'Add' that this workItem has been added to the
-	// queue.
-	// It is not strictly necessary for regular operation, but is necessary to be
-	// able to reliably unit test this package.
+	// queue. It is not strictly necessary for regular operation, but is
+	// necessary to be able to reliably unit test this package.
 	itemAdded chan<- struct{}
 }
 

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -3,6 +3,8 @@ package scheduler
 import (
 	"sync"
 	"time"
+
+	"k8s.io/client-go/util/workqueue"
 )
 
 // For mocking purposes.
@@ -23,41 +25,48 @@ type ProcessFunc func(interface{})
 
 // ScheduledWorkQueue is an interface to describe a queue that will execute the
 // given ProcessFunc with the object given to Add once the time.Duration is up,
-// since the time of calling Add.
+// since the time of calling Add. It supports passing in a RateLimiter as well,
+// which will add an additional delay to the provided schedule automatically.
 type ScheduledWorkQueue interface {
 	// Add will add an item to this queue, executing the ProcessFunc after the
 	// Duration has come (since the time Add was called). If an existing Timer
 	// for obj already exists, the previous timer will be cancelled.
-	Add(interface{}, time.Duration)
+	// It returns the duration it will wait before processing the item, including
+	// any additional time added by the rate limiter.
+	Add(interface{}, time.Duration) time.Duration
 	// Forget will cancel the timer for the given object, if the timer exists.
 	Forget(interface{})
 }
 
 type scheduledWorkQueue struct {
+	limiter     workqueue.RateLimiter
 	processFunc ProcessFunc
 	work        map[interface{}]stoppable
 	workLock    sync.Mutex
 }
 
 // NewScheduledWorkQueue will create a new workqueue with the given processFunc
-func NewScheduledWorkQueue(processFunc ProcessFunc) ScheduledWorkQueue {
-	return &scheduledWorkQueue{processFunc, make(map[interface{}]stoppable), sync.Mutex{}}
+func NewScheduledWorkQueue(processFunc ProcessFunc, limiter workqueue.RateLimiter) ScheduledWorkQueue {
+	return &scheduledWorkQueue{limiter, processFunc, make(map[interface{}]stoppable), sync.Mutex{}}
 }
 
 // Add will add an item to this queue, executing the ProcessFunc after the
 // Duration has come (since the time Add was called). If an existing Timer for
 // obj already exists, the previous timer will be cancelled.
-func (s *scheduledWorkQueue) Add(obj interface{}, duration time.Duration) {
+func (s *scheduledWorkQueue) Add(obj interface{}, duration time.Duration) time.Duration {
 	s.workLock.Lock()
 	defer s.workLock.Unlock()
 	s.forget(obj)
-	s.work[obj] = afterFunc(duration, func() {
-		defer s.Forget(obj)
-		s.processFunc(obj)
+	delay := s.limiter.When(obj)
+	s.work[obj] = afterFunc(duration+delay, func() {
+		s.processItem(obj)
 	})
+
+	return duration + delay
 }
 
 // Forget will cancel the timer for the given object, if the timer exists.
+// It will not reset any rate limits for the given object, only a successful completion of that object will.
 func (s *scheduledWorkQueue) Forget(obj interface{}) {
 	s.workLock.Lock()
 	defer s.workLock.Unlock()
@@ -70,4 +79,18 @@ func (s *scheduledWorkQueue) forget(obj interface{}) {
 		timer.Stop()
 		delete(s.work, obj)
 	}
+}
+
+// processItem processes the given item, removes it from the queue, and resets
+// its rate limit.
+func (s *scheduledWorkQueue) processItem(obj interface{}) {
+	// since we don't know how long processFunc will run, don't hold the lock during it.
+	// Run it before we've removed the item from the queue so if we race, we race
+	// towards being more stingy.
+	s.processFunc(obj)
+
+	s.workLock.Lock()
+	s.limiter.Forget(obj)
+	s.forget(obj)
+	s.workLock.Unlock()
 }

--- a/vendor/k8s.io/utils/LICENSE
+++ b/vendor/k8s.io/utils/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/k8s.io/utils/clock/clock.go
+++ b/vendor/k8s.io/utils/clock/clock.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clock
+
+import "time"
+
+// Clock allows for injecting fake or real clocks into code that
+// needs to do arbitrary things based on time.
+type Clock interface {
+	Now() time.Time
+	Since(time.Time) time.Duration
+	After(d time.Duration) <-chan time.Time
+	NewTimer(d time.Duration) Timer
+	Sleep(d time.Duration)
+	Tick(d time.Duration) <-chan time.Time
+}
+
+var _ = Clock(RealClock{})
+
+// RealClock really calls time.Now()
+type RealClock struct{}
+
+// Now returns the current time.
+func (RealClock) Now() time.Time {
+	return time.Now()
+}
+
+// Since returns time since the specified timestamp.
+func (RealClock) Since(ts time.Time) time.Duration {
+	return time.Since(ts)
+}
+
+// Same as time.After(d).
+func (RealClock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}
+
+func (RealClock) NewTimer(d time.Duration) Timer {
+	return &realTimer{
+		timer: time.NewTimer(d),
+	}
+}
+
+func (RealClock) Tick(d time.Duration) <-chan time.Time {
+	return time.Tick(d)
+}
+
+func (RealClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}
+
+// Timer allows for injecting fake or real timers into code that
+// needs to do arbitrary things based on time.
+type Timer interface {
+	C() <-chan time.Time
+	Stop() bool
+	Reset(d time.Duration) bool
+}
+
+var _ = Timer(&realTimer{})
+
+// realTimer is backed by an actual time.Timer.
+type realTimer struct {
+	timer *time.Timer
+}
+
+// C returns the underlying timer's channel.
+func (r *realTimer) C() <-chan time.Time {
+	return r.timer.C
+}
+
+// Stop calls Stop() on the underlying timer.
+func (r *realTimer) Stop() bool {
+	return r.timer.Stop()
+}
+
+// Reset calls Reset() on the underlying timer.
+func (r *realTimer) Reset(d time.Duration) bool {
+	return r.timer.Reset(d)
+}

--- a/vendor/k8s.io/utils/clock/testing/fake_clock.go
+++ b/vendor/k8s.io/utils/clock/testing/fake_clock.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"sync"
+	"time"
+
+	"k8s.io/utils/clock"
+)
+
+var (
+	_ = clock.Clock(&FakeClock{})
+	_ = clock.Clock(&IntervalClock{})
+)
+
+// FakeClock implements clock.Clock, but returns an arbitrary time.
+type FakeClock struct {
+	lock sync.RWMutex
+	time time.Time
+
+	// waiters are waiting for the fake time to pass their specified time
+	waiters []*fakeClockWaiter
+}
+
+type fakeClockWaiter struct {
+	targetTime    time.Time
+	stepInterval  time.Duration
+	skipIfBlocked bool
+	destChan      chan time.Time
+	fired         bool
+}
+
+// NewFakeClock constructs a fake clock set to the provided time.
+func NewFakeClock(t time.Time) *FakeClock {
+	return &FakeClock{
+		time: t,
+	}
+}
+
+// Now returns f's time.
+func (f *FakeClock) Now() time.Time {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time
+}
+
+// Since returns time since the time in f.
+func (f *FakeClock) Since(ts time.Time) time.Duration {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return f.time.Sub(ts)
+}
+
+// After is the fake version of time.After(d).
+func (f *FakeClock) After(d time.Duration) <-chan time.Time {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime: stopTime,
+		destChan:   ch,
+	})
+	return ch
+}
+
+// NewTimer constructs a fake timer, akin to time.NewTimer(d).
+func (f *FakeClock) NewTimer(d time.Duration) clock.Timer {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	stopTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // Don't block!
+	timer := &fakeTimer{
+		fakeClock: f,
+		waiter: fakeClockWaiter{
+			targetTime: stopTime,
+			destChan:   ch,
+		},
+	}
+	f.waiters = append(f.waiters, &timer.waiter)
+	return timer
+}
+
+// Tick constructs a fake ticker, akin to time.Tick
+func (f *FakeClock) Tick(d time.Duration) <-chan time.Time {
+	if d <= 0 {
+		return nil
+	}
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	tickTime := f.time.Add(d)
+	ch := make(chan time.Time, 1) // hold one tick
+	f.waiters = append(f.waiters, &fakeClockWaiter{
+		targetTime:    tickTime,
+		stepInterval:  d,
+		skipIfBlocked: true,
+		destChan:      ch,
+	})
+
+	return ch
+}
+
+// Step moves the clock by Duration and notifies anyone that's called After,
+// Tick, or NewTimer.
+func (f *FakeClock) Step(d time.Duration) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(f.time.Add(d))
+}
+
+// SetTime sets the time.
+func (f *FakeClock) SetTime(t time.Time) {
+	f.lock.Lock()
+	defer f.lock.Unlock()
+	f.setTimeLocked(t)
+}
+
+// Actually changes the time and checks any waiters. f must be write-locked.
+func (f *FakeClock) setTimeLocked(t time.Time) {
+	f.time = t
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.waiters))
+	for i := range f.waiters {
+		w := f.waiters[i]
+		if !w.targetTime.After(t) {
+
+			if w.skipIfBlocked {
+				select {
+				case w.destChan <- t:
+					w.fired = true
+				default:
+				}
+			} else {
+				w.destChan <- t
+				w.fired = true
+			}
+
+			if w.stepInterval > 0 {
+				for !w.targetTime.After(t) {
+					w.targetTime = w.targetTime.Add(w.stepInterval)
+				}
+				newWaiters = append(newWaiters, w)
+			}
+
+		} else {
+			newWaiters = append(newWaiters, f.waiters[i])
+		}
+	}
+	f.waiters = newWaiters
+}
+
+// HasWaiters returns true if After has been called on f but not yet satisfied (so you can
+// write race-free tests).
+func (f *FakeClock) HasWaiters() bool {
+	f.lock.RLock()
+	defer f.lock.RUnlock()
+	return len(f.waiters) > 0
+}
+
+// Sleep is akin to time.Sleep
+func (f *FakeClock) Sleep(d time.Duration) {
+	f.Step(d)
+}
+
+// IntervalClock implements clock.Clock, but each invocation of Now steps the clock forward the specified duration
+type IntervalClock struct {
+	Time     time.Time
+	Duration time.Duration
+}
+
+// Now returns i's time.
+func (i *IntervalClock) Now() time.Time {
+	i.Time = i.Time.Add(i.Duration)
+	return i.Time
+}
+
+// Since returns time since the time in i.
+func (i *IntervalClock) Since(ts time.Time) time.Duration {
+	return i.Time.Sub(ts)
+}
+
+// After is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) After(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement After")
+}
+
+// NewTimer is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) NewTimer(d time.Duration) clock.Timer {
+	panic("IntervalClock doesn't implement NewTimer")
+}
+
+// Tick is unimplemented, will panic.
+// TODO: make interval clock use FakeClock so this can be implemented.
+func (*IntervalClock) Tick(d time.Duration) <-chan time.Time {
+	panic("IntervalClock doesn't implement Tick")
+}
+
+// Sleep is unimplemented, will panic.
+func (*IntervalClock) Sleep(d time.Duration) {
+	panic("IntervalClock doesn't implement Sleep")
+}
+
+var _ = clock.Timer(&fakeTimer{})
+
+// fakeTimer implements clock.Timer based on a FakeClock.
+type fakeTimer struct {
+	fakeClock *FakeClock
+	waiter    fakeClockWaiter
+}
+
+// C returns the channel that notifies when this timer has fired.
+func (f *fakeTimer) C() <-chan time.Time {
+	return f.waiter.destChan
+}
+
+// Stop stops the timer and returns true if the timer has not yet fired, or false otherwise.
+func (f *fakeTimer) Stop() bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	newWaiters := make([]*fakeClockWaiter, 0, len(f.fakeClock.waiters))
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w != &f.waiter {
+			newWaiters = append(newWaiters, w)
+		}
+	}
+
+	f.fakeClock.waiters = newWaiters
+
+	return !f.waiter.fired
+}
+
+// Reset resets the timer to the fake clock's "now" + d. It returns true if the timer has not yet
+// fired, or false otherwise.
+func (f *fakeTimer) Reset(d time.Duration) bool {
+	f.fakeClock.lock.Lock()
+	defer f.fakeClock.lock.Unlock()
+
+	active := !f.waiter.fired
+
+	f.waiter.fired = false
+	f.waiter.targetTime = f.fakeClock.time.Add(d)
+
+	var isWaiting bool
+	for i := range f.fakeClock.waiters {
+		w := f.fakeClock.waiters[i]
+		if w == &f.waiter {
+			isWaiting = true
+			break
+		}
+	}
+	if !isWaiting {
+		f.fakeClock.waiters = append(f.fakeClock.waiters, &f.waiter)
+	}
+
+	return active
+}

--- a/vendor/k8s.io/utils/clock/testing/fake_clock_test.go
+++ b/vendor/k8s.io/utils/clock/testing/fake_clock_test.go
@@ -1,0 +1,274 @@
+/*
+Copyright 2015 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFakeClock(t *testing.T) {
+	startTime := time.Now()
+	tc := NewFakeClock(startTime)
+	tc.Step(time.Second)
+	now := tc.Now()
+	if now.Sub(startTime) != time.Second {
+		t.Errorf("input: %s now=%s gap=%s expected=%s", startTime, now, now.Sub(startTime), time.Second)
+	}
+
+	tt := tc.Now()
+	tc.SetTime(tt.Add(time.Hour))
+	if tc.Now().Sub(tt) != time.Hour {
+		t.Errorf("input: %s now=%s gap=%s expected=%s", tt, tc.Now(), tc.Now().Sub(tt), time.Hour)
+	}
+}
+
+func TestFakeClockSleep(t *testing.T) {
+	startTime := time.Now()
+	tc := NewFakeClock(startTime)
+	tc.Sleep(time.Duration(1) * time.Hour)
+	now := tc.Now()
+	if now.Sub(startTime) != time.Hour {
+		t.Errorf("Fake sleep failed, expected time to advance by one hour, instead, its %v", now.Sub(startTime))
+	}
+}
+
+func TestFakeAfter(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	if tc.HasWaiters() {
+		t.Errorf("unexpected waiter?")
+	}
+	oneSec := tc.After(time.Second)
+	if !tc.HasWaiters() {
+		t.Errorf("unexpected lack of waiter?")
+	}
+
+	oneOhOneSec := tc.After(time.Second + time.Millisecond)
+	twoSec := tc.After(2 * time.Second)
+	select {
+	case <-oneSec:
+		t.Errorf("unexpected channel read")
+	case <-oneOhOneSec:
+		t.Errorf("unexpected channel read")
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+	}
+
+	tc.Step(999 * time.Millisecond)
+	select {
+	case <-oneSec:
+		t.Errorf("unexpected channel read")
+	case <-oneOhOneSec:
+		t.Errorf("unexpected channel read")
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+	}
+
+	tc.Step(time.Millisecond)
+	select {
+	case <-oneSec:
+		// Expected!
+	case <-oneOhOneSec:
+		t.Errorf("unexpected channel read")
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+		t.Errorf("unexpected non-channel read")
+	}
+	tc.Step(time.Millisecond)
+	select {
+	case <-oneSec:
+		// should not double-trigger!
+		t.Errorf("unexpected channel read")
+	case <-oneOhOneSec:
+		// Expected!
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+		t.Errorf("unexpected non-channel read")
+	}
+}
+
+func TestFakeTick(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	if tc.HasWaiters() {
+		t.Errorf("unexpected waiter?")
+	}
+	oneSec := tc.Tick(time.Second)
+	if !tc.HasWaiters() {
+		t.Errorf("unexpected lack of waiter?")
+	}
+
+	oneOhOneSec := tc.Tick(time.Second + time.Millisecond)
+	twoSec := tc.Tick(2 * time.Second)
+	select {
+	case <-oneSec:
+		t.Errorf("unexpected channel read")
+	case <-oneOhOneSec:
+		t.Errorf("unexpected channel read")
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+	}
+
+	tc.Step(999 * time.Millisecond) // t=.999
+	select {
+	case <-oneSec:
+		t.Errorf("unexpected channel read")
+	case <-oneOhOneSec:
+		t.Errorf("unexpected channel read")
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+	}
+
+	tc.Step(time.Millisecond) // t=1.000
+	select {
+	case <-oneSec:
+		// Expected!
+	case <-oneOhOneSec:
+		t.Errorf("unexpected channel read")
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+		t.Errorf("unexpected non-channel read")
+	}
+	tc.Step(time.Millisecond) // t=1.001
+	select {
+	case <-oneSec:
+		// should not double-trigger!
+		t.Errorf("unexpected channel read")
+	case <-oneOhOneSec:
+		// Expected!
+	case <-twoSec:
+		t.Errorf("unexpected channel read")
+	default:
+		t.Errorf("unexpected non-channel read")
+	}
+
+	tc.Step(time.Second) // t=2.001
+	tc.Step(time.Second) // t=3.001
+	tc.Step(time.Second) // t=4.001
+	tc.Step(time.Second) // t=5.001
+
+	// The one second ticker should not accumulate ticks
+	accumulatedTicks := 0
+	drained := false
+	for !drained {
+		select {
+		case <-oneSec:
+			accumulatedTicks++
+		default:
+			drained = true
+		}
+	}
+	if accumulatedTicks != 1 {
+		t.Errorf("unexpected number of accumulated ticks: %d", accumulatedTicks)
+	}
+}
+
+func TestFakeStop(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	timer := tc.NewTimer(time.Second)
+	if !tc.HasWaiters() {
+		t.Errorf("expected a waiter to be present, but it is not")
+	}
+	timer.Stop()
+	if tc.HasWaiters() {
+		t.Errorf("expected existing waiter to be cleaned up, but it is still present")
+	}
+}
+
+// This tests the pattern documented in the go docs here: https://golang.org/pkg/time/#Timer.Stop
+// This pattern is required to safely reset a timer, so should be common.
+// This also tests resetting the timer
+func TestFakeStopDrain(t *testing.T) {
+	start := time.Time{}
+	tc := NewFakeClock(start)
+	timer := tc.NewTimer(time.Second)
+	tc.Step(1 * time.Second)
+	// Effectively `if !timer.Stop { <-t.C }` but with more asserts
+	if timer.Stop() {
+		t.Errorf("stop should report the timer had triggered")
+	}
+	if readTime := assertReadTime(t, timer.C()); !readTime.Equal(start.Add(1 * time.Second)) {
+		t.Errorf("timer should have ticked after 1 second, got %v", readTime)
+	}
+
+	timer.Reset(time.Second)
+	if !tc.HasWaiters() {
+		t.Errorf("expected a waiter to be present, but it is not")
+	}
+	select {
+	case <-timer.C():
+		t.Fatal("got time early on clock; haven't stepped yet")
+	default:
+	}
+	tc.Step(1 * time.Second)
+	if readTime := assertReadTime(t, timer.C()); !readTime.Equal(start.Add(2 * time.Second)) {
+		t.Errorf("timer should have ticked again after reset + 1 more second, got %v", readTime)
+	}
+}
+
+func TestTimerNegative(t *testing.T) {
+	tc := NewFakeClock(time.Now())
+	timer := tc.NewTimer(-1 * time.Second)
+	if !tc.HasWaiters() {
+		t.Errorf("expected a waiter to be present, but it is not")
+	}
+	// force waiters to be called
+	tc.Step(0)
+	tick := assertReadTime(t, timer.C())
+	if tick != tc.Now() {
+		t.Errorf("expected -1s to turn into now: %v != %v", tick, tc.Now())
+	}
+}
+
+func TestTickNegative(t *testing.T) {
+	// The stdlib 'Tick' returns nil for negative and zero values, so our fake
+	// should too.
+	tc := NewFakeClock(time.Now())
+	if tick := tc.Tick(-1 * time.Second); tick != nil {
+		t.Errorf("expected negative tick to be nil: %v", tick)
+	}
+	if tick := tc.Tick(0); tick != nil {
+		t.Errorf("expected negative tick to be nil: %v", tick)
+	}
+}
+
+// assertReadTime asserts that the channel can be read and returns the time it
+// reads from the channel.
+func assertReadTime(t testing.TB, c <-chan time.Time) time.Time {
+	type helper interface {
+		Helper()
+	}
+	if h, ok := t.(helper); ok {
+		h.Helper()
+	}
+	select {
+	case ti, ok := <-c:
+		if !ok {
+			t.Fatalf("expected to read time from channel, but it was closed")
+		}
+		return ti
+	default:
+		t.Fatalf("expected to read time from channel, but couldn't")
+	}
+	panic("unreachable")
+}


### PR DESCRIPTION

**Which issue this PR fixes**: Fixes #341, might improve #407 a little by waiting 30s+ between retries for already expired certs.

This handles a followup that was called out in https://github.com/jetstack/cert-manager/pull/667

**Special notes for your reviewer**:

This is a rather drastic refactor of the scheduler, so I'd like to run it for at least a few days in my cluster and make sure it doesn't blow up in any weird way.

**Release note**:
```release-note
Fixed bug where negative renewal schedules were printed
```
