### PR TITLE
Add cnameStrategy field to configure how CNAME records should be handled during DNS01

### DIFF
--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -745,6 +745,7 @@ Appears In:
 </tr>
 </tbody>
 </table>
+<p>ACMEIssuerDNS01Provider contains configuration for a DNS provider that can be used to solve ACME DNS01 challenges.</p>
 <aside class="notice">
 Appears In:
 
@@ -781,12 +782,16 @@ Appears In:
 <td></td>
 </tr>
 <tr>
+<td><code>cnameStrategy</code><br /> <em>string</em></td>
+<td>CNAMEStrategy configures how the DNS01 provider should handle CNAME records when found in DNS zones.</td>
+</tr>
+<tr>
 <td><code>digitalocean</code><br /> <em><a href="#acmeissuerdns01providerdigitalocean-v1alpha1">ACMEIssuerDNS01ProviderDigitalOcean</a></em></td>
 <td></td>
 </tr>
 <tr>
 <td><code>name</code><br /> <em>string</em></td>
-<td></td>
+<td>Name is the name of the DNS provider, which should be used to reference this DNS provider configuration on Certificate resources.</td>
 </tr>
 <tr>
 <td><code>rfc2136</code><br /> <em><a href="#acmeissuerdns01providerrfc2136-v1alpha1">ACMEIssuerDNS01ProviderRFC2136</a></em></td>

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -152,8 +152,16 @@ type ACMEIssuerDNS01Config struct {
 	Providers []ACMEIssuerDNS01Provider `json:"providers"`
 }
 
