### PR TITLE
Use Helper structure to call GetGenericIssuer everywhere

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -57,6 +57,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/client/clientset/versioned/fake:go_default_library",
+        "//pkg/client/informers/externalversions:go_default_library",
+        "//test/unit/gen:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -39,6 +39,7 @@ import (
 
 type Controller struct {
 	*controllerpkg.Context
+	helper controllerpkg.Helper
 
 	// To allow injection for testing.
 	syncHandler func(ctx context.Context, key string) error
@@ -94,6 +95,7 @@ func New(ctx *controllerpkg.Context) *Controller {
 	ordersInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleOwnedResource})
 	ctrl.syncedFuncs = append(ctrl.syncedFuncs, ordersInformer.Informer().HasSynced)
 
+	ctrl.helper = controllerpkg.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 	ctrl.metrics = metrics.Default
 
 	return ctrl

--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -43,11 +43,9 @@ go_test(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned/fake:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
-        "//pkg/controller/test:go_default_library",
         "//test/unit/gen:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
     ],
 )
 

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -57,6 +57,8 @@ type Controller struct {
 	CMClient clientset.Interface
 	Recorder record.EventRecorder
 
+	helper controllerpkg.Helper
+
 	// To allow injection for testing.
 	syncHandler func(ctx context.Context, key string) error
 
@@ -102,6 +104,8 @@ func New(
 		ctrl.clusterIssuerLister = clusterIssuerInformer.Lister()
 		ctrl.syncedFuncs = append(ctrl.syncedFuncs, clusterIssuerInformer.Informer().HasSynced)
 	}
+
+	ctrl.helper = controllerpkg.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 
 	return ctrl
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This removes all bespoke implementations of GetGenericIssuer aside from the new one that's attached to the controller context's Helper. This should make refactors in future easier, and avoid any weird behaviour as a result of differing implementations 😄 

**Special notes for your reviewer**:

I had to refactor the unit test to not use the `test.Builder` structure, as it introduced a circular dependency.

**Release note**:
```release-note
NONE
```
