### PR TITLE
Update nginx acme quickstart guide with details on Orders and Challenges

### DIFF
--- a/docs/tutorials/quick-start/index.rst
+++ b/docs/tutorials/quick-start/index.rst
@@ -768,8 +768,8 @@ certificate.
       Normal  Generated     18s   cert-manager  Generated new private key
       Normal  OrderCreated  18s   cert-manager  Created Order resource "quickstart-example-tls-889745041"
 
-You can monitor the progress of your ACME Order by 'describing' the Order
-resource that cert-manager has created for your Certificate:
+You can monitor the progress of the ACME Order by running ``kubectl describe``
+on the Order resource that cert-manager has created for your Certificate:
 
 .. code-block:: shell
 
@@ -780,9 +780,9 @@ resource that cert-manager has created for your Certificate:
       ----    ------      ----  ----          -------
       Normal  Created     90s   cert-manager  Created Challenge resource "quickstart-example-tls-889745041-0" for domain "example.your-domain.com"
 
-Here, we can see that cert-manager has created 1 'Challenge' resource in order
-to fulfill the Order. You can dig into the state of the current ACME challenge
-by 'describing' the challenge resource:
+Here, we can see that cert-manager has created 1 'Challenge' resource to fulfil
+the Order. You can dig into the state of the current ACME challenge by running
+``kubectl describe`` on the automatically created Challenge resource:
 
 .. code-block:: shell
 

--- a/docs/tutorials/quick-start/index.rst
+++ b/docs/tutorials/quick-start/index.rst
@@ -352,10 +352,13 @@ install cert-manager. This example installed cert-manager into the
 
     # Install the cert-manager CRDs. We must do this before installing the Helm
     # chart in the next step
-    $ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+
+    # Update your local Helm chart repositories
+    $ helm repo update
 
     # Install cert-manager
-    $ helm install --name cert-manager --namespace cert-manager --version v0.6.0-alpha.0 stable/cert-manager
+    $ helm install --name cert-manager --namespace cert-manager stable/cert-manager
 
     NAME:   cert-manager
     LAST DEPLOYED: Wed Jan  9 13:36:13 2019
@@ -768,7 +771,7 @@ certificate.
       Normal  Generated     18s   cert-manager  Generated new private key
       Normal  OrderCreated  18s   cert-manager  Created Order resource "quickstart-example-tls-889745041"
 
-You can monitor the progress of the ACME Order by running ``kubectl describe``
+You can see the current state of the ACME Order by running ``kubectl describe``
 on the Order resource that cert-manager has created for your Certificate:
 
 .. code-block:: shell
@@ -822,6 +825,13 @@ your ingress controller is at updating rules):
       Normal  Started         71s   cert-manager  Challenge scheduled for processing
       Normal  Presented       70s   cert-manager  Presented challenge using http-01 challenge mechanism
       Normal  DomainVerified  2s    cert-manager  Domain "example.your-domain.com" verified with "http-01" validation
+
+.. note::
+   If your challenges are not becoming 'valid' and remain in the 'pending'
+   state (or enter into a 'failed' state), it is likely there is some kind of
+   configuration error.
+   Read the :doc:`Challenge resource reference docs </reference/challenges>`
+   for more information on debugging failing challenges.
 
 Once the challenge(s) have been completed, their corresponding challenge
 resources will be *deleted*, and the 'Order' will be updated to reflect the


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the nginx acme quickstart guide with details on the new Order and Challenge resource types, which can be used to track the progress of a certificate being issued.

**Release note**:
```release-note
NONE
```

/cc @heckj
/kind documentation
/milestone v0.6