### PR TITLE
Update SignatureAlgorithm function to also return PublicKey type

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -78,7 +78,7 @@ func GenerateCSR(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate) (*x50
 		return nil, fmt.Errorf("no domains specified on certificate")
 	}
 
-	sigAlgo, err := SignatureAlgorithm(crt)
+	pubKeyAlgo, sigAlgo, err := SignatureAlgorithm(crt)
 	if err != nil {
 		return nil, err
 	}
@@ -86,6 +86,7 @@ func GenerateCSR(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate) (*x50
 	return &x509.CertificateRequest{
 		Version:            3,
 		SignatureAlgorithm: sigAlgo,
+		PublicKeyAlgorithm: pubKeyAlgo,
 		Subject: pkix.Name{
 			Organization: organization,
 			CommonName:   commonName,
@@ -114,7 +115,7 @@ func GenerateTemplate(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, 
 		return nil, fmt.Errorf("failed to generate serial number: %s", err.Error())
 	}
 
-	sigAlgo, err := SignatureAlgorithm(crt)
+	pubKeyAlgo, sigAlgo, err := SignatureAlgorithm(crt)
 	if err != nil {
 		return nil, err
 	}
@@ -123,11 +124,13 @@ func GenerateTemplate(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate, 
 	if crt.Spec.IsCA {
 		keyUsages |= x509.KeyUsageCertSign
 	}
+
 	return &x509.Certificate{
 		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		SignatureAlgorithm:    sigAlgo,
+		PublicKeyAlgorithm:    pubKeyAlgo,
 		IsCA:                  crt.Spec.IsCA,
 		Subject: pkix.Name{
 			Organization: organization,
@@ -198,34 +201,40 @@ func EncodeX509(cert *x509.Certificate) ([]byte, error) {
 
 // Return the appropriate signature algorithm for the certificate
 // Adapted from https://github.com/cloudflare/cfssl/blob/master/csr/csr.go#L102
-func SignatureAlgorithm(crt *v1alpha1.Certificate) (x509.SignatureAlgorithm, error) {
+func SignatureAlgorithm(crt *v1alpha1.Certificate) (x509.PublicKeyAlgorithm, x509.SignatureAlgorithm, error) {
+	var sigAlgo x509.SignatureAlgorithm
+	var pubKeyAlgo x509.PublicKeyAlgorithm
 	switch crt.Spec.KeyAlgorithm {
 	case v1alpha1.KeyAlgorithm(""):
 		// If keyAlgorithm is not specified, we default to rsa with keysize 2048
-		return x509.SHA256WithRSA, nil
+		pubKeyAlgo = x509.RSA
+		sigAlgo = x509.SHA256WithRSA
 	case v1alpha1.RSAKeyAlgorithm:
+		pubKeyAlgo = x509.RSA
 		switch {
 		case crt.Spec.KeySize >= 4096:
-			return x509.SHA512WithRSA, nil
+			sigAlgo = x509.SHA512WithRSA
 		case crt.Spec.KeySize >= 3072:
-			return x509.SHA384WithRSA, nil
+			sigAlgo = x509.SHA384WithRSA
 		case crt.Spec.KeySize >= 2048:
-			return x509.SHA256WithRSA, nil
+			sigAlgo = x509.SHA256WithRSA
 		default:
-			return x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported rsa keysize specified: %d. min keysize %d", crt.Spec.KeySize, MinRSAKeySize)
+			return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported rsa keysize specified: %d. min keysize %d", crt.Spec.KeySize, MinRSAKeySize)
 		}
 	case v1alpha1.ECDSAKeyAlgorithm:
+		pubKeyAlgo = x509.ECDSA
 		switch crt.Spec.KeySize {
 		case 521:
-			return x509.ECDSAWithSHA512, nil
+			sigAlgo = x509.ECDSAWithSHA512
 		case 384:
-			return x509.ECDSAWithSHA384, nil
+			sigAlgo = x509.ECDSAWithSHA384
 		case 256:
-			return x509.ECDSAWithSHA256, nil
+			sigAlgo = x509.ECDSAWithSHA256
 		default:
-			return x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported ecdsa keysize specified: %d", crt.Spec.KeySize)
+			return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported ecdsa keysize specified: %d", crt.Spec.KeySize)
 		}
 	default:
-		return x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported algorithm specified: %s. should be either 'ecdsa' or 'rsa", crt.Spec.KeyAlgorithm)
+		return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported algorithm specified: %s. should be either 'ecdsa' or 'rsa", crt.Spec.KeyAlgorithm)
 	}
+	return pubKeyAlgo, sigAlgo, nil
 }

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -145,6 +145,7 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 		keySize         int
 		expectErr       bool
 		expectedSigAlgo x509.SignatureAlgorithm
+		expectedKeyType x509.PublicKeyAlgorithm
 	}
 
 	tests := []testT{
@@ -157,42 +158,49 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 			name:            "certificate with KeyAlgorithm not set",
 			keyAlgo:         v1alpha1.KeyAlgorithm(""),
 			expectedSigAlgo: x509.SHA256WithRSA,
+			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and size 2048",
 			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
 			keySize:         2048,
 			expectedSigAlgo: x509.SHA256WithRSA,
+			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and size 3072",
 			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
 			keySize:         3072,
 			expectedSigAlgo: x509.SHA384WithRSA,
+			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and size 4096",
 			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
 			keySize:         4096,
 			expectedSigAlgo: x509.SHA512WithRSA,
+			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 256",
 			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
 			keySize:         256,
 			expectedSigAlgo: x509.ECDSAWithSHA256,
+			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 384",
 			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
 			keySize:         384,
 			expectedSigAlgo: x509.ECDSAWithSHA384,
+			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 521",
 			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
 			keySize:         521,
 			expectedSigAlgo: x509.ECDSAWithSHA512,
+			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:      "certificate with KeyAlgorithm ecdsa and size 100",
@@ -200,16 +208,15 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 			expectErr: true,
 		},
 		{
-			name:            "certificate with KeyAlgorithm set to unknown key algo",
-			keyAlgo:         v1alpha1.KeyAlgorithm("blah"),
-			expectErr:       true,
-			expectedSigAlgo: x509.UnknownSignatureAlgorithm,
+			name:      "certificate with KeyAlgorithm set to unknown key algo",
+			keyAlgo:   v1alpha1.KeyAlgorithm("blah"),
+			expectErr: true,
 		},
 	}
 
 	testFn := func(test testT) func(*testing.T) {
 		return func(t *testing.T) {
-			actualSigAlgo, err := SignatureAlgorithm(buildCertificateWithKeyParams(test.keyAlgo, test.keySize))
+			actualPKAlgo, actualSigAlgo, err := SignatureAlgorithm(buildCertificateWithKeyParams(test.keyAlgo, test.keySize))
 			if test.expectErr && err == nil {
 				t.Error("expected err, but got no error")
 				return
@@ -223,6 +230,11 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 
 				if actualSigAlgo != test.expectedSigAlgo {
 					t.Errorf("expected %q but got %q", test.expectedSigAlgo, actualSigAlgo)
+					return
+				}
+
+				if actualPKAlgo != test.expectedKeyType {
+					t.Errorf("expected %q but got %q", test.expectedKeyType, actualPKAlgo)
 					return
 				}
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows the GenerateCSR & GenerateTemplate functions to set the PublicKeyAlgorithm field on the resources it creates, useful for issuers that may require the field to be set.

**Release note**:
```release-note
NONE
```
