### PR TITLE
Bump e2e image used on gitlab

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20180910-b8de01d-0.16.1
+image: eu.gcr.io/jetstack-build-infra-images/cert-manager-e2e:v20181022-34682de-0.18.0
 
 variables:
   DOCKER_DRIVER: overlay


### PR DESCRIPTION
**What this PR does / why we need it**:

Since we now require Bazel >=0.17.1, we need to use an updated test image on GitLab.

**Release note**:
```release-note
NONE
```
