### PR TITLE
Add manual tag to charts image targets

### DIFF
--- a/test/e2e/charts/BUILD.bazel
+++ b/test/e2e/charts/BUILD.bazel
@@ -10,6 +10,7 @@ container_bundle(
         "vault:bazel": "@com_hashicorp_vault//image",
         "gcr.io/kubernetes-helm/tiller:bazel": "@io_gcr_helm_tiller//image",
     },
+    tags = ["manual"],
 )
 
 filegroup(


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a manual tag to e2e image targets to reduce the number of things that need pulling when running `bazel build //...`

**Release note**:
```release-note
NONE
```
