### PR TITLE
Fix issuing a certificate into a pre-existing secret

### DIFF
--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -19,7 +19,6 @@ package kube
 import (
 	"crypto"
 	"crypto/x509"
-	"fmt"
 
 	api "k8s.io/api/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -39,7 +38,7 @@ func SecretTLSKeyRef(secretLister corelisters.SecretLister, namespace, name, key
 
 	keyBytes, ok := secret.Data[keyName]
 	if !ok {
-		return nil, fmt.Errorf("no data for %q in secret '%s/%s'", keyName, namespace, name)
+		return nil, errors.NewInvalidData("no data for %q in secret '%s/%s'", keyName, namespace, name)
 	}
 	key, err := pki.DecodePrivateKeyBytes(keyBytes)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously, if the `secretName` specified on a Certificate references a secret that already exists but does not have the `tls.key` field set, we would refuse to attempt to issue a certificate.

By wrapping the error we return here with InvalidData, the ACME issuer will generate a new private key and 'insert' values into the existing Secret resource.

This issue was reported by @swade1987 😄

**Release note**:
```release-note
Fix issuing a certificate into a pre-existing secret resource
```
