### PR TITLE
Add keyAlgorithm and keySize fields to Certificates, and support ECDSA keys

### DIFF
--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -101,6 +101,14 @@ Appears In:
 <td>IssuerRef is a reference to the issuer for this certificate. If the namespace field is not set, it is assumed to be in the same namespace as the certificate. If the namespace field is set to the empty value &#34;&#34;, a ClusterIssuer of the given name will be used. Any other value is invalid.</td>
 </tr>
 <tr>
+<td><code>keyAlgorithm</code><br /> <em>string</em></td>
+<td>KeyAlgorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either &#34;rsa&#34; or &#34;ecdsa&#34; If KeyAlgorithm is specified and KeySize is not provided, key size of 256 will be used for &#34;ecdsa&#34; key algorithm and key size of 2048 will be used for &#34;rsa&#34; key algorithm.</td>
+</tr>
+<tr>
+<td><code>keySize</code><br /> <em>integer</em></td>
+<td>KeySize is the key bit size of the corresponding private key for this certificate. If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is empty or is set to &#34;rsa&#34;, and value must be one of (256, 384, 521) when KeyAlgorithm is set to &#34;ecdsa&#34;.</td>
+</tr>
+<tr>
 <td><code>secretName</code><br /> <em>string</em></td>
 <td>SecretName is the name of the secret resource to store this secret in</td>
 </tr>

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -287,6 +287,13 @@ type CertificateList struct {
 	Items []Certificate `json:"items"`
 }
 
+type KeyAlgorithm string
+
+const (
+	RSAKeyAlgorithm   KeyAlgorithm = "rsa"
+	ECDSAKeyAlgorithm KeyAlgorithm = "ecdsa"
+)
+
 // CertificateSpec defines the desired state of Certificate
 type CertificateSpec struct {
 	// CommonName is a common name to be used on the Certificate
@@ -303,6 +310,18 @@ type CertificateSpec struct {
 	IssuerRef ObjectReference `json:"issuerRef"`
 
 	ACME *ACMECertificateConfig `json:"acme,omitempty"`
+
+	// KeySize is the key bit size of the corresponding private key for this certificate.
+	// If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is
+	// empty or is set to "rsa", and value must be one of (256, 384, 521) when
+	// KeyAlgorithm is set to "ecdsa".
+	KeySize int `json:"keySize,omitempty"`
+	// KeyAlgorithm is the private key algorithm of the corresponding private key
+	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
+	// If KeyAlgorithm is specified and KeySize is not provided,
+	// key size of 256 will be used for "ecdsa" key algorithm and
+	// key size of 2048 will be used for "rsa" key algorithm.
+	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
 }
 
 // ACMEConfig contains the configuration for the ACME certificate provider

--- a/pkg/apis/certmanager/validation/certificate_test.go
+++ b/pkg/apis/certmanager/validation/certificate_test.go
@@ -178,6 +178,170 @@ func TestValidateCertificate(t *testing.T) {
 				field.Required(fldPath.Child("acme", "config"), "no ACME solver configuration specified for domain \"commonname\""),
 			},
 		},
