### PR TITLE
Wait for ACME Orders to be in 'ready' state before attempting finalization

### DIFF
--- a/contrib/charts/pebble/Chart.yaml
+++ b/contrib/charts/pebble/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: pebble
-version: 0.1.0
+version: 0.1.1

--- a/contrib/charts/pebble/values.yaml
+++ b/contrib/charts/pebble/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 image:
   repository: quay.io/munnerz/pebble
-  tag: "20180323"
+  tag: "20180725"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP

--- a/test/chart/.testenv
+++ b/test/chart/.testenv
@@ -13,8 +13,8 @@ CHART_DIRS=(
 
 # Charts that should be skipped
 EXCLUDED_CHARTS=(
-    pebble
-    vault
+    contrib/charts/pebble
+    contrib/charts/vault
 )
 
 # Additional chart repos to add (<name>=<url>), separated by a space


### PR DESCRIPTION
**What this PR does / why we need it**:

When the new 'ready' state for orders was added, we did not add code into the obtainCertificate function to gate finalising orders with the ACME server until they are in a 'ready' state.

This PR adds a gate to ensure that the order is in a valid state for finalisation.

It may also require us to bump the version of Pebble used in our e2e tests, as the older versions will never set the `status` to 'ready'

**Which issue this PR fixes**: fixes #758

**Release note**:
```release-note
Fix a race that could cause ACME orders to fail despite them being in a 'valid' state
```

/cc @kragniz
@tlycken @damienwebdev