### PR TITLE
Add option to enforce acme http solver namespace

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -170,6 +170,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			HTTP01SolverResourceRequestMemory: HTTP01SolverResourceRequestMemory,
 			HTTP01SolverResourceLimitsCPU:     HTTP01SolverResourceLimitsCPU,
 			HTTP01SolverResourceLimitsMemory:  HTTP01SolverResourceLimitsMemory,
+			HTTP01SolverNamespace:             opts.ACMEHTTP01SolverNamespace,
 			DNS01Nameservers:                  nameservers,
 		},
 		IssuerOptions: controller.IssuerOptions{

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -48,6 +48,7 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverResourceRequestMemory string
 	ACMEHTTP01SolverResourceLimitsCPU     string
 	ACMEHTTP01SolverResourceLimitsMemory  string
+	ACMEHTTP01SolverNamespace             string
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
@@ -81,14 +82,16 @@ const (
 	defaultTLSACMEIssuerKind           = "Issuer"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
-)
 
-var (
-	defaultACMEHTTP01SolverImage                 = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
 	defaultACMEHTTP01SolverResourceRequestCPU    = "10m"
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "10m"
 	defaultACMEHTTP01SolverResourceLimitsMemory  = "64Mi"
+	defaultACMEHTTP01SolverNamespace             = ""
+)
+
+var (
+	defaultACMEHTTP01SolverImage                 = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
 
 	defaultEnabledControllers = []string{
 		issuerscontroller.ControllerName,
@@ -163,6 +166,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ACMEHTTP01SolverResourceLimitsMemory, "acme-http01-solver-resource-limits-memory", defaultACMEHTTP01SolverResourceLimitsMemory, ""+
 		"Defines the resource limits Memory size when spawning new ACME HTTP01 challenge solver pods.")
+	fs.StringVar(&s.ACMEHTTP01SolverNamespace, "acme-http01-solver-namespace", defaultACMEHTTP01SolverNamespace, ""+
+		"The namespace to use for start ACME HTTP01 Solver pod. By default, it will use the same namespace "+
+		"as the related ingress resource.")
 
 	fs.BoolVar(&s.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", defaultClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -96,6 +96,9 @@ type ACMEOptions struct {
 	// DNS01Nameservers is a list of nameservers to use when performing self-checks
 	// for ACME DNS01 validations.
 	DNS01Nameservers []string
+
+	// ACMEHTTP01SolverNamespace is the namespace where to start ACME HTTP01 Solver
+	HTTP01SolverNamespace string
 }
 
 type IngressShimOptions struct {

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -30,8 +30,8 @@ import (
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
-func (s *Solver) ensureService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) (*corev1.Service, error) {
-	existingServices, err := s.getServicesForChallenge(crt, ch)
+func (s *Solver) ensureService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge, namespace string) (*corev1.Service, error) {
+	existingServices, err := s.getServicesForChallenge(crt, ch, namespace)
 	if err != nil {
 		return nil, err
 	}
@@ -39,22 +39,22 @@ func (s *Solver) ensureService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Cert
 		return existingServices[0], nil
 	}
 	if len(existingServices) > 1 {
-		errMsg := fmt.Sprintf("multiple challenge solver services found for certificate '%s/%s'. Cleaning up existing services.", crt.Namespace, crt.Name)
+		errMsg := fmt.Sprintf("multiple challenge solver services found for certificate '%s/%s'. Cleaning up existing services.", namespace, crt.Name)
 		glog.Infof(errMsg)
-		err := s.cleanupServices(crt, ch)
+		err := s.cleanupServices(crt, ch, namespace)
 		if err != nil {
 			return nil, err
 		}
 		return nil, fmt.Errorf(errMsg)
 	}
 
-	glog.Infof("No existing HTTP01 challenge solver service found for Certificate %q. One will be created.", crt.Namespace+"/"+crt.Name)
-	return s.createService(issuer, crt, ch)
+	glog.Infof("No existing HTTP01 challenge solver service found for Certificate %q. One will be created.", namespace+"/"+crt.Name)
+	return s.createService(issuer, crt, ch, namespace)
 }
 
 // getServicesForChallenge returns a list of services that were created to solve
 // http challenges for the given domain
-func (s *Solver) getServicesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) ([]*corev1.Service, error) {
+func (s *Solver) getServicesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge, namespace string) ([]*corev1.Service, error) {
 	podLabels := podLabels(ch)
 	selector := labels.NewSelector()
 	for key, val := range podLabels {
@@ -65,7 +65,7 @@ func (s *Solver) getServicesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.
 		selector = selector.Add(*req)
 	}
 
-	serviceList, err := s.serviceLister.Services(crt.Namespace).List(selector)
+	serviceList, err := s.serviceLister.Services(namespace).List(selector)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +74,7 @@ func (s *Solver) getServicesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.
 	for _, service := range serviceList {
 		if !metav1.IsControlledBy(service, crt) {
 			glog.Infof("Found service %q with acme-order-url annotation set to that of Certificate %q"+
-				"but it is not owned by the Certificate resource, so skipping it.", service.Namespace+"/"+service.Name, crt.Namespace+"/"+crt.Name)
+				"but it is not owned by the Certificate resource, so skipping it.", service.Namespace+"/"+service.Name, namespace+"/"+crt.Name)
 			continue
 		}
 		relevantServices = append(relevantServices, service)
@@ -85,16 +85,16 @@ func (s *Solver) getServicesForChallenge(crt *v1alpha1.Certificate, ch v1alpha1.
 
 // createService will create the service required to solve this challenge
 // in the target API server.
-func (s *Solver) createService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) (*corev1.Service, error) {
-	return s.Client.CoreV1().Services(crt.Namespace).Create(buildService(issuer, crt, ch))
+func (s *Solver) createService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge, namespace string) (*corev1.Service, error) {
+	return s.Client.CoreV1().Services(namespace).Create(buildService(issuer, crt, ch, namespace))
 }
 
-func buildService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) *corev1.Service {
+func buildService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge, namespace string) *corev1.Service {
 	podLabels := podLabels(ch)
 	service := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "cm-acme-http-solver-",
-			Namespace:    crt.Namespace,
+			Namespace:    namespace,
 			Labels:       podLabels,
 			Annotations: map[string]string{
 				"auth.istio.io/8089": "NONE",
@@ -122,8 +122,8 @@ func buildService(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, ch v
 	return service
 }
 
-func (s *Solver) cleanupServices(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge) error {
-	services, err := s.getServicesForChallenge(crt, ch)
+func (s *Solver) cleanupServices(crt *v1alpha1.Certificate, ch v1alpha1.ACMEOrderChallenge, namespace string) error {
+	services, err := s.getServicesForChallenge(crt, ch, namespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**What this PR does / why we need it:**
It adds an option to enforce the namespace where all acme http01 solver resources (pod, service and ingress) will be created. This overrides the default configuration, which is create all those resources on the namespace where the ingress rule with the tls annotation has been created.

It creates a little bit of extra-noise on code, but in our case it's necessary because:
- on a multitenancy cluster, you don't want to create resources on a customer namespace, and maybe confuse him, because he has requested a certificate.
- we have special resource quotas in customer namespaces that prevents the acme http01 solver pod to start given the current configuration

**Special notes for your reviewer:**
I've tested on our environment (kubernetes 1.9). I attach you the logs on the certificate generation:
```
I1011 15:02:24.667246       1 controller.go:171] certificates controller: syncing item 'customer-dev/minio-tls'
I1011 15:02:24.667359       1 sync.go:282] Preparing certificate customer-dev/minio-tls with issuer
I1011 15:02:24.762260       1 logger.go:43] Calling GetOrder
I1011 15:02:24.971075       1 logger.go:73] Calling GetAuthorization
I1011 15:02:25.163475       1 logger.go:93] Calling HTTP01ChallengeResponse
I1011 15:02:25.163507       1 prepare.go:279] Cleaning up old/expired challenges for Certificate customer-dev/minio-tls
I1011 15:02:25.163522       1 logger.go:68] Calling GetChallenge
I1011 15:02:36.465463       1 prepare.go:488] Accepting challenge for domain "minio.ingress.foo.io"
I1011 15:02:36.465484       1 logger.go:63] Calling AcceptChallenge
I1011 15:02:37.462182       1 prepare.go:500] Waiting for authorization for domain "minio.ingress.foo.io"
I1011 15:02:37.462204       1 logger.go:78] Calling WaitAuthorization
I1011 15:02:38.667169       1 controller.go:168] ingress-shim controller: syncing item 'customer-dev/minio-minio'
I1011 15:02:38.667216       1 sync.go:140] Certificate "minio-tls" for ingress "minio-minio" already exists
I1011 15:02:38.667310       1 sync.go:143] Certificate "minio-tls" for ingress "minio-minio" is up to date
I1011 15:02:38.667322       1 controller.go:182] ingress-shim controller: Finished processing work item "customer-dev/minio-minio"
I1011 15:02:38.667408       1 controller.go:168] ingress-shim controller: syncing item 'default/cm-acme-http-solver-bgx4t'
I1011 15:02:38.667448       1 sync.go:65] Not syncing ingress default/cm-acme-http-solver-bgx4t as it does not contain necessary annotations
I1011 15:02:38.667457       1 controller.go:182] ingress-shim controller: Finished processing work item "default/cm-acme-http-solver-bgx4t"
I1011 15:02:39.662192       1 prepare.go:510] Successfully authorized domain "minio.ingress.foo.io"
I1011 15:02:39.662321       1 prepare.go:303] Cleaning up challenge for domain "minio.ingress.foo.io" as part of Certificate customer-dev/minio-tls
I1011 15:02:39.697893       1 ingress.go:49] Looking up Ingresses for selector certmanager.k8s.io/acme-http-domain=<somedomain>,certmanager.k8s.io/acme-http-token=<sometoken>
I1011 15:02:39.706492       1 sync.go:289] Issuing certificate...
I1011 15:02:39.706891       1 logger.go:43] Calling GetOrder
I1011 15:02:39.708893       1 controller.go:168] ingress-shim controller: syncing item 'default/cm-acme-http-solver-bgx4t'
E1011 15:02:39.708976       1 controller.go:198] ingress 'default/cm-acme-http-solver-bgx4t' in work queue no longer exists
I1011 15:02:39.709096       1 controller.go:182] ingress-shim controller: Finished processing work item "default/cm-acme-http-solver-bgx4t"
I1011 15:02:42.165322       1 logger.go:58] Calling FinalizeOrder
I1011 15:02:43.472364       1 issue.go:196] successfully obtained certificate: cn="minio.ingress.foo.io" altNames=minio.ingress.foo.io] url="https://acme-staging-v02.api.letsencrypt.org/acme/order/<someorder>"
I1011 15:02:43.479414       1 sync.go:308] Certificate issued successfully
I1011 15:02:43.479568       1 helpers.go:201] Found status change for Certificate "minio-tls" condition "Ready": "False" -> "True"; setting lastTransitionTime to 2018-10-11 15:02:43.479561707 +0000 UTC m=+131.866861115
I1011 15:02:43.479847       1 sync.go:210] Certificate customer-dev/minio-tls scheduled for renewal in 1438 hours
I1011 15:02:43.483749       1 controller.go:168] ingress-shim controller: syncing item 'customer-dev/minio-minio'
I1011 15:02:43.483827       1 sync.go:140] Certificate "minio-tls" for ingress "minio-minio" already exists
I1011 15:02:43.483845       1 sync.go:143] Certificate "minio-tls" for ingress "minio-minio" is up to date
I1011 15:02:43.483881       1 controller.go:182] ingress-shim controller: Finished processing work item "customer-dev/minio-minio"
I1011 15:02:43.484640       1 controller.go:185] certificates controller: Finished processing work item "customer-dev/minio-tls"
I1011 15:03:43.562076       1 controller.go:171] certificates controller: syncing item 'customer-dev/minio-tls'
I1011 15:03:43.562503       1 sync.go:210] Certificate customer-dev/minio-tls scheduled for renewal in 1438 hours
I1011 15:03:43.562562       1 controller.go:185] certificates controller: Finished processing work item "customer-dev/minio-tls"
```

I've also moved some vars defined in https://github.com/jetstack/cert-manager/pull/923/files which are related and I think they should be const.

```release-note
Add option to enforce the namespace where acme http01 solver resources will be created
```