### PR TITLE
Automated cherry pick of #754

### DIFF
--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -149,7 +149,7 @@ func (c *DNSProvider) Present(domain, token, key string) error {
 func (c *DNSProvider) CleanUp(domain, token, key string) error {
 	fqdn, _, _ := util.DNS01Record(domain, key)
 
-	zone, err := c.getHostedZone(domain)
+	zone, err := c.getHostedZone(fqdn)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cherry pick of #754 on release-0.4.

#754: clouddns: use fqdn for challenge cleanup