### PR TITLE
Fix invalid secret name used in certificates controller

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -137,7 +137,7 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 		return false, err
 	}
 
-	key, err := kube.SecretTLSKey(c.secretLister, crtCopy.Namespace, crtCopy.Name)
+	key, err := kube.SecretTLSKey(c.secretLister, crtCopy.Namespace, crtCopy.Spec.SecretName)
 	// if we don't have a private key, we need to trigger a re-issue immediately
 	if k8sErrors.IsNotFound(err) || errors.IsInvalidData(err) {
 		return c.issue(ctx, i, crtCopy)


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes a bug that caused an infinite loop when the Certificate and its target secret name are not named identically.

This bug only exists on the master branch of the project, so does not need to be backported.

**Which issue this PR fixes**: fixes #1038

**Release note**:
```release-note
NONE
```
