### PR TITLE
Use github.com/munnerz/goautoneg mirror to resolve bitbucket issues

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "default"
   digest = "1:24df057f15e7a09e75c1241cbe6f6590fd3eac9804f1110b02efade3214f042d"
   name = "bitbucket.org/ww/goautoneg"
   packages = ["."]
   pruneopts = "UT"
-  revision = "75cd24fc2f2c2a2088577d12123ddee5f54e0675"
+  revision = "a547fc61f48d567d5b4ec6f8aee5573d8efce11d"
+  source = "https://github.com/munnerz/goautoneg.git"
 
 [[projects]]
   digest = "1:28181cff95634e84b01ac5d9d5bffd201cd02404b78a0e69ba29e9bc41703ff0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -48,6 +48,12 @@ required = [
   name = "github.com/hashicorp/vault"
   version = "v0.9.3"
 
+# Use the GitHub mirror of goautoneg to save issues with bitbucket being down
+[[override]]
+  name = "bitbucket.org/ww/goautoneg"
+  revision = "a547fc61f48d567d5b4ec6f8aee5573d8efce11d"
+  source = "https://github.com/munnerz/goautoneg.git"
+
 ### Overrides for transitive kubernetes dependencies
 ### These should be updated whenever we bump the kubernetes version we depend on
 [[override]]


### PR DESCRIPTION
**What this PR does / why we need it**:

Bitbucket keeps failing/giving i/o timeouts, so this PR pins us to use a mirror of this one package that is hosted on Bitbucket.

This also means that you no longer need `hg` installed to verify/update dependencies 😄 

**Release note**:
```release-note
NONE
```
