### PR TITLE
Make Certificate Ready condition behaviour consistent between all issuer types

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -140,13 +140,11 @@ type CertificateCondition struct {
 type CertificateConditionType string
 
 const (
-	// CertificateConditionReady represents the fact that a given Certificate condition
-	// is in ready state.
+	// CertificateConditionReady indicates that a certificate is ready for use.
+	// This is defined as:
+	// - The target secret exists
+	// - The target secret contains a certificate that has not expired
+	// - The target secret contains a private key valid for the certificate
+	// - The commonName and dnsNames attributes match those specified on the Certificate
 	CertificateConditionReady CertificateConditionType = "Ready"
-
-	// CertificateConditionValidationFailed is used to indicate whether a
-	// validation for a Certificate has failed.
-	// This is currently used by the ACME issuer to track when the last
-	// validation was attempted.
-	CertificateConditionValidationFailed CertificateConditionType = "ValidateFailed"
 )

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -16,4 +16,60 @@ limitations under the License.
 
 package acmeorders
 
-// no checks for the acme orders controller yet
+import (
+	"fmt"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/util/runtime"
+)
+
+func (c *Controller) handleGenericIssuer(obj interface{}) {
+	iss, ok := obj.(cmapi.GenericIssuer)
+	if !ok {
+		runtime.HandleError(fmt.Errorf("Object does not implement GenericIssuer %#v", obj))
+		return
+	}
+
+	certs, err := c.ordersForGenericIssuer(iss)
+	if err != nil {
+		runtime.HandleError(fmt.Errorf("Error looking up Orders observing Issuer/ClusterIssuer: %s/%s", iss.GetObjectMeta().Namespace, iss.GetObjectMeta().Name))
+		return
+	}
+	for _, crt := range certs {
+		key, err := keyFunc(crt)
+		if err != nil {
+			runtime.HandleError(err)
+			continue
+		}
+		c.queue.Add(key)
+	}
+}
+
+func (c *Controller) ordersForGenericIssuer(iss cmapi.GenericIssuer) ([]*cmapi.Order, error) {
+	orders, err := c.orderLister.List(labels.NewSelector())
+
+	if err != nil {
+		return nil, fmt.Errorf("error listing certificiates: %s", err.Error())
+	}
+
+	_, isClusterIssuer := iss.(*cmapi.ClusterIssuer)
+
+	var affected []*cmapi.Order
+	for _, o := range orders {
+		if isClusterIssuer && o.Spec.IssuerRef.Kind != cmapi.ClusterIssuerKind {
+			continue
+		}
+		if !isClusterIssuer {
+			if o.Namespace != iss.GetObjectMeta().Namespace {
+				continue
+			}
+		}
+		if o.Spec.IssuerRef.Name != iss.GetObjectMeta().Name {
+			continue
+		}
+		affected = append(affected, o)
+	}
+
+	return affected, nil
+}

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -150,6 +150,8 @@ func (c *Controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 			return fmt.Errorf("error finalizing order: %v", err)
 		}
 
+		c.Recorder.Event(o, corev1.EventTypeNormal, "OrderValid", "Order completed successfully")
+
 		return nil
 
 	// if the order is still pending or processing, we should continue to check
@@ -215,7 +217,7 @@ func (c *Controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 		if spec.Wildcard {
 			domainName = "*." + domainName
 		}
-		c.Recorder.Eventf(ch, corev1.EventTypeNormal, "Created", "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
+		c.Recorder.Eventf(o, corev1.EventTypeNormal, "Created", "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
 
 		existingChallenges = append(existingChallenges, ch)
 	}

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -73,10 +73,12 @@ func New(ctx *controllerpkg.Context) *Controller {
 	ctrl.syncedFuncs = append(ctrl.syncedFuncs, certificateInformer.Informer().HasSynced)
 
 	issuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
+	issuerInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleGenericIssuer})
 	ctrl.issuerLister = issuerInformer.Lister()
 	ctrl.syncedFuncs = append(ctrl.syncedFuncs, issuerInformer.Informer().HasSynced)
 
 	clusterIssuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers()
+	clusterIssuerInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleGenericIssuer})
 	ctrl.clusterIssuerLister = clusterIssuerInformer.Lister()
 	ctrl.syncedFuncs = append(ctrl.syncedFuncs, clusterIssuerInformer.Informer().HasSynced)
 

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -18,19 +18,20 @@ package certificates
 
 import (
 	"context"
+	"crypto"
 	"crypto/x509"
 	"fmt"
 	"reflect"
 	"strings"
 	"time"
 
+	"github.com/golang/glog"
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
 
-	"github.com/golang/glog"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/validation"
 	"github.com/jetstack/cert-manager/pkg/issuer"
@@ -82,7 +83,7 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 	}()
 
 	// grab existing certificate and validate private key
