### PR TITLE
Fire Events when challenges succeed or fail

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -124,6 +124,7 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 		}
 
 		ch.Status.Presented = true
+		c.Recorder.Eventf(ch, corev1.EventTypeNormal, "Presented", "Presented challenge using %s challenge mechanism", ch.Spec.Type)
 	}
 
 	ok, err := solver.Check(ch)
@@ -203,6 +204,8 @@ func (c *Controller) acceptChallenge(ctx context.Context, cl acmecl.Interface, c
 
 		ch.Status.State = cmapi.State(authErr.Authorization.Status)
 		ch.Status.Reason = fmt.Sprintf("Error accepting authorization: %v", authErr)
+
+		c.Recorder.Eventf(ch, corev1.EventTypeWarning, "Failed", "Accepting challenge authorization failed: %v", authErr)
 
 		// return nil here, as accepting the challenge did not error, the challenge
 		// simply failed


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds some extra event logging when a Challenge succeeds or fails

**Release note**:
```release-note
NONE
```
