### PR TITLE
Remove requeue option and fix small race in controllers

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -141,30 +141,25 @@ func (c *Controller) worker(stopCh <-chan struct{}) {
 		}
 
 		var key string
-		err := func(obj interface{}) error {
+		// use an inlined function so we can use defer
+		func() {
 			defer c.queue.Done(obj)
 			var ok bool
 			if key, ok = obj.(string); !ok {
-				return nil
+				return
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			ctx = util.ContextWithStopCh(ctx, stopCh)
 			glog.Infof("%s controller: syncing item '%s'", ControllerName, key)
 			if err := c.syncHandler(ctx, key); err != nil {
-				return err
+				glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
+				c.queue.AddRateLimited(obj)
+				return
 			}
+			glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
 			c.queue.Forget(obj)
-			return nil
-		}(obj)
-
-		if err != nil {
-			glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
-			c.queue.AddRateLimited(obj)
-			continue
-		}
-
-		glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
+		}()
 	}
 	glog.V(4).Infof("Exiting %q worker loop", ControllerName)
 }

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -168,30 +168,25 @@ func (c *Controller) worker(stopCh <-chan struct{}) {
 		}
 
 		var key string
-		err := func(obj interface{}) error {
+		// use an inlined function so we can use defer
+		func() {
 			defer c.queue.Done(obj)
 			var ok bool
 			if key, ok = obj.(string); !ok {
-				return nil
+				return
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			ctx = util.ContextWithStopCh(ctx, stopCh)
 			glog.Infof("%s controller: syncing item '%s'", ControllerName, key)
 			if err := c.syncHandler(ctx, key); err != nil {
-				return err
+				glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
+				c.queue.AddRateLimited(obj)
+				return
 			}
+			glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
 			c.queue.Forget(obj)
-			return nil
-		}(obj)
-
-		if err != nil {
-			glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
-			c.queue.AddRateLimited(obj)
-			continue
-		}
-
-		glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
+		}()
 	}
 	glog.V(4).Infof("Exiting %q worker loop", ControllerName)
 }

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -36,7 +36,7 @@ const (
 	messageErrorInitIssuer = "Error initializing issuer: "
 )
 
