### PR TITLE
Set the certificate as an owner of the secret

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -184,7 +184,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			DefaultACMEIssuerChallengeType:     opts.DefaultACMEIssuerChallengeType,
 			DefaultACMEIssuerDNS01ProviderName: opts.DefaultACMEIssuerDNS01ProviderName,
 		},
-		CertifcateOptions: controller.CertificateOptions{
+		CertificateOptions: controller.CertificateOptions{
 			EnableOwnerRef: opts.EnableCertificateOwnerRef,
 		},
 	}, kubeCfg, nil

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -184,6 +184,9 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			DefaultACMEIssuerChallengeType:     opts.DefaultACMEIssuerChallengeType,
 			DefaultACMEIssuerDNS01ProviderName: opts.DefaultACMEIssuerDNS01ProviderName,
 		},
+		CertifcateOptions: controller.CertificateOptions{
+			EnableOwnerRef: opts.EnableCertificateOwnerRef,
+		},
 	}, kubeCfg, nil
 }
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -63,6 +63,8 @@ type ControllerOptions struct {
 
 	// DNS01Nameservers allows specifying a list of custom nameservers to perform DNS checks
 	DNS01Nameservers []string
+
+	EnableCertificateOwnerRef bool
 }
 
 const (
@@ -83,6 +85,7 @@ const (
 	defaultTLSACMEIssuerKind           = "Issuer"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
+	defaultEnableCertificateOwnerRef   = true
 )
 
 var (
@@ -120,6 +123,7 @@ func NewControllerOptions() *ControllerOptions {
 		DefaultACMEIssuerChallengeType:     defaultACMEIssuerChallengeType,
 		DefaultACMEIssuerDNS01ProviderName: defaultACMEIssuerDNS01ProviderName,
 		DNS01Nameservers:                   []string{},
+		EnableCertificateOwnerRef:          defaultEnableCertificateOwnerRef,
 	}
 }
 
@@ -193,6 +197,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.DNS01Nameservers, "dns01-self-check-nameservers", []string{}, ""+
 		"A list of comma seperated DNS server endpoints used for DNS01 check requests. "+
 		"This should be a list containing IP address and port, for example: 8.8.8.8:53,8.8.4.4:53")
+	fs.BoolVar(&s.EnableCertificateOwnerRef, "enable-certificate-owner-ref", defaultEnableCertificateOwnerRef, ""+
+		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+
+		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -85,7 +85,7 @@ const (
 	defaultTLSACMEIssuerKind           = "Issuer"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
-	defaultEnableCertificateOwnerRef   = true
+	defaultEnableCertificateOwnerRef   = false
 )
 
 var (

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -59,6 +59,7 @@ type ObjectReference struct {
 const (
 	ClusterIssuerKind = "ClusterIssuer"
 	IssuerKind        = "Issuer"
+	CertificateKind   = "Certificate"
 )
 
 type SecretKeySelector struct {

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -301,7 +301,10 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 	// if it is a new resource
 	if secret.SelfLink == "" {
 		secret, err = c.Client.CoreV1().Secrets(namespace).Create(secret)
-		secret.SetOwnerReferences(append(secret.GetOwnerReferences(), ownerRef(crt)))
+		enableOwner := c.CertificateOptions.EnableOwnerRef
+		if enableOwner {
+			secret.SetOwnerReferences(append(secret.GetOwnerReferences(), ownerRef(crt)))
+		}
 	} else {
 		secret, err = c.Client.CoreV1().Secrets(namespace).Update(secret)
 	}

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -300,11 +300,11 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 
 	// if it is a new resource
 	if secret.SelfLink == "" {
-		secret, err = c.Client.CoreV1().Secrets(namespace).Create(secret)
 		enableOwner := c.CertificateOptions.EnableOwnerRef
 		if enableOwner {
 			secret.SetOwnerReferences(append(secret.GetOwnerReferences(), ownerRef(crt)))
 		}
+		secret, err = c.Client.CoreV1().Secrets(namespace).Create(secret)
 	} else {
 		secret, err = c.Client.CoreV1().Secrets(namespace).Update(secret)
 	}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -50,6 +50,7 @@ type Context struct {
 	IssuerOptions
 	ACMEOptions
 	IngressShimOptions
+	CertificateOptions
 }
 
 func (c *Context) IssuerFactory() IssuerFactory {
@@ -104,4 +105,10 @@ type IngressShimOptions struct {
 	DefaultIssuerKind                  string
 	DefaultACMEIssuerChallengeType     string
 	DefaultACMEIssuerDNS01ProviderName string
+}
+
+type CertificateOptions struct {
+	// EnableOwnerRef controls wheter wheter the certificate is configured as an owner of
+	// secret where the effective TLS certificate is stored.
+	EnableOwnerRef bool
 }


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Sets the certificate as an owner of the secret

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

In this way, the secret will be garbage collected when a certificate is deleted.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add a flag which controls whether the certificate resource is configured as an owner of the secret where the effective TLS certificate is stored. This flag is set by default to 'on'. When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.
```
