### PR TITLE
Re-enable webhook during e2e tests and fix panic on start

### DIFF
--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/apis/certmanager/validation/webhooks:go_default_library",
-        "//pkg/logs:go_default_library",
         "//vendor/github.com/openshift/generic-admission-server/pkg/cmd:go_default_library",
     ],
 )

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/generic-admission-server/pkg/cmd"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/validation/webhooks"
-	"github.com/jetstack/cert-manager/pkg/logs"
 )
 
 var certHook cmd.ValidatingAdmissionHook = &webhooks.CertificateAdmissionHook{}
@@ -30,9 +29,6 @@ var issuerHook cmd.ValidatingAdmissionHook = &webhooks.IssuerAdmissionHook{}
 var clusterIssuerHook cmd.ValidatingAdmissionHook = &webhooks.ClusterIssuerAdmissionHook{}
 
 func main() {
-	logs.InitLogs()
-	defer logs.FlushLogs()
-
 	// Avoid "logging before flag.Parse" errors from glog
 	flag.CommandLine.Parse([]string{})
 

--- a/test/e2e/framework/helper/pod_start.go
+++ b/test/e2e/framework/helper/pod_start.go
@@ -63,6 +63,10 @@ func (h *Helper) WaitForAllPodsRunningInNamespaceTimeout(ns string, timeout time
 				errs = append(errs, fmt.Sprintf("Pod %q not ready (no Ready condition)", p.Name))
 				continue
 			}
+			if c.Reason == "PodCompleted" {
+				Logf("Pod %q has Completed, assuming it is ready/expected", p.Name)
+				continue
+			}
 			// This pod does not have the ready condition set to True
 			if c.Status != corev1.ConditionTrue {
 				errs = append(errs, fmt.Sprintf("Pod %q not ready: %s", p.Name, c.String()))

--- a/test/fixtures/cert-manager-values.yaml
+++ b/test/fixtures/cert-manager-values.yaml
@@ -19,10 +19,10 @@ extraArgs:
 - --leader-election-retry-period=2s
 
 webhook:
-  # enabled: true
-  # image:
-  #   tag: build
-  #   pullPolicy: Never
+  enabled: true
+  image:
+    tag: build
+    pullPolicy: Never
   resources:
     requests:
       cpu: 10m


### PR DESCRIPTION
**What this PR does / why we need it**:

The webhook was disabled during e2e's when the new framework came in, as we needed to add an explicit wait for pods to become ready before continuing after provisioning an addon.

We now do this as part of the `chart` base addon, so this *should* pass.

This PR also fixes a panic on webhook startup.

**Release note**:
```release-note
NONE
```
