### PR TITLE
acmeorders: instantiate real clock

### DIFF
--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -56,6 +56,7 @@ type Controller struct {
 
 	watchedInformers []cache.InformerSynced
 	queue            workqueue.RateLimitingInterface
+
 	// used for testing
 	clock clock.Clock
 }
@@ -97,6 +98,7 @@ func New(ctx *controllerpkg.Context) *Controller {
 
 	ctrl.helper = controllerpkg.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 	ctrl.acmeHelper = acme.NewHelper(ctrl.secretLister, ctrl.Context.ClusterResourceNamespace)
+	ctrl.clock = clock.RealClock{}
 
 	return ctrl
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We added a fake clock for testing, but never actually instantiated it in our constructor! 🤦‍♂️ 

**Release note**:
```release-note
NONE
```