+		"valid certificate with rsa keyAlgorithm specified and no keySize": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.RSAKeyAlgorithm,
+				},
+			},
+		},
+		"valid certificate with rsa keyAlgorithm specified with keySize 2048": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.RSAKeyAlgorithm,
+					KeySize:      2048,
+				},
+			},
+		},
+		"valid certificate with rsa keyAlgorithm specified with keySize 4096": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.RSAKeyAlgorithm,
+					KeySize:      4096,
+				},
+			},
+		},
+		"valid certificate with rsa keyAlgorithm specified with keySize 8192": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.RSAKeyAlgorithm,
+					KeySize:      8192,
+				},
+			},
+		},
+		"valid certificate with ecdsa keyAlgorithm specified and no keySize": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.ECDSAKeyAlgorithm,
+				},
+			},
+		},
+		"valid certificate with ecdsa keyAlgorithm specified with keySize 256": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.ECDSAKeyAlgorithm,
+					KeySize:      256,
+				},
+			},
+		},
+		"valid certificate with ecdsa keyAlgorithm specified with keySize 384": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.ECDSAKeyAlgorithm,
+					KeySize:      384,
+				},
+			},
+		},
+		"valid certificate with ecdsa keyAlgorithm specified with keySize 521": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.ECDSAKeyAlgorithm,
+					KeySize:      521,
+				},
+			},
+		},
+		"valid certificate with keyAlgorithm not specified and keySize specified": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					KeySize:    2048,
+				},
+			},
+		},
+		"certificate with keysize less than zero": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					KeySize:    -99,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("keySize"), -99, "cannot be less than zero"),
+			},
+		},
+		"certificate with rsa keyAlgorithm specified and invalid keysize 1024": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.RSAKeyAlgorithm,
+					KeySize:      1024,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("keySize"), 1024, "must be between 2048 & 8192 for rsa keyAlgorithm"),
+			},
+		},
+		"certificate with rsa keyAlgorithm specified and invalid keysize 8196": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.RSAKeyAlgorithm,
+					KeySize:      8196,
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("keySize"), 8196, "must be between 2048 & 8192 for rsa keyAlgorithm"),
+			},
+		},
+		"certificate with ecdsa keyAlgorithm specified and invalid keysize": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.ECDSAKeyAlgorithm,
+					KeySize:      100,
+				},
+			},
+			errs: []*field.Error{
+				field.NotSupported(fldPath.Child("keySize"), 100, []string{"256", "384", "521"}),
+			},
+		},
+		"certificate with invalid keyAlgorithm": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName:   "testcn",
+					SecretName:   "abc",
+					IssuerRef:    validIssuerRef,
+					KeyAlgorithm: v1alpha1.KeyAlgorithm("blah"),
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("keyAlgorithm"), v1alpha1.KeyAlgorithm("blah"), "must be either empty or one of rsa or ecdsa"),
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/issuer/acme/acme.go
+++ b/pkg/issuer/acme/acme.go
@@ -157,7 +157,7 @@ func (a *Acme) acmeClientWithKey(accountPrivKey *rsa.PrivateKey) client.Interfac
 func (a *Acme) acmeClientImpl() (client.Interface, error) {
 	secretName, secretKey := a.acmeAccountPrivateKeyMeta()
 	glog.Infof("getting private key (%s->%s) for acme issuer %s/%s", secretName, secretKey, a.issuerResourcesNamespace, a.issuer.GetObjectMeta().Name)
-	accountPrivKey, err := kube.SecretTLSKeyRef(a.secretsLister, a.issuerResourcesNamespace, secretName, secretKey)
+	accountPrivKey, err := kube.SecretRSAKeyRef(a.secretsLister, a.issuerResourcesNamespace, secretName, secretKey)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -111,7 +111,7 @@ func (a *Acme) registerAccount(ctx context.Context, cl client.Interface) (*acme.
 
 func (a *Acme) createAccountPrivateKey() (*rsa.PrivateKey, error) {
 	secretName, secretKey := a.acmeAccountPrivateKeyMeta()
-	accountPrivKey, err := pki.GenerateRSAPrivateKey(2048)
+	accountPrivKey, err := pki.GenerateRSAPrivateKey(pki.MinRSAKeySize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/issuer/ca/renew.go
+++ b/pkg/issuer/ca/renew.go
@@ -37,5 +37,12 @@ func (c *CA) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []by
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertRenewed, messageCertRenewed, true)
 
-	return pki.EncodePKCS1PrivateKey(signeeKey), certPem, nil
+	keyPem, err := pki.EncodePrivateKey(signeeKey)
+	if err != nil {
+		s := messageErrorEncodePrivateKey + err.Error()
+		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorEncodePrivateKey, s, false)
+		return nil, nil, err
+	}
+
+	return keyPem, certPem, nil
 }

--- a/pkg/issuer/selfsigned/renew.go
+++ b/pkg/issuer/selfsigned/renew.go
@@ -37,5 +37,12 @@ func (c *SelfSigned) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]by
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertRenewed, messageCertRenewed, true)
 
