### PR TITLE
Don't update Certificate status condition upon issuance

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -55,12 +55,6 @@ const (
 	successCertificateRenewed = "CertRenewed"
 
 	messageErrorSavingCertificate = "Error saving TLS certificate: "
-
-	messageIssuingCertificate  = "Issuing certificate..."
-	messageRenewingCertificate = "Renewing certificate..."
-
-	messageCertificateIssued  = "Certificate issued successfully"
-	messageCertificateRenewed = "Certificate renewed successfully"
 )
 
 const (
@@ -365,11 +359,7 @@ func (c *Controller) issue(ctx context.Context, issuer issuer.Interface, crt *v1
 	}
 
 	if len(resp.Certificate) > 0 {
-		s := messageCertificateIssued
-		glog.Info(s)
-		c.Recorder.Event(crt, corev1.EventTypeNormal, successCertificateIssued, s)
-		crt.UpdateStatusCondition(v1alpha1.CertificateConditionReady, v1alpha1.ConditionTrue, successCertificateIssued, s, true)
-
+		c.Recorder.Event(crt, corev1.EventTypeNormal, successCertificateIssued, "Certificate issued successfully")
 		// as we have just written a certificate, we should schedule it for renewal
 		c.scheduleRenewal(crt)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

We've recently changed what the Ready condition means to be a reflection of the actual x509 certificate status.

This should have been removed as part of that PR, as we now use events to log this kind of 'event' occurring.

**Release note**:
```release-note
NONE
```
