### PR TITLE
Set CA sync backoff limit & add verifying installation docs

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.0-beta.1
+version: v0.6.0-beta.2
 appVersion: v0.6.0-beta.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-beta.0
-digest: sha256:fcbb95a8494138cfb4f01735cf8a4fa181952d3bd2a628b10eb082c145130f38
-generated: 2019-01-17T15:44:50.976304931Z
+  version: v0.6.0-beta.1
+digest: sha256:9775bc7a85cde517b043552472b2cb52016e8c944673cd5eee3827e11f175869
+generated: 2019-01-22T12:13:09.082779567Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-beta.0"
+  version: "v0.6.0-beta.1"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -8,6 +8,9 @@ global:
   imagePullSecrets: []
   # - name: "image-pull-secret"
 
+  # Optional priority class to be used for the cert-manager pods
+  priorityClassName: ""
+
 replicaCount: 1
 
 strategy: {}
@@ -114,6 +117,3 @@ affinity: {}
 #     value: master
 #     effect: NoSchedule
 tolerations: []
-
-global:
-  priorityClassName: ""

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: "v0.6.0-beta.0"
+version: "v0.6.0-beta.1"
 appVersion: "v0.6.0-beta.0"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook

--- a/deploy/charts/cert-manager/webhook/templates/ca-sync.yaml
+++ b/deploy/charts/cert-manager/webhook/templates/ca-sync.yaml
@@ -16,6 +16,7 @@ spec:
   schedule: "@weekly"
   jobTemplate:
     spec:
+      backoffLimit: 20
       template:
         metadata:
           labels:
@@ -55,6 +56,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  backoffLimit: 20
   template:
     metadata:
       labels:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.1
+    chart: cert-manager-v0.6.0-beta.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.1
+    chart: cert-manager-v0.6.0-beta.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.1
+    chart: cert-manager-v0.6.0-beta.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.1
+    chart: cert-manager-v0.6.0-beta.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.1
+    chart: cert-manager-v0.6.0-beta.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -255,7 +255,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -280,7 +280,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -301,7 +301,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -323,7 +323,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -345,7 +345,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.1
+    chart: cert-manager-v0.6.0-beta.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -445,7 +445,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -488,7 +488,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -528,7 +528,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 data:
@@ -561,7 +561,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -571,7 +571,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -597,7 +597,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -617,7 +617,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -641,7 +641,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -657,7 +657,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -677,7 +677,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -694,7 +694,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -714,7 +714,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.0
+    chart: webhook-v0.6.0-beta.1
     release: cert-manager
     heritage: Tiller
 webhooks:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -452,6 +452,7 @@ spec:
   schedule: "@weekly"
   jobTemplate:
     spec:
+      backoffLimit: 20
       template:
         metadata:
           labels:
@@ -491,6 +492,7 @@ metadata:
     release: cert-manager
     heritage: Tiller
 spec:
+  backoffLimit: 20
   template:
     metadata:
       labels:

--- a/docs/getting-started/2-installing.rst
+++ b/docs/getting-started/2-installing.rst
@@ -67,6 +67,82 @@ To install cert-manager using the static manifests, you should run:
    This issue is resolved in Kubernetes 1.13 onwards. More details can be found
    in `kubernetes/kubernetes#69590`_.
 
