### PR TITLE
Add note about disabling validation on existing namespaces to Helm chart

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.0
+version: v0.6.1
 appVersion: v0.6.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -23,6 +23,12 @@ To install the chart with the release name `my-release`:
 $ kubectl apply \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
 
+## IMPORTANT: if you are deploying into a namespace that **already exists**,
+## you MUST ensure the namespace has an additional label on it in order for
+## the deployment to succeed
+$ kubectl label namespace <deployment-namespace> certmanager.k8s.io/disable-validation="true"
+
+## Install the cert-manager helm chart
 $ helm install --name my-release stable/cert-manager
 ```
 

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -166,7 +166,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -186,7 +186,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -204,7 +204,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -221,7 +221,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -239,7 +239,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.0
+    chart: cert-manager-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

Helps users when deploying into a namespace that already exists

**Which issue this PR fixes**: fixes https://github.com/helm/charts/issues/10856

**Release note**:
```release-note
NONE
```
