### PR TITLE
Add Certificate and Issuer unit gen functions

### DIFF
--- a/test/unit/gen/BUILD.bazel
+++ b/test/unit/gen/BUILD.bazel
@@ -3,8 +3,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "certificate.go",
         "challenge.go",
         "doc.go",
+        "issuer.go",
         "objectmeta.go",
     ],
     importpath = "github.com/jetstack/cert-manager/test/unit/gen",

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2018 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+type CertificateModifier func(*v1alpha1.Certificate)
+
+func Certificate(name string, mods ...CertificateModifier) *v1alpha1.Certificate {
+	c := &v1alpha1.Certificate{
+		ObjectMeta: ObjectMeta(name),
+	}
+	for _, mod := range mods {
+		mod(c)
+	}
+	return c
+}
+
+func CertificateFrom(crt *v1alpha1.Certificate, mods ...CertificateModifier) *v1alpha1.Certificate {
+	for _, mod := range mods {
+		mod(crt)
+	}
+	return crt
+}
+
+// SetIssuer sets the Certificate.spec.issuerRef field
+func SetCertificateIssuer(o v1alpha1.ObjectReference) CertificateModifier {
+	return func(c *v1alpha1.Certificate) {
+		c.Spec.IssuerRef = o
+	}
+}
+
+func SetCertificateDNSNames(dnsNames ...string) CertificateModifier {
+	return func(crt *v1alpha1.Certificate) {
+		crt.Spec.DNSNames = dnsNames
+	}
+}
+
+func SetCertificateSecretName(secretName string) CertificateModifier {
+	return func(crt *v1alpha1.Certificate) {
+		crt.Spec.SecretName = secretName
+	}
+}
+
+func SetCertificateLastFailureTime(p metav1.Time) CertificateModifier {
+	return func(crt *v1alpha1.Certificate) {
+		crt.Status.LastFailureTime = &p
+	}
+}

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2018 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+type IssuerModifier func(*v1alpha1.Issuer)
+
+func Issuer(name string, mods ...IssuerModifier) *v1alpha1.Issuer {
+	c := &v1alpha1.Issuer{
+		ObjectMeta: ObjectMeta(name),
+	}
+	for _, mod := range mods {
+		mod(c)
+	}
+	return c
+}
+
+func IssuerFrom(iss *v1alpha1.Issuer, mods ...IssuerModifier) *v1alpha1.Issuer {
+	for _, mod := range mods {
+		mod(iss)
+	}
+	return iss
+}
+
+func SetIssuerACME(a v1alpha1.ACMEIssuer) IssuerModifier {
+	return func(iss *v1alpha1.Issuer) {
+		iss.Spec.ACME = &a
+	}
+}
+
+func SetIssuerCA(a v1alpha1.CAIssuer) IssuerModifier {
+	return func(iss *v1alpha1.Issuer) {
+		iss.Spec.CA = &a
+	}
+}
+
+func SetIssuerSelfSigned(a v1alpha1.SelfSignedIssuer) IssuerModifier {
+	return func(iss *v1alpha1.Issuer) {
+		iss.Spec.SelfSigned = &a
+	}
+}
+
+func AddIssuerCondition(c v1alpha1.IssuerCondition) IssuerModifier {
+	return func(iss *v1alpha1.Issuer) {
+		iss.Status.Conditions = append(iss.Status.Conditions, c)
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to support various other PRs when writing tests that use Certificate and Issuer resources.

**Release note**:
```release-note
NONE
```
