### PR TITLE
Improve ACME DNS validation tutorial

### DIFF
--- a/docs/tutorials/acme/dns-validation.rst
+++ b/docs/tutorials/acme/dns-validation.rst
@@ -123,7 +123,7 @@ If the certificate is obtained successfully, the resulting key pair will be
 stored in a secret called ``example-com-tls`` in the same namespace as the Certificate.
 
 The certificate will have a common name of ``*.example.com`` and the
-`Subject Alternative Names `_ (SANs) will be ``*.example.com``, ``example.com`` and ``foo.com``.
+`Subject Alternative Names`_ (SANs) will be ``*.example.com``, ``example.com`` and ``foo.com``.
 
 In our Certificate we have referenced the ``letsencrypt-staging`` Issuer above.
 The Issuer must be in the same namespace as the Certificate.

--- a/docs/tutorials/acme/dns-validation.rst
+++ b/docs/tutorials/acme/dns-validation.rst
@@ -123,7 +123,7 @@ If the certificate is obtained successfully, the resulting key pair will be
 stored in a secret called ``example-com-tls`` in the same namespace as the Certificate.
 
 The certificate will have a common name of ``*.example.com`` and the
-`Subject Alternative Names `_ (SANs) will be ``example.com`` and ``foo.com``.
+`Subject Alternative Names `_ (SANs) will be ``*.example.com``, ``example.com`` and ``foo.com``.
 
 In our Certificate we have referenced the ``letsencrypt-staging`` Issuer above.
 The Issuer must be in the same namespace as the Certificate.


### PR DESCRIPTION
**What this PR does / why we need it**:

It rectifies the list of Subject Alternative Names for the ACME DNS validation tutorial.

**Release note**:
```release-note
Rectifies the list of Subject Alternative Names for the ACME DNS validation tutorial.
```
