### PR TITLE
Introduce an option to enable/disable DNS01 CNAME delegation

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -176,6 +176,7 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			HTTP01SolverResourceLimitsCPU:     HTTP01SolverResourceLimitsCPU,
 			HTTP01SolverResourceLimitsMemory:  HTTP01SolverResourceLimitsMemory,
 			DNS01Nameservers:                  nameservers,
+			DNS01EnableDelegationViaCNAME:     opts.ACMEDNS01EnableDelegationViaCNAME,
 		},
 		IssuerOptions: controller.IssuerOptions{
 			ClusterIssuerAmbientCredentials: opts.ClusterIssuerAmbientCredentials,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -65,6 +65,8 @@ type ControllerOptions struct {
 
 	// DNS01Nameservers allows specifying a list of custom nameservers to perform DNS checks
 	DNS01Nameservers []string
+	
+	ACMEDNS01EnableDelegationViaCNAME bool
 }
 
 const (
@@ -85,6 +87,8 @@ const (
 	defaultTLSACMEIssuerKind           = "Issuer"
 	defaultACMEIssuerChallengeType     = "http01"
 	defaultACMEIssuerDNS01ProviderName = ""
+	
+	defaultACMEDNS01EnableDelegationViaCNAME = false
 )
 
 var (
@@ -201,6 +205,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&s.DNS01Nameservers, "dns01-self-check-nameservers", []string{}, ""+
 		"A list of comma seperated DNS server endpoints used for DNS01 check requests. "+
 		"This should be a list containing IP address and port, for example: 8.8.8.8:53,8.8.4.4:53")
+	
+	fs.BoolVar(&s.ACMEDNS01EnableDelegationViaCNAME, "acme-dns01-enable-delegation-via-cname", defaultACMEDNS01EnableDelegationViaCNAME, ""+
+		"Whether to enable support for domains that have delegated DNS01 challenges to another zone/provider, using a CNAME record."+
+		"Warning: this feature is not compatible with domains that use a wildcard CNAME record.")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -96,6 +96,9 @@ type ACMEOptions struct {
 	// DNS01Nameservers is a list of nameservers to use when performing self-checks
 	// for ACME DNS01 validations.
 	DNS01Nameservers []string
+
+	// DNS01EnableDelegationViaCNAME enables/disables challenge delegation via CNAME
+	DNS01EnableDelegationViaCNAME bool
 }
 
 type IngressShimOptions struct {

--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -12,20 +12,27 @@ import (
 	"fmt"
 
 	"github.com/miekg/dns"
+
+	"github.com/jetstack/cert-manager/pkg/controller"
 )
 
 // DNS01Record returns a DNS record which will fulfill the `dns-01` challenge
 // TODO: move this into a non-generic place by resolving import cycle in dns package
 func DNS01Record(domain, value string, nameservers []string) (string, string, int, error) {
 	fqdn := fmt.Sprintf("_acme-challenge.%s.", domain)
+	
+	ctx := *controller.Context
 
-	// Check if the domain has CNAME then return that
-	r, err := dnsQuery(fqdn, dns.TypeCNAME, nameservers, true)
-	if err == nil && r.Rcode == dns.RcodeSuccess {
-		fqdn = updateDomainWithCName(r, fqdn)
+	// Check if the domain has CNAME delegation then return that (only if feature is enabled)
+	if ctx.ACMEOptions.DNS01EnableDelegationViaCNAME {
+		r, err := dnsQuery(fqdn, dns.TypeCNAME, nameservers, true)
+		if err == nil && r.Rcode == dns.RcodeSuccess {
+			fqdn = updateDomainWithCName(r, fqdn)
+		}
+		if err != nil {
+			return "", "", 0, err
+		}
 	}
-	if err != nil {
-		return "", "", 0, err
-	}
+
 	return fqdn, value, 60, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**: This introduces an option to enable or disable cert-manager's new logic that checks for DNS01 delegation via a CNAME record. This logic was introduced in #670, but broke support for domains with wildcard CNAMEs.

**Which issue this PR fixes** fixes #837 and fixes #1035 

**Special notes for your reviewer**: I have very little experience working with Go, so I'm not confident this is implemented correctly... Hopefully, it's close enough to get this bug fix rolling.

**Release note**:
```release-note
Add option to enable/disable DNS01 challenge delegation via CNAME, disabled by default (breaking change from v0.5.0, but restores behavior from previous versions)
```
