### PR TITLE
Don't fail e2e's if cloudflare dns01 credentials are not provided

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,18 +18,7 @@ APP_VERSION := canary
 HACK_DIR ?= hack
 
 ## e2e test vars
-# Domain name to use in e2e tests. This is important for ACME HTTP01 e2e tests,
-# which require a domain that resolves to the ingress controller to be used for
-# e2e tests.
-# The IP address provided *must* be the IP that the domain, and all of its subdomains
-# point to.
-# When using the local testing environment, we use the certmanager.kubernetes.network
-# domain name which has been fixed to resolve to 10.0.0.15.
-E2E_NGINX_CERTIFICATE_DOMAIN=certmanager.kubernetes.network
-E2E_NGINX_CERTIFICATE_IP=10.0.0.15
-
 KUBECONFIG ?= $$HOME/.kube/config
-PEBBLE_IMAGE_REPO=quay.io/munnerz/pebble
 
 # Get a list of all binaries to be built
 CMDS := $(shell find ./cmd/ -maxdepth 1 -type d -exec basename {} \; | grep -v cmd)
@@ -121,11 +110,6 @@ e2e_test:
 			-nodes 20 \
 			$$(bazel info bazel-genfiles)/test/e2e/e2e.test \
 			-- \
-			--global-nginx-ingress-domain=$(E2E_NGINX_CERTIFICATE_DOMAIN) \
-			--global-nginx-ingress-ip-address=$(E2E_NGINX_CERTIFICATE_IP) \
-			--suite.acme-cloudflare-domain=$${CLOUDFLARE_E2E_DOMAIN} \
-			--suite.acme-cloudflare-api-key=$${CLOUDFLARE_E2E_API_TOKEN} \
-			--suite.acme-cloudflare-email=$${CLOUDFLARE_E2E_EMAIL} \
 			--helm-binary-path=$$(bazel info bazel-genfiles)/hack/bin/helm \
 			--tiller-image-tag=$$($$(bazel info bazel-genfiles)/hack/bin/helm version --client --template '{{.Client.SemVer}}') \
 			--repo-root="$$(pwd)" \

--- a/test/e2e/framework/BUILD.bazel
+++ b/test/e2e/framework/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/config:go_default_library",
         "//test/e2e/framework/util:go_default_library",
+        "//test/e2e/framework/util/errors:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/authorization/v1:go_default_library",

--- a/test/e2e/framework/config/suite.go
+++ b/test/e2e/framework/config/suite.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package config
 
-import "flag"
+import (
+	"flag"
+	"os"
+)
 
 type Suite struct {
 	ACME ACME
@@ -47,15 +50,14 @@ func (c *ACME) AddFlags(fs *flag.FlagSet) {
 }
 
 func (c *ACME) Validate() []error {
-	// TODO: validate Cloudflare config
 	return nil
 }
 
 func (c *Cloudflare) AddFlags(fs *flag.FlagSet) {
-	fs.StringVar(&c.Domain, "suite.acme-cloudflare-domain", "", ""+
+	fs.StringVar(&c.Domain, "suite.acme-cloudflare-domain", os.Getenv("CLOUDFLARE_E2E_DOMAIN"), ""+
 		"The cloudflare API domain name. If not specified, DNS tests will be skipped")
-	fs.StringVar(&c.Email, "suite.acme-cloudflare-email", "", ""+
+	fs.StringVar(&c.Email, "suite.acme-cloudflare-email", os.Getenv("CLOUDFLARE_E2E_EMAIL"), ""+
 		"The cloudflare API email address. If not specified, DNS tests will be skipped")
-	fs.StringVar(&c.APIKey, "suite.acme-cloudflare-api-key", "", ""+
+	fs.StringVar(&c.APIKey, "suite.acme-cloudflare-api-key", os.Getenv("CLOUDFLARE_E2E_API_TOKEN"), ""+
 		"The cloudflare API key. If not specified, DNS tests will be skipped")
 }

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -28,6 +28,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
 	"github.com/jetstack/cert-manager/test/e2e/framework/util"
+	"github.com/jetstack/cert-manager/test/e2e/framework/util/errors"
 )
 
 // DefaultConfig contains the default shared config the is likely parsed from
@@ -142,6 +143,9 @@ func (f *Framework) RequireAddon(a addon.Addon) {
 	BeforeEach(func() {
 		By("Provisioning test-scoped addon")
 		err := a.Setup(f.Config)
+		if errors.IsSkip(err) {
+			Skipf("Skipping test as addon could not be setup: %v", err)
+		}
 		Expect(err).NotTo(HaveOccurred())
 
 		err = a.Provision()

--- a/test/e2e/framework/util/BUILD.bazel
+++ b/test/e2e/framework/util/BUILD.bazel
@@ -22,7 +22,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//test/e2e/framework/util/errors:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/test/e2e/framework/util/errors/BUILD.bazel
+++ b/test/e2e/framework/util/errors/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["errors.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/framework/util/errors",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/util/errors/errors.go
+++ b/test/e2e/framework/util/errors/errors.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2018 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package errors contains shared error types that tests and addons can depend
+// upon to communicate information about why something has failed
+package errors
+
+type errSkipTest struct {
+	error
+}
+
+func IsSkip(err error) bool {
+	if _, ok := err.(errSkipTest); ok {
+		return true
+	}
+	return false
+}
+
+func NewSkip(err error) error {
+	return errSkipTest{error: err}
+}

--- a/test/e2e/suite/issuers/acme/dnsproviders/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/dnsproviders/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//test/e2e/framework/addon/base:go_default_library",
         "//test/e2e/framework/config:go_default_library",
+        "//test/e2e/framework/util/errors:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/test/e2e/suite/issuers/acme/dnsproviders/cloudflare.go
+++ b/test/e2e/suite/issuers/acme/dnsproviders/cloudflare.go
@@ -23,6 +23,7 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/base"
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
+	"github.com/jetstack/cert-manager/test/e2e/framework/util/errors"
 )
 
 // Cloudflare provisions cloudflare credentials in a namespace for cert-manager
@@ -44,7 +45,7 @@ func (b *Cloudflare) Setup(c *config.Config) error {
 	if c.Suite.ACME.Cloudflare.APIKey == "" ||
 		c.Suite.ACME.Cloudflare.Domain == "" ||
 		c.Suite.ACME.Cloudflare.Email == "" {
-		return ErrNoCredentials
+		return errors.NewSkip(ErrNoCredentials)
 	}
 
 	if b.Base == nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Since the change to e2e's, we now fail tests instead of skipping them if DNS01 credentials are not provided.

This patch reverts us to the previous behaviour, skipping the tests if credentials are not provided.

It also adjusts the way we provide details to the e2e's, removing usage of CLI args from the Makefile.

**Release note**:
```release-note
NONE
```
