### PR TITLE
Don't bundle the CA certificate when selfsigned

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -131,10 +131,14 @@ func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, p
 		return nil, nil, fmt.Errorf("error encoding certificate PEM: %s", err.Error())
 	}
 
-	// bundle the CA
-	err = pem.Encode(pemBytes, &pem.Block{Type: "CERTIFICATE", Bytes: issuerCert.Raw})
-	if err != nil {
-		return nil, nil, fmt.Errorf("error encoding issuer cetificate PEM: %s", err.Error())
+	// don't bundle the CA for selfsigned certificates
+	// TODO: better comparison method here? for now we can just compare pointers.
+	if issuerCert != template {
+		// bundle the CA
+		err = pem.Encode(pemBytes, &pem.Block{Type: "CERTIFICATE", Bytes: issuerCert.Raw})
+		if err != nil {
+			return nil, nil, fmt.Errorf("error encoding issuer cetificate PEM: %s", err.Error())
+		}
 	}
 
 	return pemBytes.Bytes(), cert, err


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't bundle the CA certificate when that certificate is selfsigned.

**Which issue this PR fixes**: fixes #779

**Release note**:
```release-note
Don't bundle the CA certificate when using the self signed issuer
```
