### PR TITLE
Bump Helm chart version for beta.0

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0-alpha.3
-appVersion: v0.6.0-alpha.1
+version: v0.6.0-beta.0
+appVersion: v0.6.0-beta.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/deploy/chart/README.md
+++ b/deploy/chart/README.md
@@ -21,7 +21,7 @@ To install the chart with the release name `my-release`:
 ## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
 ## cert-manager Helm chart
 $ kubectl apply \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/v0.6.0-alpha.1/deploy/manifests/00-crds.yaml
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
 
 $ helm install --name my-release stable/cert-manager
 ```
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | --------- | ----------- | ------- |
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.6.0-alpha.1` |
+| `image.tag` | Image tag | `v0.6.0-beta.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
@@ -98,7 +98,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.6.0-alpha.1` |
+| `webhook.image.tag` | Webhook image tag | `v0.6.0-beta.0` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
 | `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |

--- a/deploy/chart/requirements.lock
+++ b/deploy/chart/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-alpha.3
-digest: sha256:266c4cc6e138ad1d82d95d77028a1102050b08ac248371143f7f63dbdcfa4793
-generated: 2019-01-14T10:35:30.403733726Z
+  version: v0.6.0-beta.0
+digest: sha256:fcbb95a8494138cfb4f01735cf8a4fa181952d3bd2a628b10eb082c145130f38
+generated: 2019-01-17T15:44:50.976304931Z

--- a/deploy/chart/requirements.yaml
+++ b/deploy/chart/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-alpha.3"
+  version: "v0.6.0-beta.0"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -18,7 +18,7 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.6.0-alpha.1
+  tag: v0.6.0-beta.0
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer

--- a/deploy/chart/webhook/Chart.yaml
+++ b/deploy/chart/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: "v0.6.0-alpha.3"
-appVersion: "v0.6.0-alpha.1"
+version: "v0.6.0-beta.0"
+appVersion: "v0.6.0-beta.0"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook

--- a/deploy/chart/webhook/values.yaml
+++ b/deploy/chart/webhook/values.yaml
@@ -18,7 +18,7 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.6.0-alpha.1
+  tag: v0.6.0-beta.0
   pullPolicy: IfNotPresent
 
 caSyncImage:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.3
+    chart: cert-manager-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.3
+    chart: cert-manager-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.3
+    chart: cert-manager-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.3
+    chart: cert-manager-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.3
+    chart: cert-manager-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -255,7 +255,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -280,7 +280,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -301,7 +301,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -323,7 +323,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -345,7 +345,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -364,7 +364,7 @@ spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0-alpha.1"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0-beta.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-alpha.3
+    chart: cert-manager-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -416,7 +416,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-alpha.1"
+          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-beta.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -445,7 +445,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -487,7 +487,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -526,7 +526,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 data:
@@ -559,7 +559,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -569,7 +569,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -595,7 +595,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -615,7 +615,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -639,7 +639,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -655,7 +655,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -675,7 +675,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -692,7 +692,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -712,7 +712,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-alpha.3
+    chart: webhook-v0.6.0-beta.0
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump the manifest/chart/doc versions for a new v0.6.0 beta release. This should hopefully be the last change in this release!

Once this has merged and release-0.6 has been fast forwarded, we can begin accepting patches for v0.7 into master.

Any new changes will need to be cherry picked into release-0.6.

**Release note**:
```release-note
NONE
```
