### PR TITLE
Add details on DCO sign-off

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Contributing
+## DCO Sign off
+
+All authors to the project retain copyright to their work. However, to ensure
+that they are only submitting work that they have rights to, we are requiring
+everyone to acknowledge this by signing their work.
+
+Any copyright notices in this repo should specify the authors as "the Jetstack
+cert-manager contributors".
+
+To sign your work, just add a line like this at the end of your commit message:
+
+```
+Signed-off-by: Joe Bloggs <joe@example.com>
+```
+
+This can easily be done with the `--signoff` option to `git commit`.
+You can also mass sign-off a whole PR with `git rebase --signoff master`, replacing
+`master` with the branch you are creating a pull request again if not master.
+
+By doing this you state that you can certify the following (from https://developercertificate.org/):
+
+```
+Developer Certificate of Origin
+Version 1.1
+
+Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+1 Letterman Drive
+Suite D4700
+San Francisco, CA, 94129
+
+Everyone is permitted to copy and distribute verbatim copies of this
+license document, but changing it is not allowed.
+
+
+Developer's Certificate of Origin 1.1
+
+By making a contribution to this project, I certify that:
+
+(a) The contribution was created in whole or in part by me and I
+    have the right to submit it under the open source license
+    indicated in the file; or
+
+(b) The contribution is based upon previous work that, to the best
+    of my knowledge, is covered under an appropriate open source
+    license and I have the right under that license to submit that
+    work with modifications, whether created in whole or in part
+    by me, under the same open source license (unless I am
+    permitted to submit under a different license), as indicated
+    in the file; or
+
+(c) The contribution was provided directly to me by some other
+    person who certified (a), (b) or (c) and I have not modified
+    it.
+
+(d) I understand and agree that this project and the contribution
+    are public and that a record of the contribution (including all
+    personal information I submit with it, including my sign-off) is
+    maintained indefinitely and may be redistributed consistent with
+    this project or the open source license(s) involved.
+```

--- a/docs/devel/dco-sign-off.rst
+++ b/docs/devel/dco-sign-off.rst
@@ -1,0 +1,63 @@
+============
+DCO Sign off
+============
+
+All authors to the project retain copyright to their work. However, to ensure
+that they are only submitting work that they have rights to, we are requiring
+everyone to acknowledge this by signing their work.
+
+Any copyright notices in this repo should specify the authors as "the Jetstack
+cert-manager contributors".
+
+To sign your work, just add a line like this at the end of your commit message:
+
+.. code::
+
+   Signed-off-by: Joe Bloggs <joe@example.com>
+
+This can easily be done with the ``--signoff`` option to ``git commit``.
+You can also mass sign-off a whole PR with ``git rebase --signoff master``,
+replacing ``master`` with the branch you are creating a pull request again if
+not master.
+
+By doing this you state that you can certify the following (from https://developercertificate.org/):
+
+.. code::
+
+   Developer Certificate of Origin
+   Version 1.1
+
+   Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
+   1 Letterman Drive
+   Suite D4700
+   San Francisco, CA, 94129
+
+   Everyone is permitted to copy and distribute verbatim copies of this
+   license document, but changing it is not allowed.
+
+
+   Developer's Certificate of Origin 1.1
+
+   By making a contribution to this project, I certify that:
+
+   (a) The contribution was created in whole or in part by me and I
+       have the right to submit it under the open source license
+       indicated in the file; or
+
+   (b) The contribution is based upon previous work that, to the best
+       of my knowledge, is covered under an appropriate open source
+       license and I have the right under that license to submit that
+       work with modifications, whether created in whole or in part
+       by me, under the same open source license (unless I am
+       permitted to submit under a different license), as indicated
+       in the file; or
+
+   (c) The contribution was provided directly to me by some other
+       person who certified (a), (b) or (c) and I have not modified
+       it.
+
+   (d) I understand and agree that this project and the contribution
+       are public and that a record of the contribution (including all
+       personal information I submit with it, including my sign-off) is
+       maintained indefinitely and may be redistributed consistent with
+       this project or the open source license(s) involved.

--- a/docs/devel/index.rst
+++ b/docs/devel/index.rst
@@ -6,3 +6,4 @@ Development documentation
 
    develop-with-minikube
    dns01-providers
+   dco-sign-off


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds details on DCO sign-off to our documentation and root of the repo.

Wording here has been borrowed from the `heptio/ark` repository: https://github.com/heptio/ark/blob/master/CONTRIBUTING.md