### PR TITLE
feat(helm chart): add priorityClassName option

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.0-alpha.1
+version: v0.6.0-alpha.2
 appVersion: v0.6.0-alpha.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -87,7 +87,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |
 | `podDnsConfig` | Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config) |  |
 | `podLabels` | Labels to add to the cert-manager pod | `{}` |
-| `priorityClassName`| Priority class name for cert-manager pod | `""` |
+| `priorityClassName`| Priority class name for cert-manager and webhook pods | `""` |
 | `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -87,6 +87,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |
 | `podDnsConfig` | Optional cert-manager pod [DNS configurations](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-config) |  |
 | `podLabels` | Labels to add to the cert-manager pod | `{}` |
+| `priorityClassName`| Priority class name for cert-manager pod | `""` |
 | `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |

--- a/deploy/chart/requirements.lock
+++ b/deploy/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-alpha.1
-digest: sha256:9fea4877357e5486c332beedab74db6389f0feb3e48959a5915843ccb732e4ba
-generated: 2019-01-08T23:30:18.622382Z
+  version: v0.6.0-alpha.2
+digest: sha256:556189c3d5a54b47a55498ad8b8256deec4acd39c72ae8ed751e5899ee7a2f97
+generated: 2019-01-11T08:28:30.5991435Z

--- a/deploy/chart/requirements.yaml
+++ b/deploy/chart/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-alpha.1"
+  version: "v0.6.0-alpha.2"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/chart/templates/deployment.yaml
+++ b/deploy/chart/templates/deployment.yaml
@@ -32,8 +32,8 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
-      {{- if .Values.priorityClassName }}
-      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName | quote }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -65,6 +65,9 @@ podLabels: {}
 
 nodeSelector: {}
 
+priorityClassName: ""
+
+
 ingressShim: {}
   # defaultIssuerName: ""
   # defaultIssuerKind: ""

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -67,7 +67,6 @@ nodeSelector: {}
 
 priorityClassName: ""
 
-
 ingressShim: {}
   # defaultIssuerName: ""
   # defaultIssuerKind: ""

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -65,8 +65,6 @@ podLabels: {}
 
 nodeSelector: {}
 
-priorityClassName: ""
-
 ingressShim: {}
   # defaultIssuerName: ""
   # defaultIssuerKind: ""
@@ -102,3 +100,6 @@ affinity: {}
 #     value: master
 #     effect: NoSchedule
 tolerations: []
+
+global:
+  priorityClassName: ""

--- a/deploy/chart/webhook/Chart.yaml
+++ b/deploy/chart/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: "v0.6.0-alpha.1"
+version: "v0.6.0-alpha.2"
 appVersion: "v0.6.0-alpha.0"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook

--- a/deploy/chart/webhook/templates/deployment.yaml
+++ b/deploy/chart/webhook/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ include "webhook.fullname" . }}
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -7,7 +7,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 
@@ -107,7 +107,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -132,7 +132,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -153,7 +153,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -175,7 +175,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -197,7 +197,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -297,7 +297,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -339,7 +339,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -378,7 +378,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 data:
@@ -411,7 +411,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -421,7 +421,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -447,7 +447,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -467,7 +467,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -491,7 +491,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -507,7 +507,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -527,7 +527,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -544,7 +544,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -564,7 +564,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.1
+    chart: webhook-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 webhooks:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -20,7 +20,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.1
+    chart: cert-manager-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -31,7 +31,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.1
+    chart: cert-manager-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -51,7 +51,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.1
+    chart: cert-manager-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -69,7 +69,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.1
+    chart: cert-manager-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -86,7 +86,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.1
+    chart: cert-manager-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -249,7 +249,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.1
+    chart: cert-manager-v0.6.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
Signed-off-by: Artem Kajalainen <artem.kajalainen@gofore.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

this PR adds priorityClassName option to helm chart, allowing user to specify priorityClassName for cert-manager pod.

```release-note
Add global.priorityClassName option to Helm chart
```