### PR TITLE
Save global addon logs as CI artifacts & fixup logging

### DIFF
--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     deps = [
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
     ],
 )

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -54,6 +54,7 @@ filegroup(
         ":package-srcs",
         "//test/e2e/framework:all-srcs",
         "//test/e2e/suite:all-srcs",
+        "//test/e2e/util:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -66,7 +66,7 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {},
 		}
 
 		for k, v := range globalLogs {
-			outPath := path.Join(framework.DefaultConfig.Ginkgo.ReportDirectory, k)
+			outPath := path.Join(framework.DefaultConfig.Ginkgo.ReportDirectory, "logs", k)
 			// Create a directory for the file if needed
 			err := os.MkdirAll(path.Dir(outPath), 0755)
 			if err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -60,6 +60,8 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {},
 			ginkgo.GinkgoWriter.Write([]byte("Failed to retrieve global addon logs: " + err.Error()))
 		}
 
+		ginkgo.GinkgoWriter.Write([]byte(globalLogs))
+
 		ginkgo.By("Cleaning up the provisioned globals")
 		err = addon.DeprovisionGlobals(cfg)
 		if err != nil {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -26,6 +25,7 @@ import (
 
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 )
 
 var (
@@ -62,7 +62,7 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {},
 		var err error
 		globalLogs, err = addon.GlobalLogs()
 		if err != nil {
-			ginkgo.GinkgoWriter.Write([]byte("Failed to retrieve global addon logs: " + err.Error()))
+			log.Logf("Failed to retrieve global addon logs: " + err.Error())
 		}
 
 		for k, v := range globalLogs {
@@ -70,13 +70,13 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {},
 			// Create a directory for the file if needed
 			err := os.MkdirAll(path.Dir(outPath), 0755)
 			if err != nil {
-				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Failed to create directory for logs: %v", err)))
+				log.Logf("Failed to create directory for logs: %v", err)
 				continue
 			}
 
 			err = ioutil.WriteFile(outPath, []byte(v), 0644)
 			if err != nil {
-				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Failed to write log file: %v", err)))
+				log.Logf("Failed to write log file: %v", err)
 				continue
 			}
 		}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,7 +19,6 @@ package e2e
 import (
 	"flag"
 	"fmt"
-	"log"
 	"path"
 	"testing"
 	"time"
@@ -74,9 +73,5 @@ func TestE2E(t *testing.T) {
 				ginkgoconfig.GinkgoConfig.ParallelNode))))
 	}
 
-	if !ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "cert-manager e2e suite", r) {
-		if len(globalLogs) > 0 {
-			log.Printf("Test suite failed, global addon logs: \n%v", globalLogs)
-		}
-	}
+	ginkgo.RunSpecsWithDefaultAndCustomReporters(t, "cert-manager e2e suite", r)
 }

--- a/test/e2e/framework/addon/BUILD.bazel
+++ b/test/e2e/framework/addon/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "//test/e2e/framework/addon/nginxingress:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/config:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
     ],
 )

--- a/test/e2e/framework/addon/certmanager/addon.go
+++ b/test/e2e/framework/addon/certmanager/addon.go
@@ -113,6 +113,6 @@ func (p *Certmanager) SupportsGlobal() bool {
 	return true
 }
 
