### PR TITLE
Fix typo

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -113,9 +113,9 @@ func buildIngressResource(ch *v1alpha1.Challenge, svcName string) *extv1beta1.In
 
 	podLabels := podLabels(ch)
 	// TODO: add additional annotations to help workaround problematic ingress controller behaviours
-	ingAnnotaions := make(map[string]string)
+	ingAnnotations := make(map[string]string)
 	if ingClass != nil {
-		ingAnnotaions[class.IngressKey] = *ingClass
+		ingAnnotations[class.IngressKey] = *ingClass
 	}
 
 	ingPathToAdd := ingressPath(ch.Spec.Token, svcName)
@@ -125,7 +125,7 @@ func buildIngressResource(ch *v1alpha1.Challenge, svcName string) *extv1beta1.In
 			GenerateName:    "cm-acme-http-solver-",
 			Namespace:       ch.Namespace,
 			Labels:          podLabels,
-			Annotations:     ingAnnotaions,
+			Annotations:     ingAnnotations,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},
 		},
 		Spec: extv1beta1.IngressSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes a typo

```release-note
NONE
```
P.S. is there an issue involved with [this todo](https://github.com/jetstack/cert-manager/pull/975/files#diff-2b2ac1a6787c876cc4503fab092cebe3R115)? Because where I work we just had services go down in production and we think it's because annotations aren't being set here.