### PR TITLE
Bump manifests for v0.5.1

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.5.0
-appVersion: v0.5.0
+version: v0.5.1
+appVersion: v0.5.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -54,7 +54,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.5.0` |
+| `image.tag` | Image tag | `v0.5.1` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `createCustomResource` | Create CRD/TPR with this release | `true` |
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.5.0` |
+| `webhook.image.tag` | Webhook image tag | `v0.5.1` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.5.0
+  tag: v0.5.1
   pullPolicy: IfNotPresent
 
 createCustomResource: true

--- a/contrib/charts/cert-manager/webhook/Chart.yaml
+++ b/contrib/charts/cert-manager/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.5.0"
+appVersion: "v0.5.1"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook
 version: "v0.5.0"

--- a/contrib/charts/cert-manager/webhook/values.yaml
+++ b/contrib/charts/cert-manager/webhook/values.yaml
@@ -12,5 +12,5 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.5.0
+  tag: v0.5.1
   pullPolicy: IfNotPresent

--- a/contrib/manifests/cert-manager/with-rbac-webhook.yaml
+++ b/contrib/manifests/cert-manager/with-rbac-webhook.yaml
@@ -132,7 +132,7 @@ spec:
       serviceAccountName: webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.5.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.5.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -55,7 +55,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -75,7 +75,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -93,7 +93,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -113,7 +113,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -133,7 +133,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -152,7 +152,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.5.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/contrib/manifests/cert-manager/without-rbac-webhook.yaml
+++ b/contrib/manifests/cert-manager/without-rbac-webhook.yaml
@@ -132,7 +132,7 @@ spec:
       serviceAccountName: webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.5.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.5.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -19,7 +19,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -43,7 +43,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -63,7 +63,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -82,7 +82,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.5.0
+    chart: cert-manager-v0.5.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -101,7 +101,7 @@ spec:
       serviceAccountName: default
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.5.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.5.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump deployment manifests for v0.5.1.

**Release note**:
```release-note
NONE
```
