### PR TITLE
only init globals data once

### DIFF
--- a/test/e2e/framework/addon/globals.go
+++ b/test/e2e/framework/addon/globals.go
@@ -59,10 +59,16 @@ var (
 	provisioned []Addon
 )
 
+var globalsInited = false
+
 // InitGlobals actually allocates the addon values that are defined above.
 // We do this here so that we can access the suites config structure during
 // the definition of global addons.
 func InitGlobals(cfg *config.Config) {
+	if globalsInited {
+		return
+	}
+	globalsInited = true
 	*Base = base.Base{}
 	*Tiller = tiller.Tiller{
 		Base:               Base,


### PR DESCRIPTION
This fixes the issue of global addons not being cleaned up after tests

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
