### PR TITLE
Fix using Bazel built helm during e2e tests

### DIFF
--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -84,6 +84,10 @@ type Details struct {
 func (c *Chart) Setup(cfg *config.Config) error {
 	var err error
 
+	c.config = cfg
+	if c.config.Addons.Helm.Path == "" {
+		return fmt.Errorf("--helm-binary-path must be set")
+	}
 	if c.Tiller == nil {
 		return fmt.Errorf("tiller base addon must be provided")
 	}
@@ -168,7 +172,7 @@ func (c *Chart) buildHelmCmd(args ...string) *exec.Cmd {
 		"--kube-context", c.tillerDetails.KubeContext,
 		"--tiller-namespace", c.tillerDetails.Namespace,
 	}, args...)
-	cmd := exec.Command("helm", args...)
+	cmd := exec.Command(c.config.Addons.Helm.Path, args...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd


### PR DESCRIPTION
Previously during end-to-end tests we still relied on a system provided helm and did not honour the --helm-binary-path flag.

This changes fixes that to require a path to helm be provided at e2e invocation time.

This is all handled by the Makefile `make e2e_test` target (and consequently through `./hack/ci/run-e2e-kind.sh`) so should not really effect development workflow.

```release-note
NONE
```