### PR TITLE
Add reason when an order/challenge gets marked invalid

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -224,16 +224,15 @@ func (c *Controller) syncChallengeStatus(ctx context.Context, cl acmecl.Interfac
 
 	// TODO: should we validate the State returned by the ACME server here?
 	cmState := cmapi.State(acmeChallenge.Status)
-	if cmState == cmapi.Invalid {
-		// be nice to our users and check if there is an error that we
-		// can tell them about in the reason field
-		// TODO(dmo): problems may be compound and they may be tagged with
-		// a type field that suggests changes we should make (like provisioning
-		// an account). We might be able to handle errors more gracefully using
-		// this info
-		if acmeChallenge.Error != nil {
-			ch.Status.Reason = acmeChallenge.Error.Detail
-		}
+	// be nice to our users and check if there is an error that we
+	// can tell them about in the reason field
+	// TODO(dmo): problems may be compound and they may be tagged with
+	// a type field that suggests changes we should make (like provisioning
+	// an account). We might be able to handle errors more gracefully using
+	// this info
+	ch.Status.Reason = ""
+	if acmeChallenge.Error != nil {
+		ch.Status.Reason = acmeChallenge.Error.Detail
 	}
 	ch.Status.State = cmState
 

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -222,13 +222,7 @@ func (c *Controller) syncChallengeStatus(ctx context.Context, cl acmecl.Interfac
 		return err
 	}
 
-	switch acmeChallenge.Status {
-	case acmeapi.StatusPending, acmeapi.StatusValid, acmeapi.StatusInvalid:
-		// do nothing
-	default:
-		// bogus status from acme API that we can't handle.
-		return fmt.Errorf("acme api returned bogus status for challenge: %v", acmeChallenge.Status)
-	}
+	// TODO: should we validate the State returned by the ACME server here?
 	cmState := cmapi.State(acmeChallenge.Status)
 	if cmState == cmapi.Invalid {
 		// be nice to our users and check if there is an error that we

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -222,8 +222,25 @@ func (c *Controller) syncChallengeStatus(ctx context.Context, cl acmecl.Interfac
 		return err
 	}
 
-	// TODO: should we validate the State returned by the ACME server here?
+	switch acmeChallenge.Status {
+	case acmeapi.StatusPending, acmeapi.StatusValid, acmeapi.StatusInvalid:
+		// do nothing
+	default:
+		// bogus status from acme API that we can't handle.
+		return fmt.Errorf("acme api returned bogus status for challenge: %v", acmeChallenge.Status)
+	}
 	cmState := cmapi.State(acmeChallenge.Status)
+	if cmState == cmapi.Invalid {
+		// be nice to our users and check if there is an error that we
+		// can tell them about in the reason field
+		// TODO(dmo): problems may be compound and they may be tagged with
+		// a type field that suggests changes we should make (like provisioning
+		// an account). We might be able to handle errors more gracefully using
+		// this info
+		if acmeChallenge.Error != nil {
+			ch.Status.Reason = acmeChallenge.Error.Detail
+		}
+	}
 	ch.Status.State = cmState
 
 	return nil

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -318,7 +318,10 @@ func (c *Controller) createOrder(ctx context.Context, cl acmecl.Interface, issue
 		return fmt.Errorf("error creating new order: %v", err)
 	}
 
-	c.setOrderStatus(&o.Status, acmeOrder)
+	err = c.setOrderStatus(&o.Status, acmeOrder)
+	if err != nil {
+		return err
+	}
 
 	chals := make([]cmapi.ChallengeSpec, len(acmeOrder.Authorizations))
 	// we only set the status.challenges field when we first create the order,
@@ -427,9 +430,7 @@ func (c *Controller) syncOrderStatus(ctx context.Context, cl acmecl.Interface, o
 		return err
 	}
 
-	c.setOrderStatus(&o.Status, acmeOrder)
-
-	return nil
+	return c.setOrderStatus(&o.Status, acmeOrder)
 }
 
 func buildChallenge(i int, o *cmapi.Order, chalSpec cmapi.ChallengeSpec) *cmapi.Challenge {
@@ -449,13 +450,32 @@ func buildChallenge(i int, o *cmapi.Order, chalSpec cmapi.ChallengeSpec) *cmapi.
 
 // setOrderStatus will populate the given OrderStatus struct with the details from
 // the provided ACME Order.
-func (c *Controller) setOrderStatus(o *cmapi.OrderStatus, acmeOrder *acmeapi.Order) {
-	// TODO: should we validate the State returned by the ACME server here?
+func (c *Controller) setOrderStatus(o *cmapi.OrderStatus, acmeOrder *acmeapi.Order) error {
+	switch acmeOrder.Status {
+	case acmeapi.StatusPending, acmeapi.StatusReady, acmeapi.StatusProcessing, acmeapi.StatusValid, acmeapi.StatusInvalid:
+		// do nothing
+	default:
+		// bogus status from acme API that we can't handle.
+		return fmt.Errorf("acme api returned bogus status for order: %v", acmeOrder.Status)
+	}
 	cmState := cmapi.State(acmeOrder.Status)
+	if cmState == cmapi.Invalid {
+		// be nice to our users and check if there is an error that we
+		// can tell them about in the reason field
+		// TODO(dmo): problems may be compound and they may be tagged with
+		// a type field that suggests changes we should make (like provisioning
+		// an account). We might be able to handle errors more gracefully using
+		// this info
+		if acmeOrder.Error != nil {
+			o.Reason = acmeOrder.Error.Detail
+		}
+	}
 	c.setOrderState(o, cmState)
 
 	o.URL = acmeOrder.URL
 	o.FinalizeURL = acmeOrder.FinalizeURL
+
+	return nil
 }
 
 func challengeLabelsForOrder(o *cmapi.Order) map[string]string {

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -452,16 +452,15 @@ func buildChallenge(i int, o *cmapi.Order, chalSpec cmapi.ChallengeSpec) *cmapi.
 func (c *Controller) setOrderStatus(o *cmapi.OrderStatus, acmeOrder *acmeapi.Order) {
 	// TODO: should we validate the State returned by the ACME server here?
 	cmState := cmapi.State(acmeOrder.Status)
-	if cmState == cmapi.Invalid {
-		// be nice to our users and check if there is an error that we
-		// can tell them about in the reason field
-		// TODO(dmo): problems may be compound and they may be tagged with
-		// a type field that suggests changes we should make (like provisioning
-		// an account). We might be able to handle errors more gracefully using
-		// this info
-		if acmeOrder.Error != nil {
-			o.Reason = acmeOrder.Error.Detail
-		}
+	// be nice to our users and check if there is an error that we
+	// can tell them about in the reason field
+	// TODO(dmo): problems may be compound and they may be tagged with
+	// a type field that suggests changes we should make (like provisioning
+	// an account). We might be able to handle errors more gracefully using
+	// this info
+	o.Reason = ""
+	if acmeOrder.Error != nil {
+		o.Reason = acmeOrder.Error.Detail
 	}
 	c.setOrderState(o, cmState)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When an ACME server tells us that a challenge or an order is invalid, it's helpful to get some information on why that's the case. Populate the reason field with the error information so that these issues can be more easily debugged.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
