### PR TITLE
Relax resource validation for CloudDNS service account credentials

### DIFF
--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -167,7 +167,11 @@ func ValidateACMEIssuerDNS01Config(iss *v1alpha1.ACMEIssuerDNS01Config, fldPath 
 				el = append(el, field.Forbidden(fldPath.Child("clouddns"), "may not specify more than one provider type"))
 			} else {
 				numProviders++
-				el = append(el, ValidateSecretKeySelector(&p.CloudDNS.ServiceAccount, fldPath.Child("clouddns", "serviceAccountSecretRef"))...)
+				// if either of serviceAccount.name or serviceAccount.key is set, we
+				// validate the entire secret key selector
+				if p.CloudDNS.ServiceAccount.Name != "" || p.CloudDNS.ServiceAccount.Key != "" {
+					el = append(el, ValidateSecretKeySelector(&p.CloudDNS.ServiceAccount, fldPath.Child("clouddns", "serviceAccountSecretRef"))...)
+				}
 				if len(p.CloudDNS.Project) == 0 {
 					el = append(el, field.Required(fldPath.Child("clouddns", "project"), ""))
 				}

--- a/pkg/apis/certmanager/validation/issuer_test.go
+++ b/pkg/apis/certmanager/validation/issuer_test.go
@@ -278,7 +278,45 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(providersPath.Index(0).Child("clouddns", "project"), ""),
 			},
 		},
-		"missing clouddns service account": {
+		"missing clouddns service account key": {
+			cfg: &v1alpha1.ACMEIssuerDNS01Config{
+				Providers: []v1alpha1.ACMEIssuerDNS01Provider{
+					{
+						Name: "a name",
+						CloudDNS: &v1alpha1.ACMEIssuerDNS01ProviderCloudDNS{
+							Project: "valid",
+							ServiceAccount: v1alpha1.SecretKeySelector{
+								LocalObjectReference: v1alpha1.LocalObjectReference{Name: "something"},
+								Key:                  "",
+							},
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Required(providersPath.Index(0).Child("clouddns", "serviceAccountSecretRef", "key"), "secret key is required"),
+			},
+		},
+		"missing clouddns service account name": {
+			cfg: &v1alpha1.ACMEIssuerDNS01Config{
+				Providers: []v1alpha1.ACMEIssuerDNS01Provider{
+					{
+						Name: "a name",
+						CloudDNS: &v1alpha1.ACMEIssuerDNS01ProviderCloudDNS{
+							Project: "valid",
+							ServiceAccount: v1alpha1.SecretKeySelector{
+								LocalObjectReference: v1alpha1.LocalObjectReference{Name: ""},
+								Key:                  "something",
+							},
+						},
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.Required(providersPath.Index(0).Child("clouddns", "serviceAccountSecretRef", "name"), "secret name is required"),
+			},
+		},
+		"clouddns serviceAccount field not set should be allowed for ambient auth": {
 			cfg: &v1alpha1.ACMEIssuerDNS01Config{
 				Providers: []v1alpha1.ACMEIssuerDNS01Provider{
 					{
@@ -288,10 +326,6 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 						},
 					},
 				},
-			},
-			errs: []*field.Error{
-				field.Required(providersPath.Index(0).Child("clouddns", "serviceAccountSecretRef", "name"), "secret name is required"),
-				field.Required(providersPath.Index(0).Child("clouddns", "serviceAccountSecretRef", "key"), "secret key is required"),
 			},
 		},
 		"missing cloudflare token": {


### PR DESCRIPTION
**What this PR does / why we need it**:

#664 added support for resource validation using the CloudDNS metadata server.

As a result, we need to relax the validation rules around the serviceAccount field to allow omitting a secret ref, as per https://github.com/jetstack/cert-manager/issues/241#issuecomment-420097826

**Release note**:
```release-note
NONE
```
