### PR TITLE
Create HaveCondition gomega matcher and use it in e2e test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1430,6 +1430,7 @@
     "github.com/onsi/ginkgo/ginkgo",
     "github.com/onsi/ginkgo/reporters",
     "github.com/onsi/gomega",
+    "github.com/onsi/gomega/types",
     "github.com/openshift/generic-admission-server/pkg/cmd",
     "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",

--- a/test/e2e/framework/BUILD.bazel
+++ b/test/e2e/framework/BUILD.bazel
@@ -51,6 +51,7 @@ filegroup(
         "//test/e2e/framework/config:all-srcs",
         "//test/e2e/framework/helper:all-srcs",
         "//test/e2e/framework/log:all-srcs",
+        "//test/e2e/framework/matcher:all-srcs",
         "//test/e2e/framework/util:all-srcs",
     ],
     tags = ["automanaged"],

--- a/test/e2e/framework/matcher/BUILD.bazel
+++ b/test/e2e/framework/matcher/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["have_condition_matcher.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/framework/matcher",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/matcher/have_condition_matcher.go
+++ b/test/e2e/framework/matcher/have_condition_matcher.go
@@ -1,0 +1,209 @@
+/*
+Copyright 2018 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package matcher
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+)
+
+// HaveCondition will wait for up to the
+func HaveCondition(f *framework.Framework, condition interface{}) *conditionMatcher {
+	return &conditionMatcher{
+		f:         f,
+		condition: condition,
+	}
+}
+
+//// begin resource condition type mapping.
+// modify this block of code to add support for new types
+
+func toGenericCondition(c interface{}) (*genericCondition, error) {
+	switch c := c.(type) {
+	case cmapi.CertificateCondition:
+		return buildGenericCondition(string(c.Type), string(c.Status), c.Reason), nil
+	case cmapi.IssuerCondition:
+		return buildGenericCondition(string(c.Type), string(c.Status), c.Reason), nil
+	default:
+		return nil, fmt.Errorf("unsupported condition type %T", c)
+	}
+}
+
+func (c *conditionMatcher) getUpToDateResource(obj interface{}) (interface{}, error) {
+	switch obj := obj.(type) {
+	case *cmapi.Certificate:
+		return c.f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
+	case *cmapi.Issuer:
+		return c.f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(obj.Namespace).Get(obj.Name, metav1.GetOptions{})
+	default:
+		return nil, fmt.Errorf("unsupported resource type %T", c)
+	}
+}
+
+func extractConditionSlice(obj interface{}) ([]interface{}, error) {
+	var actualConditions []interface{}
+	switch obj := obj.(type) {
+	case *cmapi.Certificate:
+		for _, c := range obj.Status.Conditions {
+			actualConditions = append(actualConditions, c)
+		}
+	case *cmapi.Issuer:
+		for _, c := range obj.Status.Conditions {
+			actualConditions = append(actualConditions, c)
+		}
+	default:
+		return nil, fmt.Errorf("unsupported resource type %T", obj)
+	}
+	return actualConditions, nil
+}
+
+//// end resource condition type mapping.
+
+type conditionMatcher struct {
+	f         *framework.Framework
+	condition interface{}
+}
+
+type genericCondition struct {
+	Type   *string
+	Status *string
+	Reason *string
+}
+
+func (g *genericCondition) String() string {
+	t := "<nil>"
+	s := "<nil>"
+	r := "<nil>"
+	if g.Type != nil {
+		t = *g.Type
+	}
+	if g.Status != nil {
+		s = *g.Status
+	}
+	if g.Reason != nil {
+		r = *g.Reason
+	}
+	return fmt.Sprintf("Type: %q, Status: %q, Reason: %q", t, s, r)
+}
+
+var _ types.GomegaMatcher = &conditionMatcher{}
+
+func (c *conditionMatcher) Match(actual interface{}) (bool, error) {
+	expected, err := toGenericCondition(c.condition)
+	if err != nil {
+		return false, err
+	}
+
+	upToDateActual, err := c.getUpToDateResource(actual)
+	if err != nil {
+		return false, err
+	}
+
+	conditionsSlice, err := extractConditionSlice(upToDateActual)
+	if err != nil {
+		return false, err
+	}
+
+	for _, c := range conditionsSlice {
+		g, err := toGenericCondition(c)
+		if err != nil {
+			return false, err
+		}
+		if matches(expected, g) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+func matches(expected, actual *genericCondition) bool {
+	if expected.Type != nil {
+		if !reflect.DeepEqual(expected.Type, actual.Type) {
+			return false
+		}
+	}
+	if expected.Status != nil {
+		if !reflect.DeepEqual(expected.Status, actual.Status) {
+			return false
+		}
+	}
+	if expected.Reason != nil {
+		if !reflect.DeepEqual(expected.Reason, actual.Reason) {
+			return false
+		}
+	}
+	return true
+}
+
+func buildGenericCondition(cType, status, reason string) *genericCondition {
+	g := &genericCondition{}
+	if cType != "" {
+		g.Type = &cType
+	}
+	if status != "" {
+		g.Status = &status
+	}
+	if reason != "" {
+		g.Reason = &reason
+	}
+	return g
+}
+
+func (c *conditionMatcher) FailureMessage(actual interface{}) string {
+	expected, err := toGenericCondition(c.condition)
+	if err != nil {
+		return "Did not have required condition"
+	}
+
+	upToDateActual, err := c.getUpToDateResource(actual)
+	if err != nil {
+		return "Did not have required condition"
+	}
+
+	conditionsSlice, err := extractConditionSlice(upToDateActual)
+	if err != nil {
+		return "Did not have required condition"
+	}
+
+	return fmt.Sprintf("Did not have expected condition (%s), had conditions: %v", expected.String(), conditionsSlice)
+}
+
+func (c *conditionMatcher) NegatedFailureMessage(actual interface{}) string {
+	expected, err := toGenericCondition(c.condition)
+	if err != nil {
+		return "Condition found"
+	}
+
+	upToDateActual, err := c.getUpToDateResource(actual)
+	if err != nil {
+		return "Did not have required condition"
+	}
+
+	conditionsSlice, err := extractConditionSlice(upToDateActual)
+	if err != nil {
+		return "Did not have required condition"
+	}
+
+	return fmt.Sprintf("Found unexpected condition (%s), had conditions: %v", expected.String(), conditionsSlice)
+}

--- a/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/pebble:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
+        "//test/e2e/framework/matcher:go_default_library",
         "//test/e2e/suite/issuers/acme/dnsproviders:go_default_library",
         "//test/e2e/util:go_default_library",
         "//test/util/generate:go_default_library",

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -182,8 +182,9 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 	It("should fail to obtain a certificate for an invalid ACME dns name", func() {
 		// create test fixture
 		cert := util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, nil, nil, acmeIngressClass, "google.com")
+		cert, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(cert)
+		Expect(err).NotTo(HaveOccurred())
 
-		Expect(f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(cert))
 		Consistently(cert, "1m", "10s").Should(HaveCondition(f, v1alpha1.CertificateCondition{
 			Type:   v1alpha1.CertificateConditionReady,
 			Status: v1alpha1.ConditionFalse,

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -185,10 +185,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		cert, err := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name).Create(cert)
 		Expect(err).NotTo(HaveOccurred())
 
-		Consistently(cert, "1m", "10s").Should(HaveCondition(f, v1alpha1.CertificateCondition{
+		notReadyCondition := v1alpha1.CertificateCondition{
 			Type:   v1alpha1.CertificateConditionReady,
 			Status: v1alpha1.ConditionFalse,
-		}))
+		}
+		Eventually(cert, "30s", "1s").Should(HaveCondition(f, notReadyCondition))
+		Consistently(cert, "1m", "10s").Should(HaveCondition(f, notReadyCondition))
 
 		By("Verifying TLS certificate secret does not exist")
 		d, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(certificateSecretName, metav1.GetOptions{})


### PR DESCRIPTION
**What this PR does / why we need it**:

Tests out creating a custom Gomega matcher for checking for conditions on resources during e2e tests.

Depending on how this goes, we can look at creating more custom matchers to test different functionality & cleanup the e2e test framework codebase.

**Release note**:
```release-note
NONE
```
