### PR TITLE
Fix link in Helm chart README

### DIFF
--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -113,4 +113,4 @@ $ helm install --name my-release -f values.yaml .
 
 ## Contributing
 
-This chart is maintained at [github.com/jetstack/cert-manager](https://github.com/jetstack/cert-manager/tree/master/contrib/charts/cert-manager).
+This chart is maintained at [github.com/jetstack/cert-manager](https://github.com/jetstack/cert-manager/tree/master/deploy/chart).


### PR DESCRIPTION
Somehow slipped through our testing pipeline previously when we moved the chart from contrib/charts to deploy/

```release-note
NONE
```