### PR TITLE
Use GinkgoWriter to print Helm install output

### DIFF
--- a/test/e2e/framework/addon/base/base.go
+++ b/test/e2e/framework/addon/base/base.go
@@ -19,10 +19,10 @@ limitations under the License.
 package base
 
 import (
-	"github.com/jetstack/cert-manager/test/e2e/framework/helper"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
+	"github.com/jetstack/cert-manager/test/e2e/framework/helper"
 	"github.com/jetstack/cert-manager/test/e2e/framework/util"
 )
 

--- a/test/e2e/framework/addon/chart/BUILD.bazel
+++ b/test/e2e/framework/addon/chart/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/config:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],

--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 )
 
 // Chart is a generic Helm chart addon for the test environment
@@ -182,8 +183,8 @@ func (c *Chart) buildHelmCmd(args ...string) *exec.Cmd {
 		"--tiller-namespace", c.tillerDetails.Namespace,
 	}, args...)
 	cmd := exec.Command(c.config.Addons.Helm.Path, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = log.Writer
+	cmd.Stderr = log.Writer
 	return cmd
 }
 

--- a/test/e2e/framework/helper/pod_start.go
+++ b/test/e2e/framework/helper/pod_start.go
@@ -20,13 +20,12 @@ import (
 	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo"
-
+	"github.com/onsi/ginkgo"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	. "github.com/jetstack/cert-manager/test/e2e/framework/log"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 )
 
 const (
@@ -44,7 +43,7 @@ func (h *Helper) WaitForAllPodsRunningInNamespace(ns string) error {
 }
 
 func (h *Helper) WaitForAllPodsRunningInNamespaceTimeout(ns string, timeout time.Duration) error {
-	By("Waiting " + timeout.String() + " for all pods in namespace '" + ns + "' to be Ready")
+	ginkgo.By("Waiting " + timeout.String() + " for all pods in namespace '" + ns + "' to be Ready")
 	return wait.PollImmediate(Poll, timeout, func() (bool, error) {
 		pods, err := h.KubeClient.CoreV1().Pods(ns).List(metav1.ListOptions{})
 		if err != nil {
@@ -52,7 +51,7 @@ func (h *Helper) WaitForAllPodsRunningInNamespaceTimeout(ns string, timeout time
 		}
 
 		if len(pods.Items) == 0 {
-			Logf("No pods found in namespace %s - checking again...")
+			log.Logf("No pods found in namespace %s - checking again...")
 			return false, nil
 		}
 
@@ -64,7 +63,7 @@ func (h *Helper) WaitForAllPodsRunningInNamespaceTimeout(ns string, timeout time
 				continue
 			}
 			if c.Reason == "PodCompleted" {
-				Logf("Pod %q has Completed, assuming it is ready/expected", p.Name)
+				log.Logf("Pod %q has Completed, assuming it is ready/expected", p.Name)
 				continue
 			}
 			// This pod does not have the ready condition set to True
@@ -75,7 +74,7 @@ func (h *Helper) WaitForAllPodsRunningInNamespaceTimeout(ns string, timeout time
 
 		if len(errs) > 0 {
 			for _, err := range errs {
-				Logf(err)
+				log.Logf(err)
 			}
 			return false, nil
 		}

--- a/test/e2e/framework/log/log.go
+++ b/test/e2e/framework/log/log.go
@@ -23,12 +23,14 @@ import (
 	"github.com/onsi/ginkgo"
 )
 
+var Writer = ginkgo.GinkgoWriter
+
 func nowStamp() string {
 	return time.Now().Format(time.StampMilli)
 }
 
 func log(level string, format string, args ...interface{}) {
-	fmt.Fprintf(ginkgo.GinkgoWriter, nowStamp()+": "+level+": "+format+"\n", args...)
+	fmt.Fprintf(Writer, nowStamp()+": "+level+": "+format+"\n", args...)
 }
 
 func Logf(format string, args ...interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously Helm install output was always logged - this changes the e2e framework to only print helm output if the test case fails.

**Release note**:
```release-note
NONE
```
