### PR TITLE
Make http01 solver serviceType configurable

### DIFF
--- a/docs/generated/reference/openapi/openapi_generated.go
+++ b/docs/generated/reference/openapi/openapi_generated.go
@@ -407,7 +407,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 				SchemaProps: spec.SchemaProps{
 					Description: "ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options",
 					Properties: map[string]spec.Schema{
-						"solverServiceType": {
+						"serviceType": {
 							SchemaProps: spec.SchemaProps{
 								Type:   []string{"string"},
 								Format: "",

--- a/docs/generated/reference/openapi/openapi_generated.go
+++ b/docs/generated/reference/openapi/openapi_generated.go
@@ -86,7 +86,7 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 						},
 						"http01": {
 							SchemaProps: spec.SchemaProps{
-								Description: "HTTP01 config",
+								Description: "HTTP-01 config",
 								Ref:         ref("github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1.ACMEIssuerHTTP01Config"),
 							},
 						},
@@ -409,8 +409,9 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 					Properties: map[string]spec.Schema{
 						"serviceType": {
 							SchemaProps: spec.SchemaProps{
-								Type:   []string{"string"},
-								Format: "",
+								Description: "Optional service type for Kubernetes solver service",
+								Type:        []string{"string"},
+								Format:      "",
 							},
 						},
 					},

--- a/docs/generated/reference/openapi/openapi_generated.go
+++ b/docs/generated/reference/openapi/openapi_generated.go
@@ -405,7 +405,15 @@ func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenA
 		"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1.ACMEIssuerHTTP01Config": {
 			Schema: spec.Schema{
 				SchemaProps: spec.SchemaProps{
-					Properties: map[string]spec.Schema{},
+					Description: "ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options",
+					Properties: map[string]spec.Schema{
+						"solverServiceType": {
+							SchemaProps: spec.SchemaProps{
+								Type:   []string{"string"},
+								Format: "",
+							},
+						},
+					},
 				},
 			},
 			Dependencies: []string{},

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -392,7 +392,7 @@ Appears In:
 </tr>
 <tr>
 <td><code>http01</code><br /> <em><a href="#acmeissuerhttp01config-v1alpha1">ACMEIssuerHTTP01Config</a></em></td>
-<td>HTTP01 config</td>
+<td>HTTP-01 config</td>
 </tr>
 <tr>
 <td><code>privateKeySecretRef</code><br /> <em><a href="#secretkeyselector-v1alpha1">SecretKeySelector</a></em></td>
@@ -889,7 +889,7 @@ Appears In:
 <tbody>
 <tr>
 <td><code>serviceType</code><br /> <em>string</em></td>
-<td></td>
+<td>Optional service type for Kubernetes solver service</td>
 </tr>
 </tbody>
 </table>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -871,6 +871,7 @@ Appears In:
 </tr>
 </tbody>
 </table>
+<p>ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options</p>
 <aside class="notice">
 Appears In:
 
@@ -887,6 +888,7 @@ Appears In:
 </thead>
 <tbody>
 <tr>
+<td><code>solverServiceType</code><br /> <em>string</em></td>
 <td></td>
 </tr>
 </tbody>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -888,7 +888,7 @@ Appears In:
 </thead>
 <tbody>
 <tr>
-<td><code>solverServiceType</code><br /> <em>string</em></td>
+<td><code>serviceType</code><br /> <em>string</em></td>
 <td></td>
 </tr>
 </tbody>

--- a/docs/reference/issuers/acme/http01.rst
+++ b/docs/reference/issuers/acme/http01.rst
@@ -33,7 +33,7 @@ In rare cases it might be not possible/desired to use NodePort as type for the h
          # Valid values are ClusterIP and NodePort
          serviceType: ClusterIP
 
-By default type NodePort will be used when you don't set http01 or when you set solverServiceType to an empty string. Normally there's no need to change this.
+By default type NodePort will be used when you don't set http01 or when you set serviceType to an empty string. Normally there's no need to change this.
 
 .. note::
    Let's Encrypt does not support issuing wildcard certificates with HTTP-01 challenges.

--- a/docs/reference/issuers/acme/http01.rst
+++ b/docs/reference/issuers/acme/http01.rst
@@ -26,6 +26,15 @@ using Ingress resources
        http01: {}
 
 
+To define which Kubernetes service type to use during challenge response specify the following http01 config
+
+.. code-block:: yaml
+       http01:
+         # Valid values are ClusterIP and NodePort
+         solverServiceType: ClusterIP
+
+By default type NodePort will be used when you don't set http01 or when you set solverServiceType to an empty string. This may change in future.
+
 .. note::
    Let's Encrypt does not support issuing wildcard certificates with HTTP-01 challenges.
    To issue wildcard certificates, you must use the DNS-01 challenge.

--- a/docs/reference/issuers/acme/http01.rst
+++ b/docs/reference/issuers/acme/http01.rst
@@ -26,14 +26,14 @@ using Ingress resources
        http01: {}
 
 
-To define which Kubernetes service type to use during challenge response specify the following http01 config
+In rare cases it might be not possible/desired to use NodePort as type for the http01 challenge response service, e.g. because of Kubernetes limit restrictions. To define which Kubernetes service type to use during challenge response specify the following http01 config
 
 .. code-block:: yaml
        http01:
          # Valid values are ClusterIP and NodePort
-         solverServiceType: ClusterIP
+         serviceType: ClusterIP
 
-By default type NodePort will be used when you don't set http01 or when you set solverServiceType to an empty string. This may change in future.
+By default type NodePort will be used when you don't set http01 or when you set solverServiceType to an empty string. Normally there's no need to change this.
 
 .. note::
    Let's Encrypt does not support issuing wildcard certificates with HTTP-01 challenges.

--- a/pkg/apis/certmanager/v1alpha1/BUILD.bazel
+++ b/pkg/apis/certmanager/v1alpha1/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
     deps = [
         "//pkg/apis/certmanager:go_default_library",
         "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -129,7 +129,7 @@ type ACMEIssuer struct {
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
 	PrivateKey SecretKeySelector `json:"privateKeySecretRef"`
-	// HTTP01 config
+	// HTTP-01 config
 	HTTP01 *ACMEIssuerHTTP01Config `json:"http01,omitempty"`
 	// DNS-01 config
 	DNS01 *ACMEIssuerDNS01Config `json:"dns01,omitempty"`
@@ -137,6 +137,7 @@ type ACMEIssuer struct {
 
 // ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options
 type ACMEIssuerHTTP01Config struct {
+	// Optional service type for Kubernetes solver service
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 }
 

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -137,7 +137,7 @@ type ACMEIssuer struct {
 
 // ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options
 type ACMEIssuerHTTP01Config struct {
-	SolverServiceType corev1.ServiceType `json:"solverServiceType,omitempty"`
+	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 }
 
 // ACMEIssuerDNS01Config is a structure containing the ACME DNS configuration

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -134,7 +135,9 @@ type ACMEIssuer struct {
 	DNS01 *ACMEIssuerDNS01Config `json:"dns01,omitempty"`
 }
 
+// ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options
 type ACMEIssuerHTTP01Config struct {
+	SolverServiceType corev1.ServiceType `json:"solverServiceType,omitempty"`
 }
 
 // ACMEIssuerDNS01Config is a structure containing the ACME DNS configuration

--- a/pkg/apis/certmanager/validation/BUILD.bazel
+++ b/pkg/apis/certmanager/validation/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/issuer/acme/dns/rfc2136:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )
@@ -30,6 +31,7 @@ go_test(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/issuer/acme/dns/rfc2136:go_default_library",
         "//test/util/generate:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
     ],
 )

--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -129,20 +129,20 @@ func ValidateVaultIssuerConfig(iss *v1alpha1.VaultIssuer, fldPath *field.Path) f
 func ValidateACMEIssuerHTTP01Config(iss *v1alpha1.ACMEIssuerHTTP01Config, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 
-	if len(iss.SolverServiceType) > 0 {
+	if len(iss.ServiceType) > 0 {
 		validTypes := []corev1.ServiceType{
 			corev1.ServiceTypeClusterIP,
 			corev1.ServiceTypeNodePort,
 		}
 		validType := false
 		for _, validTypeName := range validTypes {
-			if iss.SolverServiceType == validTypeName {
+			if iss.ServiceType == validTypeName {
 				validType = true
 				break
 			}
 		}
 		if !validType {
-			el = append(el, field.Invalid(fldPath.Child("solverServiceType"), iss.SolverServiceType, fmt.Sprintf("optional field solverServiceType must be one of %q", validTypes)))
+			el = append(el, field.Invalid(fldPath.Child("serviceType"), iss.ServiceType, fmt.Sprintf("optional field serviceType must be one of %q", validTypes)))
 		}
 	}
 

--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -17,10 +17,12 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/rfc2136"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -125,7 +127,26 @@ func ValidateVaultIssuerConfig(iss *v1alpha1.VaultIssuer, fldPath *field.Path) f
 }
 
 func ValidateACMEIssuerHTTP01Config(iss *v1alpha1.ACMEIssuerHTTP01Config, fldPath *field.Path) field.ErrorList {
-	return nil
+	el := field.ErrorList{}
+
+	if len(iss.SolverServiceType) > 0 {
+		validTypes := []corev1.ServiceType{
+			corev1.ServiceTypeClusterIP,
+			corev1.ServiceTypeNodePort,
+		}
+		validType := false
+		for _, validTypeName := range validTypes {
+			if iss.SolverServiceType == validTypeName {
+				validType = true
+				break
+			}
+		}
+		if !validType {
+			el = append(el, field.Invalid(fldPath.Child("solverServiceType"), iss.SolverServiceType, fmt.Sprintf("optional field solverServiceType must be one of %q", validTypes)))
+		}
+	}
+
+	return el
 }
 
 func ValidateACMEIssuerDNS01Config(iss *v1alpha1.ACMEIssuerDNS01Config, fldPath *field.Path) field.ErrorList {

--- a/pkg/apis/certmanager/validation/issuer_test.go
+++ b/pkg/apis/certmanager/validation/issuer_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 	"testing"
 
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -144,6 +145,19 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 				Server:     "valid-server",
 				PrivateKey: validSecretKeyRef,
 				HTTP01:     &v1alpha1.ACMEIssuerHTTP01Config{},
+			},
+		},
+		"acme issue with invalid http01 service config": {
+			spec: &v1alpha1.ACMEIssuer{
+				Email:      "valid-email",
+				Server:     "valid-server",
+				PrivateKey: validSecretKeyRef,
+				HTTP01: &v1alpha1.ACMEIssuerHTTP01Config{
+					SolverServiceType: corev1.ServiceType("InvalidServiceType"),
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("http01", "solverServiceType"), corev1.ServiceType("InvalidServiceType"), "optional field solverServiceType must be one of [\"ClusterIP\" \"NodePort\"]"),
 			},
 		},
 	}

--- a/pkg/apis/certmanager/validation/issuer_test.go
+++ b/pkg/apis/certmanager/validation/issuer_test.go
@@ -147,17 +147,47 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 				HTTP01:     &v1alpha1.ACMEIssuerHTTP01Config{},
 			},
 		},
+		"acme issue with valid http01 service config serviceType ClusterIP": {
+			spec: &v1alpha1.ACMEIssuer{
+				Email:      "valid-email",
+				Server:     "valid-server",
+				PrivateKey: validSecretKeyRef,
+				HTTP01: &v1alpha1.ACMEIssuerHTTP01Config{
+					ServiceType: corev1.ServiceType("ClusterIP"),
+				},
+			},
+		},
+		"acme issue with valid http01 service config serviceType NodePort": {
+			spec: &v1alpha1.ACMEIssuer{
+				Email:      "valid-email",
+				Server:     "valid-server",
+				PrivateKey: validSecretKeyRef,
+				HTTP01: &v1alpha1.ACMEIssuerHTTP01Config{
+					ServiceType: corev1.ServiceType("NodePort"),
+				},
+			},
+		},
+		"acme issue with valid http01 service config serviceType (empty string)": {
+			spec: &v1alpha1.ACMEIssuer{
+				Email:      "valid-email",
+				Server:     "valid-server",
+				PrivateKey: validSecretKeyRef,
+				HTTP01: &v1alpha1.ACMEIssuerHTTP01Config{
+					ServiceType: corev1.ServiceType(""),
+				},
+			},
+		},
 		"acme issue with invalid http01 service config": {
 			spec: &v1alpha1.ACMEIssuer{
 				Email:      "valid-email",
 				Server:     "valid-server",
 				PrivateKey: validSecretKeyRef,
 				HTTP01: &v1alpha1.ACMEIssuerHTTP01Config{
-					SolverServiceType: corev1.ServiceType("InvalidServiceType"),
+					ServiceType: corev1.ServiceType("InvalidServiceType"),
 				},
 			},
 			errs: []*field.Error{
-				field.Invalid(fldPath.Child("http01", "solverServiceType"), corev1.ServiceType("InvalidServiceType"), "optional field solverServiceType must be one of [\"ClusterIP\" \"NodePort\"]"),
+				field.Invalid(fldPath.Child("http01", "serviceType"), corev1.ServiceType("InvalidServiceType"), "optional field serviceType must be one of [\"ClusterIP\" \"NodePort\"]"),
 			},
 		},
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -81,7 +81,7 @@ func NewSolver(ctx *controller.Context) *Solver {
 // will return nil (i.e. this function is idempotent).
 func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
 	_, podErr := s.ensurePod(crt, ch)
-	svc, svcErr := s.ensureService(crt, ch)
+	svc, svcErr := s.ensureService(issuer, crt, ch)
 	if svcErr != nil {
 		return utilerrors.NewAggregate([]error{podErr, svcErr})
 	}

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -113,11 +113,10 @@ func buildService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v
 		},
 	}
 
-	// http01 config is still optional, thus checking for presence and setting previous default
-	if issuer.GetSpec().ACME.HTTP01 == nil {
-		service.Spec.Type = corev1.ServiceTypeNodePort //TODO drop this line in future to use Kubernetes' default
-	} else if issuer.GetSpec().ACME.HTTP01.SolverServiceType != "" {
-		service.Spec.Type = issuer.GetSpec().ACME.HTTP01.SolverServiceType
+	// checking for presence of http01 config and if set serviceType is set, override our default (NodePort)
+	service.Spec.Type = corev1.ServiceTypeNodePort
+	if issuer.GetSpec().ACME.HTTP01 != nil && issuer.GetSpec().ACME.HTTP01.ServiceType != "" {
+		service.Spec.Type = issuer.GetSpec().ACME.HTTP01.ServiceType
 	}
 
 	return service

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -46,7 +46,7 @@ func TestEnsureService(t *testing.T) {
 				Domain: "example.com",
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				svc, err := s.Solver.createService(s.Certificate, s.Challenge)
+				svc, err := s.Solver.createService(s.Issuer, s.Certificate, s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -89,7 +89,7 @@ func TestEnsureService(t *testing.T) {
 				Domain: "example.com",
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService := buildService(s.Certificate, s.Challenge)
+				expectedService := buildService(s.Issuer, s.Certificate, s.Challenge)
 				// create a reactor that fails the test if a service is created
 				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
@@ -142,11 +142,11 @@ func TestEnsureService(t *testing.T) {
 			},
 			Err: true,
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createService(s.Certificate, s.Challenge)
+				_, err := s.Solver.createService(s.Issuer, s.Certificate, s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
-				_, err = s.Solver.createService(s.Certificate, s.Challenge)
+				_, err = s.Solver.createService(s.Issuer, s.Certificate, s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -169,7 +169,7 @@ func TestEnsureService(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.ensureService(test.Certificate, test.Challenge)
+			resp, err := test.Solver.ensureService(test.Issuer, test.Certificate, test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}
@@ -198,7 +198,7 @@ func TestGetServicesForCertificate(t *testing.T) {
 				Domain: "example.com",
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createService(s.Certificate, s.Challenge)
+				ing, err := s.Solver.createService(s.Issuer, s.Certificate, s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -232,7 +232,7 @@ func TestGetServicesForCertificate(t *testing.T) {
 				Domain: "example.com",
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createService(s.Certificate, v1alpha1.ACMEOrderChallenge{
+				_, err := s.Solver.createService(s.Issuer, s.Certificate, v1alpha1.ACMEOrderChallenge{
 					Domain: "invaliddomain",
 				})
 				if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
I have a scenario where services with type=NodePort can't be deployed (disabled by quota). This PR simply switches it back to type=ClusterIP (default) since I have no indication why NodePort should make sense for our http01 implementation.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make http01 solver serviceType configurable, so one can use ClusterIP instead of the previously hardcoded type NodePort. NodePort still remains as default but may be changed in future.
```
