### PR TITLE
Build using Go 1.11.5

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,8 +6,8 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 ## Load rules_go and dependencies
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.5/rules_go-0.16.5.tar.gz"],
-    sha256 = "7be7dc01f1e0afdba6c8eb2b43d2fa01c743be1b9273ab1eaf6c233df078d705",
+    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.6/rules_go-0.16.6.tar.gz"],
+    sha256 = "ade51a315fa17347e5c31201fdc55aa5ffb913377aa315dceb56ee9725e620ee",
 )
 
 load(
@@ -19,7 +19,7 @@ load(
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.11.4",
+    go_version = "1.11.5",
 )
 
 ## Load gazelle and dependencies


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps golang version to 1.11.5

**Release note**:
```release-note
Bump Go version to 1.11.5
```
