### PR TITLE
Include wildcard field in comparison of challenge specs

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -182,10 +182,13 @@ func (c *Controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 	// therefore, if there is a cache timing issue, the Create will fail as the
 	// challenge with that name will already exist.
 	specsToCreate := make(map[int]cmapi.ChallengeSpec)
+	// TODO: we could potentially parse the challenge's name to find the index
+	// expected here instead of iterating over both lists
 	for i, s := range o.Status.Challenges {
 		create := true
 		for _, ch := range existingChallenges {
-			if s.DNSName == ch.Spec.DNSName {
+			if s.Wildcard == ch.Spec.Wildcard &&
+				s.DNSName == ch.Spec.DNSName {
 				create = false
 				break
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we could get into a situation where we 'miss' a challenge resource for an order if that order has *.example.com and example.com named on the same certificate.

This PR includes the 'Wildcard' field in the comparison that dictates whether to create a new challenge resource or not.

**Release note**:
```release-note
NONE
```