-	return pki.EncodePKCS1PrivateKey(signeeKey), certPem, nil
+	keyPem, err := pki.EncodePrivateKey(signeeKey)
+	if err != nil {
+		s := messageErrorEncodePrivateKey + err.Error()
+		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorEncodePrivateKey, s, false)
+		return nil, nil, err
+	}
+
+	return keyPem, certPem, nil
 }

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -1,6 +1,7 @@
 package pki
 
 import (
+	"crypto/x509"
 	"testing"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -116,6 +117,102 @@ func TestDNSNamesForCertificate(t *testing.T) {
 			}
 		}
 	}
+	for _, test := range tests {
+		t.Run(test.name, testFn(test))
+	}
+}
+
+func TestSignatureAlgorithmForCertificate(t *testing.T) {
+	type testT struct {
+		name            string
+		keyAlgo         v1alpha1.KeyAlgorithm
+		keySize         int
+		expectErr       bool
+		expectedSigAlgo x509.SignatureAlgorithm
+	}
+
+	tests := []testT{
+		{
+			name:      "certificate with KeyAlgorithm rsa and size 1024",
+			keyAlgo:   v1alpha1.RSAKeyAlgorithm,
+			expectErr: true,
+		},
+		{
+			name:            "certificate with KeyAlgorithm not set",
+			keyAlgo:         v1alpha1.KeyAlgorithm(""),
+			expectedSigAlgo: x509.SHA256WithRSA,
+		},
+		{
+			name:            "certificate with KeyAlgorithm rsa and size 2048",
+			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
+			keySize:         2048,
+			expectedSigAlgo: x509.SHA256WithRSA,
+		},
+		{
+			name:            "certificate with KeyAlgorithm rsa and size 3072",
+			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
+			keySize:         3072,
+			expectedSigAlgo: x509.SHA384WithRSA,
+		},
+		{
+			name:            "certificate with KeyAlgorithm rsa and size 4096",
+			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
+			keySize:         4096,
+			expectedSigAlgo: x509.SHA512WithRSA,
+		},
+		{
+			name:            "certificate with KeyAlgorithm ecdsa and size 256",
+			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
+			keySize:         256,
+			expectedSigAlgo: x509.ECDSAWithSHA256,
+		},
+		{
+			name:            "certificate with KeyAlgorithm ecdsa and size 384",
+			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
+			keySize:         384,
+			expectedSigAlgo: x509.ECDSAWithSHA384,
+		},
+		{
+			name:            "certificate with KeyAlgorithm ecdsa and size 521",
+			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
+			keySize:         521,
+			expectedSigAlgo: x509.ECDSAWithSHA512,
+		},
+		{
+			name:      "certificate with KeyAlgorithm ecdsa and size 100",
+			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			expectErr: true,
+		},
+		{
+			name:            "certificate with KeyAlgorithm set to unknown key algo",
+			keyAlgo:         v1alpha1.KeyAlgorithm("blah"),
+			expectErr:       true,
+			expectedSigAlgo: x509.UnknownSignatureAlgorithm,
+		},
+	}
+
+	testFn := func(test testT) func(*testing.T) {
+		return func(t *testing.T) {
+			actualSigAlgo, err := SignatureAlgorithm(buildCertificateWithKeyParams(test.keyAlgo, test.keySize))
+			if test.expectErr && err == nil {
+				t.Error("expected err, but got no error")
+				return
+			}
+
+			if !test.expectErr {
+				if err != nil {
+					t.Errorf("expected no err, but got '%q'", err)
+					return
+				}
+
+				if actualSigAlgo != test.expectedSigAlgo {
+					t.Errorf("expected %q but got %q", test.expectedSigAlgo, actualSigAlgo)
+					return
+				}
+			}
+		}
+	}
+
 	for _, test := range tests {
 		t.Run(test.name, testFn(test))
 	}

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -1,18 +1,114 @@
 package pki
 
 import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
+	"fmt"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
+const (
+	MinRSAKeySize = 2048
+	MaxRSAKeySize = 8192
+
+	ECCurve256 = 256
+	ECCurve384 = 384
+	ECCurve521 = 521
+)
+
+func GeneratePrivateKeyForCertificate(crt *v1alpha1.Certificate) (crypto.PrivateKey, error) {
+	switch crt.Spec.KeyAlgorithm {
+	case v1alpha1.KeyAlgorithm(""), v1alpha1.RSAKeyAlgorithm:
+		keySize := MinRSAKeySize
+
+		if crt.Spec.KeySize > 0 {
+			keySize = crt.Spec.KeySize
+		}
+
+		return GenerateRSAPrivateKey(keySize)
+	case v1alpha1.ECDSAKeyAlgorithm:
+		keySize := ECCurve256
+
+		if crt.Spec.KeySize > 0 {
+			keySize = crt.Spec.KeySize
+		}
+
+		return GenerateECPrivateKey(keySize)
+	default:
+		return nil, fmt.Errorf("unsupported private key algorithm specified: %s", crt.Spec.KeyAlgorithm)
+	}
+}
+
 func GenerateRSAPrivateKey(keySize int) (*rsa.PrivateKey, error) {
+	// Do not allow keySize < 2048
+	// https://en.wikipedia.org/wiki/Key_size#cite_note-twirl-14
+	if keySize < MinRSAKeySize {
+		return nil, fmt.Errorf("weak rsa key size specified: %d. minimum key size: %d", keySize, MinRSAKeySize)
+	}
+	if keySize > MaxRSAKeySize {
+		return nil, fmt.Errorf("rsa key size specified too big: %d. maximum key size: %d", keySize, MaxRSAKeySize)
+	}
+
 	return rsa.GenerateKey(rand.Reader, keySize)
+}
+
+func GenerateECPrivateKey(keySize int) (*ecdsa.PrivateKey, error) {
+	var ecCurve elliptic.Curve
+
+	switch keySize {
+	case ECCurve256:
+		ecCurve = elliptic.P256()
+	case ECCurve384:
+		ecCurve = elliptic.P384()
+	case ECCurve521:
+		ecCurve = elliptic.P521()
+	default:
+		return nil, fmt.Errorf("unsupported ecdsa key size specified: %d", keySize)
+	}
+
+	return ecdsa.GenerateKey(ecCurve, rand.Reader)
+}
+
+func EncodePrivateKey(pk crypto.PrivateKey) ([]byte, error) {
+	switch k := pk.(type) {
+	case *rsa.PrivateKey:
+		return EncodePKCS1PrivateKey(k), nil
+	case *ecdsa.PrivateKey:
+		return EncodeECPrivateKey(k)
+	default:
+		return nil, fmt.Errorf("error encoding private key: unknown key type: %T", pk)
+	}
 }
 
 func EncodePKCS1PrivateKey(pk *rsa.PrivateKey) []byte {
 	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pk)}
 
 	return pem.EncodeToMemory(block)
