### PR TITLE
Add additionalPrinterColumns fields to CustomResourceDefintions

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -5,6 +5,29 @@ metadata:
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.commonName
+    name: Common Name
+    type: string
+  - JSONPath: .spec.dnsNames
+    name: DNS Names
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .status.lastFailureTime
+    name: Last Failure
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   scope: Namespaced
@@ -56,6 +79,23 @@ metadata:
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   names:
@@ -72,6 +112,23 @@ metadata:
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   names:

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -6,21 +6,32 @@ metadata:
     app: cert-manager
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.commonName
-    name: Common Name
-    type: string
-  - JSONPath: .spec.dnsNames
-    name: DNS Names
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
     type: string
   - JSONPath: .spec.secretName
     name: Secret
     type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+    priority: 1
+  - JSONPath: .spec.commonName
+    name: Common Name
+    type: string
+    priority: 1
+  - JSONPath: .spec.dnsNames
+    name: DNS Names
+    type: string
+    priority: 1
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+    priority: 1
   - JSONPath: .status.lastFailureTime
     name: Last Failure
     type: date
+    priority: 1
   - JSONPath: .metadata.creationTimestamp
     description: |-
       CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -5,6 +5,29 @@ metadata:
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.commonName
+    name: Common Name
+    type: string
+  - JSONPath: .spec.dnsNames
+    name: DNS Names
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+  - JSONPath: .spec.secretName
+    name: Secret
+    type: string
+  - JSONPath: .status.lastFailureTime
+    name: Last Failure
+    type: date
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   scope: Namespaced
@@ -56,6 +79,23 @@ metadata:
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   names:
@@ -72,6 +112,23 @@ metadata:
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   names:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -6,21 +6,32 @@ metadata:
     app: cert-manager
 spec:
   additionalPrinterColumns:
-  - JSONPath: .spec.commonName
-    name: Common Name
-    type: string
-  - JSONPath: .spec.dnsNames
-    name: DNS Names
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
+  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+    name: Ready
     type: string
   - JSONPath: .spec.secretName
     name: Secret
     type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    type: string
+    priority: 1
+  - JSONPath: .spec.commonName
+    name: Common Name
+    type: string
+    priority: 1
+  - JSONPath: .spec.dnsNames
+    name: DNS Names
+    type: string
+    priority: 1
+  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    name: Status
+    type: string
+    priority: 1
   - JSONPath: .status.lastFailureTime
     name: Last Failure
     type: date
+    priority: 1
   - JSONPath: .metadata.creationTimestamp
     description: |-
       CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.


### PR DESCRIPTION
**What this PR does / why we need it**:

This gives far more useful kubectl output when running `kubectl get certificate,order,challenge` 😄 

**Special notes for your reviewer**:

~We can't currently make use of the Ready condition that we publish on the Certificate resource due to https://github.com/kubernetes/kubernetes/issues/67268 - once that merges, I think we should propagate the 'readiness' as a column too 😄~

**Release note**:
```release-note
Print more useful information about Certificate, Order and Challenge resources when running `kubectl get`
```
