### PR TITLE
Add --controllers flag to set which controllers are run

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -22,6 +22,7 @@ import (
 	intscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
 	informers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
 	"github.com/jetstack/cert-manager/pkg/controller"
+	ingressshimcontroller "github.com/jetstack/cert-manager/pkg/controller/ingress-shim"
 	"github.com/jetstack/cert-manager/pkg/issuer"
 	dnsutil "github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/jetstack/cert-manager/pkg/util/kube"
@@ -40,6 +41,11 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) {
 	run := func(_ <-chan struct{}) {
 		var wg sync.WaitGroup
 		for n, fn := range controller.Known() {
+			// don't enable ingress-shim if it's been disabled
+			if n == ingressshimcontroller.ControllerName && !opts.EnableIngressShim {
+				continue
+			}
+
 			wg.Add(1)
 			go func(n string, fn controller.Interface) {
 				defer wg.Done()

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -20,6 +20,8 @@ type ControllerOptions struct {
 	LeaderElectionRenewDeadline time.Duration
 	LeaderElectionRetryPeriod   time.Duration
 
+	EnableIngressShim bool
+
 	ACMEHTTP01SolverImage string
 
 	ClusterIssuerAmbientCredentials bool
@@ -45,6 +47,8 @@ const (
 	defaultLeaderElectionRenewDeadline = 10 * time.Second
 	defaultLeaderElectionRetryPeriod   = 2 * time.Second
 
+	defaultEnableIngressShim = true
+
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false
 
@@ -67,6 +71,7 @@ func NewControllerOptions() *ControllerOptions {
 		LeaderElectionLeaseDuration:        defaultLeaderElectionLeaseDuration,
 		LeaderElectionRenewDeadline:        defaultLeaderElectionRenewDeadline,
 		LeaderElectionRetryPeriod:          defaultLeaderElectionRetryPeriod,
+		EnableIngressShim:                  defaultEnableIngressShim,
 		ClusterIssuerAmbientCredentials:    defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:           defaultIssuerAmbientCredentials,
 		DefaultIssuerName:                  defaultTLSACMEIssuerName,
@@ -102,6 +107,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.DurationVar(&s.LeaderElectionRetryPeriod, "leader-election-retry-period", defaultLeaderElectionRetryPeriod, ""+
 		"The duration the clients should wait between attempting acquisition and renewal "+
 		"of a leadership. This is only applicable if leader election is enabled.")
+
+	fs.BoolVar(&s.EnableIngressShim, "enable-ingress-shim", defaultEnableIngressShim, ""+
+		"If true, the ingress-shim component will be enabled")
 
 	fs.StringVar(&s.ACMEHTTP01SolverImage, "acme-http01-solver-image", defaultACMEHTTP01SolverImage, ""+
 		"The docker image to use to solve ACME HTTP01 challenges. You most likely will not "+

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -49,3 +49,13 @@ func RandStringRunes(n int) string {
 	}
 	return string(b)
 }
+
+// Contains returns true if a string is contained in a string slice
+func Contains(ss []string, s string) bool {
+	for _, v := range ss {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -53,3 +53,41 @@ func TestEqualUnsorted(t *testing.T) {
 		}(test))
 	}
 }
+
+func TestContains(t *testing.T) {
+	type testT struct {
+		desc  string
+		slice []string
+		value string
+		equal bool
+	}
+	tests := []testT{
+		{
+			desc:  "slice containing value",
+			slice: []string{"a", "b", "c"},
+			value: "a",
+			equal: true,
+		},
+		{
+			desc:  "slice not containing value",
+			slice: []string{"a", "b", "c"},
+			value: "x",
+			equal: false,
+		},
+		{
+			desc:  "empty slice",
+			slice: []string{},
+			value: "x",
+			equal: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.desc, func(test testT) func(*testing.T) {
+			return func(t *testing.T) {
+				if actual := Contains(test.slice, test.value); actual != test.equal {
+					t.Errorf("Contains(%+v, %+v) = %t, but expected %t", test.slice, test.value, actual, test.equal)
+				}
+			}
+		}(test))
+	}
+}


### PR DESCRIPTION
This adds a new flag, which can be used to disable running the
ingress-shim controller (and any of the other controllers):

     --controllers=issuers,clusterissuers,certificates

Fixes #567.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
To disable ingress-shim, you can now set this flag: `--controllers=issuers,clusterissuers,certificates`
```
