### PR TITLE
[chart] Adding imagePullSecrets to Service Account

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.0-dev.6
+version: v0.6.0-dev.7
 appVersion: v0.6.0-dev.4
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -64,6 +64,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
+| `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
 | `image.tag` | Image tag | `canary` |
 | `image.pullPolicy` | Image pull policy | `Always` |

--- a/deploy/chart/templates/serviceaccount.yaml
+++ b/deploy/chart/templates/serviceaccount.yaml
@@ -1,6 +1,9 @@
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
 metadata:
   name: {{ template "cert-manager.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -1,6 +1,13 @@
 # Default values for cert-manager.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+global:
+  ## Reference to one or more secrets to be used when pulling images
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  ##
+  imagePullSecrets: []
+  # - name: "image-pull-secret"
+
 replicaCount: 1
 
 strategy: {}

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-dev.7
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-dev.7
     release: cert-manager
     heritage: Tiller
 rules:
@@ -51,7 +51,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-dev.7
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-dev.7
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -86,7 +86,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-dev.7
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -249,7 +249,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-dev.7
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it:**
Allows specifying a imagePullSecrets when the image is stored in private registry

**Special notes for your reviewer**:
Inspiration from: https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L30-L34

**Release note**:
```release-note
NONE
```
