### PR TITLE
Add Prometheus CertificateIssuedLatency Metric

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -644,7 +644,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:332bb012a26310a9f54d347e384ccfef19dbaa3d0f0a1489eed054f898392f33"
+  digest = "1:b658f1af994f893629b83334c60240d40b02bf9f5df1979e50c9cdc1b6d06335"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
@@ -653,8 +653,8 @@
     "prometheus/testutil",
   ]
   pruneopts = "UT"
-  revision = "abad2d1bd44235a26707c172eab6bca5bf2dbad3"
-  version = "v0.9.1"
+  revision = "505eaef017263e299324067d40ca2c48f6a2cf50"
+  version = "v0.9.2"
 
 [[projects]]
   branch = "master"

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -93,7 +93,7 @@ var CertificateIssuedLatency = prometheus.NewHistogram(
 		Namespace: namespace,
 		Name:      "certificate_issued_latency_seconds",
 		Buckets:   []float64{30, 60, 120, 180, 240, 300},
-		Help:      "The amount of time for a namespace secret to be issued after a certificate has been created.",
+		Help:      "The amount of time for a certificate to be issued in the case of nonexistance, invalid spec match, or expiration.",
 	},
 )
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -86,6 +86,17 @@ var ACMEClientRequestDurationSeconds = prometheus.NewSummaryVec(
 	[]string{"scheme", "host", "path", "method", "status"},
 )
 
