### PR TITLE
Include CRD and Namespace resources in static deployment manifest file

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -1,12 +1,3 @@
-## THIS FILE IS MANUALLY WRITTEN AND NOT AUTOMATICALLY GENERATED
-##
-## You should install this file with "kubectl apply -f" before installing the
-## cert-manager Helm chart or applying the "deploy/manifests/cert-manager.yaml"
-## file.
-##
-
----
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:

--- a/deploy/manifests/01-namespace.yaml
+++ b/deploy/manifests/01-namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    certmanager.k8s.io/disable-validation: "true"
+
+---

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1,3 +1,93 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: certificates.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: Certificate
+    plural: certificates
+    shortNames:
+    - cert
+    - certs
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: clusterissuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: orders.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Order
+    plural: orders
+  scope: Namespaced
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: challenges.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Challenge
+    plural: challenges
+  scope: Namespaced
+
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cert-manager
+  labels:
+    certmanager.k8s.io/disable-validation: "true"
+
+---
 ---
 # Source: cert-manager/charts/webhook/templates/serviceaccount.yaml
 apiVersion: v1

--- a/docs/getting-started/2-installing.rst
+++ b/docs/getting-started/2-installing.rst
@@ -17,7 +17,7 @@ You can perform these two steps with the following commands:
 
     # Install the cert-manager CRDs
     $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
+        -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
 
     # Update helm repository cache
     $ helm repo update
@@ -26,11 +26,11 @@ You can perform these two steps with the following commands:
     $ helm install \
         --name cert-manager \
         --namespace cert-manager \
-        --version v0.6.0-alpha.0 \
+        --version v0.6.0 \
         stable/cert-manager
 
 Each time you upgrade, you will need to re-apply the ``00-crds.yaml`` manifest
-above (updating the version number, in this case ``v0.6.0-alpha.0``, accordingly).
+above (updating the version number, in this case ``v0.6.0``, accordingly).
 
 The default cert-manager configuration is good for the majority of users, but a
 full list of the available options can be found in the `Helm chart README`_.
@@ -55,19 +55,9 @@ To install cert-manager using the static manifests, you should run:
 
 .. code-block:: shell
 
-   # Install the cert-manager CRDs
-   $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
-
-   # Create a namespace to run cert-manager in
-   $ kubectl create namespace cert-manager
-
-   # Disable resource validation on the cert-manager namespace
-   $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
-
    # Install cert-manager
    $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/cert-manager.yaml
+        -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/cert-manager.yaml
 
 .. _`charts repository`: https://github.com/kubernetes/charts
 .. _`Helm chart README`: https://github.com/kubernetes/charts/blob/master/stable/cert-manager/README.md

--- a/hack/update-deploy-gen.sh
+++ b/hack/update-deploy-gen.sh
@@ -36,9 +36,10 @@ gen() {
 		--values "${REPO_ROOT}/deploy/manifests/helm-values.yaml" \
 		--kube-version "${KUBE_VERSION}" \
 		--namespace "cert-manager" \
-		--name "cert-manager" \
-		--set "createNamespaceResource=true" > "${TMP_OUTPUT}"
-	mv "${TMP_OUTPUT}" "${OUTPUT}"
+		--name "cert-manager" > "${TMP_OUTPUT}"
+    cat "${REPO_ROOT}/deploy/manifests/00-crds.yaml" \
+        "${REPO_ROOT}/deploy/manifests/01-namespace.yaml" \
+        "${TMP_OUTPUT}" > "${OUTPUT}"
 }
 
 export HELM_HOME="$(mktemp -d)"


### PR DESCRIPTION
**What this PR does / why we need it**:

Switches us to include the CRD & Namespace resources as part of the single all-in-one deployment manifest.

This simplifies installation for users that don't use Helm to a single command.

**Which issue this PR fixes**: fixes #1171

**Release note**:
```release-note
NONE
```
