### PR TITLE
Add RBAC rules for finalizers

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.2
+version: v0.6.3
 appVersion: v0.6.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers", "orders", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "events", "services", "pods"]

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -171,7 +171,7 @@ metadata:
     heritage: Tiller
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers", "orders", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "events", "services", "pods"]

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 ---
@@ -166,7 +166,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -186,7 +186,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -204,7 +204,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -221,7 +221,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -239,7 +239,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -184,7 +184,7 @@ metadata:
     heritage: Tiller
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "issuers", "clusterissuers", "orders", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
     verbs: ["*"]
   - apiGroups: [""]
     resources: ["configmaps", "secrets", "events", "services", "pods"]

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.2
+    chart: cert-manager-v0.6.3
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
For the cert-manager to be able to set ownerReferences, the RBAC rules
for finalizers need to be in place.

Fixes #1257

Signed-off-by: Simon Rüegg <simon.ruegg@vshn.ch>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes #1257

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #1257

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
