### PR TITLE
Respect HTTP01Timeout, improve logging

### DIFF
--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -27,9 +27,9 @@ import (
 // countReachabilityTestCalls is a wrapper function that allows us to count the number
 // of calls to a reachabilityTest.
 func countReachabilityTestCalls(counter *int, t reachabilityTest) reachabilityTest {
-	return func(ctx context.Context, domain, path, key string) (bool, error) {
+	return func(ctx context.Context, url, key string) (bool, error) {
 		*counter++
-		return t(ctx, domain, path, key)
+		return t(ctx, url, key)
 	}
 }
 
@@ -44,20 +44,26 @@ func TestCheck(t *testing.T) {
 	tests := []testT{
 		{
 			name: "should pass",
-			reachabilityTest: func(context.Context, string, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, string, string) (bool, error) {
 				return true, nil
 			},
 			expectedOk: true,
 		},
 		{
 			name: "should fail",
-			reachabilityTest: func(context.Context, string, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, string, string) (bool, error) {
 				return false, nil
 			},
 		},
 		{
+			name: "should fail with absorbed error",
+			reachabilityTest: func(context.Context, string, string) (bool, error) {
+				return false, &absorbErr{err: fmt.Errorf("failed")}
+			},
+		},
+		{
 			name: "should error",
-			reachabilityTest: func(context.Context, string, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, string, string) (bool, error) {
 				return false, fmt.Errorf("failed")
 			},
 			expectedErr: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

* A context was created with `WithTimeout` of `HTTP01Timeout`, but not used in the HTTP requests in `testReachability`
* `testReachability` completely absorbed HTTP client errors which makes it very hard in some situations to debug issues where the challenge does not succeed (in 0.5.0 it only logs a "... self check failed for domain ..."