### PR TITLE
Automated cherry pick of #1294

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.3
+version: v0.6.4
 appVersion: v0.6.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.1
-digest: sha256:c578f2693199ba800cc840471d644a196152da11d754cd4fd3c1dc92ede1ea19
-generated: 2019-01-29T13:00:43.014715413Z
+  version: v0.6.2
+digest: sha256:e87128b03546761a8a2273f3d72c78f6133ecae66b9ec08dc1969628aac57f90
+generated: 2019-01-31T21:00:29.754276649Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.1"
+  version: "v0.6.2"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.1"
+version: "v0.6.2"
 appVersion: "v0.6.0"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/webhook/templates/pki.yaml
+++ b/deploy/charts/cert-manager/webhook/templates/pki.yaml
@@ -12,7 +12,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
-  selfsigned: {}
+  selfSigned: {}
 
 ---
 

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 ---
@@ -166,7 +166,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 rules:
@@ -186,7 +186,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -204,7 +204,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -221,7 +221,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -239,7 +239,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -255,7 +255,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -280,7 +280,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -301,7 +301,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -323,7 +323,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -345,7 +345,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.3
+    chart: cert-manager-v0.6.4
     release: cert-manager
     heritage: Tiller
 spec:
@@ -445,7 +445,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -488,7 +488,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -528,7 +528,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 data:
@@ -561,7 +561,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -571,7 +571,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -597,7 +597,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -617,7 +617,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -641,11 +641,11 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
-  selfsigned: {}
+  selfSigned: {}
 
 ---
 
@@ -657,7 +657,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -678,7 +678,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -695,7 +695,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -716,7 +716,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.1
+    chart: webhook-v0.6.2
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
Cherry pick of #1294 on release-0.6.

#1294: Fix 'selfsigned' key on webhook issuer