### PR TITLE
Run hack/update-deploy-gen.sh

### DIFF
--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -24,6 +24,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -46,6 +48,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -64,6 +68,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -12,6 +12,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: certificates.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -34,6 +36,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: clusterissuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4
@@ -52,6 +56,8 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: issuers.certmanager.k8s.io
+  annotations:
+    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
     chart: cert-manager-v0.4.0-dev.4


### PR DESCRIPTION
**What this PR does / why we need it**:

#823 was merged before the quick-verify job bumped its Helm version to 2.10.

This means that future jobs are now failing, as these values are not set on the CRDs generated as part of update-deploy-gen.

**Special notes for your reviewer**:

This unblocks the merge queue and fixes issues in #849  😄 

**Release note**:
```release-note
NONE
```
