### PR TITLE
Fix bug when specify keyAlgorithm without an explicit keySize

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -280,6 +280,9 @@ func SignatureAlgorithm(crt *v1alpha1.Certificate) (x509.PublicKeyAlgorithm, x50
 			sigAlgo = x509.SHA384WithRSA
 		case crt.Spec.KeySize >= 2048:
 			sigAlgo = x509.SHA256WithRSA
+		// 0 == not set
+		case crt.Spec.KeySize == 0:
+			sigAlgo = x509.SHA256WithRSA
 		default:
 			return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported rsa keysize specified: %d. min keysize %d", crt.Spec.KeySize, MinRSAKeySize)
 		}
@@ -291,6 +294,8 @@ func SignatureAlgorithm(crt *v1alpha1.Certificate) (x509.PublicKeyAlgorithm, x50
 		case 384:
 			sigAlgo = x509.ECDSAWithSHA384
 		case 256:
+			sigAlgo = x509.ECDSAWithSHA256
+		case 0:
 			sigAlgo = x509.ECDSAWithSHA256
 		default:
 			return x509.UnknownPublicKeyAlgorithm, x509.UnknownSignatureAlgorithm, fmt.Errorf("unsupported ecdsa keysize specified: %d", crt.Spec.KeySize)

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -153,7 +153,14 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 		{
 			name:      "certificate with KeyAlgorithm rsa and size 1024",
 			keyAlgo:   v1alpha1.RSAKeyAlgorithm,
+			keySize:   1024,
 			expectErr: true,
+		},
+		{
+			name:            "certificate with KeyAlgorithm rsa and no size set should default to rsa256",
+			keyAlgo:         v1alpha1.RSAKeyAlgorithm,
+			expectedSigAlgo: x509.SHA256WithRSA,
+			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm not set",
@@ -183,6 +190,12 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 			expectedKeyType: x509.RSA,
 		},
 		{
+			name:            "certificate with ecdsa key algorithm set and no key size default to ecdsa256",
+			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
+			expectedSigAlgo: x509.ECDSAWithSHA256,
+			expectedKeyType: x509.ECDSA,
+		},
+		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 256",
 			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
 			keySize:         256,
@@ -206,6 +219,7 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 		{
 			name:      "certificate with KeyAlgorithm ecdsa and size 100",
 			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
+			keySize:   100,
 			expectErr: true,
 		},
 		{


### PR DESCRIPTION
**What this PR does / why we need it**:

The previous logic here meant that if a user explicitly specified a keyAlgorithm but not keySize, a certificate would fail to be issued.

I've also updated some unit tests that had invalid input data, and added two more test cases to cover this patch.

**Release note**:
```release-note
Fix bug when specify certificate keyAlgorithm without an explicit keySize
```

/kind bug
/milestone v0.6
