### PR TITLE
Use go_sdk gofmt instead of goimports

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,15 +35,6 @@ load(
 
 gazelle_dependencies()
 
-## Load go tools repo for goimports
-# This the git commit hash **must** be updated when the r
-go_repository(
-    name = "org_golang_x_tools",
-    commit = "156d532d4f67148ceab07c3b59ed7fa13bdbf00c",
-    remote = "https://github.com/golang/tools.git",
-    importpath = "golang.org/x/tools",
-)
-
 ## Load kubernetes repo-infra for tools like kazel
 git_repository(
     name = "io_kubernetes_build",

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -144,7 +144,7 @@ sh_binary(
     name = "update-gofmt",
     srcs = ["update-gofmt.sh"],
     data = [
-        "//hack/bin:goimports",
+        "//hack/bin:gofmt",
     ],
 )
 
@@ -153,7 +153,7 @@ sh_test(
     srcs = ["verify-gofmt.sh"],
     data = [
         "//:all-srcs",
-        "//hack/bin:goimports",
+        "//hack/bin:gofmt",
     ],
 )
 

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -48,9 +48,9 @@ genrule(
 )
 
 genrule(
-    name = "fetch_goimports",
-    srcs = ["@org_golang_x_tools//cmd/goimports"],
-    outs = ["goimports"],
+    name = "fetch_gofmt",
+    srcs = ["@go_sdk//:bin/gofmt"],
+    outs = ["gofmt"],
     cmd = "cp $(SRCS) $@",
     visibility = ["//visibility:public"],
 )

--- a/hack/update-gofmt.sh
+++ b/hack/update-gofmt.sh
@@ -24,5 +24,5 @@ runfiles="$(pwd)"
 export PATH="${runfiles}/hack/bin:${PATH}"
 cd "${REPO_ROOT}"
 
-echo "+++ Running goimports"
-find . -type f -name '*.go' | grep -v 'vendor/' | xargs goimports -w
+echo "+++ Running gofmt"
+find . -type f -name '*.go' | grep -v 'vendor/' | xargs gofmt -s -w

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -36,8 +36,8 @@ mkdir -p "$(dirname ${TMP_DIFFROOT})"
 ln -s "$(pwd)" "${TMP_DIFFROOT}"
 cd "${TMP_DIFFROOT}"
 
-echo "+++ Running goimports"
-output=$(find . -name '*.go' | grep -v 'vendor/' | xargs goimports -d -e)
+echo "+++ Running gofmt"
+output=$(find . -name '*.go' | grep -v 'vendor/' | xargs gofmt -s -d)
 if [ ! -z "${output}" ]; then
     echo "${output}"
     echo "Please run 'bazel run //hack:update-gofmt'"

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -316,7 +316,7 @@ func TestSolverConfigurationForAuthorization(t *testing.T) {
 		expectedErr bool
 	}
 	tests := map[string]testT{
-		"correctly selects normal domain": testT{
+		"correctly selects normal domain": {
 			cfg: []v1alpha1.DomainSolverConfig{
 				{
 					Domains: []string{"example.com"},
@@ -338,7 +338,7 @@ func TestSolverConfigurationForAuthorization(t *testing.T) {
 				},
 			},
 		},
-		"correctly selects normal domain with multiple domains configured": testT{
+		"correctly selects normal domain with multiple domains configured": {
 			cfg: []v1alpha1.DomainSolverConfig{
 				{
 					Domains: []string{"notexample.com", "example.com"},
@@ -360,7 +360,7 @@ func TestSolverConfigurationForAuthorization(t *testing.T) {
 				},
 			},
 		},
-		"correctly selects normal domain with multiple domains configured separately": testT{
+		"correctly selects normal domain with multiple domains configured separately": {
 			cfg: []v1alpha1.DomainSolverConfig{
 				{
 					Domains: []string{"example.com"},
@@ -390,7 +390,7 @@ func TestSolverConfigurationForAuthorization(t *testing.T) {
 				},
 			},
 		},
-		"correctly selects configuration for wildcard domain": testT{
+		"correctly selects configuration for wildcard domain": {
 			cfg: []v1alpha1.DomainSolverConfig{
 				{
 					Domains: []string{"example.com"},
@@ -423,7 +423,7 @@ func TestSolverConfigurationForAuthorization(t *testing.T) {
 				},
 			},
 		},
-		"returns an error when configuration for the domain is not found": testT{
+		"returns an error when configuration for the domain is not found": {
 			cfg: []v1alpha1.DomainSolverConfig{
 				{
 					Domains: []string{"notexample.com"},

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -586,7 +586,7 @@ func TestBuildCertificates(t *testing.T) {
 			},
 			IssuerLister: []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
 			CertificateLister: []*v1alpha1.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "existing-crt",
 						Namespace: "ingress-namespace",
@@ -637,7 +637,7 @@ func TestBuildCertificates(t *testing.T) {
 			IssuerLister:      []*v1alpha1.Issuer{buildACMEIssuer("issuer-name", "ingress-namespace")},
 			CertificateLister: []*v1alpha1.Certificate{buildCertificate("existing-crt", "ingress-namespace")},
 			ExpectedUpdate: []*v1alpha1.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "existing-crt",
 						Namespace: "ingress-namespace",
@@ -716,7 +716,7 @@ func TestBuildCertificates(t *testing.T) {
 				},
 			},
 			ExpectedUpdate: []*v1alpha1.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "existing-crt",
 						Namespace: "ingress-namespace",
@@ -784,7 +784,7 @@ func TestBuildCertificates(t *testing.T) {
 				},
 			},
 			ExpectedUpdate: []*v1alpha1.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "existing-crt",
 						Namespace: "ingress-namespace",

--- a/pkg/util/version_test.go
+++ b/pkg/util/version_test.go
@@ -29,48 +29,48 @@ func TestVersion(t *testing.T) {
 		description     string
 	}
 	tests := []testT{
-		testT{
+		{
 			appVersion:      "canary",
 			expectedVersion: "canary",
 			description:     "canary version with no commit hash and no git state",
 		},
-		testT{
+		{
 			appVersion:      "canary",
 			appGitCommit:    "abc123",
 			expectedVersion: "canary-abc123",
 			description:     "canary version with a commit hash and no git state",
 		},
-		testT{
+		{
 			appVersion:      "canary",
 			appGitState:     "dirty",
 			expectedVersion: "canary (dirty)",
 			description:     "canary version with no commit hash and a git state",
 		},
-		testT{
+		{
 			appVersion:      "canary",
 			appGitCommit:    "abc123",
 			appGitState:     "dirty",
 			expectedVersion: "canary-abc123 (dirty)",
 			description:     "canary version with a commit hash and a git state",
 		},
-		testT{
+		{
 			appVersion:      "v0.3.0",
 			expectedVersion: "v0.3.0",
 			description:     "semver version with no commit hash and no git state",
 		},
-		testT{
+		{
 			appVersion:      "v0.3.0",
 			appGitCommit:    "abc123",
 			expectedVersion: "v0.3.0",
 			description:     "semver version with a commit hash and no git state",
 		},
-		testT{
+		{
 			appVersion:      "v0.3.0",
 			appGitState:     "dirty",
 			expectedVersion: "v0.3.0 (dirty)",
 			description:     "semver version with no commit hash and a git state",
 		},
-		testT{
+		{
 			appVersion:      "v0.3.0",
 			appGitCommit:    "abc123",
 			appGitState:     "dirty",


### PR DESCRIPTION
**What this PR does / why we need it**:

This ensures we are using the correct code format for the Golang version we are using, instead of relying on goimports for this.

**Release note**:
```release-note
NONE
```
