### PR TITLE
Automated cherry pick of #981 #1017

### DIFF
--- a/docs/tutorials/acme/migrating-from-kube-lego.rst
+++ b/docs/tutorials/acme/migrating-from-kube-lego.rst
@@ -246,16 +246,13 @@ There should be an entry for each ingress in your cluster with the kube-lego
 annotation.
 
 We can also verify that cert-manager has 'adopted' the old TLS certificates by
-'describing' one of these newly created certificates:
+viewing the logs for cert-manager:
 
 .. code-block:: shell
 
-   $ kubectl describe certificate my-example-certificate
+   $ kubectl logs -n kube-system -l app=cert-manager -c cert-manager
    ...
-   Events:
-     Type    Reason            Age                 From                     Message
-     ----    ------            ----                ----                     -------
-     Normal  RenewalScheduled  1m                  cert-manager-controller  Certificate scheduled for renewal in 292 hours
+   I1025 21:54:02.869269       1 sync.go:206] Certificate my-example-certificate scheduled for renewal in 292 hours
 
 Here we can see cert-manager has verified the existing TLS certificate and
 scheduled it to be renewed in 292h time.

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -54,7 +54,7 @@ type Controller struct {
 func New(ctx *controllerpkg.Context) *Controller {
 	ctrl := &Controller{Context: *ctx}
 	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "clusterissuers")
+	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*5, time.Minute*1), "clusterissuers")
 
 	clusterIssuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers()
 	clusterIssuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -84,7 +84,7 @@ func New(
 ) *Controller {
 	ctrl := &Controller{Client: client, CMClient: cmClient, Recorder: recorder, defaults: defaults}
 	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "ingresses")
+	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*5, time.Minute*1), "ingresses")
 
 	ingressInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})
 	ctrl.ingressLister = ingressInformer.Lister()

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -55,7 +55,7 @@ func New(ctx *controllerpkg.Context) *Controller {
 	}
 
 	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "issuers")
+	ctrl.queue = workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*5, time.Minute*1), "issuers")
 
 	issuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
 	issuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})


### PR DESCRIPTION
Cherry pick of #981 #1017 on release-0.5.

#981: Update workqueue rate limiters on issuers and ingress-shim
#1017: Update kube-lego migration guide towards logs