### PR TITLE
Add 'make generate' target to run all hack generators

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,10 @@ help:
 	# verify_docs       - verify the generated reference docs for API types is up to date
 	# verify_chart      - runs Helm chart linter (e.g. ensuring version has been bumped etc)
 	#
+	### Generate targets
+	#
+	# generate          - regenerate all generated files
+	#
 	### Build targets
 	#
 	# controller        - build a binary of the 'controller'
@@ -114,6 +118,17 @@ e2e_test:
 			-acme-cloudflare-domain=$${CLOUDFLARE_E2E_DOMAIN} \
 			-pebble-image-repo=$(PEBBLE_IMAGE_REPO) \
 			-report-dir="$${ARTIFACTS:-./_artifacts}"
+
+# Generate targets
+##################
+
+generate:
+	bazel run //hack:update-bazel
+	bazel run //hack:update-gofmt
+	bazel run //hack:update-codegen
+	bazel run //hack:update-deploy-gen
+	bazel run //hack:update-reference-docs
+	bazel run //hack:update-deps
 
 # Docker targets
 ################


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a new target that can be used to regenerate all generated files.

This should make it easier for users developing new features, by providing a single command that can be run in order to update *all* generated files.

cc @Queuecumber 

**Release note**:
```release-note
NONE
```
