### PR TITLE
Use --wait flag when installing e2e charts

### DIFF
--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -144,7 +144,7 @@ func (c *Chart) runDepUpdate() error {
 
 func (c *Chart) runInstall() error {
 	args := []string{"install", c.ChartName,
-		// "--wait",
+		"--wait",
 		"--namespace", c.Namespace,
 		"--name", c.ReleaseName}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the --wait flag was causing issues as helm was not returning.

Since we have merged #983, I want to re-try this as we're using a newer version of Helm which should hopefully have resolved the issue!

**Release note**:
```release-note
NONE
```
