### PR TITLE
Remove commit hash from Version string

### DIFF
--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -19,7 +19,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["util_test.go"],
+    srcs = [
+        "util_test.go",
+        "version_test.go",
+    ],
     embed = [":go_default_library"],
 )
 

--- a/pkg/util/version.go
+++ b/pkg/util/version.go
@@ -18,6 +18,7 @@ package util
 
 import "fmt"
 
+// This variable block holds information used to build up the version string
 var (
 	AppGitState  = ""
 	AppGitCommit = ""
@@ -26,7 +27,7 @@ var (
 
 func version() string {
 	v := AppVersion
-	if AppGitCommit != "" {
+	if AppVersion == "canary" && AppGitCommit != "" {
 		v += "-" + AppGitCommit
 	}
 	if AppGitState != "" {

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2018 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	type testT struct {
+		appGitCommit    string
+		appGitState     string
+		appVersion      string
+		expectedVersion string
+		description     string
+	}
+	tests := []testT{
+		testT{
+			appVersion:      "canary",
+			expectedVersion: "canary",
+			description:     "canary version with no commit hash and no git state",
+		},
+		testT{
+			appVersion:      "canary",
+			appGitCommit:    "abc123",
+			expectedVersion: "canary-abc123",
+			description:     "canary version with a commit hash and no git state",
+		},
+		testT{
+			appVersion:      "canary",
+			appGitState:     "dirty",
+			expectedVersion: "canary (dirty)",
+			description:     "canary version with no commit hash and a git state",
+		},
+		testT{
+			appVersion:      "canary",
+			appGitCommit:    "abc123",
+			appGitState:     "dirty",
+			expectedVersion: "canary-abc123 (dirty)",
+			description:     "canary version with a commit hash and a git state",
+		},
+		testT{
+			appVersion:      "v0.3.0",
+			expectedVersion: "v0.3.0",
+			description:     "semver version with no commit hash and no git state",
+		},
+		testT{
+			appVersion:      "v0.3.0",
+			appGitCommit:    "abc123",
+			expectedVersion: "v0.3.0",
+			description:     "semver version with a commit hash and no git state",
+		},
+		testT{
+			appVersion:      "v0.3.0",
+			appGitState:     "dirty",
+			expectedVersion: "v0.3.0 (dirty)",
+			description:     "semver version with no commit hash and a git state",
+		},
+		testT{
+			appVersion:      "v0.3.0",
+			appGitCommit:    "abc123",
+			appGitState:     "dirty",
+			expectedVersion: "v0.3.0 (dirty)",
+			description:     "semver version with a commit hash and a git state",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(test testT) func(*testing.T) {
+			AppGitCommit = test.appGitCommit
+			AppGitState = test.appGitState
+			AppVersion = test.appVersion
+			return func(t *testing.T) {
+				if versionString := version(); versionString != test.expectedVersion {
+					t.Errorf("version() == %s but expected %s", versionString, test.expectedVersion)
+				}
+			}
+		}(test))
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR removes the Git commit hash from the version string unless `github.com/JetStack/cert-manager/pkg/util.AppVersion` is set to `canary`.

**Which issue this PR fixes**: fixes #997

**Special notes for your reviewer**:
Open question on issue #997.

**Release note**:
```release-note
Removed the Git commit hash from the version string in non `canary` builds (#997)
```