### PR TITLE
Only add resources to the rate limited queue when an error occurs

### DIFF
--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -45,7 +45,7 @@ func (q *QueuingEventHandler) Enqueue(obj interface{}) {
 		runtime.HandleError(err)
 		return
 	}
-	q.Queue.AddRateLimited(key)
+	q.Queue.Add(key)
 }
 
 func (q *QueuingEventHandler) OnAdd(obj interface{}) {


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes our event handler to no longer use the AddRateLimited method when the resource is updated.

This is in-line with other Kubernetes controllers, and with how it is currently structures only serves to delay the first call of the Sync function by 5s.

**Release note**:
```release-note
NONE
```
