### PR TITLE
Fix issue causing existing ingresses to not be cleaned up properly

### DIFF
--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -25,9 +25,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	coretesting "k8s.io/client-go/testing"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/controller/test"
 	"github.com/jetstack/cert-manager/test/util/generate"
 )
 
@@ -187,6 +190,80 @@ func TestCleanupIngresses(t *testing.T) {
 				}
 				if err != nil {
 					t.Errorf("error getting ingress resource: %v", err)
+				}
+			},
+		},
+		"should clean up an ingress with a single challenge path inserted": {
+			Builder: &test.Builder{
+				KubeObjects: []runtime.Object{
+					&v1beta1.Ingress{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testingress",
+							Namespace: defaultTestNamespace,
+						},
+						Spec: v1beta1.IngressSpec{
+							Backend: &v1beta1.IngressBackend{
+								ServiceName: "testsvc",
+								ServicePort: intstr.FromInt(8080),
+							},
+							Rules: []v1beta1.IngressRule{
+								{
+									Host: "example.com",
+									IngressRuleValue: v1beta1.IngressRuleValue{
+										HTTP: &v1beta1.HTTPIngressRuleValue{
+											Paths: []v1beta1.HTTPIngressPath{
+												{
+													Path: "/.well-known/acme-challenge/abcd",
+													Backend: v1beta1.IngressBackend{
+														ServiceName: "solversvc",
+														ServicePort: intstr.FromInt(8081),
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			Certificate: generate.Certificate(generate.CertificateConfig{
+				Name:         "test",
+				Namespace:    defaultTestNamespace,
+				DNSNames:     []string{"example.com"},
+				ACMEOrderURL: "testurl",
+				SolverConfig: v1alpha1.SolverConfig{
+					HTTP01: &v1alpha1.HTTP01SolverConfig{
+						Ingress: "testingress",
+					},
+				},
+			}),
+			Challenge: v1alpha1.ACMEOrderChallenge{
+				Domain: "example.com",
+				Token:  "abcd",
+				SolverConfig: v1alpha1.SolverConfig{
+					HTTP01: &v1alpha1.HTTP01SolverConfig{
+						Ingress: "testingress",
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				expectedIng := s.KubeObjects[0].(*v1beta1.Ingress).DeepCopy()
+				expectedIng.Spec.Rules = nil
+
+				actualIng, err := s.Builder.FakeKubeClient().ExtensionsV1beta1().Ingresses(s.Certificate.Namespace).Get(expectedIng.Name, metav1.GetOptions{})
+				if apierrors.IsNotFound(err) {
+					t.Errorf("expected ingress resource %q to not be deleted, but it was deleted", expectedIng.Name)
+				}
+				if err != nil {
+					t.Errorf("error getting ingress resource: %v", err)
+				}
+
+				if !reflect.DeepEqual(expectedIng, actualIng) {
+					t.Errorf("expected did not match actual: %v", diff.ObjectDiff(expectedIng, actualIng))
 				}
 			},
 		},


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, if an ingress resource did not specify an existing `rule` containing the domain name we need to solve for (e.g. if only the default backend is configured), we would leave an empty `rule` (one with any path configuration) which would consequently fail validation when submitting back to the apiserver.

This patch fixes this so we remove empty rules after cleaning up. It also adds a unit test to verify the behaviour. The newly added unit test fails without the second commit applied 😄

The actual ingress test fixture for this was taken from #828.

**Which issue this PR fixes**: fixes #828 

**Release note**:
```release-note
Fix issue causing existing Ingresses to not be cleaned up properly after HTTP01 challenges in some cases
```
