### PR TITLE
Update Chart.yaml in webhook

### DIFF
--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,5 +1,16 @@
+name: webhook
 apiVersion: v1
 version: "v0.6.0"
 appVersion: "v0.6.0"
 description: A Helm chart for deploying the cert-manager webhook component
-name: webhook
+home: https://github.com/jetstack/cert-manager
+sources:
+  - https://github.com/jetstack/cert-manager
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+maintainers:
+  - name: munnerz
+    email: james@jetstack.io


### PR DESCRIPTION
**What this PR does / why we need it**:

Upstream helm/charts now requires additional fields be set on *all* Helm charts.

**Release note**:
```release-note
NONE
```
