### PR TITLE
chart: allow deployment strategy customization

### DIFF
--- a/contrib/charts/cert-manager/Chart.yaml
+++ b/contrib/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.0-dev.5
+version: v0.6.0-dev.6
 appVersion: v0.6.0-dev.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/contrib/charts/cert-manager/requirements.lock
+++ b/contrib/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-dev.2
-digest: sha256:9cb73ab613d91f425fedd2cda01a0e55a981059f156c18504db37e99a03f7b7b
-generated: 2018-11-07T19:08:28.452392612Z
+  version: v0.6.0-dev.3
+digest: sha256:aad542c4e9f222cf92f04ad45ec36e6a3bae7118f245c2d17491eb8e48b5869c
+generated: 2018-11-21T13:57:00.496510692+01:00

--- a/contrib/charts/cert-manager/requirements.yaml
+++ b/contrib/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-dev.2"
+  version: "v0.6.0-dev.3"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/contrib/charts/cert-manager/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     matchLabels:
       app: {{ template "cert-manager.name" . }}
       release: {{ .Release.Name }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -3,6 +3,12 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 
+strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 0
+  #   maxUnavailable: 1
+
 image:
   repository: quay.io/jetstack/cert-manager-controller
   tag: canary

--- a/contrib/charts/cert-manager/webhook/Chart.yaml
+++ b/contrib/charts/cert-manager/webhook/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "v0.6.0-dev.1"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook
-version: "v0.6.0-dev.2"
+version: "v0.6.0-dev.3"

--- a/contrib/charts/cert-manager/webhook/templates/deployment.yaml
+++ b/contrib/charts/cert-manager/webhook/templates/deployment.yaml
@@ -14,6 +14,10 @@ spec:
     matchLabels:
       app: {{ include "webhook.name" . }}
       release: {{ .Release.Name }}
+  {{- with .Values.strategy }}
+  strategy:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/contrib/charts/cert-manager/webhook/values.yaml
+++ b/contrib/charts/cert-manager/webhook/values.yaml
@@ -1,5 +1,11 @@
 replicaCount: 1
 
+strategy: {}
+  # type: RollingUpdate
+  # rollingUpdate:
+  #   maxSurge: 0
+  #   maxUnavailable: 1
+
 podAnnotations: {}
 
 # Optional additional arguments for webhook

--- a/contrib/manifests/cert-manager/with-rbac-webhook.yaml
+++ b/contrib/manifests/cert-manager/with-rbac-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 
@@ -23,7 +23,7 @@ metadata:
   name: webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 roleRef:
@@ -48,7 +48,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 rules:
@@ -91,7 +91,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -113,7 +113,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -171,7 +171,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -213,7 +213,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -252,7 +252,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 data:
@@ -285,7 +285,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 ---
@@ -295,7 +295,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 rules:
@@ -321,7 +321,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 roleRef:
@@ -341,7 +341,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -365,7 +365,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -381,7 +381,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -401,7 +401,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -418,7 +418,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -438,7 +438,7 @@ metadata:
   name: webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 webhooks:

--- a/contrib/manifests/cert-manager/with-rbac.yaml
+++ b/contrib/manifests/cert-manager/with-rbac.yaml
@@ -18,7 +18,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -53,7 +53,7 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -73,7 +73,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -93,7 +93,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -111,7 +111,7 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -129,7 +129,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 rules:
@@ -149,7 +149,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -167,7 +167,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -184,7 +184,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -202,7 +202,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/contrib/manifests/cert-manager/without-rbac-webhook.yaml
+++ b/contrib/manifests/cert-manager/without-rbac-webhook.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 
@@ -23,7 +23,7 @@ metadata:
   name: webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 roleRef:
@@ -48,7 +48,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 rules:
@@ -91,7 +91,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -113,7 +113,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -171,7 +171,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -213,7 +213,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -252,7 +252,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 data:
@@ -285,7 +285,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 ---
@@ -295,7 +295,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 rules:
@@ -321,7 +321,7 @@ metadata:
   name: webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 roleRef:
@@ -341,7 +341,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -365,7 +365,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -381,7 +381,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -401,7 +401,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -418,7 +418,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 spec:
@@ -438,7 +438,7 @@ metadata:
   name: webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.2
+    chart: webhook-v0.6.0-dev.3
     release: webhook
     heritage: Tiller
 webhooks:

--- a/contrib/manifests/cert-manager/without-rbac.yaml
+++ b/contrib/manifests/cert-manager/without-rbac.yaml
@@ -19,7 +19,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -41,7 +41,7 @@ metadata:
   name: challenges.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -61,7 +61,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -81,7 +81,7 @@ metadata:
     "helm.sh/hook": crd-install
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -99,7 +99,7 @@ metadata:
   name: orders.certmanager.k8s.io
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:
@@ -118,7 +118,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.5
+    chart: cert-manager-v0.6.0-dev.6
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR modifies cert-manager chart to allow customization of deployment strategy. This way one can modify maxSurge and maxUnavailable values.

This could be needed when deploying cert-manager on each master node and setting affinities to forbid two pods on the same node. In this situation, default values of maxSurge (25% round up to next integer = 1) and maxUnavailable (25% round down to next integer = 0) block cert-manager update as the new surge pod can't be scheduled on a master node due to the anti affinities. Setting maxSurge to 0 and maxUnavailable to 1 would solve the problem.