### PR TITLE
Surface self-check errors in challenge resource

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -149,7 +149,7 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 	err = solver.Check(ctx, genericIssuer, ch)
 	if err != nil {
 		glog.Infof("propagation check failed: %v", err)
-		ch.Status.Reason = fmt.Sprintf("Waiting for %s challenge propagation", ch.Spec.Type)
+		ch.Status.Reason = fmt.Sprintf("Waiting for %s challenge propagation: %s", ch.Spec.Type, err)
 
 		key, err := controllerpkg.KeyFunc(ch)
 		// This is an unexpected edge case and should never occur

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -42,10 +42,8 @@ const (
 type solver interface {
 	// Present the challenge value with the given solver.
 	Present(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmapi.Challenge) error
-	// Check should return Error only if propagation check cannot be performed.
-	// It MUST return `false, nil` if can contact all relevant services and all is
-	// doing is waiting for propagation
-	Check(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmapi.Challenge) (bool, error)
+	// Check returns an Error if the propagation check didn't succeed.
+	Check(ctx context.Context, issuer cmapi.GenericIssuer, ch *cmapi.Challenge) error
 	// CleanUp will remove challenge records for a given solver.
 	// This may involve deleting resources in the Kubernetes API Server, or
 	// communicating with other external components (e.g. DNS providers).
@@ -148,11 +146,9 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 		c.Recorder.Eventf(ch, corev1.EventTypeNormal, "Presented", "Presented challenge using %s challenge mechanism", ch.Spec.Type)
 	}
 
-	ok, err := solver.Check(ctx, genericIssuer, ch)
+	err = solver.Check(ctx, genericIssuer, ch)
 	if err != nil {
-		return err
-	}
-	if !ok {
+		glog.Infof("propagation check failed: %v", err)
 		ch.Status.Reason = fmt.Sprintf("Waiting for %s challenge propagation", ch.Spec.Type)
 
 		key, err := controllerpkg.KeyFunc(ch)

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -18,6 +18,7 @@ package acmechallenges
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -38,7 +39,7 @@ func (f *fakeSolver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer,
 // Check should return Error only if propagation check cannot be performed.
 // It MUST return `false, nil` if can contact all relevant services and all is
 // doing is waiting for propagation
-func (f *fakeSolver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
+func (f *fakeSolver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 	return f.fakeCheck(ctx, issuer, ch)
 }
 
@@ -51,7 +52,7 @@ func (f *fakeSolver) CleanUp(ctx context.Context, issuer v1alpha1.GenericIssuer,
 
 type fakeSolver struct {
 	fakePresent func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error
-	fakeCheck   func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error)
+	fakeCheck   func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error
 	fakeCleanUp func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error
 }
 
@@ -108,8 +109,8 @@ func TestSyncHappyPath(t *testing.T) {
 				fakePresent: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 					return nil
 				},
-				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
-					return false, nil
+				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
+					return fmt.Errorf("some error")
 				},
 			},
 			Builder: &testpkg.Builder{
@@ -146,8 +147,8 @@ func TestSyncHappyPath(t *testing.T) {
 				gen.SetChallengePresented(true),
 			),
 			HTTP01: &fakeSolver{
-				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
-					return true, nil
+				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
+					return nil
 				},
 				fakeCleanUp: func(context.Context, v1alpha1.GenericIssuer, *v1alpha1.Challenge) error {
 					return nil
@@ -198,8 +199,8 @@ func TestSyncHappyPath(t *testing.T) {
 				gen.SetChallengePresented(true),
 			),
 			HTTP01: &fakeSolver{
-				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
-					return true, nil
+				fakeCheck: func(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
+					return nil
 				},
 				fakeCleanUp: func(context.Context, v1alpha1.GenericIssuer, *v1alpha1.Challenge) error {
 					return nil

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -128,7 +128,7 @@ func TestSyncHappyPath(t *testing.T) {
 							gen.SetChallengeState(v1alpha1.Pending),
 							gen.SetChallengePresented(true),
 							gen.SetChallengeType("http-01"),
-							gen.SetChallengeReason("Waiting for http-01 challenge propagation"),
+							gen.SetChallengeReason("Waiting for http-01 challenge propagation: some error"),
 						))),
 				},
 			},

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -92,17 +92,8 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 
 // Check verifies that the DNS records for the ACME challenge have propagated.
 func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
-	providerName := ch.Spec.Config.DNS01.Provider
-	if providerName == "" {
-		return false, fmt.Errorf("dns01 challenge provider name must be set")
-	}
 
-	providerConfig, err := issuer.GetSpec().ACME.DNS01.Provider(providerName)
-	if err != nil {
-		return false, err
-	}
-
-	fqdn, value, ttl, err := util.DNS01Record(ch.Spec.DNSName, ch.Spec.Key, s.DNS01Nameservers, followCNAME(providerConfig.CNAMEStrategy))
+	fqdn, value, ttl, err := util.DNS01Record(ch.Spec.DNSName, ch.Spec.Key, s.DNS01Nameservers, false)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -99,7 +99,7 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 }
 
 func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), HTTP01Timeout)