+// CertificateIssuedLatency is a Prometheus histogram to collect duration
+// betwween initial certificate requests and issuance.
+var CertificateIssuedLatency = prometheus.NewHistogram(
+	prometheus.HistogramOpts{
+		Namespace: namespace,
+		Name:      "certificate_issued_latency_seconds",
+		Buckets:   []float64{30, 60, 120, 180, 240, 300},
+		Help:      "The amount of time for a namespace secret to be issued after a certificate has been created.",
+	},
+)
+
 type Metrics struct {
 	http.Server
 
@@ -94,6 +105,7 @@ type Metrics struct {
 	CertificateExpiryTimeSeconds     *prometheus.GaugeVec
 	ACMEClientRequestDurationSeconds *prometheus.SummaryVec
 	ACMEClientRequestCount           *prometheus.CounterVec
+	CertificateIssuedLatency         *prometheus.Histogram
 }
 
 func New() *Metrics {
@@ -113,6 +125,7 @@ func New() *Metrics {
 		CertificateExpiryTimeSeconds:     CertificateExpiryTimeSeconds,
 		ACMEClientRequestDurationSeconds: ACMEClientRequestDurationSeconds,
 		ACMEClientRequestCount:           ACMEClientRequestCount,
+		CertificateIssuedLatency:         &CertificateIssuedLatency,
 	}
 
 	router.Handle("/metrics", promhttp.HandlerFor(s.registry, promhttp.HandlerOpts{}))
@@ -139,6 +152,7 @@ func (m *Metrics) Start(stopCh <-chan struct{}) {
 	m.registry.MustRegister(m.CertificateExpiryTimeSeconds)
 	m.registry.MustRegister(m.ACMEClientRequestDurationSeconds)
 	m.registry.MustRegister(m.ACMEClientRequestCount)
+	m.registry.MustRegister(*m.CertificateIssuedLatency)
 
 	go func() {
 
@@ -176,4 +190,10 @@ func updateX509Expiry(name, namespace string, cert *x509.Certificate) {
 	CertificateExpiryTimeSeconds.With(prometheus.Labels{
 		"name":      name,
 		"namespace": namespace}).Set(float64(expiryTime.Unix()))
+}
+
+// UpdateCertificateIssuedLatency updates the amount of time for a namespace secret to be issued after a certificate has been created.
+func (m *Metrics) UpdateCertificateIssuedLatency(latency time.Duration) {
+	latencyInSeconds := float64(latency) / 1000000000
+	CertificateIssuedLatency.Observe(latencyInSeconds)
 }

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -67,7 +67,7 @@ func TestUpdateCertificateExpiry(t *testing.T) {
 
 func TestUpdateCertificateIssuedLatency(t *testing.T) {
 	const metadata = `
-	# HELP certmanager_certificate_issued_latency_seconds The amount of time for a namespace secret to be issued after a certificate has been created.
+	# HELP certmanager_certificate_issued_latency_seconds The amount of time for a certificate to be issued in the case of nonexistance, invalid spec match, or expiration.
 	# TYPE certmanager_certificate_issued_latency_seconds histogram
 `
 

--- a/vendor/github.com/prometheus/client_golang/prometheus/desc.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/desc.go
@@ -93,7 +93,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	// First add only the const label names and sort them...
 	for labelName := range constLabels {
 		if !checkLabelName(labelName) {
-			d.err = fmt.Errorf("%q is not a valid label name", labelName)
+			d.err = fmt.Errorf("%q is not a valid label name for metric %q", labelName, fqName)
 			return d
 		}
 		labelNames = append(labelNames, labelName)
@@ -115,7 +115,7 @@ func NewDesc(fqName, help string, variableLabels []string, constLabels Labels) *
 	// dimension with a different mix between preset and variable labels.
 	for _, labelName := range variableLabels {
 		if !checkLabelName(labelName) {
-			d.err = fmt.Errorf("%q is not a valid label name", labelName)
+			d.err = fmt.Errorf("%q is not a valid label name for metric %q", labelName, fqName)
 			return d
 		}
 		labelNames = append(labelNames, "$"+labelName)

--- a/vendor/github.com/prometheus/client_golang/prometheus/registry.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/registry.go
@@ -872,7 +872,13 @@ func checkMetricConsistency(
 	h = hashAddByte(h, separatorByte)
 	// Make sure label pairs are sorted. We depend on it for the consistency
 	// check.
-	sort.Sort(labelPairSorter(dtoMetric.Label))
+	if !sort.IsSorted(labelPairSorter(dtoMetric.Label)) {
+		// We cannot sort dtoMetric.Label in place as it is immutable by contract.
+		copiedLabels := make([]*dto.LabelPair, len(dtoMetric.Label))
+		copy(copiedLabels, dtoMetric.Label)
+		sort.Sort(labelPairSorter(copiedLabels))
+		dtoMetric.Label = copiedLabels
+	}
 	for _, lp := range dtoMetric.Label {
 		h = hashAdd(h, lp.GetName())
 		h = hashAddByte(h, separatorByte)
@@ -903,8 +909,8 @@ func checkDescConsistency(
 	}
 
 	// Is the desc consistent with the content of the metric?
-	lpsFromDesc := make([]*dto.LabelPair, 0, len(dtoMetric.Label))
-	lpsFromDesc = append(lpsFromDesc, desc.constLabelPairs...)
+	lpsFromDesc := make([]*dto.LabelPair, len(desc.constLabelPairs), len(dtoMetric.Label))
+	copy(lpsFromDesc, desc.constLabelPairs)
 	for _, l := range desc.variableLabels {
 		lpsFromDesc = append(lpsFromDesc, &dto.LabelPair{
 			Name: proto.String(l),

--- a/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/testutil/testutil.go
@@ -37,7 +37,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"reflect"
 
 	"github.com/prometheus/common/expfmt"
 
@@ -125,38 +124,43 @@ func CollectAndCompare(c prometheus.Collector, expected io.Reader, metricNames .
 // exposition format. If any metricNames are provided, only metrics with those
 // names are compared.
 func GatherAndCompare(g prometheus.Gatherer, expected io.Reader, metricNames ...string) error {
-	metrics, err := g.Gather()
+	got, err := g.Gather()
 	if err != nil {
 		return fmt.Errorf("gathering metrics failed: %s", err)
 	}
 	if metricNames != nil {
-		metrics = filterMetrics(metrics, metricNames)
+		got = filterMetrics(got, metricNames)
 	}
 	var tp expfmt.TextParser
-	expectedMetrics, err := tp.TextToMetricFamilies(expected)
+	wantRaw, err := tp.TextToMetricFamilies(expected)
 	if err != nil {
 		return fmt.Errorf("parsing expected metrics failed: %s", err)
 	}
+	want := internal.NormalizeMetricFamilies(wantRaw)
 
-	if !reflect.DeepEqual(metrics, internal.NormalizeMetricFamilies(expectedMetrics)) {
-		// Encode the gathered output to the readable text format for comparison.
-		var buf1 bytes.Buffer
-		enc := expfmt.NewEncoder(&buf1, expfmt.FmtText)
-		for _, mf := range metrics {
-			if err := enc.Encode(mf); err != nil {
-				return fmt.Errorf("encoding result failed: %s", err)
-			}
-		}
-		// Encode normalized expected metrics again to generate them in the same ordering
-		// the registry does to spot differences more easily.
-		var buf2 bytes.Buffer
-		enc = expfmt.NewEncoder(&buf2, expfmt.FmtText)
-		for _, mf := range internal.NormalizeMetricFamilies(expectedMetrics) {
-			if err := enc.Encode(mf); err != nil {
-				return fmt.Errorf("encoding result failed: %s", err)
-			}
-		}
+	return compare(got, want)
+}
 
+// compare encodes both provided slices of metric families into the text format,
+// compares their string message, and returns an error if they do not match.
+// The error contains the encoded text of both the desired and the actual
+// result.
+func compare(got, want []*dto.MetricFamily) error {
+	var gotBuf, wantBuf bytes.Buffer
+	enc := expfmt.NewEncoder(&gotBuf, expfmt.FmtText)
+	for _, mf := range got {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding gathered metrics failed: %s", err)
+		}
+	}
+	enc = expfmt.NewEncoder(&wantBuf, expfmt.FmtText)
+	for _, mf := range want {
+		if err := enc.Encode(mf); err != nil {
+			return fmt.Errorf("encoding expected metrics failed: %s", err)
+		}
+	}
+
+	if wantBuf.String() != gotBuf.String() {
 		return fmt.Errorf(`
 metric output does not match expectation; want:
 
@@ -165,7 +169,8 @@ metric output does not match expectation; want:
 got:
 
 %s
-`, buf2.String(), buf1.String())
+`, wantBuf.String(), gotBuf.String())
+
 	}
 	return nil
 }

--- a/vendor/github.com/prometheus/client_golang/prometheus/timer.go
+++ b/vendor/github.com/prometheus/client_golang/prometheus/timer.go
@@ -39,13 +39,16 @@ func NewTimer(o Observer) *Timer {
 
 // ObserveDuration records the duration passed since the Timer was created with
 // NewTimer. It calls the Observe method of the Observer provided during
-// construction with the duration in seconds as an argument. ObserveDuration is
-// usually called with a defer statement.
+// construction with the duration in seconds as an argument. The observed
+// duration is also returned. ObserveDuration is usually called with a defer
+// statement.
 //
 // Note that this method is only guaranteed to never observe negative durations
 // if used with Go1.9+.
-func (t *Timer) ObserveDuration() {
+func (t *Timer) ObserveDuration() time.Duration {
+	d := time.Since(t.begin)
 	if t.observer != nil {
-		t.observer.Observe(time.Since(t.begin).Seconds())
+		t.observer.Observe(d.Seconds())
 	}
+	return d
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds a new prometheus metric of type `histogram` to measure the latency between creating a certificate to issuing a secret. This will allow users to know how long it takes for a certificate to be issued. 

**Special notes for your reviewer**:
This PR is built on top of https://github.com/jetstack/cert-manager/pull/1159.

I had to update the `github.com/prometheus/client_golang` package because this fix https://github.com/prometheus/client_golang/commit/86702ea6b427ab178f0353345fc69cfd80b63d8f updates `testutils` and was required to make the unit tests work. 

While doing this I had to make a few changes in the `WORKSPACE` because bazel deprecated the use of certain rules as of version 0.20.0 (or maybe earlier).
```
Zenaras-MacBook-Pro:cert-manager zenaradaley$ bazel version
INFO: Invocation ID: 2e816296-86b4-484d-bf51-e60e6daf465f
Build label: 0.20.0
Build target: bazel-out/darwin-opt/bin/src/main/java/com/google/devtools/build/lib/bazel/BazelServer_deploy.jar
Build time: Fri Nov 30 14:38:25 2018 (1543588705)
Build timestamp: 1543588705
Build timestamp as int: 1543588705
```

**Release Notes**:
```release-note
NONE
```

