### PR TITLE
helm chart: remove endpoints from rbac resources

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.4.0-dev.2
+version: v0.4.0-dev.3
 appVersion: v0.4.0-dev.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/templates/rbac.yaml
+++ b/contrib/charts/cert-manager/templates/rbac.yaml
@@ -13,12 +13,7 @@ rules:
     resources: ["certificates", "issuers", "clusterissuers"]
     verbs: ["*"]
   - apiGroups: [""]
-    # TODO: remove endpoints once 0.4 is released. We include it here in case
-    # users use the 'master' version of the Helm chart with a 0.2.x release of
-    # cert-manager that still performs leader election with Endpoint resources.
-    # We advise users don't do this, but some will anyway and this will reduce
-    # friction.
-    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
+    resources: ["configmaps", "secrets", "events", "services", "pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -39,6 +39,7 @@ spec:
     shortNames:
       - cert
       - certs
+      
 ---
 # Source: cert-manager/templates/clusterissuer-crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -156,4 +157,5 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+            
 

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 ---
@@ -26,7 +26,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -39,7 +39,6 @@ spec:
     shortNames:
       - cert
       - certs
-      
 ---
 # Source: cert-manager/templates/clusterissuer-crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -48,7 +47,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -66,7 +65,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -84,7 +83,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -92,12 +91,7 @@ rules:
     resources: ["certificates", "issuers", "clusterissuers"]
     verbs: ["*"]
   - apiGroups: [""]
-    # TODO: remove endpoints once 0.4 is released. We include it here in case
-    # users use the 'master' version of the Helm chart with a 0.2.x release of
-    # cert-manager that still performs leader election with Endpoint resources.
-    # We advise users don't do this, but some will anyway and this will reduce
-    # friction.
-    resources: ["endpoints", "configmaps", "secrets", "events", "services", "pods"]
+    resources: ["configmaps", "secrets", "events", "services", "pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
     resources: ["ingresses"]
@@ -109,7 +103,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -129,7 +123,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -162,5 +156,4 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
-            
 

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -14,7 +14,7 @@ metadata:
   name: certificates.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -27,7 +27,6 @@ spec:
     shortNames:
       - cert
       - certs
-      
 ---
 # Source: cert-manager/templates/clusterissuer-crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -36,7 +35,7 @@ metadata:
   name: clusterissuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -54,7 +53,7 @@ metadata:
   name: issuers.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +72,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.2
+    chart: cert-manager-v0.4.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -106,7 +105,6 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
-            
 
 ---
 # Source: cert-manager/templates/rbac.yaml

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -27,6 +27,7 @@ spec:
     shortNames:
       - cert
       - certs
+      
 ---
 # Source: cert-manager/templates/clusterissuer-crd.yaml
 apiVersion: apiextensions.k8s.io/v1beta1
@@ -105,6 +106,7 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
+            
 
 ---
 # Source: cert-manager/templates/rbac.yaml


### PR DESCRIPTION
As version `0.4` is used now, it should be safe to remove `endpoints` from the ClusterRole resources. See old `TODO` in code.

Release Note
```release-note
NONE
```