### PR TITLE
Bump go to 1.11.4

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,7 +19,7 @@ load(
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.11.2",
+    go_version = "1.11.4",
 )
 
 ## Load gazelle and dependencies


### PR DESCRIPTION
More information on the contents of the 2 patch releases: https://golang.org/doc/devel/release.html

**Release note**:
```release-note
Build using go 1.11.4
```
