### PR TITLE
Add certmanager.k8s.io/acme-http01-ingress-class annotation

### DIFF
--- a/docs/reference/ingress-shim.rst
+++ b/docs/reference/ingress-shim.rst
@@ -86,6 +86,14 @@ Certificate resources to be automatically created:
   cert-manager which DNS provider (as configured on the specified Issuer resource)
   should be used. This field is required if the challenge type is set to DNS01.
 
+* ``certmanager.k8s.io/acme-http01-ingress-class`` - if the ACME challenge type has
+  been set to http01, this annotation allows you to configure ingress class
+  that will be used to solve challenges for this ingress. Customising this is useful
+  when you are trying to secure internal services, and need to solve challenges
+  using different ingress class to that of the ingress. If not specified and
+  the 'acme-http01-edit-in-place' annotation is not set, this defaults to the ingress
+  class of the ingress resource.
+
 * ``kubernetes.io/tls-acme: "true"`` - this annotation requires additional
   configuration of the ingress-shim (see above). Namely, a default issuer must be
   specified as arguments to the ingress-shim container.

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -54,6 +54,9 @@ const (
 	// acmeIssuerDNS01ProviderNameAnnotation can be used to override the default dns01 provider
 	// configured on the issuer if the challenge type is set to dns01
 	acmeIssuerDNS01ProviderNameAnnotation = "certmanager.k8s.io/acme-dns01-provider"
+	// acmeIssuerHTTP01IngressClassAnnotation can be used to override the http01 ingressClass
+	// if the challenge type is set to http01
+	acmeIssuerHTTP01IngressClassAnnotation = "certmanager.k8s.io/acme-http01-ingress-class"
 
 	ingressClassAnnotation = class.IngressKey
 )
@@ -229,9 +232,14 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 			if ok && editInPlace == "true" {
 				domainCfg.HTTP01.Ingress = ing.Name
 			} else {
-				ingressClass, ok := ingAnnotations[ingressClassAnnotation]
+				ingressClass, ok := ingAnnotations[acmeIssuerHTTP01IngressClassAnnotation]
 				if ok {
 					domainCfg.HTTP01.IngressClass = &ingressClass
+				} else {
+					ingressClass, ok := ingAnnotations[ingressClassAnnotation]
+					if ok {
+						domainCfg.HTTP01.IngressClass = &ingressClass
+					}
 				}
 			}
 		case "dns01":


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: to get letsencrypt's certificates for internal services.

Allow ingress-shim to use certificate ingress class other then original ingress class. Part of #942.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added certmanager.k8s.io/acme-http01-ingress-class annotation
```
