### PR TITLE
Include CA Certificate In Secrets

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -62,7 +62,7 @@ const (
 )
 
 const (
-	nginxCAKey = "ca.crt"
+	TLSCAKey = "ca.crt"
 )
 
 func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err error) {
@@ -238,7 +238,7 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 	secret.Data[api.TLSPrivateKeyKey] = key
 
 	if crt.Spec.IsCA {
-		secret.Data[nginxCAKey] = cert
+		secret.Data[TLSCAKey] = cert
 	}
 
 	if secret.Annotations == nil {

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -61,6 +61,10 @@ const (
 	messageCertificateRenewed = "Certificate renewed successfully"
 )
 
+const (
+	nginxCAKey = "ca.crt"
+)
+
 func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err error) {
 	crtCopy := crt.DeepCopy()
 	defer func() {
@@ -232,6 +236,10 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 	}
 	secret.Data[api.TLSCertKey] = cert
 	secret.Data[api.TLSPrivateKeyKey] = key
+
+	if crt.Spec.IsCA {
+		secret.Data[nginxCAKey] = cert
+	}
 
 	if secret.Annotations == nil {
 		secret.Annotations = make(map[string]string)

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -205,10 +205,10 @@ func (a *Acme) obtainCertificate(ctx context.Context, crt *v1alpha1.Certificate)
 	return keyPem, certBuffer.Bytes(), nil
 }
 
-func (a *Acme) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {
+func (a *Acme) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
 	key, cert, err := a.obtainCertificate(ctx, crt)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return key, cert, err
+	return key, cert, nil, err
 }

--- a/pkg/issuer/acme/renew.go
+++ b/pkg/issuer/acme/renew.go
@@ -22,10 +22,10 @@ import (
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
-func (a *Acme) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {
+func (a *Acme) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
 	key, cert, err := a.obtainCertificate(ctx, crt)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
-	return key, cert, err
+	return key, cert, nil, err
 }

--- a/pkg/issuer/ca/issue.go
+++ b/pkg/issuer/ca/issue.go
@@ -18,6 +18,7 @@ package ca
 
 import (
 	"context"
+	"crypto/x509"
 	"fmt"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -44,7 +45,7 @@ const (
 	messageCertIssued = "Certificate issued successfully"
 )
 
-func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {
+func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
 	signeeKey, err := kube.SecretTLSKey(c.secretsLister, crt.Namespace, crt.Spec.SecretName)
 
 	if k8sErrors.IsNotFound(err) || errors.IsInvalidData(err) {
@@ -54,22 +55,27 @@ func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []by
 	if err != nil {
 		s := messageErrorGetCertKeyPair + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorGetCertKeyPair, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	publicKey, err := pki.PublicKeyForPrivateKey(signeeKey)
 	if err != nil {
 		s := messageErrorPublicKey + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorGetPublicKey, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	certPem, err := c.obtainCertificate(crt, publicKey)
+	caCert, err := kube.SecretTLSCert(c.secretsLister, c.resourceNamespace, c.issuer.GetSpec().CA.SecretName)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	certPem, err := c.obtainCertificate(crt, publicKey, caCert)
 
 	if err != nil {
 		s := messageErrorIssueCert + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueCert, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertIssued, messageCertIssued, true)
@@ -78,22 +84,22 @@ func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []by
 	if err != nil {
 		s := messageErrorEncodePrivateKey + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorEncodePrivateKey, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return keyPem, certPem, nil
+	caPem, err := pki.EncodeX509(caCert)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	return keyPem, certPem, caPem, nil
 }
 
-func (c *CA) obtainCertificate(crt *v1alpha1.Certificate, signeeKey interface{}) ([]byte, error) {
+func (c *CA) obtainCertificate(crt *v1alpha1.Certificate, signeeKey interface{}, signerCert *x509.Certificate) ([]byte, error) {
 	commonName := crt.Spec.CommonName
 	altNames := crt.Spec.DNSNames
 	if len(commonName) == 0 && len(altNames) == 0 {
 		return nil, fmt.Errorf("no domains specified on certificate")
-	}
-
-	signerCert, err := kube.SecretTLSCert(c.secretsLister, c.resourceNamespace, c.issuer.GetSpec().CA.SecretName)
-	if err != nil {
-		return nil, fmt.Errorf("error getting issuer certificate: %s", err.Error())
 	}
 
 	signerKey, err := kube.SecretTLSKey(c.secretsLister, c.resourceNamespace, c.issuer.GetSpec().CA.SecretName)

--- a/pkg/issuer/issuer.go
+++ b/pkg/issuer/issuer.go
@@ -31,8 +31,8 @@ type Interface interface {
 	Prepare(context.Context, *v1alpha1.Certificate) error
 	// Issue attempts to issue a certificate as described by the certificate
 	// resource given
-	Issue(context.Context, *v1alpha1.Certificate) ([]byte, []byte, error)
+	Issue(context.Context, *v1alpha1.Certificate) ([]byte, []byte, []byte, error)
 	// Renew attempts to renew the certificate describe by the certificate
 	// resource given. If no certificate exists, an error is returned.
-	Renew(context.Context, *v1alpha1.Certificate) ([]byte, []byte, error)
+	Renew(context.Context, *v1alpha1.Certificate) ([]byte, []byte, []byte, error)
 }

--- a/pkg/issuer/selfsigned/renew.go
+++ b/pkg/issuer/selfsigned/renew.go
@@ -34,13 +34,13 @@ const (
 	messageCertRenewed = "Certificate issued successfully"
 )
 
-func (c *SelfSigned) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {
+func (c *SelfSigned) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
 	signeeKey, err := kube.SecretTLSKey(c.secretsLister, crt.Namespace, crt.Spec.SecretName)
 
 	if err != nil {
 		s := messageErrorGetCertKeyPair + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorGetCertKeyPair, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	certPem, err := c.obtainCertificate(crt, signeeKey)
@@ -48,7 +48,7 @@ func (c *SelfSigned) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]by
 	if err != nil {
 		s := messageErrorRenewCert + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorRenewCert, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertRenewed, messageCertRenewed, true)
@@ -57,8 +57,8 @@ func (c *SelfSigned) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]by
 	if err != nil {
 		s := messageErrorEncodePrivateKey + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorEncodePrivateKey, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
-	return keyPem, certPem, nil
+	return keyPem, certPem, certPem, nil
 }

--- a/pkg/issuer/vault/issue.go
+++ b/pkg/issuer/vault/issue.go
@@ -192,10 +192,10 @@ func (v *Vault) requestVaultCert(commonName string, altNames []string, csr []byt
 	glog.V(4).Infof("Vault certificate request for commonName %s altNames: %q", commonName, altNames)
 
 	parameters := map[string]string{
-		"common_name":          commonName,
-		"alt_names":            strings.Join(altNames, ","),
-		"ttl":                  defaultCertificateDuration.String(),
-		"csr":                  string(csr),
+		"common_name": commonName,
+		"alt_names":   strings.Join(altNames, ","),
+		"ttl":         defaultCertificateDuration.String(),
+		"csr":         string(csr),
 		"exclude_cn_from_sans": "true",
 	}
 

--- a/pkg/issuer/vault/issue.go
+++ b/pkg/issuer/vault/issue.go
@@ -48,17 +48,17 @@ const (
 	defaultCertificateDuration = time.Hour * 24 * 90
 )
 
-func (v *Vault) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {
+func (v *Vault) Issue(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
 	key, certPem, err := v.obtainCertificate(ctx, crt)
 	if err != nil {
 		s := messageErrorIssueCert + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorIssueCert, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertIssued, messageCertIssued, true)
 
-	return key, certPem, nil
+	return key, certPem, nil, nil
 }
 
 func (v *Vault) obtainCertificate(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {

--- a/pkg/issuer/vault/issue.go
+++ b/pkg/issuer/vault/issue.go
@@ -232,13 +232,8 @@ func (v *Vault) requestVaultCert(commonName string, altNames []string, csr []byt
 	}
 
 	var caPem []byte = nil
-	if len(parsedBundle.CAChain) > 0 {
-		block := pem.Block{
-			Type: "CERTIFICATE",
-		}
-		block.Bytes = parsedBundle.CAChain[0].Bytes
-		caString := strings.TrimSpace(string(pem.EncodeToMemory(&block)))
-		caPem = []byte(caString)
+	if len(bundle.CAChain) > 0 {
+		caPem = []byte(bundle.CAChain[0])
 	}
 
 	return []byte(bundle.ToPEMBundle()), caPem, nil

--- a/pkg/issuer/vault/renew.go
+++ b/pkg/issuer/vault/renew.go
@@ -30,15 +30,15 @@ const (
 	messageCertRenewed = "Certificate renewed successfully"
 )
 
-func (c *Vault) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, error) {
+func (c *Vault) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
 	key, cert, err := c.obtainCertificate(ctx, crt)
 	if err != nil {
 		s := messageErrorRenewCert + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorRenewCert, s, false)
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertRenewed, messageCertRenewed, true)
 
-	return key, cert, err
+	return key, cert, nil, err
 }

--- a/pkg/issuer/vault/renew.go
+++ b/pkg/issuer/vault/renew.go
@@ -31,7 +31,7 @@ const (
 )
 
 func (c *Vault) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, []byte, []byte, error) {
-	key, cert, err := c.obtainCertificate(ctx, crt)
+	key, cert, caPem, err := c.obtainCertificate(ctx, crt)
 	if err != nil {
 		s := messageErrorRenewCert + err.Error()
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, errorRenewCert, s, false)
@@ -40,5 +40,5 @@ func (c *Vault) Renew(ctx context.Context, crt *v1alpha1.Certificate) ([]byte, [
 
 	crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertRenewed, messageCertRenewed, true)
 
-	return key, cert, nil, err
+	return key, cert, caPem, err
 }

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -185,6 +185,16 @@ func EncodeCSR(template *x509.CertificateRequest, key interface{}) ([]byte, erro
 	return derBytes, nil
 }
 
+func EncodeX509(cert *x509.Certificate) ([]byte, error) {
+	caPem := bytes.NewBuffer([]byte{})
+	err := pem.Encode(caPem, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	if err != nil {
+		return nil, err
+	}
+
+	return caPem.Bytes(), nil
+}
+
 // Return the appropriate signature algorithm for the certificate
 // Adapted from https://github.com/cloudflare/cfssl/blob/master/csr/csr.go#L102
 func SignatureAlgorithm(crt *v1alpha1.Certificate) (x509.SignatureAlgorithm, error) {

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -235,7 +235,7 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 
 				return false, err
 			}
-			if len(secret.Data) != 2 {
+			if !(len(secret.Data) == 2 || len(secret.Data) == 3) {
 				glog.Infof("Expected 2 keys in certificate secret, but there was %d", len(secret.Data))
 				return false, nil
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR includes the CA cert as a field in the issued TLS secret as `ca.crt`. 

Although the TLS secret specification does not explicitly support this field, some projects (like nginx-ingress for example) check the existence of the `ca.crt` field and use it's value to provide special handling for the certificate. For example, if nginx-ingress is aware that a certificate is (or has) a ca, it will allow that field to be used to validate tls mutual authentication. In general it can be useful to know the CA certificate and to be able to get at it without parsing a PEM chain. 

Right now this works for vault, ca, and self-signed issuers, ACME support is more complex since it requires retrieving the CA certificate from the ACME server. Support for this is deferred to a later PR.

**Which issue this PR fixes**: 

fixes #839 

**Release note**:
```release-note
Include ca.crt in created secrets for Issuers that support it (vault, ca and selfsigned)
```
