### PR TITLE
chart: annotate all CRDs with "crd-install" hook

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.4.0-dev.3
+version: v0.4.0-dev.4
 appVersion: v0.4.0-dev.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/templates/certificate-crd.yaml
+++ b/contrib/charts/cert-manager/templates/certificate-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/certificate-crd.yaml
+++ b/contrib/charts/cert-manager/templates/certificate-crd.yaml
@@ -3,8 +3,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+{{- if semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer }}
   annotations:
     "helm.sh/hook": crd-install
+{{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/clusterissuer-crd.yaml
@@ -3,8 +3,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+{{- if semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer }}
   annotations:
     "helm.sh/hook": crd-install
+{{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/issuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/issuer-crd.yaml
@@ -3,6 +3,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/issuer-crd.yaml
+++ b/contrib/charts/cert-manager/templates/issuer-crd.yaml
@@ -3,8 +3,10 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+{{- if semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer }}
   annotations:
     "helm.sh/hook": crd-install
+{{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -24,8 +24,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -48,8 +46,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -68,8 +64,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -24,6 +24,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.3
@@ -46,6 +48,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.3
@@ -64,6 +68,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.3

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -15,7 +15,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 ---
@@ -28,7 +28,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -52,7 +52,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -72,7 +72,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -90,7 +90,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 rules:
@@ -110,7 +110,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -130,7 +130,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -12,8 +12,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -36,8 +34,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -56,8 +52,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -12,6 +12,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.3
@@ -34,6 +36,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.3
@@ -52,6 +56,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.3

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -16,7 +16,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -40,7 +40,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -60,7 +60,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -79,7 +79,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.4.0-dev.3
+    chart: cert-manager-v0.4.0-dev.4
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

It annotates all CRDs with "crd-install" hook.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

This fix is required in order to make helm properly verify the CRDs
when cert-manager chart is referenced as a dependency of another chart.

**Special notes for your reviewer**:

@munnerz Do I have to send this patch also to `stable/cert-manager` chart, or are you going to sync that chart from this repo? 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
