### PR TITLE
Remove crd-install annotation from Challenges and Orders

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0-dev.2
-appVersion: v0.6.0-dev.2
+version: v0.6.0-dev.3
+appVersion: v0.6.0-dev.3
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/contrib/charts/cert-manager/templates/challenge-crd.yaml
+++ b/contrib/charts/cert-manager/templates/challenge-crd.yaml
@@ -3,10 +3,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: challenges.certmanager.k8s.io
-{{- if semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer }}
-  annotations:
-    "helm.sh/hook": crd-install
-{{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/charts/cert-manager/templates/order-crd.yaml
+++ b/contrib/charts/cert-manager/templates/order-crd.yaml
@@ -3,10 +3,6 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: orders.certmanager.k8s.io
-{{- if semverCompare ">=2.10-0" .Capabilities.TillerVersion.SemVer }}
-  annotations:
-    "helm.sh/hook": crd-install
-{{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
     chart: {{ template "cert-manager.chart" . }}

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -51,11 +51,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: challenges.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -75,7 +73,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -95,7 +93,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -111,11 +109,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: orders.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -133,7 +129,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -153,7 +149,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -171,7 +167,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -188,7 +184,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -206,7 +202,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -19,7 +19,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -39,11 +39,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: challenges.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -63,7 +61,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -83,7 +81,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -99,11 +97,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   name: orders.certmanager.k8s.io
-  annotations:
-    "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -122,7 +118,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.2
+    chart: cert-manager-v0.6.0-dev.3
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The Helm crd-install annotation is not applied during upgrades, and has numerous issues with how it is handled during installation, upgrade and even uninstall (ref https://github.com/helm/helm/issues/4863)

Whilst a fix for this should hopefully be coming, for the time being we should work to mitigate these problems.

The new Order and Challenge resource types are not required during the helm chart installation phase, and as such, this PR removes the crd-install annotation from these CRDs to attempt to avoid issues in future.

The only two resource types that *are* required during installation are Certificates and Issuers. I have avoided removing the annotation from *ClusterIssuer* resources for now, as I am unsure exactly how this will behave when users later upgrade (I fear it'll either return AlreadyExists errors, or worse, delete the CRD).

It is safe to remove the annotation from Order and Challenge resources however, because these CRDs are not present in any tagged release (only on master).

**Release note**:
```release-note
NONE
```