-	cert, err := kube.SecretTLSCert(c.secretLister, crtCopy.Namespace, crtCopy.Spec.SecretName)
+	cert, key, err := kube.SecretTLSKeyPair(c.secretLister, crtCopy.Namespace, crtCopy.Spec.SecretName)
 	// if we don't have a certificate, we need to trigger a re-issue immediately
 	if err != nil && !(k8sErrors.IsNotFound(err) || errors.IsInvalidData(err)) {
 		return false, err
@@ -90,7 +91,7 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 
 	// update certificate expiry metric
 	defer c.metrics.UpdateCertificateExpiry(crtCopy, c.secretLister)
-	c.setCertificateStatus(crtCopy, cert)
+	c.setCertificateStatus(crtCopy, key, cert)
 
 	el := validation.ValidateCertificate(crtCopy)
 	if len(el) > 0 {
@@ -129,44 +130,15 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 		return false, nil
 	}
 
-	key, err := kube.SecretTLSKey(c.secretLister, crtCopy.Namespace, crtCopy.Spec.SecretName)
-	// if we don't have a private key, we need to trigger a re-issue immediately
-	if k8sErrors.IsNotFound(err) || errors.IsInvalidData(err) {
-		glog.V(4).Infof("Invoking issue function due to certificate private not found or invalid")
-		return c.issue(ctx, i, crtCopy)
-	}
-	if err != nil {
-		return false, err
-	}
-
-	if cert == nil {
+	if key == nil || cert == nil {
 		glog.V(4).Infof("Invoking issue function as existing certificate does not exist")
 		return c.issue(ctx, i, crtCopy)
 	}
 
 	// begin checking if the TLS certificate is valid/needs a re-issue or renew
-
-	// check if the private key is the corresponding pair to the certificate
-	matches, err := pki.PublicKeyMatchesCertificate(key.Public(), cert)
-	if err != nil {
-		return false, err
-	}
+	matches, matchErrs := c.certificateMatchesSpec(crtCopy, key, cert)
 	if !matches {
-		glog.V(4).Infof("Invoking issue function due to certificate private key not matching certificate")
-		return c.issue(ctx, i, crtCopy)
-	}
-
-	// validate the common name is correct
-	expectedCN := pki.CommonNameForCertificate(crtCopy)
-	if expectedCN != cert.Subject.CommonName {
-		glog.V(4).Infof("Invoking issue function due to certificate common name not matching spec")
-		return c.issue(ctx, i, crtCopy)
-	}
-
-	// validate the dns names are correct
-	expectedDNSNames := pki.DNSNamesForCertificate(crtCopy)
-	if !util.EqualUnsorted(cert.DNSNames, expectedDNSNames) {
-		glog.V(4).Infof("Invoking issue function due to certificate dns names not matching spec")
+		glog.V(4).Infof("Invoking issue function due to certificate not matching spec: %s", strings.Join(matchErrs, ", "))
 		return c.issue(ctx, i, crtCopy)
 	}
 
@@ -176,11 +148,6 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 		glog.V(4).Infof("Invoking issue function due to certificate needing renewal")
 		return c.issue(ctx, i, crtCopy)
 	}
-
-	// TODO: add checks for KeySize, KeyAlgorithm fields
-	// TODO: add checks for Organization field
-	// TODO: add checks for IsCA field
-
 	// end checking if the TLS certificate is valid/needs a re-issue or renew
 
 	// If the Certificate is valid and up to date, we schedule a renewal in
@@ -192,8 +159,8 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 
 // setCertificateStatus will update the status subresource of the certificate.
 // It will not actually submit the resource to the apiserver.
-func (c *Controller) setCertificateStatus(crt *v1alpha1.Certificate, cert *x509.Certificate) {
-	if cert == nil {
+func (c *Controller) setCertificateStatus(crt *v1alpha1.Certificate, key crypto.Signer, cert *x509.Certificate) {
+	if key == nil || cert == nil {
 		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, "NotFound", "Certificate does not exist", false)
 		return
 	}
@@ -202,7 +169,7 @@ func (c *Controller) setCertificateStatus(crt *v1alpha1.Certificate, cert *x509.
 	crt.Status.NotAfter = &metaNotAfter
 
 	// Derive & set 'Ready' condition on Certificate resource
-	matches, matchErrs := c.certificateMatchesSpec(crt, cert)
+	matches, matchErrs := c.certificateMatchesSpec(crt, key, cert)
 	reason := "Ready"
 	if cert.NotAfter.Before(now()) {
 		reason = "Expired"
@@ -221,8 +188,21 @@ func (c *Controller) setCertificateStatus(crt *v1alpha1.Certificate, cert *x509.
 	return
 }
 
-func (c *Controller) certificateMatchesSpec(crt *v1alpha1.Certificate, cert *x509.Certificate) (bool, []string) {
+func (c *Controller) certificateMatchesSpec(crt *v1alpha1.Certificate, key crypto.Signer, cert *x509.Certificate) (bool, []string) {
 	var errs []string
+
+	// TODO: add checks for KeySize, KeyAlgorithm fields
+	// TODO: add checks for Organization field
+	// TODO: add checks for IsCA field
+
+	// check if the private key is the corresponding pair to the certificate
+	matches, err := pki.PublicKeyMatchesCertificate(key.Public(), cert)
+	if err != nil {
+		errs = append(errs, err.Error())
+	} else if !matches {
+		errs = append(errs, fmt.Sprintf("Certificate private key does not match certificate"))
+	}
+
 	// validate the common name is correct
 	expectedCN := pki.CommonNameForCertificate(crt)
 	if expectedCN != cert.Subject.CommonName {

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -115,6 +115,13 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (reque
 		return false, nil
 	}
 
+	// If this is an ACME certificate, ensure the certificate.spec.acme field is
+	// non-nil
+	if issuerObj.GetSpec().ACME != nil && crtCopy.Spec.ACME == nil {
+		c.Recorder.Eventf(crtCopy, corev1.EventTypeWarning, "BadConfig", "spec.acme field must be set")
+		return false, nil
+	}
+
 	issuerReady := issuerObj.HasCondition(v1alpha1.IssuerCondition{
 		Type:   v1alpha1.IssuerConditionReady,
 		Status: v1alpha1.ConditionTrue,

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -158,7 +158,7 @@ func (a *Acme) Issue(ctx context.Context, crt *v1alpha1.Certificate) (issuer.Iss
 		return issuer.IssueResponse{}, nil
 	}
 
-	a.Recorder.Eventf(crt, corev1.EventTypeNormal, "Order %q completed successfully", existingOrder.Name)
+	a.Recorder.Eventf(crt, corev1.EventTypeNormal, "OrderComplete", "Order %q completed successfully", existingOrder.Name)
 
 	// If the order is valid, we can attempt to retrieve the Certificate.
 	// First obtain an ACME client to make this easier.
@@ -316,7 +316,7 @@ func (a *Acme) createNewOrder(crt *v1alpha1.Certificate, template *v1alpha1.Orde
 		return err
 	}
 
-	a.Recorder.Eventf(crt, corev1.EventTypeNormal, "OrderCreated", "Create Order resource %q", o.Name)
+	a.Recorder.Eventf(crt, corev1.EventTypeNormal, "OrderCreated", "Created Order resource %q", o.Name)
 	glog.V(4).Infof("Created new Order resource named %q for Certificate %s/%s", template.Name, crt.Namespace, crt.Name)
 
 	return nil

--- a/pkg/issuer/ca/issue.go
+++ b/pkg/issuer/ca/issue.go
@@ -18,9 +18,9 @@ package ca
 
 import (
 	"context"
-	"crypto/x509"
-	"fmt"
 
+	"github.com/golang/glog"
+	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -50,54 +50,57 @@ func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) (issuer.Issue
 		// if one does not already exist, generate a new one
 		signeeKey, err = pki.GeneratePrivateKeyForCertificate(crt)
 		if err != nil {
-			crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-				reasonErrorPrivateKey, fmt.Sprintf("Error generating private key for certificate: %v", err), false)
-			return issuer.IssueResponse{}, err
+			c.Recorder.Eventf(crt, corev1.EventTypeWarning, "PrivateKeyError", "Error generating certificate private key: %v", err)
+			// don't trigger a retry. An error from this function implies some
+			// invalid input parameters, and retrying without updating the
+			// resource will not help.
+			return issuer.IssueResponse{}, nil
 		}
 	}
 	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-			reasonErrorPrivateKey, fmt.Sprintf("Error getting private key for certificate: %v", err), false)
+		glog.Errorf("Error getting private key %q for certificate: %v", crt.Spec.SecretName, err)
 		return issuer.IssueResponse{}, err
 	}
 
 	// extract the public component of the key
-	publicKey, err := pki.PublicKeyForPrivateKey(signeeKey)
+	signeePublicKey, err := pki.PublicKeyForPrivateKey(signeeKey)
 	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-			reasonErrorPrivateKey, fmt.Sprintf("Error getting public key from private key: %v", err), false)
+		glog.Errorf("Error getting public key from private key: %v", err)
 		return issuer.IssueResponse{}, err
 	}
 
-	// get a copy of the *CA* certificate named on the Issuer
-	caCert, err := kube.SecretTLSCert(c.secretsLister, c.resourceNamespace, c.issuer.GetSpec().CA.SecretName)
+	// get a copy of the CA certificate named on the Issuer
+	caCert, caKey, err := kube.SecretTLSKeyPair(c.secretsLister, c.resourceNamespace, c.issuer.GetSpec().CA.SecretName)
 	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-			reasonErrorCA, fmt.Sprintf("Error getting signing CA: %v", err), false)
+		glog.Errorf("Error getting signing CA for Issuer: %v", err)
 		return issuer.IssueResponse{}, err
 	}
 
-	// actually sign the certificate
-	certPem, err := c.obtainCertificate(crt, publicKey, caCert)
+	// generate a x509 certificate template for this Certificate
+	template, err := pki.GenerateTemplate(c.issuer, crt)
 	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-			reasonErrorSigning, fmt.Sprintf("Error signing certificate: %v", err), false)
+		c.Recorder.Eventf(crt, corev1.EventTypeWarning, "ErrorSigning", "Error signing certificate: %v", err)
+		return issuer.IssueResponse{}, err
+	}
+
+	// sign and encode the certificate
+	certPem, _, err := pki.SignCertificate(template, caCert, signeePublicKey, caKey)
+	if err != nil {
+		c.Recorder.Eventf(crt, corev1.EventTypeWarning, "ErrorSigning", "Error signing certificate: %v", err)
 		return issuer.IssueResponse{}, err
 	}
 
 	// Encode output private key and CA cert ready for return
 	keyPem, err := pki.EncodePrivateKey(signeeKey)
 	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-			reasonErrorPrivateKey, fmt.Sprintf("Error encoding certificate private key: %v", err), false)
