### PR TITLE
Schedule certificate renewal at the end of Certificate Sync function

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -191,6 +191,10 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 
 	// end checking if the TLS certificate is valid/needs a re-issue or renew
 
+	// If the Certificate is valid and up to date, we schedule a renewal in
+	// the future.
+	c.scheduleRenewal(crt)
+
 	return false, nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

#788 changed the certificate sync function in a way that meant we wouldn't always schedule a renewal for a certificate if cert-manager has been restarted since the first time the certificate was issued.

This PR updates the Certificate controller to always schedule a renewal if a certificate has been validated as up to date and valid.

ref #893 

**Release note**:
```release-note
NONE
```
