### PR TITLE
Use Events API to report validation errors with ingress-shim

### DIFF
--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers/extensions/v1beta1:go_default_library",
@@ -42,8 +43,11 @@ go_test(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned/fake:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
+        "//pkg/controller/test:go_default_library",
+        "//test/unit/gen:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -27,6 +27,7 @@ import (
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/ingress/core/pkg/ingress/annotations/class"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -64,7 +65,32 @@ func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
 		return nil
 	}
 
-	newCrts, updateCrts, err := c.buildCertificates(ing)
+	issuerName, issuerKind := c.issuerForIngress(ing)
+	if issuerName == "" {
+		c.Recorder.Eventf(ing, corev1.EventTypeWarning, "BadConfig", "Issuer name annotation is not set and a default issuer has not been configured")
+		return nil
+	}
+
+	issuer, err := c.getGenericIssuer(ing.Namespace, issuerName, issuerKind)
+	if apierrors.IsNotFound(err) {
+		c.Recorder.Eventf(ing, corev1.EventTypeWarning, "BadConfig", "%s resource %q not found", issuerKind, issuerName)
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	errs := c.validateIngress(ing)
+	if len(errs) > 0 {
+		errMsg := errs[0].Error()
+		if len(errs) > 1 {
+			errMsg = utilerrors.NewAggregate(errs).Error()
+		}
+		c.Recorder.Eventf(ing, corev1.EventTypeWarning, "BadConfig", errMsg)
+		return nil
+	}
+
+	newCrts, updateCrts, err := c.buildCertificates(ing, issuer, issuerKind)
 	if err != nil {
 		return err
 	}
@@ -88,24 +114,37 @@ func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
 	return nil
 }
 
-func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*v1alpha1.Certificate, _ error) {
-	issuerName, issuerKind := c.issuerForIngress(ing)
-	issuer, err := c.getGenericIssuer(ing.Namespace, issuerName, issuerKind)
-	if err != nil {
-		return nil, nil, err
+func (c *Controller) validateIngress(ing *extv1beta1.Ingress) []error {
+	var errs []error
+	if ing.Annotations != nil {
+		challengeType := ing.Annotations[acmeIssuerChallengeTypeAnnotation]
+		switch challengeType {
+		case "", "http01":
+		case "dns01":
+			providerName := ing.Annotations[acmeIssuerDNS01ProviderNameAnnotation]
+			if providerName == "" {
+				errs = append(errs, fmt.Errorf("No acme dns01 challenge provider specified"))
+			}
+		default:
+			errs = append(errs, fmt.Errorf("Invalid acme challenge type specified %q", challengeType))
+		}
 	}
-
-	var newCrts []*v1alpha1.Certificate
-	var updateCrts []*v1alpha1.Certificate
 	for i, tls := range ing.Spec.TLS {
 		// validate the ingress TLS block
 		if len(tls.Hosts) == 0 {
-			return nil, nil, fmt.Errorf("secret %q for ingress %q has no hosts specified", tls.SecretName, ing.Name)
+			errs = append(errs, fmt.Errorf("Secret %q for ingress TLS has no hosts specified", tls.SecretName))
 		}
 		if tls.SecretName == "" {
-			return nil, nil, fmt.Errorf("TLS entry %d for ingress %q must specify a secretName", i, ing.Name)
+			errs = append(errs, fmt.Errorf("TLS entry %d for hosts %v must specify a secretName", i, tls.Hosts))
 		}
+	}
+	return errs
+}
 
+func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.GenericIssuer, issuerKind string) (new, update []*v1alpha1.Certificate, _ error) {
+	var newCrts []*v1alpha1.Certificate
+	var updateCrts []*v1alpha1.Certificate
+	for _, tls := range ing.Spec.TLS {
 		existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(tls.SecretName)
 		if !apierrors.IsNotFound(err) && err != nil {
 			return nil, nil, err
@@ -121,7 +160,7 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*
 				DNSNames:   tls.Hosts,
 				SecretName: tls.SecretName,
 				IssuerRef: v1alpha1.ObjectReference{
-					Name: issuerName,
+					Name: issuer.GetObjectMeta().Name,
 					Kind: issuerKind,
 				},
 			},
@@ -146,7 +185,7 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress) (new, update []*
 
 			updateCrt.Spec.DNSNames = tls.Hosts
 			updateCrt.Spec.SecretName = tls.SecretName
-			updateCrt.Spec.IssuerRef.Name = issuerName
+			updateCrt.Spec.IssuerRef.Name = issuer.GetObjectMeta().Name
 			updateCrt.Spec.IssuerRef.Kind = issuerKind
 			err = c.setIssuerSpecificConfig(updateCrt, issuer, ing, tls)
 			if err != nil {

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -20,7 +20,25 @@ import (
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
-type IssuerModifier func(*v1alpha1.Issuer)
+type IssuerModifier func(v1alpha1.GenericIssuer)
+
+func ClusterIssuer(name string, mods ...IssuerModifier) *v1alpha1.ClusterIssuer {
+	c := &v1alpha1.ClusterIssuer{
+		ObjectMeta: ObjectMeta(name),
+	}
+	c.ObjectMeta.Namespace = ""
+	for _, mod := range mods {
+		mod(c)
+	}
+	return c
+}
+
+func ClusterIssuerFrom(iss *v1alpha1.ClusterIssuer, mods ...IssuerModifier) *v1alpha1.ClusterIssuer {
+	for _, mod := range mods {
+		mod(iss)
+	}
+	return iss
+}
 
 func Issuer(name string, mods ...IssuerModifier) *v1alpha1.Issuer {
 	c := &v1alpha1.Issuer{
@@ -40,25 +58,25 @@ func IssuerFrom(iss *v1alpha1.Issuer, mods ...IssuerModifier) *v1alpha1.Issuer {
 }
 
 func SetIssuerACME(a v1alpha1.ACMEIssuer) IssuerModifier {
-	return func(iss *v1alpha1.Issuer) {
-		iss.Spec.ACME = &a
+	return func(iss v1alpha1.GenericIssuer) {
+		iss.GetSpec().ACME = &a
 	}
 }
 
 func SetIssuerCA(a v1alpha1.CAIssuer) IssuerModifier {
-	return func(iss *v1alpha1.Issuer) {
-		iss.Spec.CA = &a
+	return func(iss v1alpha1.GenericIssuer) {
+		iss.GetSpec().CA = &a
 	}
 }
 
 func SetIssuerSelfSigned(a v1alpha1.SelfSignedIssuer) IssuerModifier {
-	return func(iss *v1alpha1.Issuer) {
-		iss.Spec.SelfSigned = &a
+	return func(iss v1alpha1.GenericIssuer) {
+		iss.GetSpec().SelfSigned = &a
 	}
 }
 
 func AddIssuerCondition(c v1alpha1.IssuerCondition) IssuerModifier {
-	return func(iss *v1alpha1.Issuer) {
-		iss.Status.Conditions = append(iss.Status.Conditions, c)
+	return func(iss v1alpha1.GenericIssuer) {
+		iss.GetStatus().Conditions = append(iss.GetStatus().Conditions, c)
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Reworks ingress-shim so we can print validation errors as Events instead of just logging to stdout.

This also stops us infinitely retrying processing on resources that are invalid.

**Release note**:
```release-note
Validate ingresses marked for processing and report errors using the Events API on Ingress resources
```
