### PR TITLE
Bump versions for 0.6.0-alpha.0

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0-dev.6
-appVersion: v0.6.0-dev.4
+version: v0.6.0-alpha.0
+appVersion: v0.6.0-alpha.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -21,7 +21,7 @@ To install the chart with the release name `my-release`:
 ## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
 ## cert-manager Helm chart
 $ kubectl apply \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0/deploy/manifests/00-crds.yaml
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
 
 $ helm install --name my-release stable/cert-manager
 ```
@@ -65,8 +65,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `canary` |
-| `image.pullPolicy` | Image pull policy | `Always` |
+| `image.tag` | Image tag | `v0.6.0-alpha.0` |
+| `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
 | `leaderElection.Namespace` | Override the namespace used to store the ConfigMap for leader election | Same namespace as cert-manager pod
@@ -96,8 +96,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `canary` |
-| `webhook.image.pullPolicy` | Webhook image pull policy | `Always` |
+| `webhook.image.tag` | Webhook image tag | `v0.6.0-alpha.0` |
+| `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
 | `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |
 | `webhook.caSyncImage.pullPolicy` | CA sync image pull policy | `IfNotPresent` |

--- a/deploy/chart/requirements.lock
+++ b/deploy/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-dev.3
-digest: sha256:aad542c4e9f222cf92f04ad45ec36e6a3bae7118f245c2d17491eb8e48b5869c
-generated: 2018-11-21T13:57:00.496510692+01:00
+  version: v0.6.0-alpha.0
+digest: sha256:14b94c9813490feca44262a3bf1846e7dc458a52b14746053844a91f79b89f0a
+generated: 2019-01-08T16:42:33.905664717Z

--- a/deploy/chart/requirements.yaml
+++ b/deploy/chart/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-dev.3"
+  version: "v0.6.0-alpha.0"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -11,8 +11,8 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: canary
-  pullPolicy: Always
+  tag: v0.6.0-alpha.0
+  pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
 # resources. By default, the same namespace as cert-manager is deployed within is

--- a/deploy/chart/webhook/Chart.yaml
+++ b/deploy/chart/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: "v0.6.0-dev.1"
+version: "v0.6.0-alpha.0"
+appVersion: "v0.6.0-alpha.0"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook
-version: "v0.6.0-dev.3"

--- a/deploy/chart/webhook/values.yaml
+++ b/deploy/chart/webhook/values.yaml
@@ -18,8 +18,8 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: canary
-  pullPolicy: Always
+  tag: v0.6.0-alpha.0
+  pullPolicy: IfNotPresent
 
 caSyncImage:
   repository: quay.io/munnerz/apiextensions-ca-helper

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 
@@ -20,7 +20,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -51,7 +51,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -86,7 +86,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -107,7 +107,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -132,7 +132,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -153,7 +153,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -175,7 +175,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -197,7 +197,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -216,8 +216,8 @@ spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:canary"
-          imagePullPolicy: Always
+          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0-alpha.0"
+          imagePullPolicy: IfNotPresent
           args:
           - --v=12
           - --secure-port=6443
@@ -249,7 +249,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-dev.6
+    chart: cert-manager-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -268,8 +268,8 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:canary"
-          imagePullPolicy: Always
+          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-alpha.0"
+          imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)
@@ -297,7 +297,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -339,7 +339,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -378,7 +378,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 data:
@@ -411,7 +411,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -421,7 +421,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -447,7 +447,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -467,7 +467,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -491,7 +491,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -507,7 +507,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -527,7 +527,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -544,7 +544,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -564,7 +564,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-dev.3
+    chart: webhook-v0.6.0-alpha.0
     release: cert-manager
     heritage: Tiller
 webhooks:

--- a/docs/getting-started/2-installing.rst
+++ b/docs/getting-started/2-installing.rst
@@ -17,7 +17,7 @@ You can perform these two steps with the following commands:
 
     # Install the cert-manager CRDs
     $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0/deploy/manifests/00-crds.yaml
+        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
 
     # Update helm repository cache
     $ helm repo update
@@ -26,11 +26,11 @@ You can perform these two steps with the following commands:
     $ helm install \
         --name cert-manager \
         --namespace cert-manager \
-        --version v0.6.0 \
+        --version v0.6.0-alpha.0 \
         stable/cert-manager
 
 Each time you upgrade, you will need to re-apply the ``00-crds.yaml`` manifest
-above (updating the version number, in this case ``v0.6.0``, accordingly).
+above (updating the version number, in this case ``v0.6.0-alpha.0``, accordingly).
 
 The default cert-manager configuration is good for the majority of users, but a
 full list of the available options can be found in the `Helm chart README`_.
@@ -57,7 +57,7 @@ To install cert-manager using the static manifests, you should run:
 
    # Install the cert-manager CRDs
    $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0/deploy/manifests/00-crds.yaml
+        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
 
    # Create a namespace to run cert-manager in
    $ kubectl create namespace cert-manager
@@ -67,7 +67,7 @@ To install cert-manager using the static manifests, you should run:
 
    # Install cert-manager
    $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0/deploy/manifests/cert-manager.yaml
+        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/cert-manager.yaml
 
 .. _`charts repository`: https://github.com/kubernetes/charts
 .. _`Helm chart README`: https://github.com/kubernetes/charts/blob/master/stable/cert-manager/README.md


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps versions everywhere for pending v0.6.0-alpha.0 release

**Release note**:
```release-note
NONE
```
