### PR TITLE
Workaround quay.io not support v2.2 docker image manifests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,16 @@
 image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180910-b8de01d-0.16.1
 
+variables:
+  DOCKER_DRIVER: overlay
+
+services:
+- docker:1.12-dind
+
+before_script:
+- curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
+- export DOCKER_HOST=${DOCKER_PORT}
+- docker info > /dev/null
+
 build:
   tags:
   - docker

--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,12 @@ images:
 	$(BAZEL_IMAGE_ENV) \
 		bazel run //:images
 
-images_push:
-	$(BAZEL_IMAGE_ENV) \
-		bazel run //:images.push
+images_push: images
+	# we do not use the :push target as Quay.io does not support v2.2
+	# manifests for Docker images, and rules_docker only supports 2.2+
+	# https://github.com/moby/buildkit/issues/409#issuecomment-394757219
+	# source the bazel workspace environment
+	eval $$($(BAZEL_IMAGE_ENV) ./hack/print-workspace-status.sh | tr ' ' '='); \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-acmesolver:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-controller:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-webhook:$${STABLE_DOCKER_TAG}"


### PR DESCRIPTION
**What this PR does / why we need it**:

Bazel's rules_docker pushes v2.2 manifests to the image registry.

Quay.io *still* does not support manifest lists, so this step is currently failing in our GitLab CI release environment.

This PR switches us to using standard docker to *push images only*.

**Release note**:
```release-note
NONE
```

/cc @kragniz 