### PR TITLE
Add Pebble 'strict' mode support in e2e test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ APP_VERSION := canary
 HACK_DIR ?= hack
 
 GINKGO_SKIP :=
+PEBBLE_STRICT ?= false
 
 ## e2e test vars
 KUBECONFIG ?= $$HOME/.kube/config
@@ -116,7 +117,8 @@ e2e_test:
 			--tiller-image-tag=$$($$(bazel info bazel-genfiles)/hack/bin/helm version --client --template '{{.Client.SemVer}}') \
 			--repo-root="$$(pwd)" \
 			--report-dir="$${ARTIFACTS:-./_artifacts}" \
-			--ginkgo.skip="$(GINKGO_SKIP)"
+			--ginkgo.skip="$(GINKGO_SKIP)" \
+			--pebble-strict=$(PEBBLE_STRICT)
 
 # Generate targets
 ##################

--- a/hack/ci/run-e2e-kind.sh
+++ b/hack/ci/run-e2e-kind.sh
@@ -49,5 +49,7 @@ kubectl get nodes
 
 "${SCRIPT_ROOT}/lib/build_images.sh"
 
+PEBBLE_STRICT="${PEBBLE_STRICT:-false}"
 make e2e_test \
-    KUBECONFIG=${KUBECONFIG}
+    KUBECONFIG=${KUBECONFIG} \
+    PEBBLE_STRICT="${PEBBLE_STRICT}"

--- a/test/e2e/charts/pebble/templates/deployment.yaml
+++ b/test/e2e/charts/pebble/templates/deployment.yaml
@@ -19,6 +19,8 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+          - -strict={{ .Values.strict }}
           readinessProbe:
             tcpSocket:
               port: 14000

--- a/test/e2e/charts/pebble/values.yaml
+++ b/test/e2e/charts/pebble/values.yaml
@@ -12,3 +12,5 @@ resources:
   limits:
     cpu: 100m
     memory: 100Mi
+
+strict: "false"

--- a/test/e2e/framework/addon/pebble/pebble.go
+++ b/test/e2e/framework/addon/pebble/pebble.go
@@ -40,6 +40,9 @@ type Pebble struct {
 
 	// Namespace is the namespace to deploy Pebble into
 	Namespace string
+
+	// Strict will set the 'strict' flag on pebble
+	Strict bool
 }
 
 type Details struct {
@@ -69,6 +72,12 @@ func (p *Pebble) Setup(cfg *config.Config) error {
 		ReleaseName: "chart-pebble-" + p.Name,
 		Namespace:   p.Namespace,
 		ChartName:   cfg.RepoRoot + "/test/e2e/charts/pebble",
+		Vars: []chart.StringTuple{
+			{
+				Key:   "strict",
+				Value: fmt.Sprintf("%t", p.Strict),
+			},
+		},
 		// doesn't matter when installing from disk
 		ChartVersion: "0",
 	}

--- a/test/e2e/framework/config/pebble.go
+++ b/test/e2e/framework/config/pebble.go
@@ -26,9 +26,13 @@ type Pebble struct {
 
 	// // ImageTag for Pebble
 	// ImageTag string
+
+	// Strict enables Pebble's 'strict mode'
+	Strict bool
 }
 
 func (p *Pebble) AddFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&p.Strict, "pebble-strict", false, "If true, tests using Pebble will have strict mode enabled")
 	// fs.StringVar(&p.ImageRepo, "pebble-image-repo", "", "The container image repository for pebble to use in e2e tests")
 	// fs.StringVar(&p.ImageTag, "pebble-image-tag", "", "The container image tag for pebble to use in e2e tests")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Once this PR merges, I'm going to create an e2e job (probably a periodic instead of a presubmit) that verifies we support pebble's 'strict' mode, so we can get ahead of breaking server/client changes.

**Release note**:
```release-note
NONE
```