+}
+
+func EncodeECPrivateKey(pk *ecdsa.PrivateKey) ([]byte, error) {
+	asnBytes, err := x509.MarshalECPrivateKey(pk)
+	if err != nil {
+		return nil, fmt.Errorf("error encoding private key: %s", err.Error())
+	}
+
+	block := &pem.Block{Type: "EC PRIVATE KEY", Bytes: asnBytes}
+	return pem.EncodeToMemory(block), nil
+}
+
+func PublicKeyForPrivateKey(pk crypto.PrivateKey) (crypto.PublicKey, error) {
+	switch k := pk.(type) {
+	case *rsa.PrivateKey:
+		return k.Public(), nil
+	case *ecdsa.PrivateKey:
+		return k.Public(), nil
+	default:
+		return nil, fmt.Errorf("unknown private key type: %T", pk)
+	}
 }

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -1,0 +1,202 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+func buildCertificateWithKeyParams(keyAlgo v1alpha1.KeyAlgorithm, keySize int) *v1alpha1.Certificate {
+	return &v1alpha1.Certificate{
+		Spec: v1alpha1.CertificateSpec{
+			CommonName:   "test",
+			DNSNames:     []string{"test.test"},
+			KeyAlgorithm: keyAlgo,
+			KeySize:      keySize,
+		},
+	}
+}
+
+func ecCurveForKeySize(keySize int) (elliptic.Curve, error) {
+	switch keySize {
+	case 0, ECCurve256:
+		return elliptic.P256(), nil
+	case ECCurve384:
+		return elliptic.P384(), nil
+	case ECCurve521:
+		return elliptic.P521(), nil
+	default:
+		return nil, fmt.Errorf("unknown ecdsa key size specified: %d", keySize)
+	}
+}
+
+func TestGeneratePrivateKeyForCertificate(t *testing.T) {
+	type testT struct {
+		name         string
+		keyAlgo      v1alpha1.KeyAlgorithm
+		keySize      int
+		expectErr    bool
+		expectErrStr string
+	}
+
+	tests := []testT{
+		{
+			name:         "rsa key with weak keysize (< 2048)",
+			keyAlgo:      v1alpha1.RSAKeyAlgorithm,
+			keySize:      1024,
+			expectErr:    true,
+			expectErrStr: "weak rsa key size specified",
+		},
+		{
+			name:         "rsa key with too big keysize (> 8192)",
+			keyAlgo:      v1alpha1.RSAKeyAlgorithm,
+			keySize:      8196,
+			expectErr:    true,
+			expectErrStr: "rsa key size specified too big",
+		},
+		{
+			name:         "ecdsa key with unsupported keysize",
+			keyAlgo:      v1alpha1.ECDSAKeyAlgorithm,
+			keySize:      100,
+			expectErr:    true,
+			expectErrStr: "unsupported ecdsa key size specified",
+		},
+		{
+			name:         "unsupported key algo specified",
+			keyAlgo:      v1alpha1.KeyAlgorithm("blahblah"),
+			keySize:      256,
+			expectErr:    true,
+			expectErrStr: "unsupported private key algorithm specified",
+		},
+		{
+			name:      "rsa key with keysize 2048",
+			keyAlgo:   v1alpha1.RSAKeyAlgorithm,
+			keySize:   2048,
+			expectErr: false,
+		},
+		{
+			name:      "rsa key with keysize 4096",
+			keyAlgo:   v1alpha1.RSAKeyAlgorithm,
+			keySize:   4096,
+			expectErr: false,
+		},
+		{
+			name:      "ecdsa key with keysize 256",
+			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			keySize:   256,
+			expectErr: false,
+		},
+		{
+			name:      "ecdsa key with keysize 384",
+			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			keySize:   384,
+			expectErr: false,
+		},
+		{
+			name:      "ecdsa key with keysize 521",
+			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			keySize:   521,
+			expectErr: false,
+		},
+		{
+			name:      "valid key size with key algorithm not specified",
+			keyAlgo:   v1alpha1.KeyAlgorithm(""),
+			keySize:   2048,
+			expectErr: false,
+		},
+		{
+			name:      "rsa with keysize not specified",
+			keyAlgo:   v1alpha1.RSAKeyAlgorithm,
+			expectErr: false,
+		},
+		{
+			name:      "ecdsa with keysize not specified",
+			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			expectErr: false,
+		},
+	}
+
+	testFn := func(test testT) func(*testing.T) {
+		return func(t *testing.T) {
+			privateKey, err := GeneratePrivateKeyForCertificate(buildCertificateWithKeyParams(test.keyAlgo, test.keySize))
+			if test.expectErr {
+				if err == nil {
+					t.Error("expected err, but got no error")
+					return
+				}
+
+				if !strings.Contains(err.Error(), test.expectErrStr) {
+					t.Errorf("expected err string to match: '%s', got: '%s'", test.expectErrStr, err.Error())
+					return
+				}
+			}
+
+			if !test.expectErr {
+				if err != nil {
+					t.Errorf("expected no err, but got '%q'", err)
+					return
+				}
+
+				if test.keyAlgo == "rsa" {
+					// For rsa algorithm, if keysize is not provided, the default of 2048 will be used
+					expectedRsaKeySize := 2048
+					if test.keySize != 0 {
+						expectedRsaKeySize = test.keySize
+					}
+
+					key, ok := privateKey.(*rsa.PrivateKey)
+					if !ok {
+						t.Errorf("expected rsa private key, but got %T", privateKey)
+						return
+					}
+
+					actualKeySize := key.N.BitLen()
+					if expectedRsaKeySize != actualKeySize {
+						t.Errorf("expected %d, but got %d", expectedRsaKeySize, actualKeySize)
+						return
+					}
+				}
+
+				if test.keyAlgo == "ecdsa" {
+					// For ecdsa algorithm, if keysize is not provided, the default of 256 will be used
+					expectedEcdsaKeySize := ECCurve256
+					if test.keySize != 0 {
+						expectedEcdsaKeySize = test.keySize
+					}
+
+					key, ok := privateKey.(*ecdsa.PrivateKey)
+					if !ok {
+						t.Errorf("expected ecdsa private key, but got %T", privateKey)
+						return
+					}
+
+					actualKeySize := key.Curve.Params().BitSize
+					if expectedEcdsaKeySize != actualKeySize {
+						t.Errorf("expected %d but got %d", expectedEcdsaKeySize, actualKeySize)
+						return
+					}
+
+					curve, err := ecCurveForKeySize(test.keySize)
+					if err != nil {
+						t.Errorf(err.Error())
+						return
+					}
+
+					if !curve.IsOnCurve(key.PublicKey.X, key.PublicKey.Y) {
+						t.Error("expected key to be on specified curve")
+						return
+					}
+				}
+			}
+		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, testFn(test))
+	}
+}

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -1,12 +1,45 @@
 package pki
 
 import (
+	"crypto"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/pem"
 
 	"github.com/jetstack/cert-manager/pkg/util/errors"
 )
