### PR TITLE
Bump version strings for v0.6.0

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.0-beta.2
-appVersion: v0.6.0-beta.0
+version: v0.6.0
+appVersion: v0.6.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -66,7 +66,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | --------- | ----------- | ------- |
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.6.0-beta.0` |
+| `image.tag` | Image tag | `v0.6.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
@@ -101,7 +101,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.6.0-beta.0` |
+| `webhook.image.tag` | Webhook image tag | `v0.6.0` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
 | `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0-beta.1
-digest: sha256:9775bc7a85cde517b043552472b2cb52016e8c944673cd5eee3827e11f175869
-generated: 2019-01-22T12:13:09.082779567Z
+  version: v0.6.0
+digest: sha256:93a9a73b4f6aa718152642d6a4156fb6f9a4fb078d0136065c42bab2fe76c9b0
+generated: 2019-01-22T16:13:19.816854629Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0-beta.1"
+  version: "v0.6.0"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -21,7 +21,7 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.6.0-beta.0
+  tag: v0.6.0
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-version: "v0.6.0-beta.1"
-appVersion: "v0.6.0-beta.0"
+version: "v0.6.0"
+appVersion: "v0.6.0"
 description: A Helm chart for deploying the cert-manager webhook component
 name: webhook

--- a/deploy/charts/cert-manager/webhook/values.yaml
+++ b/deploy/charts/cert-manager/webhook/values.yaml
@@ -18,7 +18,7 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.6.0-beta.0
+  tag: v0.6.0
   pullPolicy: IfNotPresent
 
 caSyncImage:

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -166,7 +166,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -186,7 +186,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -204,7 +204,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -221,7 +221,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -239,7 +239,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -258,7 +258,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-beta.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.6.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -255,7 +255,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -280,7 +280,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -301,7 +301,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -323,7 +323,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -345,7 +345,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -364,7 +364,7 @@ spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0-beta.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.6.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0-beta.2
+    chart: cert-manager-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -416,7 +416,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.6.0-beta.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.6.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -445,7 +445,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -488,7 +488,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -528,7 +528,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 data:
@@ -561,7 +561,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -571,7 +571,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -597,7 +597,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -617,7 +617,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -641,7 +641,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -657,7 +657,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -677,7 +677,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -694,7 +694,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -714,7 +714,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0-beta.1
+    chart: webhook-v0.6.0
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump version strings for the v0.6.0 release! 🎉 😄

This will be the final PR for v0.6 - after this is merged and `release-0.6` has been fast forwarded, master will be re-opened for PRs for the v0.7 release!

**Release note**:
```release-note
NONE
```

/milestone v0.6
/cc @DanielMorsing 