### PR TITLE
Add arm32 and arm64 bazel image targets

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,16 +1,27 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
+load("//hack:def.bzl", "multiarch_bundle")
 
 # gazelle:proto disable_global
 
-container_bundle(
+# this target creates targets:
+# 'images' (all arch and os)
+# 'images.linux-amd64'
+# 'images.linux-arm64'
+# 'images.linux-arm'
+multiarch_bundle(
     name = "images",
+    arch = [
+        "amd64",
+        "arm64",
+        "arm",
+    ],
     images = {
-        "{STABLE_DOCKER_REPO}/cert-manager-controller:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
-        "{STABLE_DOCKER_REPO}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
-        "{STABLE_DOCKER_REPO}/cert-manager-webhook:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-controller-{arch}:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-acmesolver-{arch}:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-webhook-{arch}:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
     },
-    stamp = True,
+    os = ["linux"],
 )
 
 docker_push(

--- a/Makefile
+++ b/Makefile
@@ -144,6 +144,15 @@ images_push: images
 	# https://github.com/moby/buildkit/issues/409#issuecomment-394757219
 	# source the bazel workspace environment
 	eval $$($(BAZEL_IMAGE_ENV) ./hack/print-workspace-status.sh | tr ' ' '='); \
+	docker tag "$${STABLE_DOCKER_REPO}/cert-manager-acmesolver-amd64:$${STABLE_DOCKER_TAG}" "$${STABLE_DOCKER_REPO}/cert-manager-acmesolver:$${STABLE_DOCKER_TAG}"; \
+	docker tag "$${STABLE_DOCKER_REPO}/cert-manager-controller-amd64:$${STABLE_DOCKER_TAG}" "$${STABLE_DOCKER_REPO}/cert-manager-controller:$${STABLE_DOCKER_TAG}"; \
+	docker tag "$${STABLE_DOCKER_REPO}/cert-manager-webhook-amd64:$${STABLE_DOCKER_TAG}" "$${STABLE_DOCKER_REPO}/cert-manager-webhook:$${STABLE_DOCKER_TAG}"; \
 	docker push "$${STABLE_DOCKER_REPO}/cert-manager-acmesolver:$${STABLE_DOCKER_TAG}"; \
 	docker push "$${STABLE_DOCKER_REPO}/cert-manager-controller:$${STABLE_DOCKER_TAG}"; \
-	docker push "$${STABLE_DOCKER_REPO}/cert-manager-webhook:$${STABLE_DOCKER_TAG}"
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-webhook:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-acmesolver-arm64:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-controller-arm64:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-webhook-arm64:$${STABLE_DOCKER_TAG}";
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-acmesolver-arm:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-controller-arm:$${STABLE_DOCKER_TAG}"; \
+	docker push "$${STABLE_DOCKER_REPO}/cert-manager-webhook-arm:$${STABLE_DOCKER_TAG}";

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -68,10 +68,27 @@ _go_image_repos()
 
 ## Pull some standard base images
 container_pull(
-    name = "alpine",
-    registry = "gcr.io",
-    repository = "jetstack-build-infra/alpine",
-    tag = "3.7-v20180822-0201cfb11",
+    name = "alpine_linux-amd64",
+    digest = "sha256:cf2412cab4f40318e722d2604fa6c79b3d28a7cb37988d95ab2453577417359a",
+    registry = "index.docker.io",
+    repository = "munnerz/alpine",
+    tag = "3.8-amd64",
+)
+
+container_pull(
+    name = "alpine_linux-arm64",
+    digest = "sha256:4b8a5fc687674dd11ab769b8a711acba667c752b08697a03f6ffb1f1bcd123e5",
+    registry = "index.docker.io",
+    repository = "munnerz/alpine",
+    tag = "3.8-arm64",
+)
+
+container_pull(
+    name = "alpine_linux-arm",
+    digest = "sha256:185cad013588d77b0e78018b5f275a7849a63a33cd926405363825536597d9e2",
+    registry = "index.docker.io",
+    repository = "munnerz/alpine",
+    tag = "3.8-arm",
 )
 
 ## Fetch helm & tiller for use in template generation and testing

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "stamped_image")
+load("//hack:def.bzl", "multiarch_image")
 
-stamped_image(
+# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
+multiarch_image(
     name = "image",
-    base = "@alpine//image",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "stamped_image")
+load("//hack:def.bzl", "multiarch_image")
 
-stamped_image(
+# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
+multiarch_image(
     name = "image",
-    base = "@alpine//image",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -1,9 +1,9 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "stamped_image")
+load("//hack:def.bzl", "multiarch_image")
 
-stamped_image(
+# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
+multiarch_image(
     name = "image",
-    base = "@alpine//image",
     visibility = ["//visibility:public"],
 )
 

--- a/hack/ci/lib/build_images.sh
+++ b/hack/ci/lib/build_images.sh
@@ -30,9 +30,8 @@ build_images() {
     APP_VERSION="${DOCKER_TAG}" \
     DOCKER_REPO="${DOCKER_REPO}" \
     DOCKER_TAG="${DOCKER_TAG}" \
-    bazel run //:images
-    # Build e2e test images
-    bazel run //test/e2e/charts:images
+    # Build images used during e2e tests
+    bazel run //test/e2e:images
 
     local TMP_DIR=$(mktemp -d)
     local BUNDLE_FILE="${TMP_DIR}"/cmbundle.tar.gz

--- a/hack/ci/lib/lib.sh
+++ b/hack/ci/lib/lib.sh
@@ -23,21 +23,21 @@ REPO_ROOT="${_SCRIPT_ROOT}/../../.."
 
 # This file contains common definitions that are re-used in other scripts
 
-K8S_VERSION="${K8S_VERSION:-1.11}"
+export K8S_VERSION="${K8S_VERSION:-1.11}"
 KUBECTL_TARGET="${KUBECTL_TARGET:-//test/e2e/bin:kubectl-${K8S_VERSION}}"
-export KIND_IMAGE_TARGET="${KIND_IMAGE_TARGET:-@kind-${K8S_VERSION}//image}"
+KIND_IMAGE_TARGET="${KIND_IMAGE_TARGET:-@kind-${K8S_VERSION}//image}"
 
-KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-cm-local-cluster}"
-KIND_CONTAINER_NAME="kind-${KIND_CLUSTER_NAME}-control-plane"
+export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-cm-local-cluster}"
+export KIND_CONTAINER_NAME="kind-${KIND_CLUSTER_NAME}-control-plane"
 
 # DOCKER_REPO is the docker repo to use for cert-manager images, either when
 # building or deploying cert-manager using these scripts.
-DOCKER_REPO="quay.io/jetstack"
+export DOCKER_REPO="quay.io/jetstack"
 
 # DOCKER_TAG is the docker tag to use for the cert-manager images.
 # This defaults to 'build' so it doesn't conflict with images built for any
 # other purpose
-DOCKER_TAG="build"
+export DOCKER_TAG="build"
 
 if [ ! "${CM_DEPS_LOADED:-}" = "1" ]; then
     # Build all e2e test dependencies

--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_docker//container:image.bzl", "container_image")
+load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 ## stamped_image is a macro for creating :app and :image targets
@@ -37,3 +38,63 @@ def stamped_image(
       user = user,
       stamp = stamp,
       **kwargs)
+
+def multiarch_image(
+    name,
+    goarch = ["amd64", "arm64", "arm"],
+    goos = ["linux"],
+    user = "1000",
+    stamp = True,
+    **kwargs):
+
+  for arch in goarch:
+    for os in goos:
+      go_image(
+          name = "%s.app_%s-%s" % (name, os, arch),
+          base = "@alpine_%s-%s//image" % (os, arch),
+          embed = [":go_default_library"],
+          goarch = arch,
+          goos = os,
+          pure = "on",
+      )
+
+      container_image(
+          name = "%s.%s-%s" % (name, os, arch),
+          base = "%s.app_%s-%s" % (name, os, arch),
+          user = user,
+          stamp = stamp,
+          **kwargs)
+
+  container_image(
+      name = name,
+      base = "%s.%s-%s" % (name, goos[0], goarch[0]),
+      **kwargs)
+
+def multiarch_bundle(
+    name,
+    images,
+    os = ["linux"],
+    arch = ["amd64", "arm64", "arm"],
+    **kwargs):
+
+    all_images = {}
+    for a in arch:
+      for o in os:
+        oa_images = {}
+        for (k, v) in images.items():
+          image_name = k.replace("{arch}", a)
+          image_name = image_name.replace("{os}", o)
+
+          oa_images[image_name] = "%s.%s-%s" % (v, o, a)
+
+        container_bundle(
+            name = "%s.%s-%s" % (name, o, a),
+            images = oa_images,
+            **kwargs)
+
+        all_images += oa_images
+
+    container_bundle(
+        name = name,
+        images = all_images,
+        **kwargs)

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -1,4 +1,20 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
+
+container_bundle(
+    name = "images",
+    images = {
+        # A set of images to bundle up into a single tarball.
+        "pebble:bazel": "//test/e2e/charts/pebble:image",
+        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.21.0": "@io_kubernetes_ingress-nginx//image",
+        "k8s.gcr.io/defaultbackend:bazel": "@io_gcr_k8s_defaultbackend//image",
+        "vault:bazel": "@com_hashicorp_vault//image",
+        "gcr.io/kubernetes-helm/tiller:bazel": "@io_gcr_helm_tiller//image",
+        "{STABLE_DOCKER_REPO}/cert-manager-controller:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-webhook:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
+    },
+)
 
 # we add this rule so users can `bazel build //test/e2e` to run a
 # platform-independent version of the e2e test binary

--- a/test/e2e/charts/pebble/BUILD.bazel
+++ b/test/e2e/charts/pebble/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_image(
     name = "image",
-    base = "@alpine//image",
+    base = "@alpine_linux-amd64//image",
     embed = ["@org_letsencrypt_pebble//cmd/pebble:go_default_library"],
     goarch = "amd64",
     goos = "linux",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds support for building arm32 and arm64 images for cert-manager.

We'll need to set up the new quay.io repositories for the new architectures. In future, when quay.io supports manifest list 2.2, we'll be able to push proper multiarch images.

**Which issue this PR fixes**: fixes #608 

**Release note**:
```release-note
Publish arm32 and arm64 images for all cert-manager components
```
