### PR TITLE
Configurable ACME Annotation

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -181,6 +181,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 		IngressShimOptions: controller.IngressShimOptions{
 			DefaultIssuerName:                  opts.DefaultIssuerName,
 			DefaultIssuerKind:                  opts.DefaultIssuerKind,
+                        DefaultACMEAnnotation:              opts.DefaultACMEAnnotation,
 			DefaultACMEIssuerChallengeType:     opts.DefaultACMEIssuerChallengeType,
 			DefaultACMEIssuerDNS01ProviderName: opts.DefaultACMEIssuerDNS01ProviderName,
 		},

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -181,7 +181,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 		IngressShimOptions: controller.IngressShimOptions{
 			DefaultIssuerName:                  opts.DefaultIssuerName,
 			DefaultIssuerKind:                  opts.DefaultIssuerKind,
-                        DefaultACMEAnnotation:              opts.DefaultACMEAnnotation,
+			DefaultAutoCertificateAnnotations:  opts.DefaultAutoCertificateAnnotations,
 			DefaultACMEIssuerChallengeType:     opts.DefaultACMEIssuerChallengeType,
 			DefaultACMEIssuerDNS01ProviderName: opts.DefaultACMEIssuerDNS01ProviderName,
 		},

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -56,9 +56,9 @@ type ControllerOptions struct {
 	RenewBeforeExpiryDuration       time.Duration
 
 	// Default issuer/certificates details consumed by ingress-shim
-	DefaultACMEAnnotation              string
-        DefaultIssuerName                  string
+	DefaultIssuerName                  string
 	DefaultIssuerKind                  string
+	DefaultAutoCertificateAnnotations  []string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
 
@@ -80,9 +80,8 @@ const (
 	defaultIssuerAmbientCredentials        = false
 	defaultRenewBeforeExpiryDuration       = time.Hour * 24 * 30
 
-        defaultTLSACMEIssuerName           = ""
+	defaultTLSACMEIssuerName           = ""
 	defaultTLSACMEIssuerKind           = "Issuer"
-        defaultACMEAnnotation              = "kubernetes.io/tls-acme"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
 )
@@ -93,6 +92,8 @@ var (
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "10m"
 	defaultACMEHTTP01SolverResourceLimitsMemory  = "64Mi"
+
+	defaultAutoCertificateAnnotations = []string{"kubernetes.io/tls-acme"}
 
 	defaultEnabledControllers = []string{
 		issuerscontroller.ControllerName,
@@ -117,9 +118,9 @@ func NewControllerOptions() *ControllerOptions {
 		ClusterIssuerAmbientCredentials:    defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:           defaultIssuerAmbientCredentials,
 		RenewBeforeExpiryDuration:          defaultRenewBeforeExpiryDuration,
-                DefaultACMEAnnotation:              defaultACMEAnnotation,
 		DefaultIssuerName:                  defaultTLSACMEIssuerName,
 		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
+		DefaultAutoCertificateAnnotations:  defaultAutoCertificateAnnotations,
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
 		DefaultACMEIssuerDNS01ProviderName: defaultACMEIssuerDNS01ProviderName,
 		DNS01Nameservers:                   []string{},
@@ -183,7 +184,7 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The default 'renew before expiry' time for Certificates. "+
 		"Once a certificate is within this duration until expiry, a new Certificate "+
 		"will be attempted to be issued.")
-	fs.StringVar(&s.DefaultACMEAnnotation, "default-acme-annotation", defaultACMEAnnotation, ""+
+	fs.StringSliceVar(&s.DefaultAutoCertificateAnnotations, "auto-certificate-annotations", defaultAutoCertificateAnnotations, ""+
 		"The annotation consumed by the ingress-shim controller to indicate a ingress is requesting a certificate")
 
 	fs.StringVar(&s.DefaultIssuerName, "default-issuer-name", defaultTLSACMEIssuerName, ""+

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -56,7 +56,8 @@ type ControllerOptions struct {
 	RenewBeforeExpiryDuration       time.Duration
 
 	// Default issuer/certificates details consumed by ingress-shim
-	DefaultIssuerName                  string
+	DefaultACMEAnnotation              string
+        DefaultIssuerName                  string
 	DefaultIssuerKind                  string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
@@ -79,8 +80,9 @@ const (
 	defaultIssuerAmbientCredentials        = false
 	defaultRenewBeforeExpiryDuration       = time.Hour * 24 * 30
 
-	defaultTLSACMEIssuerName           = ""
+        defaultTLSACMEIssuerName           = ""
 	defaultTLSACMEIssuerKind           = "Issuer"
+        defaultACMEAnnotation              = "kubernetes.io/tls-acme"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
 )
@@ -115,6 +117,7 @@ func NewControllerOptions() *ControllerOptions {
 		ClusterIssuerAmbientCredentials:    defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:           defaultIssuerAmbientCredentials,
 		RenewBeforeExpiryDuration:          defaultRenewBeforeExpiryDuration,
+                DefaultACMEAnnotation:              defaultACMEAnnotation,
 		DefaultIssuerName:                  defaultTLSACMEIssuerName,
 		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
@@ -180,6 +183,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The default 'renew before expiry' time for Certificates. "+
 		"Once a certificate is within this duration until expiry, a new Certificate "+
 		"will be attempted to be issued.")
+	fs.StringVar(&s.DefaultACMEAnnotation, "default-acme-annotation", defaultACMEAnnotation, ""+
+		"The annotation consumed by the ingress-shim controller to indicate a ingress is requesting a certificate")
 
 	fs.StringVar(&s.DefaultIssuerName, "default-issuer-name", defaultTLSACMEIssuerName, ""+
 		"Name of the Issuer to use when the tls is requested but issuer name is not specified on the ingress resource.")

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -100,6 +100,7 @@ type ACMEOptions struct {
 
 type IngressShimOptions struct {
 	// Default issuer/certificates details consumed by ingress-shim
+	DefaultACMEAnnotation              string
 	DefaultIssuerName                  string
 	DefaultIssuerKind                  string
 	DefaultACMEIssuerChallengeType     string

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -100,9 +100,9 @@ type ACMEOptions struct {
 
 type IngressShimOptions struct {
 	// Default issuer/certificates details consumed by ingress-shim
-	DefaultACMEAnnotation              string
-	DefaultIssuerName                  string
 	DefaultIssuerKind                  string
+	DefaultIssuerName                  string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
+	DefaultAutoCertificateAnnotations  []string
 }

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -46,7 +46,7 @@ const (
 )
 
 type defaults struct {
-	acmeTLSAnnotation           string
+	autoCertificateAnnotations  []string
 	issuerName, issuerKind      string
 	acmeIssuerChallengeType     string
 	acmeIssuerDNS01ProviderName string
@@ -218,7 +218,7 @@ func init() {
 			ctx.Client,
 			ctx.CMClient,
 			ctx.Recorder,
-			defaults{ctx.DefaultACMEAnnotation, ctx.DefaultIssuerName, ctx.DefaultIssuerKind, ctx.DefaultACMEIssuerChallengeType, ctx.DefaultACMEIssuerDNS01ProviderName},
+			defaults{ctx.DefaultAutoCertificateAnnotations, ctx.DefaultIssuerName, ctx.DefaultIssuerKind, ctx.DefaultACMEIssuerChallengeType, ctx.DefaultACMEIssuerDNS01ProviderName},
 		).Run
 	})
 }

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -46,6 +46,7 @@ const (
 )
 
 type defaults struct {
+	acmeTLSAnnotation           string
 	issuerName, issuerKind      string
 	acmeIssuerChallengeType     string
 	acmeIssuerDNS01ProviderName string
@@ -217,7 +218,7 @@ func init() {
 			ctx.Client,
 			ctx.CMClient,
 			ctx.Recorder,
-			defaults{ctx.DefaultIssuerName, ctx.DefaultIssuerKind, ctx.DefaultACMEIssuerChallengeType, ctx.DefaultACMEIssuerDNS01ProviderName},
+			defaults{ctx.DefaultACMEAnnotation, ctx.DefaultIssuerName, ctx.DefaultIssuerKind, ctx.DefaultACMEIssuerChallengeType, ctx.DefaultACMEIssuerDNS01ProviderName},
 		).Run
 	})
 }

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -33,11 +33,6 @@ import (
 )
 
 const (
-	// tlsACMEAnnotation is here for compatibility with kube-lego style
-	// ingress resources. When set to "true", a Certificate resource with
-	// the default configuration provided to ingress-annotation should be
-	// created.
-	tlsACMEAnnotation = "kubernetes.io/tls-acme"
 	// editInPlaceAnnotation is used to toggle the use of ingressClass instead
 	// of ingress on the created Certificate resource
 	editInPlaceAnnotation = "certmanager.k8s.io/acme-http01-edit-in-place"
@@ -64,7 +59,7 @@ const (
 var ingressGVK = extv1beta1.SchemeGroupVersion.WithKind("Ingress")
 
 func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
-	if !shouldSync(ing) {
+	if !shouldSync(ing, c.defaults.acmeTLSAnnotation) {
 		glog.Infof("Not syncing ingress %s/%s as it does not contain necessary annotations", ing.Namespace, ing.Name)
 		return nil
 	}
@@ -261,7 +256,7 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 
 // shouldSync returns true if this ingress should have a Certificate resource
 // created for it
-func shouldSync(ing *extv1beta1.Ingress) bool {
+func shouldSync(ing *extv1beta1.Ingress, tlsACMEAnnotation string) bool {
 	annotations := ing.Annotations
 	if annotations == nil {
 		annotations = map[string]string{}

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -59,7 +59,7 @@ const (
 var ingressGVK = extv1beta1.SchemeGroupVersion.WithKind("Ingress")
 
 func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
-	if !shouldSync(ing, c.defaults.acmeTLSAnnotation) {
+	if !shouldSync(ing, c.defaults.autoCertificateAnnotations) {
 		glog.Infof("Not syncing ingress %s/%s as it does not contain necessary annotations", ing.Namespace, ing.Name)
 		return nil
 	}
@@ -256,7 +256,7 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 
 // shouldSync returns true if this ingress should have a Certificate resource
 // created for it
-func shouldSync(ing *extv1beta1.Ingress, tlsACMEAnnotation string) bool {
+func shouldSync(ing *extv1beta1.Ingress, autoCertificateAnnotations []string) bool {
 	annotations := ing.Annotations
 	if annotations == nil {
 		annotations = map[string]string{}
@@ -267,9 +267,11 @@ func shouldSync(ing *extv1beta1.Ingress, tlsACMEAnnotation string) bool {
 	if _, ok := annotations[clusterIssuerNameAnnotation]; ok {
 		return true
 	}
-	if s, ok := annotations[tlsACMEAnnotation]; ok {
-		if b, _ := strconv.ParseBool(s); b {
-			return true
+	for _, x := range autoCertificateAnnotations {
+		if s, ok := annotations[x]; ok {
+			if b, _ := strconv.ParseBool(s); b {
+				return true
+			}
 		}
 	}
 	if _, ok := annotations[acmeIssuerChallengeTypeAnnotation]; ok {

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -73,7 +73,7 @@ func TestShouldSync(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		shouldSync := shouldSync(buildIngress("", "", test.Annotations), "kubernetes.io/tls-acme")
+		shouldSync := shouldSync(buildIngress("", "", test.Annotations), []string{"kubernetes.io/tls-acme"})
 		if shouldSync != test.ShouldSync {
 			t.Errorf("Expected shouldSync=%v for annotations %#v", test.ShouldSync, test.Annotations)
 		}

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -28,6 +28,8 @@ import (
 	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
 )
 
+const testAcmeTLSAnnotation = "kubernetes.io/tls-acme"
+
 func strPtr(s string) *string {
 	return &s
 }
@@ -47,15 +49,15 @@ func TestShouldSync(t *testing.T) {
 			ShouldSync:  true,
 		},
 		{
-			Annotations: map[string]string{tlsACMEAnnotation: "true"},
+			Annotations: map[string]string{testAcmeTLSAnnotation: "true"},
 			ShouldSync:  true,
 		},
 		{
-			Annotations: map[string]string{tlsACMEAnnotation: "false"},
+			Annotations: map[string]string{testAcmeTLSAnnotation: "false"},
 			ShouldSync:  false,
 		},
 		{
-			Annotations: map[string]string{tlsACMEAnnotation: ""},
+			Annotations: map[string]string{testAcmeTLSAnnotation: ""},
 			ShouldSync:  false,
 		},
 		{
@@ -71,7 +73,7 @@ func TestShouldSync(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
-		shouldSync := shouldSync(buildIngress("", "", test.Annotations))
+		shouldSync := shouldSync(buildIngress("", "", test.Annotations), "kubernetes.io/tls-acme")
 		if shouldSync != test.ShouldSync {
 			t.Errorf("Expected shouldSync=%v for annotations %#v", test.ShouldSync, test.Annotations)
 		}
@@ -882,7 +884,7 @@ func TestIssuerForIngress(t *testing.T) {
 		},
 		{
 			Ingress: buildIngress("name", "namespace", map[string]string{
-				tlsACMEAnnotation: "true",
+				testAcmeTLSAnnotation: "true",
 			}),
 			DefaultName:  "default-name",
 			DefaultKind:  "ClusterIssuer",


### PR DESCRIPTION
- adds a option command line (default to the current behavour) which allows the user to control the acme annotation used by the shim controller
- a current migration requires us to run multiple providers at the same
