### PR TITLE
[jjo] fix panic from acmedns.go constructor failure

### DIFF
--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -53,7 +53,7 @@ func NewDNSProviderHostBytes(host string, accountJson []byte, dns01Nameservers [
 
 	var accounts map[string]goacmedns.Account
 	if err := json.Unmarshal(accountJson, &accounts); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("Error unmarshalling accountJson: %s", err)
 	}
 
 	return &DNSProvider{

--- a/pkg/issuer/acme/dns/acmedns/acmedns_test.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns_test.go
@@ -50,21 +50,19 @@ func TestValidJsonAccount(t *testing.T) {
     }`)
 	provider, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")
-
-	assert.NoError(t, err, "Expected account to be set from JSON")
 	assert.Equal(t, provider.accounts["domain"].FullDomain, "fooldom")
 }
 
 func TestNoValidJsonAccount(t *testing.T) {
 	accountJson := []byte(`{"duck": "quack"}`)
 	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
-	assert.Error(t, err, "Expected no error constructing DNSProvider")
+	assert.Error(t, err, "Expected error constructing DNSProvider from invalid accountJson")
 }
 
 func TestNoValidJson(t *testing.T) {
 	accountJson := []byte("b00m")
 	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
-	assert.Error(t, err, "Expected no error constructing DNSProvider")
+	assert.Error(t, err, "Expected error constructing DNSProvider from invalid JSON")
 }
 
 func TestLiveAcmeDnsPresent(t *testing.T) {

--- a/pkg/issuer/acme/dns/acmedns/acmedns_test.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns_test.go
@@ -39,6 +39,34 @@ func init() {
 	}
 }
 
+func TestValidJsonAccount(t *testing.T) {
+	accountJson := []byte(`{
+        "domain": {
+            "fulldomain": "fooldom",
+            "password": "secret",
+            "subdomain": "subdoom",
+            "username": "usernom"
+        }
+    }`)
+	provider, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
+	assert.NoError(t, err, "Expected no error constructing DNSProvider")
+
+	assert.NoError(t, err, "Expected account to be set from JSON")
+	assert.Equal(t, provider.accounts["domain"].FullDomain, "fooldom")
+}
+
+func TestNoValidJsonAccount(t *testing.T) {
+	accountJson := []byte(`{"duck": "quack"}`)
+	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
+	assert.Error(t, err, "Expected no error constructing DNSProvider")
+}
+
+func TestNoValidJson(t *testing.T) {
+	accountJson := []byte("b00m")
+	_, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
+	assert.Error(t, err, "Expected no error constructing DNSProvider")
+}
+
 func TestLiveAcmeDnsPresent(t *testing.T) {
 	if !acmednsLiveTest {
 		t.Skip("skipping live test")

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -262,6 +262,9 @@ func (s *Solver) solverForIssuerProvider(issuer v1alpha1.GenericIssuer, provider
 			accountSecretBytes,
 			s.DNS01Nameservers,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("error instantiating acmedns challenge solver: %s", err)
+		}
 	default:
 		return nil, fmt.Errorf("no dns provider config specified for provider %q", providerName)
 	}

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/controller/test"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/acmedns"
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/cloudflare"
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
@@ -207,6 +208,40 @@ func TestSolverFor(t *testing.T) {
 			},
 			domain:    "example.com",
 			expectErr: true,
+		},
+		"loads json for acmedns provider": {
+			solverFixture: &solverFixture{
+				Builder: &test.Builder{
+					KubeObjects: []runtime.Object{
+						newSecret("acmedns-key", "default", map[string][]byte{
+							"acmedns.json": []byte("{x}"),
+						}),
+					},
+				},
+				Issuer: newIssuer("test", "default", []v1alpha1.ACMEIssuerDNS01Provider{
+					{
+						Name: "fake-acmedns",
+						AcmeDNS: &v1alpha1.ACMEIssuerDNS01ProviderAcmeDNS{
+							Host: "http://127.0.0.1/",
+							AccountSecret: v1alpha1.SecretKeySelector{
+								LocalObjectReference: v1alpha1.LocalObjectReference{
+									Name: "acmedns-key",
+								},
+								Key: "acmedns.json",
+							},
+						},
+					},
+				}),
+				Challenge: v1alpha1.ACMEOrderChallenge{
+					SolverConfig: v1alpha1.SolverConfig{
+						DNS01: &v1alpha1.DNS01SolverConfig{
+							Provider: "fake-acmedns",
+						},
+					},
+				},
+			},
+			domain:             "example.com",
+			expectedSolverType: reflect.TypeOf(&acmedns.DNSProvider{}),
 		},
 	}
 	testFn := func(test testT) func(*testing.T) {

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -214,7 +214,7 @@ func TestSolverFor(t *testing.T) {
 				Builder: &test.Builder{
 					KubeObjects: []runtime.Object{
 						newSecret("acmedns-key", "default", map[string][]byte{
-							"acmedns.json": []byte("{x}"),
+							"acmedns.json": []byte("{}"),
 						}),
 					},
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes cert-manager panic.

**Which issue this PR fixes** : #857 

**Special notes for your reviewer**:
FYI tested on my live install, instead of panic-ing now properly getting `error instantiating acmedns challenge solver: invalid character '{'` from logs.

The key fix is that last `err != nil` check in `acme/dns/dns.go` switch/case entry
for `AcmeDNS`, to avoid following thru and wrongly returning `impl, nil` (with a `nil` impl pointer).

**Release note**: 
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
fix panic from acmedns.go constructor failure
```
