### PR TITLE
Add ability to create clusterIsuser and certificates after crd creation

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0-dev.2
-appVersion: v0.6.0-dev.2
+version: v0.6.0-dev.3
+appVersion: v0.5.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -58,6 +58,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
+| `certificates` | Create crd certificates after crd creation | `[]` |
+| `clusterIssuer` | Create crd clusterIssuer after crd creation| `{}` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
 | `leaderElection.Namespace` | Override the namespace used to store the ConfigMap for leader election | Same namespace as cert-manager pod
 | `certificateResourceShortNames` | Custom aliases for Certificate CRD | `["cert", "certs"]` |

--- a/contrib/charts/cert-manager/templates/certificates.yaml
+++ b/contrib/charts/cert-manager/templates/certificates.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.createCustomResource .Values.certificates -}}
+apiVersion: v1
+kind: List
+items:
+{{- range .Values.certificates }}
+- apiVersion: certmanager.k8s.io/v1alpha1
+  kind: Certificate
+  metadata:
+    name: "{{ .name }}"
+    namespace: "{{ .namespace }}"
+    annotations:
+      "helm.sh/hook": post-install    
+  spec:
+    acme:
+      config:
+{{ toYaml .spec.acme.config |indent 6 }}
+    commonName: "{{ .spec.commonName }}"
+    dnsNames:
+{{ toYaml .spec.dnsNames |indent 6 }}
+    issuerRef:
+      kind: "{{ .spec.issuerRef.kind }}"
+      name: "{{ .spec.issuerRef.name }}"
+    secretName: "{{ .spec.secretName }}"
+    
+{{- end -}}
+{{- end -}}

--- a/contrib/charts/cert-manager/templates/clusterissuer.yaml
+++ b/contrib/charts/cert-manager/templates/clusterissuer.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.createCustomResource .Values.clusterIssuer -}}
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: {{ .Values.clusterIssuer.name }}
+spec:
+  acme:
+    server: {{ .Values.clusterIssuer.spec.acme.server }}
+    email: {{ .Values.clusterIssuer.spec.acme.email }}
+    privateKeySecretRef:
+      key: {{ .Values.clusterIssuer.spec.acme.privateKeySecretRef.key }}
+      name: {{ .Values.clusterIssuer.spec.acme.privateKeySecretRef.name }}
+{{- if .Values.clusterIssuer.spec.acme.dns01 }}    
+    dns01:
+{{ toYaml .Values.clusterIssuer.spec.acme.dns01 | indent 6 }}
+{{- end -}}
+{{- if .Values.clusterIssuer.spec.acme.http01 }}    
+    http01:
+{{ toYaml .Values.clusterIssuer.spec.acme.http01 | indent 6 }}
+{{- end -}}
+{{- end -}}

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -103,3 +103,62 @@ affinity: {}
 #     value: master
 #     effect: NoSchedule
 tolerations: []
+
+
+clusterIssuer: {}
+# name: letsencrypt-prod
+# spec:
+#   acme:
+#     server: https://acme-v02.api.letsencrypt.org/directory
+#     email:
+#     privateKeySecretRef:
+#       key: ""
+#       name: letsencrypt-prod
+#     dns01:
+#       providers:
+#       - name: route53
+#         route53:
+#           region: eu-west-1
+#           accessKeyID: KEY
+#           hostedZoneID: ZONE1
+#           secretAccessKeySecretRef:
+#             name: custom_secret
+#             key: secret-access-key
+#      - http01:
+#          ingressClass: nginx
+#        domains:
+#        - example.com
+
+certificates: []
+# - name: 'fake-domain.com'
+#   namespace: kube-system
+#   spec:
+#     acme:
+#       config:
+#       - dns01:
+#           provider: route53
+#         domains:
+#         - 'fake-domain.com'
+#     commonName: 'fake-domain.com'
+#     dnsNames:
+#       - 'fake-domain.com'
+#     issuerRef:
+#       kind: ClusterIssuer
+#       name: letsencrypt-prod
+#     secretName: fake-domain.com
+# - name: 'fake-domain.com'
+#   namespace: nginx-ingress
+#   spec:
+#     acme:
+#       config:
+#       - dns01:
+#           provider: aws-route53
+#         domains:
+#         - 'fake-domain.com'
+#     commonName: 'fake-domain.com'
+#     dnsNames:
+#       - 'fake-domain.com'
+#     issuerRef:
+#       kind: ClusterIssuer
+#       name: letsencrypt-prod
+#     secretName: fake-domain.com


### PR DESCRIPTION
**What this PR does / why we need it**: This PR creates certificate and clusterIssuers crd during helm installation. This was not possible before helm introduced ` "helm.sh/hook": crd-install` annotations.
I could create the crds, certificates and clusterIssuer on a fresh cluster.  It requires helm >= 2.10.0

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Create certificates and clusterIssuers crds with helm```