+Verifying your installation
+===========================
+
+During installation, a number of operations including a Kubernetes 'Job' will
+be created.
+These resources **must** complete successfully in order for cert-manager to
+run.
+
+To verify your installation has completed, you should check the Status of all
+pods in your cert-manager namespace:
+
+.. code-block:: shell
+
+   # Get all pods, including Completed and Errored pods
+   $ kubectl get pods --show-all --namespace cert-manager
+   NAME                                            READY   STATUS      RESTARTS   AGE
+   cert-manager-7cbdc48784-rpgnt                   1/1     Running     0          3m
+   cert-manager-webhook-5b5dd6999-kst4x            1/1     Running     0          3m
+   cert-manager-webhook-ca-sync-1547942400-g6985   0/1     Completed   0          3m
+
+If the 'ca-sync' pod above does not show Completed, you may need to re-start
+the Job using the ``kubectl create job`` command:
+
+.. code-block:: shell
+
+   # Find the name of the CronJob resource
+   $ kubectl get cronjob --namespace cert-manager
+   NAME                           SCHEDULE   SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+   cert-manager-webhook-ca-sync   @weekly    False     0                        3m
+
+   # Trigger the CronJob to run immediately
+   $ kubectl create job \
+        --namespace cert-manager \
+        --from cronjob/cert-manager-webhook-ca-sync \
+        ca-sync-manually-triggered
+
+This will trigger the cert-manager job to run again.
+
+.. note::
+   If the job continues to fail, please read the
+   :doc:`Resource Validating Webhook </admin/resource-validation-webhook>` docs
+   for additional information.
+
+Once all the pods are 'Ready', you should be good to go. To confirm, attempt
+to create a basic 'selfsigned' ClusterIssuer. If you do not receive any errors
+when creating the resource, the deployment should be good to go!
+
+.. code-block:: shell
+
+   # Create a ClusterIssuer to test the webhook works okay
+   $ cat <<EOF > test-clusterissuer.yaml
+   apiVersion: certmanager.k8s.io/v1alpha1
+   kind: ClusterIssuer
+   metadata:
+     name: test-selfsigned
+   spec:
+     selfSigned: {}
+
+   # Create the new ClusterIssuer (if this step fails, please read the resource
+   # validation webhook doc linked in the note above)
+   $ kubectl apply -f test-clusterissuer.yaml
+
+   # Delete the newly created test ClusterIssuer
+   $ kubectl delete -f test-clusterissuer.yaml
+
+If all the above steps have completed with error, you are good to go!
+
+Next steps
+==========
+
+You'll need to set yourself at least one Issuer or ClusterIssuer resource in
+order to begin issuing certificates. Take a look at the next page,
+:doc:`Configuring your first Issuer or ClusterIssuer
+</getting-started/3-configuring-first-issuer>`
+for more information.
+
 .. _`charts repository`: https://github.com/kubernetes/charts
 .. _`Helm chart README`: https://github.com/kubernetes/charts/blob/master/stable/cert-manager/README.md
 .. _`deploy directory`: https://github.com/jetstack/cert-manager/blob/master/contrib/manifests/cert-manager

--- a/docs/getting-started/3-configuring-first-issuer.rst
+++ b/docs/getting-started/3-configuring-first-issuer.rst
@@ -2,8 +2,9 @@
 3. Configuring your first Issuer or ClusterIssuer
 =================================================
 
-Before you can issue any Certificates, you will need to configure an :doc:`Issuer </reference/issuers>`
-or :doc:`ClusterIssuer </reference/clusterissuers>` resource.
+Before you can issue any Certificates, you will need to configure an
+:doc:`Issuer </reference/issuers>` or
+:doc:`ClusterIssuer </reference/clusterissuers>` resource.
 
 These represent a certificate authority from which signed x509 certificates can
 be obtained, such as Let's Encrypt, or your own signing key pair stored in a

--- a/test/chart/lib/chartlib.sh
+++ b/test/chart/lib/chartlib.sh
@@ -75,7 +75,7 @@ chartlib::detect_changed_directories() {
     ## subdirectory, we must modify the below line from $1/$2 to be $1/$2/$3.
     ## In future, we should PR upstream so we no longer hardcode the depth of
     ## directories required for this script.
-    done < <(git diff --find-renames --name-only "$merge_base" "${CHART_DIRS[@]}" | awk -F/ '{ print $1"/"$2 }' | uniq)
+    done < <(git diff --find-renames --name-only "$merge_base" "${CHART_DIRS[@]}" | awk -F/ '{ print $1"/"$2"/"$3 }' | uniq)
 
     echo "${changed_dirs[@]}"
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

The default value for this field is 6. In some cases, this job can fail due to e.g. missing the 'disable-validation' annotation on the cert-manager Namespace.

Increasing this limit should help these cases, and this PR also adds some extra notes informing users to 'verify' their installations.

**Release note**:
```release-note
NONE
```

/milestone v0.6
/kind documentation
