### PR TITLE
Use long-lived certificates for the webhook component

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.1
+version: v0.6.2
 appVersion: v0.6.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.0
-digest: sha256:93a9a73b4f6aa718152642d6a4156fb6f9a4fb078d0136065c42bab2fe76c9b0
-generated: 2019-01-22T16:13:19.816854629Z
+  version: v0.6.1
+digest: sha256:c578f2693199ba800cc840471d644a196152da11d754cd4fd3c1dc92ede1ea19
+generated: 2019-01-29T13:00:43.014715413Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.0"
+  version: "v0.6.1"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.0"
+version: "v0.6.1"
 appVersion: "v0.6.0"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/webhook/templates/pki.yaml
+++ b/deploy/charts/cert-manager/webhook/templates/pki.yaml
@@ -29,6 +29,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "webhook.rootCACertificate" . }}
+  duration: 43800h # 5y
   issuerRef:
     name: {{ include "webhook.selfSignedIssuer" . }}
   commonName: "ca.webhook.cert-manager"
@@ -66,6 +67,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   secretName: {{ include "webhook.servingCertificate" . }}
+  duration: 8760h # 1y
   issuerRef:
     name: {{ include "webhook.rootCAIssuer" . }}
   dnsNames:

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -166,7 +166,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -186,7 +186,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -204,7 +204,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -221,7 +221,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -239,7 +239,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -255,7 +255,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -280,7 +280,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -301,7 +301,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -323,7 +323,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -345,7 +345,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.1
+    chart: cert-manager-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -445,7 +445,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -488,7 +488,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -528,7 +528,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 data:
@@ -561,7 +561,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -571,7 +571,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -597,7 +597,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -617,7 +617,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -641,7 +641,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -657,11 +657,12 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
   secretName: cert-manager-webhook-ca
+  duration: 43800h # 5y
   issuerRef:
     name: cert-manager-webhook-selfsign
   commonName: "ca.webhook.cert-manager"
@@ -677,7 +678,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -694,11 +695,12 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 spec:
   secretName: cert-manager-webhook-webhook-tls
+  duration: 8760h # 1y
   issuerRef:
     name: cert-manager-webhook-ca
   dnsNames:
@@ -714,7 +716,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.0
+    chart: webhook-v0.6.1
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:

In v0.6.0, the webhook component was installed using certificates that don't explicitly set a `duration`. This means that the new default of `90d` will be used.

We haven't currently tested auto-rotation of certificates in the webhook component, and we may need to signal with a SIGHUP or similar to make it reload the cert (or just watch the file on disk).

This PR increases the lifetime of these component certificates, which should at least help mitigate the issue until v0.7 is released when we have a more complete patch ready.

**Release note**:
```release-note
Increase x509 certificate duration from 90d to 1y for webhook component certificates
```

/kind bug
/milestone v0.6
/cc @DanielMorsing 
/shrug