### PR TITLE
Fix redirects for old docs pages

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,4 +2,4 @@ Sphinx==1.8.3
 sphinx-rtd-theme==0.4.2
 sphinxcontrib-spelling==4.2.0
 Pygments==2.3.1
-git+git://github.com/munnerz/redirects@0965b30#egg=sphinxcontrib-redirects
+git+git://github.com/munnerz/redirects@2e3803b#egg=sphinxcontrib-redirects


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the redirects plugin to support the readthedocs build environment. The recent docs refactor has broken all old links from blog posts etc.!

**Release note**:
```release-note
NONE
```

/milestone v0.6
/priority critical-urgent
/kind documentation
/cc @wwwil 
