### PR TITLE
Add flag for setting nameservers for DNS01 check

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -29,6 +29,9 @@ type ControllerOptions struct {
 	DefaultIssuerKind                  string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
+
+	// DNS01Nameservers allows specifying a list of custom nameservers to perform DNS checks
+	DNS01Nameservers string
 }
 
 const (
@@ -48,6 +51,8 @@ const (
 	defaultTLSACMEIssuerKind           = "Issuer"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
+
+	defaultDNS01Nameservers = ""
 )
 
 var (
@@ -69,6 +74,7 @@ func NewControllerOptions() *ControllerOptions {
 		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
 		DefaultACMEIssuerDNS01ProviderName: defaultACMEIssuerDNS01ProviderName,
+		DNS01Nameservers:                   defaultDNS01Nameservers,
 	}
 }
 
@@ -120,6 +126,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.DefaultACMEIssuerDNS01ProviderName, "default-acme-issuer-dns01-provider-name", defaultACMEIssuerDNS01ProviderName, ""+
 		"Required if --default-acme-issuer-challenge-type is set to dns01. The DNS01 provider to use for ingresses using ACME dns01 "+
 		"validation that do not explicitly state a dns provider.")
+	fs.StringVar(&s.DNS01Nameservers, "dns01-nameservers", defaultDNS01Nameservers, ""+
+		"A list of comma seperated DNS servers used for DNS01 check requests")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/pkg/issuer/acme/acme.go
+++ b/pkg/issuer/acme/acme.go
@@ -62,6 +62,8 @@ type Acme struct {
 	// variables.
 	// Currently, only AWS ambient credential control is implemented.
 	ambientCredentials bool
+
+	dns01Nameservers []string
 }
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -90,7 +92,8 @@ func New(issuer v1alpha1.GenericIssuer,
 	podsLister corelisters.PodLister,
 	servicesLister corelisters.ServiceLister,
 	ingressLister extlisters.IngressLister,
-	ambientCreds bool) (issuer.Interface, error) {
+	ambientCreds bool,
+	dns01Nameservers []string) (issuer.Interface, error) {
 	if issuer.GetSpec().ACME == nil {
 		return nil, fmt.Errorf("acme config may not be empty")
 	}
@@ -115,7 +118,7 @@ func New(issuer v1alpha1.GenericIssuer,
 		servicesLister: servicesLister,
 		ingressLister:  ingressLister,
 
-		dnsSolver:                dns.NewSolver(issuer, client, secretsLister, resourceNamespace, ambientCreds),
+		dnsSolver:                dns.NewSolver(issuer, client, secretsLister, resourceNamespace, ambientCreds, dns01Nameservers),
 		httpSolver:               http.NewSolver(issuer, client, podsLister, servicesLister, ingressLister, acmeHTTP01SolverImage),
 		issuerResourcesNamespace: resourceNamespace,
 	}
@@ -235,6 +238,7 @@ func init() {
 			ctx.KubeSharedInformerFactory.Core().V1().Services().Lister(),
 			ctx.KubeSharedInformerFactory.Extensions().V1beta1().Ingresses().Lister(),
 			ambientCreds,
+			ctx.DNS01Nameservers,
 		)
 	})
 }

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -104,6 +104,7 @@ func (f *fixture) solver() *Solver {
 		f.ResourceNamespace,
 		dnsProvider.constructors,
 		f.Ambient,
+		[]string{"8.8.8.8:53"},
 	}
 }
 

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -10,7 +10,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-type preCheckDNSFunc func(fqdn, value string) (bool, error)
+type preCheckDNSFunc func(fqdn, value string, nameservers []string) (bool, error)
 
 var (
 	// PreCheckDNS checks DNS propagation before notifying ACME that
@@ -51,9 +51,9 @@ func getNameservers(path string, defaults []string) []string {
 }
 
 // checkDNSPropagation checks if the expected TXT record has been propagated to all authoritative nameservers.
-func checkDNSPropagation(fqdn, value string) (bool, error) {
+func checkDNSPropagation(fqdn, value string, nameservers []string) (bool, error) {
 	// Initial attempt to resolve at the recursive NS
-	r, err := dnsQuery(fqdn, dns.TypeTXT, RecursiveNameservers, true)
+	r, err := dnsQuery(fqdn, dns.TypeTXT, nameservers, true)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -83,7 +83,7 @@ var checkResolvConfServersTests = []struct {
 
 func TestPreCheckDNS(t *testing.T) {
 	// TODO: find a better TXT record to use in tests
-	ok, err := PreCheckDNS("google.com.", "v=spf1 include:_spf.google.com ~all")
+	ok, err := PreCheckDNS("google.com.", "v=spf1 include:_spf.google.com ~all", []string{"8.8.8.8:53"})
 	if err != nil || !ok {
 		t.Errorf("preCheckDNS failed for acme-staging.api.letsencrypt.org: %s", err.Error())
 	}

--- a/pkg/issuer/acme/util_test.go
+++ b/pkg/issuer/acme/util_test.go
@@ -79,6 +79,7 @@ func buildFakeAcme(f *unit.Fixture, client *client.FakeACME, issuer v1alpha1.Gen
 		f.KubeInformerFactory().Extensions().V1beta1().Ingresses().Lister(),
 		// TODO: support overriding this field
 		false,
+		[]string{"8.8.8.8:53"},
 	)
 	if err != nil {
 		f.T.Errorf("error creating fake Acme: %v", err)

--- a/pkg/issuer/context.go
+++ b/pkg/issuer/context.go
@@ -43,4 +43,6 @@ type Context struct {
 	// IssuerAmbientCredentials controls whether an issuer should pick up ambient
 	// credentials, such as those from metadata services, to construct clients.
 	IssuerAmbientCredentials bool
+
+	DNS01Nameservers []string
 }


### PR DESCRIPTION
This adds a new flag, `--dns01-nameservers`, which allows setting a list of custom nameservers for the DNS01 check.

Fixes #506.

```release-note
Add `--dns01-nameservers` flag for setting nameservers for DNS01 check
```
