### PR TITLE
Fix potential race in e2e duration checking

### DIFF
--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -119,8 +119,8 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")
 			err = util.WaitCertificateIssuedValid(certClient, secretClient, certificateName, time.Second*30)
-			f.CertificateDurationValid(cert, v.expectedDuration)
 			Expect(err).NotTo(HaveOccurred())
+			f.CertificateDurationValid(cert, v.expectedDuration)
 		})
 	}
 

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -101,8 +101,8 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 			cert, err := certClient.Create(util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerDurationName, v1alpha1.IssuerKind, v.inputDuration, v.inputRenewBefore))
 			Expect(err).NotTo(HaveOccurred())
 			err = util.WaitCertificateIssuedValid(certClient, secretClient, certificateName, time.Second*30)
-			f.CertificateDurationValid(cert, v.expectedDuration)
 			Expect(err).NotTo(HaveOccurred())
+			f.CertificateDurationValid(cert, v.expectedDuration)
 		})
 	}
 })

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -177,10 +177,10 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole)", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			err = util.WaitCertificateIssuedValid(certClient, secretClient, certificateName, time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Vault substract 30 seconds to the NotBefore date.
 			f.CertificateDurationValid(cert, v.expectedDuration+(30*time.Second))
-			Expect(err).NotTo(HaveOccurred())
 		})
 	}
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

In e2e tests, check the certificate duration **after** verifying the certificate is issued

**Special notes for your reviewer**:

This should help cut down on some test flakes with the CA issuer I think.

**Release note**:
```release-note
NONE
```
