### PR TITLE
Only update Certificate and CA fields in secrets when they change

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -257,9 +257,9 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 			},
 			Type: api.SecretTypeTLS,
 			Data: map[string][]byte{
-				api.TLSCertKey:       []byte{},
-				api.TLSPrivateKeyKey: []byte{},
-				TLSCAKey:             []byte{},
+				api.TLSCertKey:       {},
+				api.TLSPrivateKeyKey: {},
+				TLSCAKey:             {},
 			},
 		}
 	}

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -256,7 +256,11 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 				Namespace: namespace,
 			},
 			Type: api.SecretTypeTLS,
-			Data: map[string][]byte{},
+			Data: map[string][]byte{
+				api.TLSCertKey:       []byte{},
+				api.TLSPrivateKeyKey: []byte{},
+				TLSCAKey:             []byte{},
+			},
 		}
 	}
 

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -230,7 +230,7 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 				return false, nil
 			}
 			certBytes, ok := secret.Data[v1.TLSCertKey]
-			if !ok {
+			if !ok || len(certBytes) == 0 {
 				glog.Infof("No certificate data found for Certificate %q (secret %q)", name, certificate.Spec.SecretName)
 				return false, nil
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This updates the Certificates controller to only update secret keys in the target secret when one of those values changes, e.g. a new certificate, ca bundle or private key is created.

It also tidies up how we set metadata, and makes the metadata be set based on the contents of the certificate.

**Release note**:
```release-note
NONE
```
