### PR TITLE
remove liveness checks on pebble deployments in e2e tests

### DIFF
--- a/test/e2e/charts/pebble/templates/deployment.yaml
+++ b/test/e2e/charts/pebble/templates/deployment.yaml
@@ -26,13 +26,6 @@ spec:
             periodSeconds: 1
             failureThreshold: 10
             successThreshold: 1
-          livenessProbe:
-            tcpSocket:
-              port: 14000
-            initialDelaySeconds: 1
-            periodSeconds: 1
-            failureThreshold: 10
-            successThreshold: 1
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- if .Values.nodeSelector }}


### PR DESCRIPTION
liveness checks are a feature in kubernetes meant to restart hung
workloads. Since pebble stores account information in-memory, failing
a liveness check means that any running test will fail.

Because we're using pebble as part of a testsuite, we're protected
against hangs by the test just timing out.

On resource constrained environments (like my laptop), I've seen
the liveness check fail during startup, causing reboot loops and
timeouts. Since rebooting pebble mid-test will cause tests to fail
anyhow, we should probably disable this check.

Signed-off-by: Daniel Morsing <dmo@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```