### PR TITLE
Fix nil map panic when writing to an empty existing Secret

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -299,6 +299,9 @@ func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, c
 		}
 	}
 
+	if secret.Data == nil {
+		secret.Data = map[string][]byte{}
+	}
 	secret.Data[corev1.TLSCertKey] = cert
 	secret.Data[corev1.TLSPrivateKeyKey] = key
 	secret.Data[TLSCAKey] = ca


### PR DESCRIPTION
**What this PR does / why we need it**:

Check to make sure the map is non-nil before writing data into it

**Which issue this PR fixes**: fixes #1236

**Release note**:
```release-note
NONE
```

/milestone v0.6
/kind bug
