### PR TITLE
Switch issuer.Issue to return a pointer and fix up setting secret fields

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -299,33 +299,33 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 			Data: map[string][]byte{},
 		}
 	}
+
 	secret.Data[corev1.TLSCertKey] = cert
 	secret.Data[corev1.TLSPrivateKeyKey] = key
-
-	if ca != nil {
-		secret.Data[TLSCAKey] = ca
-	}
+	secret.Data[TLSCAKey] = ca
 
 	if secret.Annotations == nil {
 		secret.Annotations = make(map[string]string)
 	}
 
-	// Note: since this sets annotations based on certificate resource, incorrect
-	// annotations will be set if resource and actual certificate somehow get out
-	// of sync
-	dnsNames := pki.DNSNamesForCertificate(crt)
-	cn := pki.CommonNameForCertificate(crt)
+	// If we are updating the Certificate, we update the secret metadata to
+	// reflect the actual certificate it contains
+	if cert != nil {
+		x509Cert, err := pki.DecodeX509CertificateBytes(cert)
+		if err != nil {
+			return nil, fmt.Errorf("invalid certificate data: %v", err)
+		}
 
-	secret.Annotations[v1alpha1.AltNamesAnnotationKey] = strings.Join(dnsNames, ",")
-	secret.Annotations[v1alpha1.CommonNameAnnotationKey] = cn
+		secret.Annotations[v1alpha1.IssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
+		secret.Annotations[v1alpha1.IssuerKindAnnotationKey] = issuerKind(crt)
+		secret.Annotations[v1alpha1.CommonNameAnnotationKey] = x509Cert.Subject.CommonName
+		secret.Annotations[v1alpha1.AltNamesAnnotationKey] = strings.Join(x509Cert.DNSNames, ",")
+	}
 
-	secret.Annotations[v1alpha1.IssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
-	secret.Annotations[v1alpha1.IssuerKindAnnotationKey] = issuerKind(crt)
-
+	// Always set the certificate name label on the target secret
 	if secret.Labels == nil {
 		secret.Labels = make(map[string]string)
 	}
-
 	secret.Labels[v1alpha1.CertificateNameKey] = crt.Name
 
 	// if it is a new resource
@@ -353,7 +353,7 @@ func (c *Controller) issue(ctx context.Context, issuer issuer.Interface, crt *v1
 		return err
 	}
 
-	if resp.PrivateKey == nil {
+	if resp == nil {
 		return nil
 	}
 

--- a/pkg/issuer/acme/issue_test.go
+++ b/pkg/issuer/acme/issue_test.go
@@ -157,7 +157,7 @@ func TestIssueHappyPath(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				// returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
 				if resp.PrivateKey == nil {
@@ -186,11 +186,11 @@ func TestIssueHappyPath(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
@@ -208,11 +208,11 @@ func TestIssueHappyPath(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
@@ -231,7 +231,7 @@ func TestIssueHappyPath(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
 				if !reflect.DeepEqual(returnedCert, testCert) {
@@ -266,14 +266,11 @@ func TestIssueHappyPath(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.Certificate != nil {
-					t.Errorf("unexpected certificate data")
-				}
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected private key data")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("output was not as expected: %s", pretty.Diff(returnedCert, testCert))
@@ -409,16 +406,12 @@ func TestIssueRetryCases(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
-				if resp.Certificate != nil {
-					t.Errorf("unexpected Certificate response set")
-				}
-				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -441,16 +434,12 @@ func TestIssueRetryCases(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
-				if resp.Certificate != nil {
-					t.Errorf("unexpected Certificate response set")
-				}
-				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -473,16 +462,12 @@ func TestIssueRetryCases(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
-				if resp.Certificate != nil {
-					t.Errorf("unexpected Certificate response set")
-				}
-				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -505,16 +490,12 @@ func TestIssueRetryCases(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
-				if resp.Certificate != nil {
-					t.Errorf("unexpected Certificate response set")
-				}
-				// the orderRef field should be set to nil
 				if !reflect.DeepEqual(returnedCert, testCert) {
 					t.Errorf("expected certificate order ref to be nil: %s", pretty.Diff(returnedCert, testCert))
 				}
@@ -533,14 +514,11 @@ func TestIssueRetryCases(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
-				}
-				if resp.Certificate != nil {
-					t.Errorf("unexpected Certificate response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
 				// the resource should not be changed
 				if !reflect.DeepEqual(returnedCert, recentlyFailedCertificate) {
@@ -561,14 +539,11 @@ func TestIssueRetryCases(t *testing.T) {
 			},
 			CheckFn: func(t *testing.T, s *acmeFixture, args ...interface{}) {
 				returnedCert := args[0].(*v1alpha1.Certificate)
-				resp := args[1].(issuer.IssueResponse)
+				resp := args[1].(*issuer.IssueResponse)
 				// err := args[2].(error)
 
-				if resp.PrivateKey != nil {
-					t.Errorf("unexpected PrivateKey response set")
-				}
-				if resp.Certificate != nil {
-					t.Errorf("unexpected Certificate response set")
+				if resp != nil {
+					t.Errorf("expected IssuerResponse to be nil")
 				}
 				// the resource should have the last failure time set
 				if !reflect.DeepEqual(returnedCert, recentlyFailedCertificate) {

--- a/pkg/issuer/ca/issue_test.go
+++ b/pkg/issuer/ca/issue_test.go
@@ -82,7 +82,7 @@ func generateSelfSignedCert(t *testing.T, crt *v1alpha1.Certificate, key crypto.
 
 func allFieldsSetCheck(expectedCA []byte) func(t *testing.T, s *caFixture, args ...interface{}) {
 	return func(t *testing.T, s *caFixture, args ...interface{}) {
-		resp := args[1].(issuer.IssueResponse)
+		resp := args[1].(*issuer.IssueResponse)
 
 		if resp.PrivateKey == nil {
 			t.Errorf("expected new private key to be generated")

--- a/pkg/issuer/issuer.go
+++ b/pkg/issuer/issuer.go
@@ -30,7 +30,7 @@ type Interface interface {
 
 	// Issue attempts to issue a certificate as described by the certificate
 	// resource given
-	Issue(context.Context, *v1alpha1.Certificate) (IssueResponse, error)
+	Issue(context.Context, *v1alpha1.Certificate) (*IssueResponse, error)
 }
 
 type IssueResponse struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces #962

Now, if the Issuer returns a non-nil IssueResponse, we will update the secret resource to contain the fields that were returned.

It also tidies up how we set metadata, and makes the metadata be set based on the contents of the certificate.

**Release note**:
```release-note
NONE
```