-func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.ClusterIssuer) (requeue bool, err error) {
+func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.ClusterIssuer) (err error) {
 	issuerCopy := iss.DeepCopy()
 	defer func() {
 		if _, saveErr := c.updateIssuerStatus(iss, issuerCopy); saveErr != nil {
@@ -62,18 +62,18 @@ func (c *Controller) Sync(ctx context.Context, iss *v1alpha1.ClusterIssuer) (req
 
 	i, err := c.IssuerFactory().IssuerFor(issuerCopy)
 	if err != nil {
-		return false, err
+		return err
 	}
 
-	resp, err := i.Setup(ctx)
+	err = i.Setup(ctx)
 	if err != nil {
 		s := messageErrorInitIssuer + err.Error()
 		glog.Info(s)
 		c.Recorder.Event(issuerCopy, v1.EventTypeWarning, errorInitIssuer, s)
-		return false, err
+		return err
 	}
 
-	return resp.Requeue, nil
+	return nil
 }
 
 func (c *Controller) updateIssuerStatus(old, new *v1alpha1.ClusterIssuer) (*v1alpha1.ClusterIssuer, error) {

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -157,30 +157,25 @@ func (c *Controller) worker(stopCh <-chan struct{}) {
 		}
 
 		var key string
-		err := func(obj interface{}) error {
+		// use an inlined function so we can use defer
+		func() {
 			defer c.queue.Done(obj)
 			var ok bool
 			if key, ok = obj.(string); !ok {
-				return nil
+				return
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			ctx = util.ContextWithStopCh(ctx, stopCh)
 			glog.Infof("%s controller: syncing item '%s'", ControllerName, key)
 			if err := c.syncHandler(ctx, key); err != nil {
-				return err
+				glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
+				c.queue.AddRateLimited(obj)
+				return
 			}
+			glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
 			c.queue.Forget(obj)
-			return nil
-		}(obj)
-
-		if err != nil {
-			glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
-			c.queue.AddRateLimited(obj)
-			continue
-		}
-
-		glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
+		}()
 	}
 	glog.V(4).Infof("Exiting %q worker loop", ControllerName)
 }

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -40,7 +40,7 @@ type Controller struct {
 	*controllerpkg.Context
 
 	// To allow injection for testing.
-	syncHandler func(ctx context.Context, key string) (bool, error)
+	syncHandler func(ctx context.Context, key string) error
 
 	issuerLister cmlisters.IssuerLister
 	secretLister corelisters.SecretLister
@@ -129,43 +129,34 @@ func (c *Controller) worker(stopCh <-chan struct{}) {
 		}
 
 		var key string
-		forceAdd, err := func(obj interface{}) (bool, error) {
+		// use an inlined function so we can use defer
+		func() {
 			defer c.queue.Done(obj)
 			var ok bool
 			if key, ok = obj.(string); !ok {
-				return false, nil
+				return
 			}
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 			ctx = util.ContextWithStopCh(ctx, stopCh)
 			glog.Infof("%s controller: syncing item '%s'", ControllerName, key)
-			forceAdd, err := c.syncHandler(ctx, key)
-			if err == nil {
-				c.queue.Forget(obj)
+			if err := c.syncHandler(ctx, key); err != nil {
+				glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
+				c.queue.AddRateLimited(obj)
+				return
 			}
-			return forceAdd, err
-		}(obj)
-
-		if err != nil {
-			glog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
-			c.queue.AddRateLimited(obj)
-			continue
-		}
-
-		if forceAdd {
-			c.queue.Add(obj)
-		}
-
-		glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
+			glog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
+			c.queue.Forget(obj)
+		}()
 	}
 	glog.V(4).Infof("Exiting %q worker loop", ControllerName)
 }
 
-func (c *Controller) processNextWorkItem(ctx context.Context, key string) (bool, error) {
+func (c *Controller) processNextWorkItem(ctx context.Context, key string) error {
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		runtime.HandleError(fmt.Errorf("invalid resource key: %s", key))
-		return false, nil
+		return nil
 	}
 
 	issuer, err := c.issuerLister.Issuers(namespace).Get(name)
@@ -173,10 +164,10 @@ func (c *Controller) processNextWorkItem(ctx context.Context, key string) (bool,
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			runtime.HandleError(fmt.Errorf("issuer '%s' in work queue no longer exists", key))
-			return false, nil
+			return nil
 		}
 
-		return false, err
+		return err
 	}
 
 	return c.Sync(ctx, issuer)

--- a/pkg/issuer/acme/issue_test.go
+++ b/pkg/issuer/acme/issue_test.go
@@ -162,9 +162,6 @@ func TestIssueHappyPath(t *testing.T) {
 				if resp.PrivateKey == nil {
 					t.Errorf("expected new private key to be generated")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 			},
 			Err: false,
 		},
@@ -194,9 +191,6 @@ func TestIssueHappyPath(t *testing.T) {
 				if resp.PrivateKey != nil {
 					t.Errorf("unexpected PrivateKey response set")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -218,9 +212,6 @@ func TestIssueHappyPath(t *testing.T) {
 
 				if resp.PrivateKey != nil {
 					t.Errorf("unexpected PrivateKey response set")
-				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
 				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
@@ -247,9 +238,6 @@ func TestIssueHappyPath(t *testing.T) {
 				resp := args[1].(issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -296,9 +284,6 @@ func TestIssueHappyPath(t *testing.T) {
 				if resp.PrivateKey != nil {
 					t.Errorf("unexpected private key data")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -320,15 +305,6 @@ func TestIssueHappyPath(t *testing.T) {
 			}
 			if err == nil && test.Err {
 				t.Errorf("Expected function to get an error, but got: %v", err)
-			}
-			if resp.Requeue == true {
-				if !reflect.DeepEqual(test.Certificate, certCopy) {
-					t.Errorf("Requeue should never be true if the Certificate is modified to prevent race conditions")
-				}
-
-				if err != nil {
-					t.Errorf("Requeue cannot be true if err is true")
-				}
 			}
 			test.Finish(t, certCopy, resp, err)
 		})
@@ -451,9 +427,6 @@ func TestIssueRetryCases(t *testing.T) {
 				if resp.Certificate != nil {
 					t.Errorf("unexpected Certificate response set")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
@@ -485,9 +458,6 @@ func TestIssueRetryCases(t *testing.T) {
 				}
 				if resp.Certificate != nil {
 					t.Errorf("unexpected Certificate response set")
-				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
 				}
 				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
@@ -521,9 +491,6 @@ func TestIssueRetryCases(t *testing.T) {
 				if resp.Certificate != nil {
 					t.Errorf("unexpected Certificate response set")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
@@ -556,9 +523,6 @@ func TestIssueRetryCases(t *testing.T) {
 				if resp.Certificate != nil {
 					t.Errorf("unexpected Certificate response set")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be requeued")
-				}
 				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
@@ -586,9 +550,6 @@ func TestIssueRetryCases(t *testing.T) {
 				}
 				if resp.Certificate != nil {
 					t.Errorf("unexpected Certificate response set")
-				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be immediately requeued")
 				}
 				// the resource should not be changed
 				if !reflect.DeepEqual(returnedCert, recentlyFailedCertificate) {
@@ -618,9 +579,6 @@ func TestIssueRetryCases(t *testing.T) {
 				if resp.Certificate != nil {
 					t.Errorf("unexpected Certificate response set")
 				}
-				if resp.Requeue == true {
-					t.Errorf("expected certificate to not be immediately requeued")
-				}
 				// the resource should have the last failure time set
 				if !reflect.DeepEqual(returnedCert, recentlyFailedCertificate) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, recentlyFailedCertificate))
@@ -645,15 +603,6 @@ func TestIssueRetryCases(t *testing.T) {
 			}
 			if err == nil && test.Err {
 				t.Errorf("Expected function to get an error, but got: %v", err)
-			}
-			if resp.Requeue == true {
-				if !reflect.DeepEqual(test.Certificate, certCopy) {
-					t.Errorf("Requeue should never be true if the Certificate is modified to prevent race conditions")
-				}
-
-				if err != nil {
-					t.Errorf("Requeue cannot be true if err is true")
-				}
 			}
 			test.Finish(t, certCopy, resp, err)
 		})

--- a/pkg/issuer/ca/issue_test.go
+++ b/pkg/issuer/ca/issue_test.go
@@ -93,9 +93,6 @@ func allFieldsSetCheck(expectedCA []byte) func(t *testing.T, s *caFixture, args 
 		if resp.CA == nil || !reflect.DeepEqual(expectedCA, resp.CA) {
 			t.Errorf("expected CA certificate to be returned")
 		}
-		if resp.Requeue == true {
-			t.Errorf("expected certificate to not be requeued")
-		}
 	}
 }
 
@@ -212,15 +209,7 @@ func TestIssue(t *testing.T) {
 			if err == nil && test.Err {
 				t.Errorf("Expected function to get an error, but got: %v", err)
 			}
-			if resp.Requeue == true {
-				if !reflect.DeepEqual(test.Certificate, certCopy) {
-					t.Errorf("Requeue should never be true if the Certificate is modified to prevent race conditions")
-				}
 
-				if err != nil {
-					t.Errorf("Requeue cannot be true if err is true")
-				}
-			}
 			test.Finish(t, certCopy, resp, err)
 		})
 	}

--- a/pkg/issuer/issuer.go
+++ b/pkg/issuer/issuer.go
@@ -26,7 +26,7 @@ type Interface interface {
 	// Setup initialises the issuer. This may include registering accounts with
 	// a service, creating a CA and storing it somewhere, or verifying
 	// credentials and authorization with a remote server.
-	Setup(ctx context.Context) (SetupResponse, error)
+	Setup(ctx context.Context) error
 
 	// Issue attempts to issue a certificate as described by the certificate
 	// resource given
@@ -34,10 +34,6 @@ type Interface interface {
 }
 
 type IssueResponse struct {
-	// If Requeue is true, the Certificate will be requeued for processing
-	// after applying the controllers rate limit.
-	Requeue bool
-
 	// Certificate is the certificate resource that should be stored in the
 	// target secret.
 	// It will only be set if the corresponding private key is also set on the
@@ -54,10 +50,4 @@ type IssueResponse struct {
 	// This field should only be set if the private key field is set, similar
 	// to the Certificate field.
 	CA []byte
-}
-
-type SetupResponse struct {
-	// If Requeue is true, the Certificate will be requeued for processing
-	// after applying the controllers rate limit.
-	Requeue bool
 }

--- a/pkg/issuer/selfsigned/setup.go
+++ b/pkg/issuer/selfsigned/setup.go
@@ -20,14 +20,13 @@ import (
 	"context"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack/cert-manager/pkg/issuer"
 )
 
 const (
 	successReady = "IsReady"
 )
 
-func (c *SelfSigned) Setup(ctx context.Context) (issuer.SetupResponse, error) {
+func (c *SelfSigned) Setup(ctx context.Context) error {
 	c.issuer.UpdateStatusCondition(v1alpha1.IssuerConditionReady, v1alpha1.ConditionTrue, successReady, "")
-	return issuer.SetupResponse{}, nil
+	return nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

We don't actually ever utilise the Requeue option, so I've removed it altogether.

This also updates the way items in the workqueue have Done and Forget called on them to avoid a potential race.

**Release note**:
```release-note
NONE
```
