### PR TITLE
Add DOCKER_HOST env var to gitlab build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,13 +2,13 @@ image: eu.gcr.io/jetstack-build-infra-images/bazelbuild:v20181107-8aac55d-0.18.0
 
 variables:
   DOCKER_DRIVER: overlay
+  DOCKER_HOST: tcp://localhost:2375
 
 services:
 - docker:1.12-dind
 
 before_script:
 - curl -L "https://get.docker.com/builds/Linux/x86_64/docker-1.9.1.tgz" | tar -C /usr/bin -xvzf- --strip-components=3 usr/local/bin/docker
-- export DOCKER_HOST=${DOCKER_PORT}
 - docker info > /dev/null
 
 build:


### PR DESCRIPTION
**What this PR does / why we need it**:

Our internal GitLab builders switched to use the Kubernetes executor instead of the Docker based executor, meaning we need to update the DOCKER_HOST env var to use tcp instead of a unix socket.

This should fix builds, and may also need cherry-picking to release-0.5 😄 

**Release note**:
```release-note
NONE
```

/cc @kragniz 