### PR TITLE
Update order status if state changes will retrieving an existing certificate

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -109,6 +109,14 @@ func (c *Controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 			return err
 		}
 
+		// If the Order state has actually changed and we've not observed it,
+		// update the order status and let the change in the resource trigger
+		// a resync
+		if acmeOrder.Status != acmeapi.StatusValid {
+			c.setOrderStatus(&o.Status, acmeOrder)
+			return nil
+		}
+
 		certs, err := cl.GetCertificate(ctx, acmeOrder.CertificateURL)
 		if err != nil {
 			// TODO: mark the order as 'errored' if this is a 404 or similar


### PR DESCRIPTION
**What this PR does / why we need it**:

There is a very edge-edge case whereby a user may have an Order resource with `state: valid` but `certificate: nil`. It's not a case that we should ever find ourselves in, but due to performing an upgrading on my own cluster from a dev build of CM I noticed that we don't handle the case very gracefully.

This PR updates the check for Valid certs with no Certificate data set, to verify that the Order *is* actually valid after calling GetOrder. If the state has changed from what we've recorded (i.e. our information is out of date), we'll then record the *new* state and re-process the Order.

I encountered this on my own cluster when some really old Order resources that did not have a `status.certificate` field, but were 'valid', had expired with the ACME server.

**Release note**:
```release-note
NONE
```

/kind bug
/milestone v0.6
/cc @kragniz 