### PR TITLE
Disable TLS verification when self-checking

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -157,6 +157,9 @@ func testReachability(ctx context.Context, url string, key string) (bool, error)
 	// TODO(dmo): figure out if we need to add a more specific timeout for
 	// individual checks
 	transport := &http.Transport{
+		// we're only doing 1 request, make the code around this
+		// simpler by disabling keepalives
+		DisableKeepAlives: true,
 		TLSClientConfig: &tls.Config{
 			InsecureSkipVerify: true,
 		},

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -18,6 +18,7 @@ package http
 
 import (
 	"context"
+	"crypto/tls"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -149,7 +150,22 @@ func testReachability(ctx context.Context, url string, key string) (bool, error)
 
 	req = req.WithContext(ctx)
 
-	response, err := http.DefaultClient.Do(req)
+	// ACME spec says that a verifier should try
+	// on http port 80 first, but follow any redirects may be thrown its way
+	// The redirects may be HTTPS and its certificate may be invalid (they are trying to get a
+	// certificate after all).
+	// TODO(dmo): figure out if we need to add a more specific timeout for
+	// individual checks
+	transport := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true,
+		},
+	}
+	client := http.Client{
+		Transport: transport,
+	}
+
+	response, err := client.Do(req)
 	if err != nil {
 		return false, &absorbErr{err: fmt.Errorf("failed to GET '%s': %v", url, err)}
 	}


### PR DESCRIPTION


**What this PR does / why we need it**:
Disable TLS verification when self-checking

**Which issue this PR fixes** 
Fixes #949

**Special notes for your reviewer**:
There's no test for this right now, since pebble doesn't implement the right redirect behavior and any E2E test would fail.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix self-check behavior with HTTP->HTTPS redirects
```
