### PR TITLE
Adds key parser for PKCS#8 encoded private keys.

### DIFF
--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -128,6 +128,17 @@ func EncodePKCS1PrivateKey(pk *rsa.PrivateKey) []byte {
 	return pem.EncodeToMemory(block)
 }
 
+// EncodePKCS8PrivateKey will marshal a private key into x509 PEM format.
+func EncodePKCS8PrivateKey(pk interface{}) ([]byte, error) {
+	keyBytes, err := x509.MarshalPKCS8PrivateKey(pk)
+	if err != nil {
+		return nil, err
+	}
+	block := &pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}
+
+	return pem.EncodeToMemory(block), nil
+}
+
 // EncodeECPrivateKey will marshal an ECDSA private key into x509 PEM format.
 func EncodeECPrivateKey(pk *ecdsa.PrivateKey) ([]byte, error) {
 	asnBytes, err := x509.MarshalECPrivateKey(pk)

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -35,6 +35,17 @@ func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 	}
 
 	switch block.Type {
+	case "PRIVATE KEY":
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, errors.NewInvalidData("error parsing pkcs#8 private key: %s", err.Error())
+		}
+
+		signer, ok := key.(crypto.Signer)
+		if !ok {
+			return nil, errors.NewInvalidData("error parsing pkcs#8 private key: invalid key type")
+		}
+		return signer, nil
 	case "EC PRIVATE KEY":
 		key, err := x509.ParseECPrivateKey(block.Bytes)
 		if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables the key parser for the ca issuer to use PKCS#8 encoded private keys.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: No Issue created

**Special notes for your reviewer**:
The changes in the file `generate.go` is only required for the tests.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow to use PKCS#8 encoded private keys in CA issuers.
```
