### PR TITLE
#872 Add certificates and issuers to aggregated RBAC

### DIFF
--- a/contrib/charts/cert-manager/templates/rbac.yaml
+++ b/contrib/charts/cert-manager/templates/rbac.yaml
@@ -36,4 +36,37 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-view
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    rbac.authorization.k8s.io/aggregate-to-view: "true"
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "cert-manager.fullname" . }}-edit
+  labels:
+    app: {{ template "cert-manager.name" . }}
+    chart: {{ template "cert-manager.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    rbac.authorization.k8s.io/aggregate-to-edit: "true"
+    rbac.authorization.k8s.io/aggregate-to-admin: "true"
+rules:
+  - apiGroups: ["certmanager.k8s.io"]
+    resources: ["certificates", "issuers"]
+    verbs: ["create", "delete", "deletecollection", "patch", "update"]
 {{- end -}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This adds two permissions to the user facing RBAC roles. This allows a user with permissions to their own namespace to be able to manage their own certificates and issuers.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #872 

**Special notes for your reviewer**:
I was unable to figure out where to put tests for the chart. I'm happy to fix with some pointers. Manual test steps are below.

When I tried to update the deployment manifest with the ./hack/update-deploy-gen.sh it generated a few unrelated changes in addition, so that will need to be done somehow, but I'm hesitant to check in unrelated changes.

**Manual Testing & Verification**
View Access:
```
# Create Namespace:
kubectl create ns test-view
# Setup Service Account:
kubectl --namespace=test-view create sa test-user
# Setup Role Binding:
kubectl --namespace=test-view create rolebinding test-rb --clusterrole=view --serviceaccount=test-view:test-user
# Wait a few seconds for RBAC to process above changes
sleep 5
# Read (should succeed)
kubectl --namespace=test-view --as=system:serviceaccount:test-view:test-user auth can-i get certificates
# Write (should fail)
kubectl --namespace=test-view --as=system:serviceaccount:test-view:test-user auth can-i create certificates
# Remove namespace
kubectl delete ns test-view
```

Edit Access:
```
# Create Namespace:
kubectl create ns test-edit
# Setup Service Account:
kubectl --namespace=test-edit create sa test-user
# Setup Role Binding:
kubectl --namespace=test-edit create rolebinding test-rb --clusterrole=edit --serviceaccount=test-edit:test-user
# Wait a few seconds for RBAC to process above changes
sleep 5
# Read (should succeed)
kubectl --namespace=test-edit --as=system:serviceaccount:test-edit:test-user auth can-i get certificates
# Write (should succeed)
kubectl --namespace=test-edit --as=system:serviceaccount:test-edit:test-user auth can-i create certificates
# Remove namespace
kubectl delete ns test-edit
```

Admin Access:
```
# Create Namespace:
kubectl create ns test-admin
# Setup Service Account:
kubectl --namespace=test-admin create sa test-user
# Setup Role Binding:
kubectl --namespace=test-admin create rolebinding test-rb --clusterrole=admin --serviceaccount=test-admin:test-user
# Wait a few seconds for RBAC to process above changes
sleep 5
# Read (should succeed)
kubectl --namespace=test-admin --as=system:serviceaccount:test-admin:test-user auth can-i get certificates
# Write (should succeed)
kubectl --namespace=test-admin --as=system:serviceaccount:test-admin:test-user auth can-i create certificates
# Remove namespace
kubectl delete ns test-admin
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added RBAC permissions for user facing roles to access Certificates and Issuers.
```