+
+func DecodePrivateKeyBytes(keyBytes []byte) (crypto.PrivateKey, error) {
+	// decode the private key pem
+	block, _ := pem.Decode(keyBytes)
+	if block == nil {
+		return nil, errors.NewInvalidData("error decoding private key PEM block")
+	}
+
+	switch block.Type {
+	case "EC PRIVATE KEY":
+		key, err := x509.ParseECPrivateKey(block.Bytes)
+		if err != nil {
+			return nil, errors.NewInvalidData("error parsing ecdsa private key: %s", err.Error())
+		}
+
+		return key, nil
+	case "RSA PRIVATE KEY":
+		key, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, errors.NewInvalidData("error parsing rsa private key: %s", err.Error())
+		}
+
+		err = key.Validate()
+		if err != nil {
+			return nil, errors.NewInvalidData("rsa private key failed validation: %s", err.Error())
+		}
+
+		return key, nil
+	default:
+		return nil, errors.NewInvalidData("unknown private key type: %s", block.Type)
+	}
+}
 
 func DecodePKCS1PrivateKeyBytes(keyBytes []byte) (*rsa.PrivateKey, error) {
 	// decode the private key pem

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -1,0 +1,118 @@
+package pki
+
+import (
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+func generatePrivateKeyBytes(keyAlgo v1alpha1.KeyAlgorithm, keySize int) ([]byte, error) {
+	privateKey, err := GeneratePrivateKeyForCertificate(buildCertificateWithKeyParams(keyAlgo, keySize))
+	if err != nil {
+		return nil, err
+	}
+
+	return EncodePrivateKey(privateKey)
+}
+
+func TestDecodePrivateKeyBytes(t *testing.T) {
+	type testT struct {
+		name         string
+		keyBytes     []byte
+		keyAlgo      v1alpha1.KeyAlgorithm
+		expectErr    bool
+		expectErrStr string
+	}
+
+	rsaKeyBytes, err := generatePrivateKeyBytes(v1alpha1.RSAKeyAlgorithm, MinRSAKeySize)
+	if err != nil {
+		t.Errorf("error generating key bytes: %s", err)
+		return
+	}
+
+	ecdsaKeyBytes, err := generatePrivateKeyBytes(v1alpha1.ECDSAKeyAlgorithm, 256)
+	if err != nil {
+		t.Errorf("error generating key bytes: %s", err)
+		return
+	}
+
+	block := &pem.Block{Type: "BLAH BLAH BLAH", Bytes: []byte("blahblahblah")}
+	blahKeyBytes := pem.EncodeToMemory(block)
+
+	invalidKeyBytes := []byte("blah-blah-invalid")
+
+	tests := []testT{
+		{
+			name:      "decode pem encoded rsa private key bytes",
+			keyBytes:  rsaKeyBytes,
+			keyAlgo:   v1alpha1.RSAKeyAlgorithm,
+			expectErr: false,
+		},
+		{
+			name:      "decode pem encoded ecdsa private key bytes",
+			keyBytes:  ecdsaKeyBytes,
+			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			expectErr: false,
+		},
+		{
+			name:         "fail to decode unknown pem encoded key bytes",
+			keyBytes:     blahKeyBytes,
+			expectErr:    true,
+			expectErrStr: "unknown private key type",
+		},
+		{
+			name:         "fail to decode unknown not pem encoded key bytes",
+			keyBytes:     invalidKeyBytes,
+			expectErr:    true,
+			expectErrStr: "error decoding private key PEM block",
+		},
+	}
+
+	testFn := func(test testT) func(*testing.T) {
+		return func(t *testing.T) {
+			privateKey, err := DecodePrivateKeyBytes(test.keyBytes)
+			if test.expectErr {
+				if err == nil {
+					t.Error("expected err, but got no error")
+					return
+				}
+
+				if !strings.Contains(err.Error(), test.expectErrStr) {
+					t.Errorf("expected err string to match: '%s', got: '%s'", test.expectErrStr, err.Error())
+					return
+				}
+			}
+
+			if !test.expectErr {
+				if err != nil {
+					t.Errorf("expected no err, but got '%q'", err)
+					return
+				}
+
+				if test.keyAlgo == v1alpha1.RSAKeyAlgorithm {
+					_, ok := privateKey.(*rsa.PrivateKey)
+					if !ok {
+						t.Errorf("expected rsa private key, but got %T", privateKey)
+						return
+					}
+				}
+
+				if test.keyAlgo == v1alpha1.ECDSAKeyAlgorithm {
+					_, ok := privateKey.(*ecdsa.PrivateKey)
+					if !ok {
+						t.Errorf("expected ecdsa private key, but got %T", privateKey)
+						return
+					}
+				}
+			}
+		}
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, testFn(test))
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
- Adds two fields to CertificateSpec:
  - `keyAlgorithm`, denotes which algorithm to use when generating
    a private key. Can be either `rsa` or `ecdsa`. When not set, the
    default algorithm used `rsa`.
  - `keySize`, denotes the key size of the private key being generated.
    For `rsa`, minimum key size is 2048 and maximum is 8192.
    For `ecdsa`, sizes 224, 256, 384 & 521 are supported.
    See https://golang.org/pkg/crypto/elliptic

  If both fields are not populated, `rsa` with key size `2048` is used

- Adds `pki.GeneratePrivateKeyForCertificate` function that takes in a `Certificate` and generates a private key based on the `keyAlgorithm` & `keySize` fields in the `CertificateSpec`
- Adds helper functions to the `pki` package to generate/parse `rsa` and `ecdsa` private keys

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
```release-note
Adds new fields: "keyAlgorithm", "keySize" onto CertificateSpec to allow specifying algorithm (rsa, ecdsa) and key size to use when generating TLS keys
```