### PR TITLE
Build images using user with id 1000

### DIFF
--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -19,6 +19,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 def stamped_image(
     name, # use "image"
     base = None,
+    user = "1000",
     stamp = True,  # stamp by default, but allow overrides
     **kwargs):
   go_image(
@@ -33,5 +34,6 @@ def stamped_image(
   container_image(
       name = name,
       base = ":%s.app" % name,
+      user = user,
       stamp = stamp,
       **kwargs)


### PR DESCRIPTION
This fixes an issue where clusters with Pod Security Policy feature
enabled cannot start the containers.

Signed-off-by: Vasilis Remmas <vasremm@gmail.com>

**What this PR does / why we need it**:

Using the [restricted](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#example-policies) Pod Security Policy from the official Kubernetes documents, there is an error which prevents the pods from starting.

```
$ kubectl get events -n cert-manager
LAST SEEN   FIRST SEEN   COUNT   NAME                                             KIND         SUBOBJECT                       TYPE      REASON                  SOURCE                  MESSAGE
12s         12s          1       cert-manager-5c8649bb9d-r5lbh.156ef9c98a92b8f9   Pod                                          Normal    Scheduled               default-scheduler       Successfully assigned cert-manager-5c8649bb9d-r5lbh to minikube
12s         12s          1       cert-manager-5c8649bb9d-r5lbh.156ef9c993c01c1a   Pod                                          Normal    SuccessfulMountVolume   kubelet, minikube       MountVolume.SetUp succeeded for volume "cert-manager-token-7vts4"
12s         12s          1       cert-manager-5c8649bb9d.156ef9c9898887b9         ReplicaSet                                   Normal    SuccessfulCreate        replicaset-controller   Created pod: cert-manager-5c8649bb9d-r5lbh
12s         12s          1       cert-manager.156ef9c98750af2d                    Deployment                                   Normal    ScalingReplicaSet       deployment-controller   Scaled up replica set cert-manager-5c8649bb9d to 1
11s         11s          1       cert-manager-5c8649bb9d-r5lbh.156ef9c9bb13c027   Pod          spec.containers{cert-manager}   Normal    Pulling                 kubelet, minikube       pulling image "quay.io/jetstack/cert-manager-controller:v0.5.2"
2s          2s           1       cert-manager-5c8649bb9d-r5lbh.156ef9cbec38a089   Pod          spec.containers{cert-manager}   Normal    Pulled                  kubelet, minikube       Successfully pulled image "quay.io/jetstack/cert-manager-controller:v0.5.2"
1s          2s           2       cert-manager-5c8649bb9d-r5lbh.156ef9cbec836221   Pod          spec.containers{cert-manager}   Warning   Failed                  kubelet, minikube       Error: container has runAsNonRoot and image has non-numeric user (certmanager), cannot verify user is non-root
1s          1s           1       cert-manager-5c8649bb9d-r5lbh.156ef9cc2f622f2b   Pod          spec.containers{cert-manager}   Normal    Pulled                  kubelet, minikube       Container image "quay.io/jetstack/cert-manager-controller:v0.5.2" already present on machine
```


**Which issue this PR fixes**: 

**Special notes for your reviewer**:
As far as I see there [were](https://github.com/jetstack/cert-manager/commit/14b0b9788c99dd3f7aad68be0bc1c378c11b376c) users before removing the `Dockerfile`. Maybe you would like to accept that PR since it is hardening the security of the containers and makes it possible to run to such clusters.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
