### PR TITLE
Change leader election duration defaults to be less chatty

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -50,7 +50,7 @@ const (
 	defaultLeaderElectionNamespace     = "kube-system"
 	defaultLeaderElectionLeaseDuration = 60 * time.Second
 	defaultLeaderElectionRenewDeadline = 40 * time.Second
-	defaultLeaderElectionRetryPeriod   = 20 * time.Second
+	defaultLeaderElectionRetryPeriod   = 15 * time.Second
 
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -48,9 +48,9 @@ const (
 
 	defaultLeaderElect                 = true
 	defaultLeaderElectionNamespace     = "kube-system"
-	defaultLeaderElectionLeaseDuration = 15 * time.Second
-	defaultLeaderElectionRenewDeadline = 10 * time.Second
-	defaultLeaderElectionRetryPeriod   = 2 * time.Second
+	defaultLeaderElectionLeaseDuration = 60 * time.Second
+	defaultLeaderElectionRenewDeadline = 40 * time.Second
+	defaultLeaderElectionRetryPeriod   = 20 * time.Second
 
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous defaults were overly chatty and causing calls to the ConfigMap update endpoint every ~2s.

This PR changes it to make a call every 15s. Instances of the controller will also hold the leader election lease for up to 60s.

Fixes #723 

**Release note**:
```release-note
Reduce rate of leader election ConfigMap updates
```
