### PR TITLE
feat: Add an optional `ipAddresses` field to certificate spec

### DIFF
--- a/docs/reference/certificates.rst
+++ b/docs/reference/certificates.rst
@@ -44,6 +44,9 @@ The ``dnsNames`` field specifies a list of `Subject Alternative Names`_ to be
 associated with the certificate. If the ``commonName`` field is omitted, the
 first element in the list will be the common name.
 
+The ``ipAddresses`` field specifies a list of `Subject Alternative Names`_ to be
+associated with the certificate and labeled as IP addresses.
+
 The referenced Issuer must exist in the same namespace as the Certificate. A
 Certificate can alternatively reference a ClusterIssuer which is non-namespaced.
 

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -57,8 +57,11 @@ type CertificateSpec struct {
 	// Organization is the organization to be used on the Certificate
 	Organization []string `json:"organization,omitempty"`
 
-	// DNSNames is a list of subject alt names to be used on the Certificate
+	// DNSNames is a list of DNS SANs to be used on the Certificate
 	DNSNames []string `json:"dnsNames,omitempty"`
+
+	// IPAddresses is a list of IP address SANs to be used on the Certificate
+	IPAddresses []string `json:"ipAddresses,omitempty"`
 
 	// SecretName is the name of the secret resource to store this secret in
 	SecretName string `json:"secretName"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This change allows provisioning certificates with SANs labeled as IP addresses
(rather than the current default, which is to label all SANs as DNS
names).

A specific use case for this is when using the CA issuer to create certificates for mTLS between services (see https://github.com/uswitch/kiam/blob/master/docs/TLS.md for an example).  When verifying a certificate for a hostname that's an IP address, the certificate must contain an IPAddress (see VerifyHostname() in https://golang.org/src/crypto/x509/verify.go).

**Special notes for your reviewer**:

I believe this should be a backwards-compatible change; I've opened this PR against the 0.5 release in the hopes that I won't have to wait until 0.6 to see a release with this functionality :)

**Release note**:
```release-note
NONE
```
Signed-off-by: Steve Huff <shuff@vecna.org>