### PR TITLE
Retry dns queries with TCP if UDP has an i/o timeout

### DIFF
--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -144,7 +144,9 @@ func dnsQuery(fqdn string, rtype uint16, nameservers []string, recursive bool) (
 		udp := &dns.Client{Net: "udp", Timeout: DNSTimeout}
 		in, _, err = udp.Exchange(m, ns)
 
-		if err == dns.ErrTruncated {
+		if err == dns.ErrTruncated ||
+			(err != nil && strings.HasPrefix(err.Error(), "read udp") && strings.HasSuffix(err.Error(), "i/o timeout")) {
+			glog.V(6).Infof("UDP dns lookup failed, retrying with TCP: %v", err)
 			tcp := &dns.Client{Net: "tcp", Timeout: DNSTimeout}
 			// If the TCP request succeeds, the err will reset to nil
 			in, _, err = tcp.Exchange(m, ns)


### PR DESCRIPTION
**What this PR does / why we need it**:

This retries dns lookups using TCP if the UDP method times out.

**Which issue this PR fixes** 

fixes #896 

**Release note**:
```release-note
Retry dns queries with TCP if UDP has an i/o timeout.
```