### PR TITLE
Add RenewBeforeExpiryDuration option to controller context

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -135,6 +135,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			ClusterIssuerAmbientCredentials: opts.ClusterIssuerAmbientCredentials,
 			IssuerAmbientCredentials:        opts.IssuerAmbientCredentials,
 			ClusterResourceNamespace:        opts.ClusterResourceNamespace,
+			RenewBeforeExpiryDuration:       opts.RenewBeforeExpiryDuration,
 		},
 		IngressShimOptions: controller.IngressShimOptions{
 			DefaultIssuerName:                  opts.DefaultIssuerName,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -31,6 +31,7 @@ type ControllerOptions struct {
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
+	RenewBeforeExpiryDuration       time.Duration
 
 	// Default issuer/certificates details consumed by ingress-shim
 	DefaultIssuerName                  string
@@ -54,6 +55,7 @@ const (
 
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false
+	defaultRenewBeforeExpiryDuration       = time.Hour * 24 * 30
 
 	defaultTLSACMEIssuerName           = ""
 	defaultTLSACMEIssuerKind           = "Issuer"
@@ -84,6 +86,7 @@ func NewControllerOptions() *ControllerOptions {
 		EnabledControllers:                 defaultEnabledControllers,
 		ClusterIssuerAmbientCredentials:    defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:           defaultIssuerAmbientCredentials,
+		RenewBeforeExpiryDuration:          defaultRenewBeforeExpiryDuration,
 		DefaultIssuerName:                  defaultTLSACMEIssuerName,
 		DefaultIssuerKind:                  defaultTLSACMEIssuerKind,
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
@@ -133,6 +136,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Whether an issuer may make use of ambient credentials. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the Issuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+
 		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata.")
+	fs.DurationVar(&s.RenewBeforeExpiryDuration, "renew-before-expiry-duration", defaultRenewBeforeExpiryDuration, ""+
+		"The default 'renew before expiry' time for Certificates. "+
+		"Once a certificate is within this duration until expiry, a new Certificate "+
+		"will be attempted to be issued.")
 
 	fs.StringVar(&s.DefaultIssuerName, "default-issuer-name", defaultTLSACMEIssuerName, ""+
 		"Name of the Issuer to use when the tls is requested but issuer name is not specified on the ingress resource.")

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -1,6 +1,8 @@
 package controller
 
 import (
+	"time"
+
 	kubeinformers "k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
@@ -50,6 +52,11 @@ type IssuerOptions struct {
 	// IssuerAmbientCredentials controls whether an issuer should pick up ambient
 	// credentials, such as those from metadata services, to construct clients.
 	IssuerAmbientCredentials bool
+
+	// RenewBeforeExpiryDuration is the default 'renew before expiry' time for Certificates.
+	// Once a certificate is within this duration until expiry, a new Certificate
+	// will be attempted to be issued.
+	RenewBeforeExpiryDuration time.Duration
 }
 
 type ACMEOptions struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This helps break out the changes in #800

It adds a new RenewBeforeExpiryDuration option to help resolve the issues described there.

**Special notes for your reviewer**:

This option can in future become the default global option when we support this as a field on the issuer spec.

~QUESTION: should this field be called `renew-before-expiry-duration`?~ yes (cc @zuzzas)

**Release note**:
```release-note
Add renew-before-expiry-duration option to configure how long before expiration a certificate should be attempted to be renewed
```

/cc @kragniz 