+	ctx, cancel := context.WithTimeout(ctx, HTTP01Timeout)
 	defer cancel()
 
 	url := s.buildChallengeUrl(ch)

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -24,7 +24,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/golang/glog"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	extv1beta1listers "k8s.io/client-go/listers/extensions/v1beta1"
@@ -89,7 +88,7 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 	return utilerrors.NewAggregate([]error{podErr, svcErr, ingressErr})
 }
 
-func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (bool, error) {
+func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 	ctx, cancel := context.WithTimeout(ctx, HTTP01Timeout)
 	defer cancel()
 
@@ -98,12 +97,11 @@ func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v
 	for i := 0; i < s.requiredPasses; i++ {
 		err := s.testReachability(ctx, url, ch.Spec.Key)
 		if err != nil {
-			glog.Infof("could not reach '%s': %v", url, err)
-			return false, nil
+			return err
 		}
 		time.Sleep(time.Second * 2)
 	}
-	return true, nil
+	return nil
 }
 
 // CleanUp will ensure the created service, ingress and pod are clean/deleted of any

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -61,7 +61,7 @@ type Solver struct {
 	requiredPasses   int
 }
 
-type reachabilityTest func(ctx context.Context, url, key string) (bool, error)
+type reachabilityTest func(ctx context.Context, url *url.URL, key string) (bool, error)
 
 // absorbErr wraps an error to mark it as absorbable (log and handle as nil)
 type absorbErr struct {
@@ -130,21 +130,21 @@ func (s *Solver) CleanUp(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 	return utilerrors.NewAggregate(errs)
 }
 
-func (s *Solver) buildChallengeUrl(ch *v1alpha1.Challenge) string {
+func (s *Solver) buildChallengeUrl(ch *v1alpha1.Challenge) *url.URL {
 	url := &url.URL{}
 	url.Scheme = "http"
 	url.Host = ch.Spec.DNSName
 	url.Path = fmt.Sprintf("%s/%s", solver.HTTPChallengePath, ch.Spec.Token)
 
-	return url.String()
+	return url
 }
 
 // testReachability will attempt to connect to the 'domain' with 'path' and
 // check if the returned body equals 'key'
-func testReachability(ctx context.Context, url string, key string) (bool, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
-	if err != nil {
-		return false, fmt.Errorf("failed to build request: %v", err)
+func testReachability(ctx context.Context, url *url.URL, key string) (bool, error) {
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    url,
 	}
 
 	req = req.WithContext(ctx)

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -40,7 +40,6 @@ func TestCheck(t *testing.T) {
 		reachabilityTest reachabilityTest
 		challenge        *v1alpha1.Challenge
 		expectedErr      bool
-		expectedOk       bool
 	}
 	tests := []testT{
 		{
@@ -48,14 +47,14 @@ func TestCheck(t *testing.T) {
 			reachabilityTest: func(context.Context, *url.URL, string) error {
 				return nil
 			},
-			expectedOk: true,
+			expectedErr: false,
 		},
 		{
 			name: "should error",
 			reachabilityTest: func(context.Context, *url.URL, string) error {
 				return fmt.Errorf("failed")
 			},
-			expectedErr: false,
+			expectedErr: true,
 		},
 	}
 
@@ -72,7 +71,7 @@ func TestCheck(t *testing.T) {
 				requiredPasses:   requiredCallsForPass,
 			}
 
-			ok, err := s.Check(context.Background(), nil, test.challenge)
+			err := s.Check(context.Background(), nil, test.challenge)
 			if err != nil && !test.expectedErr {
 				t.Errorf("Expected Check to return non-nil error, but got %v", err)
 				return
@@ -81,10 +80,7 @@ func TestCheck(t *testing.T) {
 				t.Errorf("Expected error from Check, but got none")
 				return
 			}
-			if test.expectedOk != ok {
-				t.Errorf("Expected ok=%t but got ok=%t", test.expectedOk, ok)
-			}
-			if test.expectedOk && calls != requiredCallsForPass {
+			if !test.expectedErr && calls != requiredCallsForPass {
 				t.Errorf("Expected Wait to verify reachability test passes %d times, but only checked %d", requiredCallsForPass, calls)
 				return
 			}

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -19,6 +19,7 @@ package http
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"testing"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -27,7 +28,7 @@ import (
 // countReachabilityTestCalls is a wrapper function that allows us to count the number
 // of calls to a reachabilityTest.
 func countReachabilityTestCalls(counter *int, t reachabilityTest) reachabilityTest {
-	return func(ctx context.Context, url, key string) (bool, error) {
+	return func(ctx context.Context, url *url.URL, key string) (bool, error) {
 		*counter++
 		return t(ctx, url, key)
 	}
@@ -44,26 +45,26 @@ func TestCheck(t *testing.T) {
 	tests := []testT{
 		{
 			name: "should pass",
-			reachabilityTest: func(context.Context, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
 				return true, nil
 			},
 			expectedOk: true,
 		},
 		{
 			name: "should fail",
-			reachabilityTest: func(context.Context, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
 				return false, nil
 			},
 		},
 		{
 			name: "should fail with absorbed error",
-			reachabilityTest: func(context.Context, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
 				return false, &absorbErr{err: fmt.Errorf("failed")}
 			},
 		},
 		{
 			name: "should error",
-			reachabilityTest: func(context.Context, string, string) (bool, error) {
+			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
 				return false, fmt.Errorf("failed")
 			},
 			expectedErr: true,

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -84,7 +84,7 @@ func TestCheck(t *testing.T) {
 				requiredPasses:   requiredCallsForPass,
 			}
 
-			ok, err := s.Check(nil, nil, test.challenge)
+			ok, err := s.Check(context.Background(), nil, test.challenge)
 			if err != nil && !test.expectedErr {
 				t.Errorf("Expected Check to return non-nil error, but got %v", err)
 				return

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -28,7 +28,7 @@ import (
 // countReachabilityTestCalls is a wrapper function that allows us to count the number
 // of calls to a reachabilityTest.
 func countReachabilityTestCalls(counter *int, t reachabilityTest) reachabilityTest {
-	return func(ctx context.Context, url *url.URL, key string) (bool, error) {
+	return func(ctx context.Context, url *url.URL, key string) error {
 		*counter++
 		return t(ctx, url, key)
 	}
@@ -45,29 +45,17 @@ func TestCheck(t *testing.T) {
 	tests := []testT{
 		{
 			name: "should pass",
-			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
-				return true, nil
+			reachabilityTest: func(context.Context, *url.URL, string) error {
+				return nil
 			},
 			expectedOk: true,
 		},
 		{
-			name: "should fail",
-			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
-				return false, nil
-			},
-		},
-		{
-			name: "should fail with absorbed error",
-			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
-				return false, &absorbErr{err: fmt.Errorf("failed")}
-			},
-		},
-		{
 			name: "should error",
-			reachabilityTest: func(context.Context, *url.URL, string) (bool, error) {
-				return false, fmt.Errorf("failed")
+			reachabilityTest: func(context.Context, *url.URL, string) error {
+				return fmt.Errorf("failed")
 			},
-			expectedErr: true,
+			expectedErr: false,
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR surfaces self-check errors in the challenge resource, making it more obvious what is holding up issuance of a certificate.

**Which issue this PR fixes**: 
fixes #1208

**Special notes for your reviewer**:
This PR works by changing the `Check` method on the `solver` interface. Instead of having a (retry, error) tuple, we eliminate errors from the various checkers, making it so that the only type of error returned is a retryable one. Because of this change, the PR looks like it changes a lot more things than it actually does. If a change seems weird, I suggest looking through the commits one-by-one

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
More observable errors when waiting for self-checks to propagate
```
