### PR TITLE
Retain Challenge resources for debugging if an Order enters an invalid state

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -109,6 +109,13 @@ func (c *Controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 			return err
 		}
 
+		// Don't cleanup challenge resources if the order has failed.
+		// This will make it easier for users to debug failing challenges.
+		// The challenge resources will be cleaned up when the Order is deleted.
+		if acme.IsFailureState(o.Status.State) {
+			return nil
+		}
+
 		// Cleanup challenge resources once a final state has been reached
 		for _, ch := range existingChallenges {
 			err := c.CMClient.CertmanagerV1alpha1().Challenges(ch.Namespace).Delete(ch.Name, nil)


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we deleted all Challenge resources for an Order once the Order enters any 'final' state (including failed).

This makes it harder for users to debug order failures once the order transitions to the invalid state.

@goblain brought this up on slack: https://kubernetes.slack.com/archives/C4NV3DWUC/p1547213252391000

> any idea how can I force cert-manager to keep challenge response open for debugging access to it ?

**Release note**:
```release-note
Retain Challenge resources when an Order has entered a failed state to make debugging easier
```

/area provider-acme