### PR TITLE
Update kube-lego migration guide towards logs

### DIFF
--- a/docs/tutorials/acme/migrating-from-kube-lego.rst
+++ b/docs/tutorials/acme/migrating-from-kube-lego.rst
@@ -246,16 +246,13 @@ There should be an entry for each ingress in your cluster with the kube-lego
 annotation.
 
 We can also verify that cert-manager has 'adopted' the old TLS certificates by
-'describing' one of these newly created certificates:
+viewing the logs for cert-manager:
 
 .. code-block:: shell
 
-   $ kubectl describe certificate my-example-certificate
+   $ kubectl logs -n kube-system -l app=cert-manager -c cert-manager
    ...
-   Events:
-     Type    Reason            Age                 From                     Message
-     ----    ------            ----                ----                     -------
-     Normal  RenewalScheduled  1m                  cert-manager-controller  Certificate scheduled for renewal in 292 hours
+   I1025 21:54:02.869269       1 sync.go:206] Certificate my-example-certificate scheduled for renewal in 292 hours
 
 Here we can see cert-manager has verified the existing TLS certificate and
 scheduled it to be renewed in 292h time.


### PR DESCRIPTION
Related to #773 - the previous instructions guide the user to look for events on the certificate related to when renewals are scheduled. This change directs them to view the logs to see the renewal schedule messages.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Documentation update to better reflect where to look to see renewal schedule information.

**Which issue this PR fixes**: fixes #773

