### PR TITLE
Increase resource requests and limits for cert-manager during e2e tests

### DIFF
--- a/test/fixtures/cert-manager-values.yaml
+++ b/test/fixtures/cert-manager-values.yaml
@@ -6,10 +6,10 @@ image:
 
 resources:
   requests:
-    cpu: 100m
-    memory: 50Mi
+    cpu: 500m
+    memory: 200Mi
   limits:
-    cpu: 200m
+    cpu: 1
     memory: 200Mi
 
 extraArgs:
@@ -25,8 +25,8 @@ webhook:
     pullPolicy: Never
   resources:
     requests:
-      cpu: 10m
+      cpu: 100m
       memory: 40Mi
     limits:
-      cpu: 100m
+      cpu: 200m
       memory: 256Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

We are occasionally seeing test failures with the CA Issuer, and whilst inspecting the logs to determine the problem, I've noticed that the certificates controller can take a long time during the 'issuance' phase.

I have a hunch this *could* be caused simply by lack of CPU resources to complete this in a timely manner, based on the log messages I can see (it's taking ~30-45s to run the `issue` function and in that time, the test has already timed out)

**Release note**:
```release-note
NONE
```