-func (p *Certmanager) Logs() (string, error) {
+func (p *Certmanager) Logs() (map[string]string, error) {
 	return p.chart.Logs()
 }

--- a/test/e2e/framework/addon/globals.go
+++ b/test/e2e/framework/addon/globals.go
@@ -19,7 +19,6 @@ package addon
 import (
 	"fmt"
 
-	"github.com/golang/glog"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/base"
@@ -27,6 +26,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/nginxingress"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 )
 
 type Addon interface {
@@ -150,7 +150,7 @@ func GlobalLogs() (map[string]string, error) {
 // all global addons are cleaned up after a run.
 func DeprovisionGlobals(cfg *config.Config) error {
 	if !cfg.Cleanup {
-		glog.Infof("Skipping deprovisioning as cleanup set to false.")
+		log.Logf("Skipping deprovisioning as cleanup set to false.")
 		return nil
 	}
 	var errs []error

--- a/test/e2e/framework/addon/nginxingress/nginx.go
+++ b/test/e2e/framework/addon/nginxingress/nginx.go
@@ -144,7 +144,7 @@ func (n *Nginx) SupportsGlobal() bool {
 	return true
 }
 
-func (n *Nginx) Logs() (string, error) {
+func (n *Nginx) Logs() (map[string]string, error) {
 	return n.chart.Logs()
 }
 

--- a/test/e2e/framework/addon/pebble/pebble.go
+++ b/test/e2e/framework/addon/pebble/pebble.go
@@ -102,6 +102,6 @@ func (p *Pebble) SupportsGlobal() bool {
 	return true
 }
 
-func (p *Pebble) Logs() (string, error) {
+func (p *Pebble) Logs() (map[string]string, error) {
 	return p.chart.Logs()
 }

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -188,7 +188,7 @@ func (v *Vault) SupportsGlobal() bool {
 	return false
 }
 
-func (v *Vault) Logs() (string, error) {
+func (v *Vault) Logs() (map[string]string, error) {
 	return v.chart.Logs()
 }
 

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -17,7 +17,6 @@ limitations under the License.
 package framework
 
 import (
-	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -36,6 +35,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
 	"github.com/jetstack/cert-manager/test/e2e/framework/helper"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 	"github.com/jetstack/cert-manager/test/e2e/framework/util"
 	"github.com/jetstack/cert-manager/test/e2e/framework/util/errors"
 )
@@ -144,7 +144,8 @@ func (f *Framework) printAddonLogs() {
 				l, err := a.Logs()
 				Expect(err).NotTo(HaveOccurred())
 
-				GinkgoWriter.Write([]byte(fmt.Sprintf("Got pod logs for addon: \n%s", l)))
+				// TODO: replace with writing logs to a file
+				log.Logf("Got pod logs for addon: \n%s", l)
 			}
 		}
 	}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -115,6 +115,8 @@ func (f *Framework) BeforeEach() {
 	f.Namespace, err = f.CreateKubeNamespace(f.BaseName)
 	Expect(err).NotTo(HaveOccurred())
 
+	By("Using the namespace " + f.Namespace.Name)
+
 	By("Building a ResourceQuota api object")
 	_, err = f.CreateKubeResourceQuota()
 	Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/issuers/acme/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/BUILD.bazel
@@ -16,7 +16,7 @@ go_library(
         "//test/e2e/framework/addon/pebble:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/suite/issuers/acme/certificate:go_default_library",
-        "//test/util:go_default_library",
+        "//test/e2e/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "//test/e2e/framework/addon/pebble:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/suite/issuers/acme/dnsproviders:go_default_library",
-        "//test/util:go_default_library",
+        "//test/e2e/util:go_default_library",
         "//test/util/generate:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/test/e2e/suite/issuers/acme/certificate/dns01.go
+++ b/test/e2e/suite/issuers/acme/certificate/dns01.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/suite/issuers/acme/dnsproviders"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 type dns01Provider interface {

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -30,7 +30,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/pebble"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 const invalidACMEURL = "http://not-a-real-acme-url.com"

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -28,7 +28,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/pebble"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 const invalidACMEURL = "http://not-a-real-acme-url.com"

--- a/test/e2e/suite/issuers/ca/BUILD.bazel
+++ b/test/e2e/suite/issuers/ca/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",
-        "//test/util:go_default_library",
+        "//test/e2e/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/e2e/suite/issuers/ca/clusterissuer.go
+++ b/test/e2e/suite/issuers/ca/clusterissuer.go
@@ -24,7 +24,7 @@ import (
 	cmutil "github.com/jetstack/cert-manager/pkg/util"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {

--- a/test/e2e/suite/issuers/ca/issuer.go
+++ b/test/e2e/suite/issuers/ca/issuer.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 var _ = framework.CertManagerDescribe("CA Issuer", func() {

--- a/test/e2e/suite/issuers/selfsigned/BUILD.bazel
+++ b/test/e2e/suite/issuers/selfsigned/BUILD.bazel
@@ -9,7 +9,7 @@ go_library(
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//test/e2e/framework:go_default_library",
-        "//test/util:go_default_library",
+        "//test/e2e/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -25,7 +25,7 @@ import (
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/e2e/suite/issuers/vault/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/BUILD.bazel
@@ -15,7 +15,7 @@ go_library(
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
         "//test/e2e/suite/issuers/vault/certificate:go_default_library",
-        "//test/util:go_default_library",
+        "//test/e2e/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
     ],

--- a/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
@@ -14,7 +14,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
-        "//test/util:go_default_library",
+        "//test/e2e/util:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom mount path)", func() {

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -27,7 +27,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
-	"github.com/jetstack/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer", func() {

--- a/test/e2e/util/BUILD.bazel
+++ b/test/e2e/util/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["util.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/util",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/client/clientset/versioned/scheme:go_default_library",
+        "//pkg/client/clientset/versioned/typed/certmanager/v1alpha1:go_default_library",
+        "//pkg/util:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/util/BUILD.bazel
+++ b/test/e2e/util/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "//pkg/client/clientset/versioned/typed/certmanager/v1alpha1:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/pki:go_default_library",
-        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",

--- a/test/e2e/util/BUILD.bazel
+++ b/test/e2e/util/BUILD.bazel
@@ -11,7 +11,7 @@ go_library(
         "//pkg/client/clientset/versioned/typed/certmanager/v1alpha1:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/pki:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -52,7 +52,7 @@ func CertificateOnlyValidForDomains(cert *x509.Certificate, commonName string, d
 }
 
 func WaitForIssuerStatusFunc(client clientset.IssuerInterface, name string, fn func(*v1alpha1.Issuer) (bool, error)) error {
-	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	return wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
 			issuer, err := client.Get(name, metav1.GetOptions{})
 			if err != nil {
@@ -65,7 +65,7 @@ func WaitForIssuerStatusFunc(client clientset.IssuerInterface, name string, fn f
 // WaitForIssuerCondition waits for the status of the named issuer to contain
 // a condition whose type and status matches the supplied one.
 func WaitForIssuerCondition(client clientset.IssuerInterface, name string, condition v1alpha1.IssuerCondition) error {
-	pollErr := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	pollErr := wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
 			glog.V(5).Infof("Waiting for issuer %v condition %#v", name, condition)
 			issuer, err := client.Get(name, metav1.GetOptions{})
@@ -103,7 +103,7 @@ func wrapErrorWithIssuerStatusCondition(client clientset.IssuerInterface, pollEr
 // WaitForClusterIssuerCondition waits for the status of the named issuer to contain
 // a condition whose type and status matches the supplied one.
 func WaitForClusterIssuerCondition(client clientset.ClusterIssuerInterface, name string, condition v1alpha1.IssuerCondition) error {
-	pollErr := wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	pollErr := wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
 			glog.V(5).Infof("Waiting for clusterissuer %v condition %#v", name, condition)
 			issuer, err := client.Get(name, metav1.GetOptions{})
@@ -327,7 +327,7 @@ func WaitForCertificateToExist(client clientset.CertificateInterface, name strin
 // WaitForCRDToNotExist waits for the CRD with the given name to no
 // longer exist.
 func WaitForCRDToNotExist(client apiextcs.CustomResourceDefinitionInterface, name string) error {
-	return wait.PollImmediate(500*time.Millisecond, wait.ForeverTestTimeout,
+	return wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
 			glog.V(5).Infof("Waiting for CRD %v to not exist", name)
 			_, err := client.Get(name, metav1.GetOptions{})

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -25,8 +25,8 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/golang/glog"
 	intscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
+	"github.com/onsi/ginkgo"
 	"k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
@@ -67,7 +67,7 @@ func WaitForIssuerStatusFunc(client clientset.IssuerInterface, name string, fn f
 func WaitForIssuerCondition(client clientset.IssuerInterface, name string, condition v1alpha1.IssuerCondition) error {
 	pollErr := wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for issuer %v condition %#v", name, condition)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for issuer %v condition %#v", name, condition)))
 			issuer, err := client.Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting Issuer %q: %v", name, err)
@@ -105,7 +105,7 @@ func wrapErrorWithIssuerStatusCondition(client clientset.IssuerInterface, pollEr
 func WaitForClusterIssuerCondition(client clientset.ClusterIssuerInterface, name string, condition v1alpha1.IssuerCondition) error {
 	pollErr := wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for clusterissuer %v condition %#v", name, condition)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for clusterissuer %v condition %#v", name, condition)))
 			issuer, err := client.Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting ClusterIssuer %v: %v", name, err)
@@ -143,7 +143,7 @@ func wrapErrorWithClusterIssuerStatusCondition(client clientset.ClusterIssuerInt
 func WaitForCertificateCondition(client clientset.CertificateInterface, name string, condition v1alpha1.CertificateCondition, timeout time.Duration) error {
 	pollErr := wait.PollImmediate(500*time.Millisecond, timeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for Certificate %v condition %#v", name, condition)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for Certificate %v condition %#v", name, condition)))
 			certificate, err := client.Get(name, metav1.GetOptions{})
 			if nil != err {
 				return false, fmt.Errorf("error getting Certificate %v: %v", name, err)
@@ -160,7 +160,7 @@ func WaitForCertificateCondition(client clientset.CertificateInterface, name str
 func WaitForCertificateEvent(client kubernetes.Interface, cert *v1alpha1.Certificate, reason string, timeout time.Duration) error {
 	return wait.PollImmediate(500*time.Millisecond, timeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for Certificate event %v reason %#v", cert.Name, reason)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for Certificate event %v reason %#v", cert.Name, reason)))
 			evts, err := client.Core().Events(cert.Namespace).Search(intscheme.Scheme, cert)
 			if err != nil {
 				return false, fmt.Errorf("error getting Certificate %v: %v", cert.Name, err)
@@ -206,7 +206,7 @@ func wrapErrorWithCertificateStatusCondition(client clientset.CertificateInterfa
 func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secretClient corecs.SecretInterface, name string, timeout time.Duration) error {
 	return wait.PollImmediate(time.Second, timeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for Certificate %v to be ready", name)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for Certificate %v to be ready", name)))
 			certificate, err := certClient.Get(name, metav1.GetOptions{})
 			if err != nil {
 				return false, fmt.Errorf("error getting Certificate %v: %v", name, err)
@@ -218,7 +218,7 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 			if !isReady {
 				return false, nil
 			}
-			glog.Infof("Getting the TLS certificate Secret resource")
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Getting the TLS certificate Secret resource")))
 			secret, err := secretClient.Get(certificate.Spec.SecretName, metav1.GetOptions{})
 			if err != nil {
 				if apierrors.IsNotFound(err) {
@@ -228,13 +228,13 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 				return false, err
 			}
 			if !(len(secret.Data) == 2 || len(secret.Data) == 3) {
-				glog.Infof("Expected 2 keys in certificate secret, but there was %d", len(secret.Data))
+				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Expected 2 keys in certificate secret, but there was %d", len(secret.Data))))
 				return false, nil
 			}
 
 			keyBytes, ok := secret.Data[v1.TLSPrivateKeyKey]
 			if !ok {
-				glog.Infof("No private key data found for Certificate %q (secret %q)", name, certificate.Spec.SecretName)
+				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("No private key data found for Certificate %q (secret %q)", name, certificate.Spec.SecretName)))
 				return false, nil
 			}
 			key, err := pki.DecodePrivateKeyBytes(keyBytes)
@@ -248,13 +248,13 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 				v1alpha1.RSAKeyAlgorithm:
 				_, ok := key.(*rsa.PrivateKey)
 				if !ok {
-					glog.Infof("Expected private key of type RSA, but it was: %T", key)
+					ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Expected private key of type RSA, but it was: %T", key)))
 					return false, nil
 				}
 			case v1alpha1.ECDSAKeyAlgorithm:
 				_, ok := key.(*ecdsa.PrivateKey)
 				if !ok {
-					glog.Infof("Expected private key of type ECDSA, but it was: %T", key)
+					ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Expected private key of type ECDSA, but it was: %T", key)))
 					return false, nil
 				}
 			default:
@@ -270,7 +270,7 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 
 			certBytes, ok := secret.Data[v1.TLSCertKey]
 			if !ok {
-				glog.Infof("No certificate data found for Certificate %q (secret %q)", name, certificate.Spec.SecretName)
+				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("No certificate data found for Certificate %q (secret %q)", name, certificate.Spec.SecretName)))
 				return false, nil
 			}
 
@@ -279,16 +279,16 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 				return false, err
 			}
 			if expectedCN != cert.Subject.CommonName || !util.EqualUnsorted(cert.DNSNames, expectedDNSNames) || !(len(cert.Subject.Organization) == 0 || util.EqualUnsorted(cert.Subject.Organization, expectedOrganization)) {
-				glog.Infof("Expected certificate valid for CN %q, O %v, dnsNames %v but got a certificate valid for CN %q, O %v, dnsNames %v", expectedCN, expectedOrganization, expectedDNSNames, cert.Subject.CommonName, cert.Subject.Organization, cert.DNSNames)
+				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Expected certificate valid for CN %q, O %v, dnsNames %v but got a certificate valid for CN %q, O %v, dnsNames %v", expectedCN, expectedOrganization, expectedDNSNames, cert.Subject.CommonName, cert.Subject.Organization, cert.DNSNames)))
 				return false, nil
 			}
 
 			if certificate.Status.NotAfter == nil {
-				glog.Infof("No certificate expiration found for Certificate %q", name)
+				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("No certificate expiration found for Certificate %q", name)))
 				return false, nil
 			}
 			if !cert.NotAfter.Equal(certificate.Status.NotAfter.Time) {
-				glog.Info("Expected certificate expire date to be %v, but got %v", certificate.Status.NotAfter, cert.NotAfter)
+				ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Expected certificate expiry date to be %v, but got %v", certificate.Status.NotAfter, cert.NotAfter)))
 				return false, nil
 			}
 
@@ -310,7 +310,7 @@ func WaitCertificateIssuedValid(certClient clientset.CertificateInterface, secre
 func WaitForCertificateToExist(client clientset.CertificateInterface, name string, timeout time.Duration) error {
 	return wait.PollImmediate(500*time.Millisecond, timeout,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for Certificate %v to exist", name)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for Certificate %v to exist", name)))
 			_, err := client.Get(name, metav1.GetOptions{})
 			if errors.IsNotFound(err) {
 				return false, nil
@@ -329,7 +329,7 @@ func WaitForCertificateToExist(client clientset.CertificateInterface, name strin
 func WaitForCRDToNotExist(client apiextcs.CustomResourceDefinitionInterface, name string) error {
 	return wait.PollImmediate(500*time.Millisecond, time.Minute,
 		func() (bool, error) {
-			glog.V(5).Infof("Waiting for CRD %v to not exist", name)
+			ginkgo.GinkgoWriter.Write([]byte(fmt.Sprintf("Waiting for CRD %v to not exist", name)))
 			_, err := client.Get(name, metav1.GetOptions{})
 			if nil == err {
 				return false, nil

--- a/test/fixtures/cert-manager-values.yaml
+++ b/test/fixtures/cert-manager-values.yaml
@@ -13,7 +13,7 @@ resources:
     memory: 200Mi
 
 extraArgs:
-- --v=4
+- --v=10
 - --leader-election-lease-duration=10s
 - --leader-election-renew-deadline=3s
 - --leader-election-retry-period=2s

--- a/test/util/BUILD.bazel
+++ b/test/util/BUILD.bazel
@@ -1,29 +1,3 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
-
-go_library(
-    name = "go_default_library",
-    srcs = ["util.go"],
-    importpath = "github.com/jetstack/cert-manager/test/util",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/apis/certmanager/v1alpha1:go_default_library",
-        "//pkg/client/clientset/versioned/scheme:go_default_library",
-        "//pkg/client/clientset/versioned/typed/certmanager/v1alpha1:go_default_library",
-        "//pkg/util:go_default_library",
-        "//pkg/util/pki:go_default_library",
-        "//vendor/github.com/golang/glog:go_default_library",
-        "//vendor/k8s.io/api/core/v1:go_default_library",
-        "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
-        "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
-        "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
-    ],
-)
-
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),


### PR DESCRIPTION
**What this PR does / why we need it**:

We now store global addon logs as artifacts, accessible via GCS and put into subdirectories named by their namespace. We can move to doing the same for namespace scoped addons in future too.

Also fixup some logging so it's easier to identify why tests are failing.

**Release note**:
```release-note
NONE
```
