### PR TITLE
Bump golang and dep version on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: golang:1.9
+image: golang:1.11
 
 variables:
   DOCKER_DRIVER: overlay
@@ -12,7 +12,7 @@ before_script:
   # Note: 1.11+ changes the tarball format
   - curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
   - curl -L https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz | tar -C /tmp -xvzf- && mv /tmp/linux-amd64/helm /usr/local/bin
-  - curl -L https://github.com/golang/dep/releases/download/v0.4.1/dep-linux-amd64 >/tmp/dep && chmod +x /tmp/dep && mv /tmp/dep /usr/local/bin/
+  - curl -L https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64 >/tmp/dep && chmod +x /tmp/dep && mv /tmp/dep /usr/local/bin/
   - apt-get update
   - apt-get install -y make curl
   - export DOCKER_HOST=${DOCKER_PORT}


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the version of go and dep used for GitLab builds.

In future we'll switch to using the same base image as our GitHub builds. After that, we will switch to using Prow for pushing docker images.

This fixes pushes of the master branch and tags.

**Release note**:
```release-note
NONE
```

/assign