### PR TITLE
Add certificate-name label to created secrets

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -25,6 +25,7 @@ const (
 	CommonNameAnnotationKey = "certmanager.k8s.io/common-name"
 	IssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
 	IssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
+	CertificateNameKey      = "certmanager.k8s.io/certificate-name"
 )
 
 // +genclient

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -234,6 +234,12 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 	secret.Annotations[v1alpha1.IssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
 	secret.Annotations[v1alpha1.IssuerKindAnnotationKey] = issuerKind(crt)
 
+	if secret.Labels == nil {
+		secret.Labels = make(map[string]string)
+	}
+
+	secret.Labels[v1alpha1.CertificateNameKey] = crt.Name
+
 	// if it is a new resource
 	if secret.SelfLink == "" {
 		secret, err = c.client.CoreV1().Secrets(namespace).Create(secret)

--- a/test/e2e/framework/certificate.go
+++ b/test/e2e/framework/certificate.go
@@ -49,4 +49,13 @@ func (f *Framework) WaitCertificateIssuedValidTimeout(c *v1alpha1.Certificate, t
 	if expectedCN != cert.Subject.CommonName || !util.EqualUnsorted(cert.DNSNames, expectedDNSNames) {
 		Failf("Expected certificate valid for CN %q, dnsNames %v but got a certificate valid for CN %q, dnsNames %v", expectedCN, expectedDNSNames, cert.Subject.CommonName, cert.DNSNames)
 	}
+
+	label, ok := secret.Labels[v1alpha1.CertificateNameKey]
+	if !ok {
+		Failf("Expected secret to have certificate-name label, but had none")
+	}
+
+	if label != c.Name {
+		Failf("Expected secret to have certificate-name label with a value of %q, but got %q", c.Name, label)
+	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: this applies a `certmanager.k8s.io/certificate-name` label to secrets created by cert-manager.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #566

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add `certmanager.k8s.io/certificate-name` label to secrets.
```
