### PR TITLE
hack/verify: also include 'dep version' output

### DIFF
--- a/hack/verify-deps.sh
+++ b/hack/verify-deps.sh
@@ -22,6 +22,8 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 
 pushd "${SCRIPT_ROOT}"
 echo "+++ Checking Gopkg.lock is up-to-date"
+dep version
+echo ""
 dep status
 popd
 


### PR DESCRIPTION
If "dep status" fails on CI, it's useful to know what version of dep is
being used to locally reproduce and examine the issue.

This is motivated by a verify error encountered on #746 which I can't reproduce with my version of dep locally.

**Release note**:
```release-note
NONE
```
