### PR TITLE
[chart] Add possibility to scrape metrics with prometheus

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.7
+version: v0.6.8
 appVersion: v0.6.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.4
-digest: sha256:a0af88ca014f7195e521457f22c31d8bf28c7c90b0c9a088bfc5cb8ab188b769
-generated: 2019-02-07T16:38:55.664017-07:00
+  version: v0.6.5
+digest: sha256:f053fa581f15727f3e50bc78ae1e1caa05b4a61c6e842052ceb44595a28bf4cc
+generated: 2019-02-20T11:04:12.008096943Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.4"
+  version: "v0.6.5"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
       {{- if .Values.podAnnotations }}
 {{ toYaml .Values.podAnnotations | indent 8 }}
       {{- end }}
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
       {{- if .Values.global.priorityClassName }}
@@ -72,6 +75,8 @@ spec:
           - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
           {{- end }}
           {{- end }}
+          ports:
+          - containerPort: 9402
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.4"
+version: "v0.6.5"
 appVersion: "v0.6.1"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 ---
@@ -986,7 +986,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1006,7 +1006,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1024,7 +1024,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1041,7 +1041,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1059,7 +1059,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1074,6 +1074,9 @@ spec:
         app: cert-manager
         release: cert-manager
       annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
     spec:
       serviceAccountName: cert-manager
       containers:
@@ -1083,6 +1086,8 @@ spec:
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)
+          ports:
+          - containerPort: 9402
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 
@@ -988,7 +988,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 ---
@@ -999,7 +999,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1019,7 +1019,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1037,7 +1037,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1054,7 +1054,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1075,7 +1075,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1100,7 +1100,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1121,7 +1121,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1142,7 +1142,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1164,7 +1164,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1216,7 +1216,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1231,6 +1231,9 @@ spec:
         app: cert-manager
         release: cert-manager
       annotations:
+        prometheus.io/path: "/metrics"
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9402'
     spec:
       serviceAccountName: cert-manager
       containers:
@@ -1240,6 +1243,8 @@ spec:
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
           - --leader-election-namespace=$(POD_NAMESPACE)
+          ports:
+          - containerPort: 9402
           env:
           - name: POD_NAMESPACE
             valueFrom:
@@ -1264,7 +1269,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1307,7 +1312,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1347,7 +1352,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 data:
@@ -1380,7 +1385,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 
@@ -1391,7 +1396,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1417,7 +1422,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1436,7 +1441,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1460,7 +1465,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1476,7 +1481,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1497,7 +1502,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1514,7 +1519,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1535,7 +1540,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:

Since v0.6.0 cert-manager can expose metrics, this PR permits to use these with helm chart.

fixes #1301 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```
