### PR TITLE
Fix issues with ingress-shim doc rendering and remove warning

### DIFF
--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -16,6 +16,7 @@ ensure a Certificate resource with the same name as the Ingress, and configured
 as described on the Ingress exists. For example:
 
 .. code-block:: yaml
+
   apiVersion: extensions/v1beta1
   kind: Ingress
   metadata:
@@ -38,10 +39,6 @@ as described on the Ingress exists. For example:
       - myingress.com
       secretName: myingress-cert # < cert-manager will store the created certificate in this secret.
 
-
-As of the time of writing, it **will not** update Certificate resources if your
-Ingress resource changes. It is up to yourself to ensure the corresponding
-Certificate resource is as required.
 
 Configuration
 =============


### PR DESCRIPTION
There were some issues with the rendering of code blocks in the ingress-shim doc, also remove an outdated note.

```release-note
NONE
```