### PR TITLE
Add log message showing git tag and commit during startup

### DIFF
--- a/cmd/controller/start.go
+++ b/cmd/controller/start.go
@@ -59,6 +59,9 @@ to renew certificates at an appropriate time before expiry.`,
 			if err := o.Validate(args); err != nil {
 				glog.Fatalf("error validating options: %s", err.Error())
 			}
+
+			glog.Infof("starting cert-manager %s (revision %s)", util.AppVersion, util.AppGitCommit)
+
 			go StartPrometheusMetricsServer(stopCh)
 			o.RunCertManagerController(stopCh)
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds a log entry showing the version and revision of cert-manager being run. Example:

```
g/s/g/j/cert-manager {version-in-logs} $ ./hack/build/dockerfiles/cert-manager-controller_linux_amd64
I0706 17:28:15.437043   23804 start.go:63] starting cert-manager canary (revision 2ef08e2b3c9ef93c89b3e264b05ef8514e8b4fea)
I0706 17:28:15.437546   23804 server.go:68] Listening on http://0.0.0.0:9402
...
```

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
none
```
