### PR TITLE
Automated cherry pick of #686 #695 #698

### DIFF
--- a/docs/reference/clusterissuers.rst
+++ b/docs/reference/clusterissuers.rst
@@ -44,5 +44,7 @@ the ``spec.issuerRef.kind`` field to ClusterIssuer:
        kind: ClusterIssuer
      ...
 
+When referencing a ``Secret`` resource in ``ClusterIssuer`` resources (eg ``apiKeySecretRef``) the ``Secret`` needs to be in the same namespace as the ``cert-manager`` controller pod. You can optionally override this by using the ``--cluster-resource-namespace`` argument to the controller.
+
 For more information on configuring Issuer resources, see the :doc:`Issuers </reference/issuers>`
 reference documentation.

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -134,8 +134,6 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*
 			updateCrt.Spec.SecretName = tls.SecretName
 			updateCrt.Spec.IssuerRef.Name = issuerName
 			updateCrt.Spec.IssuerRef.Kind = issuerKind
-			updateCrt.Spec.IssuerRef.Kind = issuerKind
-			updateCrt.Spec.IssuerRef.Kind = issuerKind
 			err = c.setIssuerSpecificConfig(updateCrt, issuer, ing, tls)
 			if err != nil {
 				return nil, nil, err
@@ -176,10 +174,18 @@ func certNeedsUpdate(a, b *v1alpha1.Certificate) bool {
 		return true
 	}
 
-	if a.Spec.ACME != nil && b.Spec.ACME != nil {
-		if !reflect.DeepEqual(a.Spec.ACME.Config, b.Spec.ACME.Config) {
-			return true
-		}
+	var configA, configB []v1alpha1.ACMECertificateDomainConfig
+
+	if a.Spec.ACME != nil {
+		configA = a.Spec.ACME.Config
+	}
+
+	if b.Spec.ACME != nil {
+		configB = b.Spec.ACME.Config
+	}
+
+	if !reflect.DeepEqual(configA, configB) {
+		return true
 	}
 
 	return false

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	"github.com/golang/glog"
@@ -133,6 +134,12 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*
 			updateCrt.Spec.SecretName = tls.SecretName
 			updateCrt.Spec.IssuerRef.Name = issuerName
 			updateCrt.Spec.IssuerRef.Kind = issuerKind
+			updateCrt.Spec.IssuerRef.Kind = issuerKind
+			updateCrt.Spec.IssuerRef.Kind = issuerKind
+			err = c.setIssuerSpecificConfig(updateCrt, issuer, ing, tls)
+			if err != nil {
+				return nil, nil, err
+			}
 			updateCrts = append(updateCrts, updateCrt)
 		} else {
 			newCrts = append(newCrts, crt)
@@ -167,6 +174,12 @@ func certNeedsUpdate(a, b *v1alpha1.Certificate) bool {
 
 	if a.Spec.IssuerRef.Kind != b.Spec.IssuerRef.Kind {
 		return true
+	}
+
+	if a.Spec.ACME != nil && b.Spec.ACME != nil {
+		if !reflect.DeepEqual(a.Spec.ACME.Config, b.Spec.ACME.Config) {
+			return true
+		}
 	}
 
 	return false

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -568,6 +568,98 @@ func TestBuildCertificates(t *testing.T) {
 							Name: "issuer-name",
 							Kind: "Issuer",
 						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.ACMECertificateDomainConfig{
+								{
+									Domains: []string{"example.com"},
+									ACMESolverConfig: v1alpha1.ACMESolverConfig{
+										HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
+											Ingress: "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "should update a certificate's config if an incorrect Certificate exists",
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						issuerNameAnnotation:              "issuer-name",
+						acmeIssuerChallengeTypeAnnotation: "http01",
+						ingressClassAnnotation:            "toot-ing",
+					},
+				},
+				Spec: extv1beta1.IngressSpec{
+					TLS: []extv1beta1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			IssuerLister: []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
+			CertificateLister: []*v1alpha1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-crt",
+						Namespace: "ingress-namespace",
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.ACMECertificateDomainConfig{
+								{
+									Domains: []string{"wrong-example.com"},
+									ACMESolverConfig: v1alpha1.ACMESolverConfig{
+										HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
+											Ingress: "wrong-ingress",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedUpdate: []*v1alpha1.Certificate{
+				&v1alpha1.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-crt",
+						Namespace: "ingress-namespace",
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.ACMECertificateDomainConfig{
+								{
+									Domains: []string{"example.com"},
+									ACMESolverConfig: v1alpha1.ACMESolverConfig{
+										HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
+											Ingress:      "",
+											IngressClass: strPtr("toot-ing"),
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -529,6 +529,18 @@ func TestBuildCertificates(t *testing.T) {
 							Name: "issuer-name",
 							Kind: "Issuer",
 						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.ACMECertificateDomainConfig{
+								{
+									Domains: []string{"example.com"},
+									ACMESolverConfig: v1alpha1.ACMESolverConfig{
+										HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
+											Ingress: "",
+										},
+									},
+								},
+							},
+						},
 					},
 				},
 			},

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -676,6 +676,74 @@ func TestBuildCertificates(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name: "should update a Certificate correctly if an existing one of a different type exists",
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: "ingress-namespace",
+					Annotations: map[string]string{
+						issuerNameAnnotation:              "issuer-name",
+						acmeIssuerChallengeTypeAnnotation: "http01",
+						ingressClassAnnotation:            "toot-ing",
+					},
+				},
+				Spec: extv1beta1.IngressSpec{
+					TLS: []extv1beta1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "existing-crt",
+						},
+					},
+				},
+			},
+			IssuerLister: []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
+			CertificateLister: []*v1alpha1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-crt",
+						Namespace: "ingress-namespace",
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+					},
+				},
+			},
+			ExpectedUpdate: []*v1alpha1.Certificate{
+				&v1alpha1.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "existing-crt",
+						Namespace: "ingress-namespace",
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.ACMECertificateDomainConfig{
+								{
+									Domains: []string{"example.com"},
+									ACMESolverConfig: v1alpha1.ACMESolverConfig{
+										HTTP01: &v1alpha1.ACMECertificateHTTP01Config{
+											Ingress:      "",
+											IngressClass: strPtr("toot-ing"),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	testFn := func(test testT) func(t *testing.T) {
 		return func(t *testing.T) {

--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -431,7 +431,7 @@ func (a *Acme) shouldAttemptValidation(ctx context.Context, cl client.Interface,
 	}
 
 	switch order.Status {
-	case acme.StatusPending, acme.StatusProcessing, acme.StatusValid:
+	case acme.StatusPending, acme.StatusProcessing, acme.StatusValid, acme.StatusReady:
 		// if the order has not failed, attempt authorization
 		return 0, order, nil
 	case acme.StatusRevoked, acme.StatusUnknown:

--- a/third_party/crypto/acme/types.go
+++ b/third_party/crypto/acme/types.go
@@ -20,6 +20,7 @@ const (
 	StatusInvalid     = "invalid"
 	StatusRevoked     = "revoked"
 	StatusDeactivated = "deactivated"
+	StatusReady       = "ready"
 )
 
 // CRLReasonCode identifies the reason for a certificate revocation.
@@ -215,7 +216,7 @@ type Order struct {
 	URL string
 
 	// Status is the status of the order. It will be one of StatusPending,
-	// StatusProcessing, StatusValid, and StatusInvalid.
+	// StatusReady, StatusProcessing, StatusValid, and StatusInvalid.
 	Status string
 
 	// Expires is the teimstamp after which the server will consider the order invalid.


### PR DESCRIPTION
Cherry pick of #686 #695 #698 on release-0.3.

#686: Update spec.acme.config field when ingress changes
#695: Add doc on secret references for cluster issuers
#698: Support the new "ready" order status