### PR TITLE
Update docs links to docs.cert-manager.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ API stability.
 Notably, we may choose to make breaking changes to our API specification (i.e. the
 Issuer, ClusterIssuer and Certificate resources) in new minor releases.
 
-These will always be clearly documented in the [upgrade section of the documentation](https://cert-manager.readthedocs.io/en/latest/admin/upgrading/index.html)
+These will always be clearly documented in the [upgrade section of the documentation](https://docs.cert-manager.io/en/latest/admin/upgrading/index.html)
 
 ## Documentation
 
-Documentation for cert-manager can be found at [cert-manager.readthedocs.io](https://cert-manager.readthedocs.io/en/latest/).
+Documentation for cert-manager can be found at [docs.cert-manager.io](https://docs.cert-manager.io/en/latest/).
 Please make sure to select the correct version of the documentation to view on
 the bottom left of the page.
 
@@ -33,8 +33,8 @@ Ingress resources, aka a [kube-lego](https://github.com/jetstack/kube-lego)
 replacement, see the [cert-manager nginx ingress quick start
 guide](docs/tutorials/acme/quick-start/index.rst).
 
-See [Getting started](https://cert-manager.readthedocs.io/en/latest/getting-started/)
-within the [documentation](https://cert-manager.readthedocs.io/en/latest/)
+See [Getting started](https://docs.cert-manager.io/en/latest/getting-started/)
+within the [documentation](https://docs.cert-manager.io/en/latest/)
 for installation instructions.
 
 ## Troubleshooting
@@ -51,7 +51,7 @@ You can also try [searching for an existing issue](https://github.com/jetstack/c
 Properly searching for an existing issue will help reduce the number of duplicates,
 and help you find the answer you are looking for quicker.
 
-Please also make sure to read through the relevant pages in the [documentation](https://cert-manager.readthedocs.io/en/latest/)
+Please also make sure to read through the relevant pages in the [documentation](https://docs.cert-manager.io/en/latest/)
 before opening an issue. You can also search the documentation using the search box on the
 top left of the page.
 
@@ -84,7 +84,7 @@ if you are unsure where to start with getting involved!
 We also use the #cert-manager channel on kubernetes.slack.com for chat relating to
 the project.
 
-Developer documentation is available in the [official documentation](http://cert-manager.readthedocs.io/en/latest/devel/index.html).
+Developer documentation is available in the [official documentation](https://docs.cert-manager.io/en/latest/devel/index.html).
 
 ## Changelog
 

--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.5
+version: v0.6.6
 appVersion: v0.6.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -13,7 +13,7 @@ to renew certificates at an appropriate time before expiry.
 ## Installing the Chart
 
 Full installation instructions, including details on how to configure extra
-functionality in cert-manager can be found in the [getting started docs](https://cert-manager.readthedocs.io/en/latest/getting-started/).
+functionality in cert-manager can be found in the [getting started docs](https://docs.cert-manager.io/en/latest/getting-started/).
 
 To install the chart with the release name `my-release`:
 
@@ -38,20 +38,20 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+https://docs.cert-manager.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+https://docs.cert-manager.io/en/latest/reference/ingress-shim.html
 
 > **Tip**: List all releases using `helm list`
 
 ## Upgrading the Chart
 
 Special considerations may be required when upgrading the Helm chart, and these
-are documented in our full [upgrading guide](https://cert-manager.readthedocs.io/en/latest/admin/upgrading/index.html).
+are documented in our full [upgrading guide](https://docs.cert-manager.io/en/latest/admin/upgrading/index.html).
 Please check here before perform upgrades!
 
 ## Uninstalling the Chart

--- a/deploy/charts/cert-manager/templates/NOTES.txt
+++ b/deploy/charts/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+https://docs.cert-manager.io/en/latest/reference/issuers.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+https://docs.cert-manager.io/en/latest/reference/ingress-shim.html

--- a/deploy/manifests/README.md
+++ b/deploy/manifests/README.md
@@ -2,7 +2,7 @@
 
 This directory contains the Kubernetes manifests needed to deploy cert-manager.
 
-For full information on deploying cert-manager, see the [getting started guide](https://cert-manager.readthedocs.io/en/latest/getting-started/index.html).
+For full information on deploying cert-manager, see the [getting started guide](https://docs.cert-manager.io/en/latest/getting-started/index.html).
 
 ## Where do these come from?
 

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -155,7 +155,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 ---
@@ -166,7 +166,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 rules:
@@ -186,7 +186,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -204,7 +204,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -221,7 +221,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -239,7 +239,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -168,7 +168,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 ---
@@ -179,7 +179,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 rules:
@@ -199,7 +199,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -217,7 +217,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -234,7 +234,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -397,7 +397,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.5
+    chart: cert-manager-v0.6.6
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/generated/reference/generate/static_includes/_certmanager.md
+++ b/docs/generated/reference/generate/static_includes/_certmanager.md
@@ -6,4 +6,4 @@
 This page contains reference documentation for cert-manager API types.
 
 For full documentation on how to use cert-manager, please view our
-[official documentation](https://cert-manager.readthedocs.io/).
+[official documentation](https://docs.cert-manager.io/).

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -18,7 +18,7 @@
 <hr>
 <p>This page contains reference documentation for cert-manager API types.</p>
 <p>For full documentation on how to use cert-manager, please view our
-<a href="https://cert-manager.readthedocs.io/">official documentation</a>.</p>
+<a href="https://docs.cert-manager.io/">official documentation</a>.</p>
 <hr>
 <h1 id="certificate-v1alpha1">Certificate v1alpha1</h1>
 <table>

--- a/docs/tasks/acme/configuring-http01.rst
+++ b/docs/tasks/acme/configuring-http01.rst
@@ -42,7 +42,7 @@ The HTTP01 Issuer supports a number of additional options.
 For full details on the range of options available, read the
 `reference documentation`_.
 
-.. _`reference documentation`: https://cert-manager.readthedocs.io/en/latest/reference/api-docs/index.html#acmeissuerhttp01config-v1alpha1
+.. _`reference documentation`: https://docs.cert-manager.io/en/latest/reference/api-docs/index.html#acmeissuerhttp01config-v1alpha1
 
 servicePort
 -----------

--- a/docs/tasks/issuing-certificates/index.rst
+++ b/docs/tasks/issuing-certificates/index.rst
@@ -72,7 +72,7 @@ A full list of the fields supported on the Certificate resource can be found in
 the `API reference documentation`_.
 
 .. _`#1269`: https://github.com/jetstack/cert-manager/issues/1269
-.. _`API reference documentation`: https://cert-manager.readthedocs.io/en/release-0.6/reference/api-docs/index.html#certificatespec-v1alpha1
+.. _`API reference documentation`: https://docs.cert-manager.io/en/release-0.6/reference/api-docs/index.html#certificatespec-v1alpha1
 
 Special fields on Certificate resources for ACME Issuers
 ========================================================

--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -444,13 +444,13 @@ install cert-manager. This example installed cert-manager into the
     More information on the different types of issuers and how to configure them
     can be found in our documentation:
 
-    https://cert-manager.readthedocs.io/en/latest/reference/issuers.html
+    https://docs.cert-manager.io/en/latest/reference/issuers.html
 
     For information on how to configure cert-manager to automatically provision
     Certificates for Ingress resources, take a look at the `ingress-shim`
     documentation:
 
-    https://cert-manager.readthedocs.io/en/latest/reference/ingress-shim.html
+    https://docs.cert-manager.io/en/latest/reference/ingress-shim.html
 
 Cert-manager uses two different custom resources, also known as `CRD`_'s,
 to configure and control how it operates, as well as share status of its


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that we can get free TLS certs with readthedocs, this is now easy to do... (yes, I appreciate the irony that cert-manager isn't used for its own docs...)

**Release note**:
```release-note
NONE
```
