### PR TITLE
Add logic to handle ready vs valid ACME orders properly

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -135,6 +135,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			ClusterIssuerAmbientCredentials: opts.ClusterIssuerAmbientCredentials,
 			IssuerAmbientCredentials:        opts.IssuerAmbientCredentials,
 			ClusterResourceNamespace:        opts.ClusterResourceNamespace,
+			RenewBeforeExpiryDuration:       opts.RenewBeforeExpiryDuration,
 		},
 		IngressShimOptions: controller.IngressShimOptions{
 			DefaultIssuerName:                  opts.DefaultIssuerName,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -31,6 +31,7 @@ type ControllerOptions struct {
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
+	RenewBeforeExpiryDuration       time.Duration
 
 	// Default issuer/certificates details consumed by ingress-shim
 	DefaultIssuerName                  string
@@ -54,6 +55,7 @@ const (
 
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false
+	defaultRenewBeforeExpiryDuration       = time.Hour * 24 * 30
 
 	defaultTLSACMEIssuerName           = ""
 	defaultTLSACMEIssuerKind           = "Issuer"
@@ -84,6 +86,7 @@ func NewControllerOptions() *ControllerOptions {
 		EnabledControllers:                 defaultEnabledControllers,
 		ClusterIssuerAmbientCredentials:    defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:           defaultIssuerAmbientCredentials,
+		RenewBeforeExpiryDuration:          defaultRenewBeforeExpiryDuration,
 		DefaultIssuerName:                  defaultTLSACMEIssuerName,
 		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
@@ -133,6 +136,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Whether an issuer may make use of ambient credentials. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the Issuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+
 		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata.")
+	fs.DurationVar(&s.RenewBeforeExpiryDuration, "renew-before-expiry-duration", defaultRenewBeforeExpiryDuration, ""+
+		"The default 'renew before expiry' time for Certificates. "+
+		"Once a certificate is within this duration until expiry, a new Certificate "+
+		"will be attempted to be issued.")
 
 	fs.StringVar(&s.DefaultIssuerName, "default-issuer-name", defaultTLSACMEIssuerName, ""+
 		"Name of the Issuer to use when the tls is requested but issuer name is not specified on the ingress resource.")

--- a/pkg/acme/client/fake.go
+++ b/pkg/acme/client/fake.go
@@ -14,6 +14,7 @@ import (
 type FakeACME struct {
 	FakeCreateOrder             func(ctx context.Context, order *acme.Order) (*acme.Order, error)
 	FakeGetOrder                func(ctx context.Context, url string) (*acme.Order, error)
+	FakeGetCertificate          func(ctx context.Context, url string) ([][]byte, error)
 	FakeWaitOrder               func(ctx context.Context, url string) (*acme.Order, error)
 	FakeFinalizeOrder           func(ctx context.Context, finalizeURL string, csr []byte) (der [][]byte, err error)
 	FakeAcceptChallenge         func(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error)
@@ -38,6 +39,13 @@ func (f *FakeACME) GetOrder(ctx context.Context, url string) (*acme.Order, error
 		return f.FakeGetOrder(ctx, url)
 	}
 	return nil, fmt.Errorf("GetOrder not implemented")
+}
+
+func (f *FakeACME) GetCertificate(ctx context.Context, url string) ([][]byte, error) {
+	if f.FakeGetCertificate != nil {
+		return f.FakeGetCertificate(ctx, url)
+	}
+	return nil, fmt.Errorf("GetCertificate not implemented")
 }
 
 func (f *FakeACME) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {

--- a/pkg/acme/client/interfaces.go
+++ b/pkg/acme/client/interfaces.go
@@ -9,6 +9,7 @@ import (
 type Interface interface {
 	CreateOrder(ctx context.Context, order *acme.Order) (*acme.Order, error)
 	GetOrder(ctx context.Context, url string) (*acme.Order, error)
+	GetCertificate(ctx context.Context, url string) ([][]byte, error)
 	WaitOrder(ctx context.Context, url string) (*acme.Order, error)
 	FinalizeOrder(ctx context.Context, finalizeURL string, csr []byte) (der [][]byte, err error)
 	AcceptChallenge(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error)

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -28,6 +28,11 @@ func (l *Logger) GetOrder(ctx context.Context, url string) (*acme.Order, error) 
 	return l.baseCl.GetOrder(ctx, url)
 }
 
+func (l *Logger) GetCertificate(ctx context.Context, url string) ([][]byte, error) {
+	glog.Infof("Calling GetCertificate")
+	return l.baseCl.GetCertificate(ctx, url)
+}
+
 func (l *Logger) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {
 	glog.Infof("Calling WaitOrder")
 	return l.baseCl.WaitOrder(ctx, url)

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"time"
+
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -50,6 +52,11 @@ type IssuerOptions struct {
 	// IssuerAmbientCredentials controls whether an issuer should pick up ambient
 	// credentials, such as those from metadata services, to construct clients.
 	IssuerAmbientCredentials bool
+
+	// RenewBeforeExpiryDuration is the default 'renew before expiry' time for Certificates.
+	// Once a certificate is within this duration until expiry, a new Certificate
+	// will be attempted to be issued.
+	RenewBeforeExpiryDuration time.Duration
 }
 
 type ACMEOptions struct {

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -3,6 +3,8 @@ package acme
 import (
 	"bytes"
 	"context"
+	"crypto"
+	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 
@@ -48,14 +50,8 @@ func (a *Acme) obtainCertificate(ctx context.Context, crt *v1alpha1.Certificate)
 		return nil, nil, fmt.Errorf("error getting order details: %v", err)
 	}
 
-	if order.Status != acmeapi.StatusReady {
-		err := fmt.Errorf("expected certificate status to be %q, but it is %q", acmeapi.StatusReady, order.Status)
-		// print a more helpful message to users when an order is marked 'valid'.
-		// this happens when all challenges have been completed successfully, but
-		// the acme server has not finished processing the order.
-		if order.Status == acmeapi.StatusValid {
-			err = fmt.Errorf("%v. Waiting until Order transitions into %q state", err, acmeapi.StatusReady)
-		}
+	if order.Status != acmeapi.StatusReady && order.Status != acmeapi.StatusValid {
+		err := fmt.Errorf("expected certificate status to be %q or %q, but it is %q", acmeapi.StatusReady, acmeapi.StatusValid, order.Status)
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, err.Error(), false)
 		return nil, nil, err
 	}
@@ -63,6 +59,14 @@ func (a *Acme) obtainCertificate(ctx context.Context, crt *v1alpha1.Certificate)
 	// get existing certificate private key
 	key, err := kube.SecretTLSKey(a.secretsLister, crt.Namespace, crt.Spec.SecretName)
 	if k8sErrors.IsNotFound(err) || errors.IsInvalidData(err) {
+		if order.Status == acmeapi.StatusValid {
+			// if this order is already marked 'valid', but we do not have the private
+			// key for the Certificate, we must create a new order as we cannot call
+			// Finalize on the order twice with different CSRs.
+			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, "Creating new order due to lost TLS private key", false)
+			crt.Status.ACMEStatus().Order.URL = ""
+			return nil, nil, fmt.Errorf("marking certificate as failed to trigger a new order to be created due to lost private key")
+		}
 		key, err = pki.GeneratePrivateKeyForCertificate(crt)
 		if err != nil {
 			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to generate certificate private key: %v", err), false)
@@ -74,38 +78,88 @@ func (a *Acme) obtainCertificate(ctx context.Context, crt *v1alpha1.Certificate)
 		return nil, nil, fmt.Errorf("error getting certificate private key: %s", err.Error())
 	}
 
-	// generate a csr
-	template, err := pki.GenerateCSR(a.issuer, crt)
-	if err != nil {
-		// TODO: this should probably be classed as a permanant failure
-		return nil, nil, err
-	}
-
-	derBytes, err := pki.EncodeCSR(template, key)
-	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to generate certificate request: %v", err), false)
-		return nil, nil, err
-	}
-
-	// obtain a certificate from the acme server
-	certSlice, err := cl.FinalizeOrder(ctx, order.FinalizeURL, derBytes)
-	if err != nil {
-		// this handles an edge case where a certificate ends out with an order
-		// that is in an invalid state.
-		// ideally we would instead call GetCertificate on the ACME client
-		// instead of FinalizeOrder, which would save us creating a new order
-		// just to issue a new certificate.
-		// The underlying ACME client doesn't expose this though yet.
-		if acmeErr, ok := err.(*acmeapi.Error); ok {
-			if acmeErr.StatusCode >= 400 && acmeErr.StatusCode <= 499 {
-				crt.Status.ACMEStatus().Order.URL = ""
-			}
+	var certSlice [][]byte
+	// StatusReady indicates that the order is ready to be finalized.
+	// Once the order has been finalized, it will transition into the 'valid'
+	// state.
+	// The only way to obtain a certificate from an already 'valid' order is to
+	// call the orders GetCertificate function.
+	// You can see we do this below *iff* certSlice is nil.
+	if order.Status == acmeapi.StatusReady {
+		// generate a csr
+		template, err := pki.GenerateCSR(a.issuer, crt)
+		if err != nil {
+			// TODO: this should probably be classed as a permanant failure
+			return nil, nil, err
 		}
-		// TODO: should we also set the FailedValidation status
-		// condition here so back off can be applied?
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to finalize order: %v", err), false)
-		a.Recorder.Eventf(crt, corev1.EventTypeWarning, errorIssueError, "Failed to finalize order: %v", err)
-		return nil, nil, fmt.Errorf("error getting certificate from acme server: %s", err)
+
+		derBytes, err := pki.EncodeCSR(template, key)
+		if err != nil {
+			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to generate certificate request: %v", err), false)
+			return nil, nil, err
+		}
+
+		// obtain a certificate from the acme server
+		certSlice, err = cl.FinalizeOrder(ctx, order.FinalizeURL, derBytes)
+		if err != nil {
+			// this handles an edge case where a certificate ends out with an order
+			// that is in an invalid state.
+			// ideally we would instead call GetCertificate on the ACME client
+			// instead of FinalizeOrder, which would save us creating a new order
+			// just to issue a new certificate.
+			// The underlying ACME client doesn't expose this though yet.
+			if acmeErr, ok := err.(*acmeapi.Error); ok {
+				if acmeErr.StatusCode >= 400 && acmeErr.StatusCode <= 499 {
+					crt.Status.ACMEStatus().Order.URL = ""
+				}
+			}
+			// TODO: should we also set the FailedValidation status
+			// condition here so back off can be applied?
+			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to finalize order: %v", err), false)
+			a.Recorder.Eventf(crt, corev1.EventTypeWarning, errorIssueError, "Failed to finalize order: %v", err)
+			return nil, nil, fmt.Errorf("error getting certificate from acme server: %s", err)
+		}
+
+	}
+
+	// if the Certificate was marked 'valid', we need to retrieve the certificate
+	// from the URL specified on the Order resource.
+	if certSlice == nil {
+		certSlice, err = cl.GetCertificate(ctx, order.CertificateURL)
+		if err != nil {
+			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, fmt.Sprintf("Failed to retrieve certificate: %v", err), false)
+			return nil, nil, fmt.Errorf("error retrieving certificate: %v", err)
+		}
+	}
+
+	if len(certSlice) == 0 {
+		return nil, nil, fmt.Errorf("invalid certificate returned from acme server")
+	}
+
+	x509Cert, err := x509.ParseCertificate(certSlice[0])
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to parse returned x509 certificate: %v", err.Error())
+	}
+
+	if a.Context.IssuerOptions.CertificateNeedsRenew(x509Cert) {
+		// existing orders certificate is near expiry, so we clear the order URL
+		// field and trigger a retry to create a new order for a new certificate
+		crt.Status.ACMEStatus().Order.URL = ""
+		return nil, nil, fmt.Errorf("triggering new order creation as existing order's certificate is nearing expiry")
+	}
+
+	cryptoSigner, ok := key.(crypto.Signer)
+	if !ok {
+		return nil, nil, fmt.Errorf("unreachable: private key is not of type crypto.Signer")
+	}
+	validForPrivKey, err := pki.PublicKeyMatchesCertificate(cryptoSigner.Public(), x509Cert)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error verifying certificate: %v", err)
+	}
+	if !validForPrivKey {
+		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueError, "Creating new order due to lost TLS private key", false)
+		crt.Status.ACMEStatus().Order.URL = ""
+		return nil, nil, fmt.Errorf("marking certificate as failed to trigger a new order to be created due to lost private key")
 	}
 
 	// encode the retrieved certificate

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -1,12 +1,17 @@
 package pki
 
 import (
+	"crypto"
 	"crypto/ecdsa"
 	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
@@ -198,5 +203,66 @@ func TestGeneratePrivateKeyForCertificate(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, testFn(test))
+	}
+}
+
+func signTestCert(key crypto.Signer) *x509.Certificate {
+	commonName := "testingcert"
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		panic(fmt.Errorf("failed to generate serial number: %s", err.Error()))
+	}
+
+	template := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          serialNumber,
+		SignatureAlgorithm:    x509.SHA256WithRSA,
+		Subject: pkix.Name{
+			Organization: []string{defaultOrganization},
+			CommonName:   commonName,
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(defaultNotAfter),
+		// see http://golang.org/pkg/crypto/x509/#KeyUsage
+		KeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+	}
+
+	_, crt, err := SignCertificate(template, template, key.Public(), key)
+	if err != nil {
+		panic(fmt.Errorf("error signing test cert: %v", err))
+	}
+
+	return crt
+}
+
+func TestPublicKeyMatchesCertificate(t *testing.T) {
+	privKey1, err := GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Errorf("error generating private key: %v", err)
+	}
+	privKey2, err := GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Errorf("error generating private key: %v", err)
+	}
+
+	testCert1 := signTestCert(privKey1)
+	testCert2 := signTestCert(privKey2)
+
+	matches, err := PublicKeyMatchesCertificate(privKey1.Public(), testCert1)
+	if err != nil {
+		t.Errorf("expected no error, but got: %v", err)
+	}
+	if !matches {
+		t.Errorf("expected private key to match certificate, but it did not")
+	}
+
+	matches, err = PublicKeyMatchesCertificate(privKey1.Public(), testCert2)
+	if err != nil {
+		t.Errorf("expected no error, but got: %v", err)
+	}
+	if matches {
+		t.Errorf("expected private key to not match certificate, but it did")
 	}
 }

--- a/third_party/crypto/acme/acme.go
+++ b/third_party/crypto/acme/acme.go
@@ -247,7 +247,7 @@ func (c *Client) FinalizeOrder(ctx context.Context, finalizeURL string, csr []by
 		return nil, fmt.Errorf("acme: unexpected order status %q", o.Status)
 	}
 
-	return c.getCert(ctx, o.CertificateURL)
+	return c.GetCertificate(ctx, o.CertificateURL)
 }
 
 // GetOrder retrieves an order identified by url.
@@ -818,7 +818,7 @@ func nonceFromHeader(h http.Header) string {
 	return h.Get("Replay-Nonce")
 }
 
-func (c *Client) getCert(ctx context.Context, url string) ([][]byte, error) {
+func (c *Client) GetCertificate(ctx context.Context, url string) ([][]byte, error) {
 	res, err := c.get(ctx, url)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Recent changes to Let's Encrypt have meant that they now use the 'ready' ACME status condition to indicate an order is ready to be finalized.

Order's that have already been finalized will have a state 'valid'.

If an order is ready, we must finalize it (i.e. submit a CSR to the ACME server)
If an order is valid, all we can do is retrieve the existing Certificate (as signed by the server in response to the CSR initially submitted when the order was 'ready').

This PR adapts our Issue function to handle these cases properly.

It is slightly more complex due to case (2) (where the order is already valid). If we have lost the certificate's private key, we need to detect this and trigger a new order to be created so we can re-finalize with the new private key.

**Which issue this PR fixes**: fixes #778

**Special notes for your reviewer**:

**Release note**:
```release-note
Fix issue that could cause Certificates to fail re-issuance if triggered before certificate expiry
```

/cc @kragniz 