### PR TITLE
Fix GitLab build use of APP_VERSION

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,8 +26,8 @@ master_push:
   script:
   - mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json
   - make verify
-  - APP_VERSION=${CI_BUILD_REF_SLUG}-${CI_PIPELINE_ID} make images_push
-  - APP_VERSION=canary make images_push
+  - make images_push APP_VERSION="${CI_BUILD_REF_SLUG}-${CI_PIPELINE_ID}"
+  - make images_push APP_VERSION="canary"
   only:
   - master
 
@@ -37,6 +37,6 @@ release_push:
   script:
   - mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json
   - make verify
-  - APP_VERSION=${CI_COMMIT_TAG} make images_push DOCKER_TAG="${CI_COMMIT_TAG}"
+  - make images_push APP_VERSION="${CI_COMMIT_TAG}"
   only:
   - tags


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes building/pushing images on GitLab

**Release note**:
```release-note
NONE
```