+// ACMEIssuerDNS01Provider contains configuration for a DNS provider that can
+// be used to solve ACME DNS01 challenges.
 type ACMEIssuerDNS01Provider struct {
+	// Name is the name of the DNS provider, which should be used to reference
+	// this DNS provider configuration on Certificate resources.
 	Name string `json:"name"`
+
+	// CNAMEStrategy configures how the DNS01 provider should handle CNAME
+	// records when found in DNS zones.
+	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy"`
 
 	Akamai       *ACMEIssuerDNS01ProviderAkamai       `json:"akamai,omitempty"`
 	CloudDNS     *ACMEIssuerDNS01ProviderCloudDNS     `json:"clouddns,omitempty"`
@@ -164,6 +172,24 @@ type ACMEIssuerDNS01Provider struct {
 	AcmeDNS      *ACMEIssuerDNS01ProviderAcmeDNS      `json:"acmedns,omitempty"`
 	RFC2136      *ACMEIssuerDNS01ProviderRFC2136      `json:"rfc2136,omitempty"`
 }
+
+// CNAMEStrategy configures how the DNS01 provider should handle CNAME records
+// when found in DNS zones.
+// By default, the None strategy will be applied (i.e. do not follow CNAMEs).
+type CNAMEStrategy string
+
+const (
+	// NoneStrategy indicates that no CNAME resolution strategy should be used
+	// when determining which DNS zone to update during DNS01 challenges.
+	NoneStrategy = "None"
+
+	// FollowStrategy will cause cert-manager to recurse through CNAMEs in
+	// order to determine which DNS zone to update during DNS01 challenges.
+	// This is useful if you do not want to grant cert-manager access to your
+	// root DNS zone, and instead delegate the _acme-challenge.example.com
+	// subdomain to some other, less privileged domain.
+	FollowStrategy = "Follow"
+)
 
 // ACMEIssuerDNS01ProviderAkamai is a structure containing the DNS
 // configuration for Akamai DNS—Zone Record Management API

--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -170,6 +170,16 @@ func ValidateACMEIssuerDNS01Config(iss *v1alpha1.ACMEIssuerDNS01Config, fldPath 
 		if len(p.Name) == 0 {
 			el = append(el, field.Required(fldPath.Child("name"), "name must be specified"))
 		}
+		// allow empty values for now, until we have a MutatingWebhook to apply
+		// default values to fields.
+		if len(p.CNAMEStrategy) > 0 {
+			switch p.CNAMEStrategy {
+			case v1alpha1.NoneStrategy:
+			case v1alpha1.FollowStrategy:
+			default:
+				el = append(el, field.Invalid(fldPath.Child("cnameStrategy"), p.CNAMEStrategy, fmt.Sprintf("must be one of %q or %q", v1alpha1.NoneStrategy, v1alpha1.FollowStrategy)))
+			}
+		}
 		numProviders := 0
 		if p.Akamai != nil {
 			numProviders++

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -45,7 +45,7 @@ type solver interface {
 	// Check should return Error only if propagation check cannot be performed.
 	// It MUST return `false, nil` if can contact all relevant services and all is
 	// doing is waiting for propagation
-	Check(ch *cmapi.Challenge) (bool, error)
+	Check(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmapi.Challenge) (bool, error)
 	// CleanUp will remove challenge records for a given solver.
 	// This may involve deleting resources in the Kubernetes API Server, or
 	// communicating with other external components (e.g. DNS providers).
@@ -148,7 +148,7 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 		c.Recorder.Eventf(ch, corev1.EventTypeNormal, "Presented", "Presented challenge using %s challenge mechanism", ch.Spec.Type)
 	}
 
-	ok, err := solver.Check(ch)
+	ok, err := solver.Check(ctx, genericIssuer, ch)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -38,8 +38,8 @@ func (f *fakeSolver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer,
 // Check should return Error only if propagation check cannot be performed.
 // It MUST return `false, nil` if can contact all relevant services and all is
 // doing is waiting for propagation
-func (f *fakeSolver) Check(ch *v1alpha1.Challenge) (bool, error) {
-	return f.fakeCheck(ch)
+func (f *fakeSolver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
+	return f.fakeCheck(ctx, issuer, ch)
 }
 
 // CleanUp will remove challenge records for a given solver.
@@ -51,7 +51,7 @@ func (f *fakeSolver) CleanUp(ctx context.Context, issuer v1alpha1.GenericIssuer,
 
 type fakeSolver struct {
 	fakePresent func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error
-	fakeCheck   func(ch *v1alpha1.Challenge) (bool, error)
+	fakeCheck   func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error)
 	fakeCleanUp func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error
 }
 
@@ -108,7 +108,7 @@ func TestSyncHappyPath(t *testing.T) {
 				fakePresent: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 					return nil
 				},
-				fakeCheck: func(ch *v1alpha1.Challenge) (bool, error) {
+				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
 					return false, nil
 				},
 			},
@@ -146,7 +146,7 @@ func TestSyncHappyPath(t *testing.T) {
 				gen.SetChallengePresented(true),
 			),
 			HTTP01: &fakeSolver{
-				fakeCheck: func(ch *v1alpha1.Challenge) (bool, error) {
+				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
 					return true, nil
 				},
 				fakeCleanUp: func(context.Context, v1alpha1.GenericIssuer, *v1alpha1.Challenge) error {
@@ -198,7 +198,7 @@ func TestSyncHappyPath(t *testing.T) {
 				gen.SetChallengePresented(true),
 			),
 			HTTP01: &fakeSolver{
-				fakeCheck: func(ch *v1alpha1.Challenge) (bool, error) {
+				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
 					return true, nil
 				},
 				fakeCleanUp: func(context.Context, v1alpha1.GenericIssuer, *v1alpha1.Challenge) error {

--- a/pkg/issuer/acme/dns/acmedns/BUILD.bazel
+++ b/pkg/issuer/acme/dns/acmedns/BUILD.bazel
@@ -5,10 +5,7 @@ go_library(
     srcs = ["acmedns.go"],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/acme/dns/acmedns",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/issuer/acme/dns/util:go_default_library",
-        "//vendor/github.com/cpu/goacmedns:go_default_library",
-    ],
+    deps = ["//vendor/github.com/cpu/goacmedns:go_default_library"],
 )
 
 go_test(

--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -25,10 +25,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"time"
 
 	"github.com/cpu/goacmedns"
-	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 // DNSProvider is an implementation of the acme.ChallengeProvider interface
@@ -65,14 +63,7 @@ func NewDNSProviderHostBytes(host string, accountJson []byte, dns01Nameservers [
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge
-func (c *DNSProvider) Present(domain, token, keyAuth string) error {
-	// fqdn, ttl are unused by ACME DNS
-	_, value, _, err := util.DNS01Record(domain, keyAuth, c.dns01Nameservers)
-
-	if err != nil {
-		return err
-	}
-
+func (c *DNSProvider) Present(domain, fqdn, value string) error {
 	if account, exists := c.accounts[domain]; exists {
 		// Update the acme-dns TXT record.
 		return c.client.UpdateTXTRecord(account, value)
@@ -87,10 +78,4 @@ func (c *DNSProvider) CleanUp(_, _, _ string) error {
 	// ACME-DNS doesn't support the notion of removing a record. For users of
 	// ACME-DNS it is expected the stale records remain in-place.
 	return nil
-}
-
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Adjusting here to cope with spikes in propagation times.
-func (c *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 120 * time.Second, 2 * time.Second
 }

--- a/pkg/issuer/acme/dns/akamai/akamai.go
+++ b/pkg/issuer/acme/dns/akamai/akamai.go
@@ -68,29 +68,13 @@ func findHostedDomainByFqdn(fqdn string) (string, error) {
 	return util.UnFqdn(zone), nil
 }
 
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Adjusting here to cope with spikes in propagation times.
-func (a *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 5 * time.Minute, 5 * time.Second
-}
-
 // Present creates a TXT record to fulfil the dns-01 challenge
-func (a *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl, err := util.DNS01Record(domain, keyAuth, a.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
-	return a.setTxtRecord(fqdn, &dns01Record{value, ttl})
+func (a *DNSProvider) Present(domain, fqdn, value string) error {
+	return a.setTxtRecord(fqdn, &dns01Record{value, 60})
 }
 
 // CleanUp removes the TXT record matching the specified parameters
-func (a *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _, err := util.DNS01Record(domain, keyAuth, a.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (a *DNSProvider) CleanUp(domain, fqdn, value string) error {
 	return a.setTxtRecord(fqdn, nil)
 }
 

--- a/pkg/issuer/acme/dns/akamai/akamai_test.go
+++ b/pkg/issuer/acme/dns/akamai/akamai_test.go
@@ -111,7 +111,7 @@ func TestPresent(t *testing.T) {
 	var response []byte
 	mockTransport(t, akamai, "example.com", sampleZoneData, &response)
 
-	assert.NoError(t, akamai.Present("test.example.com", "dns01-token", "dns01-key"))
+	assert.NoError(t, akamai.Present("test.example.com", "_acme-challenge.test.example.com.", "dns01-key"))
 
 	var expected, actual map[string]interface{}
 	assert.NoError(t, json.Unmarshal([]byte(sampleZoneDataWithTxt), &expected))
@@ -126,7 +126,7 @@ func TestCleanUp(t *testing.T) {
 	var response []byte
 	mockTransport(t, akamai, "example.com", sampleZoneDataWithTxt, &response)
 
-	assert.NoError(t, akamai.CleanUp("test.example.com", "dns01-token", "dns01-key"))
+	assert.NoError(t, akamai.CleanUp("test.example.com", "_acme-challenge.test.example.com.", "dns01-key"))
 
 	var expected, actual map[string]interface{}
 	assert.NoError(t, json.Unmarshal([]byte(sampleZoneData), &expected))

--- a/pkg/issuer/acme/dns/azuredns/BUILD.bazel
+++ b/pkg/issuer/acme/dns/azuredns/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//vendor/github.com/Azure/go-autorest/autorest/adal:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/azure:go_default_library",
         "//vendor/github.com/Azure/go-autorest/autorest/to:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
     ],
 )
 

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -12,10 +12,10 @@ package azuredns
 
 import (
 	"fmt"
-	"log"
 	"os"
 	"strings"
-	"time"
+
+	"github.com/golang/glog"
 
 	"github.com/Azure/azure-sdk-for-go/arm/dns"
 	"github.com/Azure/go-autorest/autorest"
@@ -78,25 +78,15 @@ func NewDNSProviderCredentials(clientID, clientSecret, subscriptionID, tenantID,
 }
 
 // Present creates a TXT record using the specified parameters
-func (c *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl, err := util.DNS01Record(domain, keyAuth, c.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
-	return c.createRecord(fqdn, value, ttl)
+func (c *DNSProvider) Present(domain, fqdn, value string) error {
+	return c.createRecord(fqdn, value, 60)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
-func (c *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _, err := util.DNS01Record(domain, keyAuth, c.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (c *DNSProvider) CleanUp(domain, fqdn, value string) error {
 	z, err := c.getHostedZoneName(fqdn)
 	if err != nil {
-		log.Fatalf("Error getting hosted zone name for: %s, %v", fqdn, err)
+		glog.Infof("Error getting hosted zone name for: %s, %v", fqdn, err)
 		return err
 	}
 
@@ -112,12 +102,6 @@ func (c *DNSProvider) CleanUp(domain, token, keyAuth string) error {
 	return nil
 }
 
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Adjusting here to cope with spikes in propagation times.
-func (c *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 120 * time.Second, 2 * time.Second
-}
-
 func (c *DNSProvider) createRecord(fqdn, value string, ttl int) error {
 	rparams := &dns.RecordSet{
 		RecordSetProperties: &dns.RecordSetProperties{
@@ -130,7 +114,7 @@ func (c *DNSProvider) createRecord(fqdn, value string, ttl int) error {
 
 	z, err := c.getHostedZoneName(fqdn)
 	if err != nil {
-		log.Fatalf("Error getting hosted zone name for: %s, %v", fqdn, err)
+		glog.Infof("Error getting hosted zone name for: %s, %v", fqdn, err)
 		return err
 	}
 
@@ -142,7 +126,7 @@ func (c *DNSProvider) createRecord(fqdn, value string, ttl int) error {
 		*rparams, "", "")
 
 	if err != nil {
-		log.Fatalf("Error creating TXT: %s, %v", c.zoneName, err)
+		glog.Infof("Error creating TXT: %s, %v", c.zoneName, err)
 		return err
 	}
 	return nil

--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -48,7 +48,7 @@ func TestLiveAzureDnsPresent(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.Present(azureDomain, "", "123d==")
+	err = provider.Present(azureDomain, "_acme-challenge."+azureDomain+".", "123d==")
 	assert.NoError(t, err)
 }
 
@@ -62,6 +62,6 @@ func TestLiveAzureDnsCleanUp(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.CleanUp(azureDomain, "", "123d==")
+	err = provider.CleanUp(azureDomain, "_acme-challenge."+azureDomain+".", "123d==")
 	assert.NoError(t, err)
 }

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -130,12 +130,7 @@ func NewDNSProviderServiceAccountBytes(project string, saBytes []byte, dns01Name
 }
 
 // Present creates a TXT record to fulfil the dns-01 challenge.
-func (c *DNSProvider) Present(domain, token, key string) error {
-	fqdn, value, ttl, err := util.DNS01Record(domain, key, c.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (c *DNSProvider) Present(domain, fqdn, value string) error {
 	zone, err := c.getHostedZone(fqdn)
 	if err != nil {
 		return err
@@ -144,7 +139,7 @@ func (c *DNSProvider) Present(domain, token, key string) error {
 	rec := &dns.ResourceRecordSet{
 		Name:    fqdn,
 		Rrdatas: []string{value},
-		Ttl:     int64(ttl),
+		Ttl:     int64(60),
 		Type:    "TXT",
 	}
 	change := &dns.Change{
@@ -180,12 +175,7 @@ func (c *DNSProvider) Present(domain, token, key string) error {
 }
 
 // CleanUp removes the TXT record matching the specified parameters.
-func (c *DNSProvider) CleanUp(domain, token, key string) error {
-	fqdn, _, _, err := util.DNS01Record(domain, key, c.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (c *DNSProvider) CleanUp(domain, fqdn, value string) error {
 	zone, err := c.getHostedZone(fqdn)
 	if err != nil {
 		return err
@@ -206,12 +196,6 @@ func (c *DNSProvider) CleanUp(domain, token, key string) error {
 		}
 	}
 	return nil
-}
-
-// Timeout customizes the timeout values used by the ACME package for checking
-// DNS record validity.
-func (c *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 180 * time.Second, 5 * time.Second
 }
 
 // getHostedZone returns the managed-zone

--- a/pkg/issuer/acme/dns/clouddns/clouddns_test.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns_test.go
@@ -75,7 +75,7 @@ func TestLiveGoogleCloudPresent(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(gcloudProject, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.Present(gcloudDomain, "", "123d==")
+	err = provider.Present(gcloudDomain, "_acme-challenge."+gcloudDomain+".", "123d==")
 	assert.NoError(t, err)
 }
 
@@ -88,8 +88,8 @@ func TestLiveGoogleCloudPresentMultiple(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Check that we're able to create multiple entries
-	err = provider.Present(gcloudDomain, "1", "123d==")
-	err = provider.Present(gcloudDomain, "2", "123d==")
+	err = provider.Present(gcloudDomain, "_acme-challenge."+gcloudDomain+".", "123d==")
+	err = provider.Present(gcloudDomain, "_acme-challenge."+gcloudDomain+".", "1123d==")
 	assert.NoError(t, err)
 }
 
@@ -103,6 +103,6 @@ func TestLiveGoogleCloudCleanUp(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(gcloudProject, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.CleanUp(gcloudDomain, "", "123d==")
+	err = provider.CleanUp(gcloudDomain, "_acme-challenge."+gcloudDomain+".", "123d==")
 	assert.NoError(t, err)
 }

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -58,19 +58,8 @@ func NewDNSProviderCredentials(email, key string, dns01Nameservers []string) (*D
 	}, nil
 }
 
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Adjusting here to cope with spikes in propagation times.
-func (c *DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 120 * time.Second, 2 * time.Second
-}
-
 // Present creates a TXT record to fulfil the dns-01 challenge
-func (c *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, _, err := util.DNS01Record(domain, keyAuth, c.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (c *DNSProvider) Present(domain, fqdn, value string) error {
 	zoneID, err := c.getHostedZoneID(fqdn)
 	if err != nil {
 		return err
@@ -114,12 +103,7 @@ func (c *DNSProvider) Present(domain, token, keyAuth string) error {
 }
 
 // CleanUp removes the TXT record matching the specified parameters
-func (c *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, _, _, err := util.DNS01Record(domain, keyAuth, c.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (c *DNSProvider) CleanUp(domain, fqdn, value string) error {
 	record, err := c.findTxtRecord(fqdn)
 	// Nothing to cleanup
 	if err == errNoExistingRecord {

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -70,7 +70,7 @@ func TestCloudFlarePresent(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.Present(cflareDomain, "", "123d==")
+	err = provider.Present(cflareDomain, "_acme-challenge."+cflareDomain+".", "123d==")
 	assert.NoError(t, err)
 }
 
@@ -84,6 +84,6 @@ func TestCloudFlareCleanUp(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(cflareEmail, cflareAPIKey, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.CleanUp(cflareDomain, "", "123d==")
+	err = provider.CleanUp(cflareDomain, "_acme-challenge."+cflareDomain+".", "123d==")
 	assert.NoError(t, err)
 }

--- a/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean_test.go
@@ -72,7 +72,7 @@ func TestDigitalOceanPresent(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(doToken, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.Present(doDomain, "", "123d==")
+	err = provider.Present(doDomain, "_acme-challenge."+doDomain+".", "123d==")
 	assert.NoError(t, err)
 }
 
@@ -86,7 +86,7 @@ func TestDigitalOceanCleanUp(t *testing.T) {
 	provider, err := NewDNSProviderCredentials(doToken, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
-	err = provider.CleanUp(doDomain, "", "123d==")
+	err = provider.CleanUp(doDomain, "_acme-challenge."+doDomain+".", "123d==")
 	assert.NoError(t, err)
 }
 

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -247,7 +247,7 @@ func TestSolverFor(t *testing.T) {
 			test.Setup(t)
 			defer test.Finish(t)
 			s := test.Solver
-			dnsSolver, err := s.solverForChallenge(test.Issuer, test.Challenge)
+			dnsSolver, _, err := s.solverForChallenge(test.Issuer, test.Challenge)
 			if err != nil && !test.expectErr {
 				t.Errorf("expected solverFor to not error, but got: %s", err.Error())
 				return
@@ -302,7 +302,7 @@ func TestSolveForDigitalOcean(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, err := s.solverForChallenge(f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(f.Issuer, f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -360,7 +360,7 @@ func TestRoute53TrimCreds(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, err := s.solverForChallenge(f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(f.Issuer, f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -464,7 +464,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 		f.Setup(t)
 		defer f.Finish(t)
 		s := f.Solver
-		_, err := s.solverForChallenge(f.Issuer, f.Challenge)
+		_, _, err := s.solverForChallenge(f.Issuer, f.Challenge)
 		if !reflect.DeepEqual(tt.out.expectedErr, err) {
 			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 		}

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136.go
@@ -165,21 +165,13 @@ func (r *DNSProvider) Timeout() (timeout, interval time.Duration) {
 }
 
 // Present creates a TXT record using the specified parameters
-func (r *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, ttl, err := util.DNS01Record(domain, keyAuth, r.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-	return r.changeRecord("INSERT", fqdn, value, ttl)
+func (r *DNSProvider) Present(domain, fqdn, value string) error {
+	return r.changeRecord("INSERT", fqdn, value, 60)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
-func (r *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, value, ttl, err := util.DNS01Record(domain, keyAuth, r.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-	return r.changeRecord("REMOVE", fqdn, value, ttl)
+func (r *DNSProvider) CleanUp(domain, fqdn, value string) error {
+	return r.changeRecord("REMOVE", fqdn, value, 60)
 }
 
 func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136_test.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136_test.go
@@ -85,7 +85,7 @@ func TestRFC2136ServerSuccess(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
-	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth); err != nil {
+	if err := provider.Present(rfc2136TestDomain, "_acme-challenge."+rfc2136TestDomain+".", rfc2136TestKeyAuth); err != nil {
 		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
 	}
 }
@@ -104,7 +104,7 @@ func TestRFC2136ServerError(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
-	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth); err == nil {
+	if err := provider.Present(rfc2136TestDomain, "_acme-challenge."+rfc2136TestDomain+".", rfc2136TestKeyAuth); err == nil {
 		t.Errorf("Expected Present() to return an error but it did not.")
 	} else if !strings.Contains(err.Error(), "NOTZONE") {
 		t.Errorf("Expected Present() to return an error with the 'NOTZONE' rcode string but it did not.")
@@ -125,7 +125,7 @@ func TestRFC2136TsigClient(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Expected NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
-	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestKeyAuth); err != nil {
+	if err := provider.Present(rfc2136TestDomain, "_acme-challenge."+rfc2136TestDomain+".", rfc2136TestKeyAuth); err != nil {
 		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
 	}
 }
@@ -234,7 +234,7 @@ func TestRFC2136ValidUpdatePacket(t *testing.T) {
 		t.Fatalf("Expected NewDNSProviderCredentials() to return no error but the error was -> %v", err)
 	}
 
-	if err := provider.Present(rfc2136TestDomain, "", rfc2136TestValue); err != nil {
+	if err := provider.Present(rfc2136TestDomain, "_acme-challenge."+rfc2136TestDomain+".", rfc2136TestValue); err != nil {
 		t.Errorf("Expected Present() to return no error but the error was -> %v", err)
 	}
 

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -114,30 +114,14 @@ func NewDNSProvider(accessKeyID, secretAccessKey, hostedZoneID, region string, a
 	}, nil
 }
 
-// Timeout returns the timeout and interval to use when checking for DNS
-// propagation. Adjusting here to cope with spikes in propagation times.
-func (*DNSProvider) Timeout() (timeout, interval time.Duration) {
-	return 120 * time.Second, 2 * time.Second
-}
-
 // Present creates a TXT record using the specified parameters
-func (r *DNSProvider) Present(domain, token, keyAuth string) error {
-	fqdn, value, _, err := util.DNS01Record(domain, keyAuth, r.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (r *DNSProvider) Present(domain, fqdn, value string) error {
 	value = `"` + value + `"`
 	return r.changeRecord(route53.ChangeActionUpsert, fqdn, value, route53TTL)
 }
 
 // CleanUp removes the TXT record matching the specified parameters
-func (r *DNSProvider) CleanUp(domain, token, keyAuth string) error {
-	fqdn, value, _, err := util.DNS01Record(domain, keyAuth, r.dns01Nameservers)
-	if err != nil {
-		return err
-	}
-
+func (r *DNSProvider) CleanUp(domain, fqdn, value string) error {
 	value = `"` + value + `"`
 	return r.changeRecord(route53.ChangeActionDelete, fqdn, value, route53TTL)
 }

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -112,6 +112,6 @@ func TestRoute53Present(t *testing.T) {
 	domain := "example.com"
 	keyAuth := "123456d=="
 
-	err := provider.Present(domain, "", keyAuth)
+	err := provider.Present(domain, "_acme-challenge."+domain+".", keyAuth)
 	assert.NoError(t, err, "Expected Present to return no error")
 }

--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -16,16 +16,19 @@ import (
 
 // DNS01Record returns a DNS record which will fulfill the `dns-01` challenge
 // TODO: move this into a non-generic place by resolving import cycle in dns package
-func DNS01Record(domain, value string, nameservers []string) (string, string, int, error) {
+func DNS01Record(domain, value string, nameservers []string, followCNAME bool) (string, string, int, error) {
 	fqdn := fmt.Sprintf("_acme-challenge.%s.", domain)
 
 	// Check if the domain has CNAME then return that
-	r, err := dnsQuery(fqdn, dns.TypeCNAME, nameservers, true)
-	if err == nil && r.Rcode == dns.RcodeSuccess {
-		fqdn = updateDomainWithCName(r, fqdn)
+	if followCNAME {
+		r, err := dnsQuery(fqdn, dns.TypeCNAME, nameservers, true)
+		if err == nil && r.Rcode == dns.RcodeSuccess {
+			fqdn = updateDomainWithCName(r, fqdn)
+		}
+		if err != nil {
+			return "", "", 0, err
+		}
 	}
-	if err != nil {
-		return "", "", 0, err
-	}
+
 	return fqdn, value, 60, nil
 }

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -98,7 +98,7 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 	return utilerrors.NewAggregate([]error{podErr, svcErr, ingressErr})
 }
 
-func (s *Solver) Check(ch *v1alpha1.Challenge) (bool, error) {
+func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), HTTP01Timeout)
 	defer cancel()
 

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -83,7 +83,7 @@ func TestCheck(t *testing.T) {
 				requiredPasses:   requiredCallsForPass,
 			}
 
-			ok, err := s.Check(test.challenge)
+			ok, err := s.Check(nil, nil, test.challenge)
 			if err != nil && !test.expectedErr {
 				t.Errorf("Expected Check to return non-nil error, but got %v", err)
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:

When the 'follow DNS CNAMES' functionality was added in v0.5, it broke DNS01 configurations for users who have a CNAME record configured for *.example.com as this CNAME matched `_acme-challenge.example.com` causing cert-manager to attempt to update the zone that this CNAME points to.

This PR adds a `followCNAME` option to the DNS01 provider's config to allow users to toggle this behaviour on a per DNS provider basis.

It also changes the default behaviour to *not* follow CNAMEs, which should fix issues that existing users have been seeing.

**Which issue this PR fixes**: fixes #1035, fixes #837

**Special notes for your reviewer**:

We *can* improve how this is handled in future to automatically detect which zone to update based on user's configuration.

To do so, we need to move the 'map' of DNS names to the DNS01 provider to use into the Issuer resource, and allow the user to configure the correct zone to use there.

I hope that by 1.0, we'll be able to implement this functionality & deprecate this field's behaviour.

**Release note**:
```release-note
Fix ACME issues relating to wildcard CNAME records and add a 'followCNAME' field to the ACME Issuer DNS01 provider config.
```