+		c.Recorder.Eventf(crt, corev1.EventTypeWarning, "ErrorPrivateKey", "Error encoding private key: %v", err)
 		return issuer.IssueResponse{}, err
 	}
 
 	// encode the CA certificate to be bundled in the output
 	caPem, err := pki.EncodeX509(caCert)
 	if err != nil {
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse,
-			reasonErrorSigning, fmt.Sprintf("Error encoding certificate: %v", err), false)
+		c.Recorder.Eventf(crt, corev1.EventTypeWarning, "ErrorSigning", "Error encoding certificate: %v", err)
 		return issuer.IssueResponse{}, err
 	}
 
@@ -106,32 +109,4 @@ func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) (issuer.Issue
 		Certificate: certPem,
 		CA:          caPem,
 	}, nil
-}
-
-func (c *CA) obtainCertificate(crt *v1alpha1.Certificate, signeeKey interface{}, signerCert *x509.Certificate) ([]byte, error) {
-	commonName := crt.Spec.CommonName
-	altNames := crt.Spec.DNSNames
-	if len(commonName) == 0 && len(altNames) == 0 {
-		return nil, fmt.Errorf("no domains specified on certificate")
-	}
-
-	// get a copy of the CAs private key
-	signerKey, err := kube.SecretTLSKey(c.secretsLister, c.resourceNamespace, c.issuer.GetSpec().CA.SecretName)
-	if err != nil {
-		return nil, fmt.Errorf("error getting issuer private key: %s", err.Error())
-	}
-
-	// generate a x509 certificate template for this Certificate
-	template, err := pki.GenerateTemplate(c.issuer, crt)
-	if err != nil {
-		return nil, err
-	}
-
-	// sign and encode the certificate
-	crtPem, _, err := pki.SignCertificate(template, signerCert, signeeKey, signerKey)
-	if err != nil {
-		return nil, err
-	}
-
-	return crtPem, nil
 }

