### PR TITLE
Fix bug with ingress path cleanup

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -233,22 +233,29 @@ func (s *Solver) cleanupIngresses(ch *v1alpha1.Challenge) error {
 	ingPathToDel := solverPathFn(ch.Spec.Token)
 	var ingRules []extv1beta1.IngressRule
 	for _, rule := range ing.Spec.Rules {
-		if rule.Host == ch.Spec.DNSName {
-			if rule.HTTP == nil {
-				ingRules = append(ingRules, rule)
-				continue
+		// always retain rules that are not for the same DNSName
+		if rule.Host != ch.Spec.DNSName {
+			ingRules = append(ingRules, rule)
+			continue
+		}
+
+		// always retain rules that don't specify `HTTP`
+		if rule.HTTP == nil {
+			ingRules = append(ingRules, rule)
+			continue
+		}
+
+		// check the rule for paths. If we find the ingress path we need to
+		// delete here, delete it
+		for i, path := range rule.HTTP.Paths {
+			if path.Path == ingPathToDel {
+				rule.HTTP.Paths = append(rule.HTTP.Paths[:i], rule.HTTP.Paths[i+1:]...)
 			}
-			// check the rule for paths. If we find the ingress path we need to
-			// delete here, delete it
-			for i, path := range rule.HTTP.Paths {
-				if path.Path == ingPathToDel {
-					rule.HTTP.Paths = append(rule.HTTP.Paths[:i], rule.HTTP.Paths[i+1:]...)
-				}
-			}
-			// if there are still paths level on this rule, we should retain it
-			if len(rule.HTTP.Paths) > 0 {
-				ingRules = append(ingRules, rule)
-			}
+		}
+
+		// if there are still paths level on this rule, we should retain it
+		if len(rule.HTTP.Paths) > 0 {
+			ingRules = append(ingRules, rule)
 		}
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, cert-manager could clean up paths that it is not meant to clean up during the ACME HTTP01 validation process.

This PR adds a unit test to verify how cert-manager behaves (which previously failed), and changes the cleanupIngress function to make this test pass 🎉 

**Which issue this PR fixes**: fixes #974

**Special notes for your reviewer**:

This may require backporting

**Release note**:
```release-note
Fix bug when cleaning up ingress resources after performing ACME HTTP01 validation
```
