### PR TITLE
Bump for v0.6.0-alpha.1

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0-alpha.2
-appVersion: v0.6.0-alpha.0
+version: v0.6.0-alpha.3
+appVersion: v0.6.0-alpha.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -21,7 +21,7 @@ To install the chart with the release name `my-release`:
 ## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
 ## cert-manager Helm chart
 $ kubectl apply \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.0/deploy/manifests/00-crds.yaml
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.1/deploy/manifests/00-crds.yaml
 
 $ helm install --name my-release stable/cert-manager
 ```
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | --------- | ----------- | ------- |
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.6.0-alpha.0` |
+| `image.tag` | Image tag | `v0.6.0-alpha.1` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.6.0-alpha.0` |
+| `webhook.image.tag` | Webhook image tag | `v0.6.0-alpha.1` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
 | `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |

--- a/deploy/chart/requirements.lock
+++ b/deploy/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-alpha.2
-digest: sha256:556189c3d5a54b47a55498ad8b8256deec4acd39c72ae8ed751e5899ee7a2f97
-generated: 2019-01-11T08:28:30.5991435Z
+  version: v0.6.0-alpha.3
+digest: sha256:266c4cc6e138ad1d82d95d77028a1102050b08ac248371143f7f63dbdcfa4793
+generated: 2019-01-14T10:35:30.403733726Z

--- a/deploy/chart/requirements.yaml
+++ b/deploy/chart/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-alpha.2"
+  version: "v0.6.0-alpha.3"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -18,7 +18,7 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.6.0-alpha.0
+  tag: v0.6.0-alpha.1
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer

--- a/deploy/chart/webhook/Chart.yaml
+++ b/deploy/chart/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: "v0.6.0-alpha.2"
-appVersion: "v0.6.0-alpha.0"
+version: "v0.6.0-alpha.3"
+appVersion: "v0.6.0-alpha.1"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook

--- a/deploy/chart/webhook/values.yaml
+++ b/deploy/chart/webhook/values.yaml
@@ -18,7 +18,7 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.6.0-alpha.0
+  tag: v0.6.0-alpha.1
   pullPolicy: IfNotPresent
 
 caSyncImage:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -165,7 +165,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 
@@ -178,7 +178,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.2
+    chart: cert-manager-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 ---
@@ -189,7 +189,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.2
+    chart: cert-manager-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -209,7 +209,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.2
+    chart: cert-manager-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -227,7 +227,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.2
+    chart: cert-manager-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -244,7 +244,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.2
+    chart: cert-manager-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -265,7 +265,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -290,7 +290,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -311,7 +311,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -333,7 +333,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -355,7 +355,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -374,7 +374,7 @@ spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0-alpha.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0-alpha.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12
@@ -407,7 +407,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.2
+    chart: cert-manager-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -426,7 +426,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-alpha.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-alpha.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -455,7 +455,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -497,7 +497,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -536,7 +536,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 data:
@@ -569,7 +569,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 ---
@@ -579,7 +579,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -605,7 +605,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -625,7 +625,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -649,7 +649,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -665,7 +665,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -685,7 +685,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -702,7 +702,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 spec:
@@ -722,7 +722,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.2
+    chart: webhook-v0.6.0-alpha.3
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps resource manifests for v0.6.0-alpha.1

**Release note**:
```release-note
NONE
```