--- a/pkg/issuer/selfsigned/BUILD.bazel
+++ b/pkg/issuer/selfsigned/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
         "//pkg/util/errors:go_default_library",
         "//pkg/util/kube:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
     ],

--- a/pkg/issuer/vault/BUILD.bazel
+++ b/pkg/issuer/vault/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/hashicorp/vault/api:go_default_library",
         "//vendor/github.com/hashicorp/vault/helper/certutil:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
     ],

--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -82,7 +82,7 @@ func SecretTLSKeyPair(secretLister corelisters.SecretLister, namespace, name str
 
 	keyBytes, ok := secret.Data[api.TLSPrivateKeyKey]
 	if !ok {
-		return nil, nil, fmt.Errorf("no private key data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+		return nil, nil, errors.NewInvalidData("no private key data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
 	}
 	key, err := pki.DecodePrivateKeyBytes(keyBytes)
 	if err != nil {
@@ -91,7 +91,7 @@ func SecretTLSKeyPair(secretLister corelisters.SecretLister, namespace, name str
 
 	certBytes, ok := secret.Data[api.TLSCertKey]
 	if !ok {
-		return nil, key, fmt.Errorf("no certificate data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+		return nil, key, errors.NewInvalidData("no certificate data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
 	}
 	cert, err := pki.DecodeX509CertificateBytes(certBytes)
 	if err != nil {

--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -73,3 +73,30 @@ func SecretTLSCert(secretLister corelisters.SecretLister, namespace, name string
 
 	return cert, nil
 }
+
+func SecretTLSKeyPair(secretLister corelisters.SecretLister, namespace, name string) (*x509.Certificate, crypto.Signer, error) {
+	secret, err := secretLister.Secrets(namespace).Get(name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	certBytes, ok := secret.Data[api.TLSCertKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("no certificate data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+	}
+	cert, err := pki.DecodeX509CertificateBytes(certBytes)
+	if err != nil {
+		return nil, nil, errors.NewInvalidData(err.Error())
+	}
+
+	keyBytes, ok := secret.Data[api.TLSPrivateKeyKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("no private key data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+	}
+	key, err := pki.DecodePrivateKeyBytes(keyBytes)
+	if err != nil {
+		return nil, key, errors.NewInvalidData(err.Error())
+	}
+
+	return cert, key, nil
+}

--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -80,20 +80,20 @@ func SecretTLSKeyPair(secretLister corelisters.SecretLister, namespace, name str
 		return nil, nil, err
 	}
 
-	certBytes, ok := secret.Data[api.TLSCertKey]
-	if !ok {
-		return nil, nil, fmt.Errorf("no certificate data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
-	}
-	cert, err := pki.DecodeX509CertificateBytes(certBytes)
-	if err != nil {
-		return nil, nil, errors.NewInvalidData(err.Error())
-	}
-
 	keyBytes, ok := secret.Data[api.TLSPrivateKeyKey]
 	if !ok {
 		return nil, nil, fmt.Errorf("no private key data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
 	}
 	key, err := pki.DecodePrivateKeyBytes(keyBytes)
+	if err != nil {
+		return nil, nil, errors.NewInvalidData(err.Error())
+	}
+
+	certBytes, ok := secret.Data[api.TLSCertKey]
+	if !ok {
+		return nil, key, fmt.Errorf("no certificate data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+	}
+	cert, err := pki.DecodeX509CertificateBytes(certBytes)
 	if err != nil {
 		return nil, key, errors.NewInvalidData(err.Error())
 	}

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -142,7 +142,6 @@ func GenerateTemplate(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate) 
 	}
 
 	pubKeyAlgo, _, err := SignatureAlgorithm(crt)
-
 	if err != nil {
 		return nil, err
 	}
@@ -176,7 +175,7 @@ func GenerateTemplate(issuer v1alpha1.GenericIssuer, crt *v1alpha1.Certificate) 
 // key of the signer.
 // It returns a PEM encoded copy of the Certificate as well as a *x509.Certificate
 // which can be used for reading the encoded values.
-func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, publicKey interface{}, signerKey interface{}) ([]byte, *x509.Certificate, error) {
+func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, publicKey crypto.PublicKey, signerKey interface{}) ([]byte, *x509.Certificate, error) {
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, issuerCert, publicKey, signerKey)
 
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates how we use the Ready condition on certificates to be stricter, as well as uniform across all different issuer types.

This has required changing where most issuers log information about failed issuance to use Events instead of overloading the Ready condition

**Which issue this PR fixes**: fixes #742

**Special notes for your reviewer**:

I imagine a number of e2e tests are going to need updating to make this mergeable 😄 

**Release note**:
```release-note
Use the Ready status condition in a consistent manner between issuer types
```

/cc @mikebryant @kragniz 