### PR TITLE
DOCS: Add kubernetes.io/ingress.class annotation description

### DIFF
--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -76,4 +76,8 @@ Certificate resources to be automatically created:
   the existing ingress will be modified. Any other value, or the absence of the
   annotation assumes "false".
 
+* ``kubernetes.io/ingress.class`` - this annotaion is used to determine
+  "ingressClass" to use when ingress has the 'kubernetes.io/tls-acme: true'. If not set
+  then the default behaviour will be similar to 'certmanager.k8s.io/acme-http01-edit-in-place: true'.
+
 .. _kube-lego: https://github.com/jetstack/kube-lego


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds description about annotation that is required for default behavior with `ingressClass`. It is used in this PR https://github.com/jetstack/cert-manager/pull/493

**Special notes for your reviewer**: We did not have `kubernetes.io/ingress.class` defined by default and this was required to use `ingressClass` instead of `ingress` in certificate resource.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added kubernetes.io/ingress.class annotation description into documentation
```
