### PR TITLE
Bump Helm chart version to canary on master

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.0-dev.4
+version: v0.6.0-dev.5
 appVersion: v0.6.0-dev.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -54,8 +54,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.5.0` |
-| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
+| `image.tag` | Image tag | `canary` |
+| `image.pullPolicy` | Image pull policy | `Always` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
@@ -87,8 +87,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.5.0` |
-| `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
+| `webhook.image.tag` | Webhook image tag | `canary` |
+| `webhook.image.pullPolicy` | Webhook image pull policy | `Always` |
 | `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
 | `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |
 | `webhook.caSyncImage.pullPolicy` | CA sync image pull policy | `IfNotPresent` |

--- a/contrib/charts/cert-manager/requirements.lock
+++ b/contrib/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-dev.1
-digest: sha256:1421ac26e93aa7df952ecf1f715f8a903c1269bc2b3e3dde5d8eeaa6f39f3da6
-generated: 2018-11-06T13:50:38.0869452+01:00
+  version: v0.6.0-dev.2
+digest: sha256:9cb73ab613d91f425fedd2cda01a0e55a981059f156c18504db37e99a03f7b7b
+generated: 2018-11-07T19:08:28.452392612Z

--- a/contrib/charts/cert-manager/requirements.yaml
+++ b/contrib/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-dev.1"
+  version: "v0.6.0-dev.2"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -5,8 +5,8 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.5.0
-  pullPolicy: IfNotPresent
+  tag: canary
+  pullPolicy: Always
 
 createCustomResource: true
 

--- a/contrib/charts/cert-manager/webhook/Chart.yaml
+++ b/contrib/charts/cert-manager/webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.6.0-dev.1"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook
-version: "v0.6.0-dev.1"
+version: "v0.6.0-dev.2"

--- a/contrib/charts/cert-manager/webhook/values.yaml
+++ b/contrib/charts/cert-manager/webhook/values.yaml
@@ -12,8 +12,8 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.5.0
-  pullPolicy: IfNotPresent
+  tag: canary
+  pullPolicy: Always
 
 caSyncImage:
   repository: quay.io/munnerz/apiextensions-ca-helper

--- a/contrib/manifests/cert-manager/with-rbac-webhook.yaml
+++ b/contrib/manifests/cert-manager/with-rbac-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 
@@ -23,7 +23,7 @@ metadata:
   name: webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 roleRef:
@@ -48,7 +48,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 rules:
@@ -91,7 +91,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -113,7 +113,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -132,8 +132,8 @@ spec:
       serviceAccountName: webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.5.0"
-          imagePullPolicy: IfNotPresent
+          image: "quay.io/jetstack/cert-manager-webhook:canary"
+          imagePullPolicy: Always
           args:
           - --v=12
           - --secure-port=6443
@@ -171,7 +171,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -213,7 +213,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -252,7 +252,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 data:
@@ -285,7 +285,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 ---
@@ -295,7 +295,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 rules:
@@ -321,7 +321,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 roleRef:
@@ -341,7 +341,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -365,7 +365,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -381,7 +381,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -401,7 +401,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -418,7 +418,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -438,7 +438,7 @@ metadata:
   name: webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 webhooks:

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -53,7 +53,7 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +73,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -93,7 +93,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -111,7 +111,7 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -129,7 +129,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 rules:
@@ -149,7 +149,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -167,7 +167,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -184,7 +184,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -202,7 +202,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -221,8 +221,8 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
-          imagePullPolicy: IfNotPresent
+          image: "quay.io/jetstack/cert-manager-controller:canary"
+          imagePullPolicy: Always
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)

--- a/contrib/manifests/cert-manager/without-rbac-webhook.yaml
+++ b/contrib/manifests/cert-manager/without-rbac-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 
@@ -23,7 +23,7 @@ metadata:
   name: webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 roleRef:
@@ -48,7 +48,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 rules:
@@ -91,7 +91,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -113,7 +113,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -132,8 +132,8 @@ spec:
       serviceAccountName: webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.5.0"
-          imagePullPolicy: IfNotPresent
+          image: "quay.io/jetstack/cert-manager-webhook:canary"
+          imagePullPolicy: Always
           args:
           - --v=12
           - --secure-port=6443
@@ -171,7 +171,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -213,7 +213,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -252,7 +252,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 data:
@@ -285,7 +285,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 ---
@@ -295,7 +295,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 rules:
@@ -321,7 +321,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 roleRef:
@@ -341,7 +341,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -365,7 +365,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -381,7 +381,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -401,7 +401,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -418,7 +418,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 spec:
@@ -438,7 +438,7 @@ metadata:
   name: webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.1
+    chart: webhook-v0.6.0-dev.2
     release: webhook
     heritage: Tiller
 webhooks:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -19,7 +19,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -41,7 +41,7 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -61,7 +61,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -81,7 +81,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -99,7 +99,7 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -118,7 +118,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.4
+    chart: cert-manager-v0.6.0-dev.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -137,8 +137,8 @@ spec:
       serviceAccountName: default
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
-          imagePullPolicy: IfNotPresent
+          image: "quay.io/jetstack/cert-manager-controller:canary"
+          imagePullPolicy: Always
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR bumps the Helm chart to use the canary image tags on the master branch.

We should have done this after release-0.5 was cut, but did not 😬 

**Release note**:
```release-note
NONE
```
