### PR TITLE
Use secretLister in updateSecret

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -289,7 +289,7 @@ func ownerRef(crt *v1alpha1.Certificate) metav1.OwnerReference {
 }
 
 func (c *Controller) updateSecret(crt *v1alpha1.Certificate, namespace string, cert, key, ca []byte) (*corev1.Secret, error) {
-	secret, err := c.Client.CoreV1().Secrets(namespace).Get(crt.Spec.SecretName, metav1.GetOptions{})
+	secret, err := c.secretLister.Secrets(namespace).Get(crt.Spec.SecretName)
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

This should avoid weird conditions that could allow a certificate to be issued multiple times.

**Release note**:
```release-note
Use secretLister in updateSecret
```
