### PR TITLE
Add an error check for AzureDNS failure to create a solver.

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -67,6 +67,7 @@ type Solver struct {
 	dnsProviderConstructors dnsProviderConstructors
 }
 
+// Present performs the work to configure DNS to resolve a DNS01 challenge.
 func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, _ *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
 	if ch.SolverConfig.DNS01 == nil {
 		return fmt.Errorf("challenge dns config must be specified")
@@ -86,6 +87,7 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, _ *
 	return slv.Present(ch.Domain, ch.Token, ch.Key)
 }
 
+// Check verifies that the DNS records for the ACME challenge have propagated.
 func (s *Solver) Check(ch v1alpha1.ACMEOrderChallenge) (bool, error) {
 	fqdn, value, ttl, err := util.DNS01Record(ch.Domain, ch.Key, s.DNS01Nameservers)
 	if err != nil {
@@ -110,6 +112,8 @@ func (s *Solver) Check(ch v1alpha1.ACMEOrderChallenge) (bool, error) {
 	return true, nil
 }
 
+// CleanUp removes DNS records which are no longer needed after
+// certificate issuance.
 func (s *Solver) CleanUp(ctx context.Context, issuer v1alpha1.GenericIssuer, _ *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
 	if ch.SolverConfig.DNS01 == nil {
 		return fmt.Errorf("challenge dns config must be specified")
@@ -254,6 +258,9 @@ func (s *Solver) solverForIssuerProvider(issuer v1alpha1.GenericIssuer, provider
 			providerConfig.AzureDNS.HostedZoneName,
 			s.DNS01Nameservers,
 		)
+		if err != nil {
+			return nil, fmt.Errorf("error instantiating azuredns challenge solver: %s", err)
+		}
 	case providerConfig.AcmeDNS != nil:
 		accountSecret, err := s.secretLister.Secrets(resourceNamespace).Get(providerConfig.AcmeDNS.AccountSecret.Name)
 		if err != nil {
@@ -280,6 +287,8 @@ func (s *Solver) solverForIssuerProvider(issuer v1alpha1.GenericIssuer, provider
 	return impl, nil
 }
 
+// NewSolver creates a Solver which can instantiate the appropriate DNS
+// provider.
 func NewSolver(ctx *controller.Context) *Solver {
 	return &Solver{
 		ctx,


### PR DESCRIPTION
Also adds documentation comments for public methods (caught by 'go lint').

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fixes a non-propagated `error` type in `dns.go`.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
