### PR TITLE
Added labels to Certificate CRD

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 
 # gazelle:proto disable_global
-
+ 
 container_bundle(
     name = "images",
     images = {

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -117,6 +117,10 @@ Appears In:
 <td>KeySize is the key bit size of the corresponding private key for this certificate. If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is empty or is set to &#34;rsa&#34;, and value must be one of (256, 384, 521) when KeyAlgorithm is set to &#34;ecdsa&#34;.</td>
 </tr>
 <tr>
+<td><code>labels</code><br /> <em>object</em></td>
+<td>Labels is a list of labels to be added to the secret SecretName</td>
+</tr>
+<tr>
 <td><code>organization</code><br /> <em>string array</em></td>
 <td>Organization is the organization to be used on the Certificate</td>
 </tr>

--- a/docs/reference/certificates.rst
+++ b/docs/reference/certificates.rst
@@ -32,6 +32,8 @@ A simple Certificate could be defined as:
        # We can reference ClusterIssuers by changing the kind here.
        # The default value is Issuer (i.e. a locally namespaced Issuer)
        kind: Issuer
+     labels:
+       env: production
 
 This Certificate will tell cert-manager to attempt to use the Issuer
 named ``letsencrypt-prod`` to obtain a certificate key pair for the
@@ -48,7 +50,14 @@ The referenced Issuer must exist in the same namespace as the Certificate.
 A Certificate can alternatively reference a ClusterIssuer which is
 non-namespaced.
 
+The ``labels` fiels specifies a list of `Labels`__ to be
+added to the certificate. A default label ``certmanager.k8s.io/certificate-name``
+is added with the name of the ``Certificate``as value.
+``Labels`` can be used to filter and group secrets by usage, like listing all the
+``production`` certificates.
+
 .. _`Subject Alternative Names`: https://en.wikipedia.org/wiki/Subject_Alternative_Name
+.. __`Labels`: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels
 
 .. toctree::
    :maxdepth: 1

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -98,6 +98,9 @@ type CertificateSpec struct {
 	// key size of 256 will be used for "ecdsa" key algorithm and
 	// key size of 2048 will be used for "rsa" key algorithm.
 	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
+
+	// Labels is a list of labels to be added to the secret SecretName
+	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // ACMECertificateConfig contains the configuration for the ACME certificate provider

--- a/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
@@ -501,6 +501,13 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 			(*in).DeepCopyInto(*out)
 		}
 	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	return
 }
 

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -330,6 +330,11 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 	}
 	secret.Labels[v1alpha1.CertificateNameKey] = crt.Name
 
+	// set Labels based on Certificate request
+	for key, val := range crt.Spec.Labels {
+		secret.Labels[key] = val
+	}
+
 	// if it is a new resource
 	if secret.SelfLink == "" {
 		enableOwner := c.CertificateOptions.EnableOwnerRef


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR adds a `Labels` value to the `Certificate` CRD. 
When set, the new Secret holding the SSL Certificate will have the provided labels.

**Which issue this PR fixes** :

 fixes #977 

**Special notes for your reviewer**:
This is a trivial addition and does not change the behaviour of Cert-Manager. Documentation have been updated too.

```release-note
Added a Labels field of type map[string][string] to support labelling the Certificate's Secret
```
