### PR TITLE
Generate CRDs using controller-tools, including validation schema

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -312,9 +312,7 @@ npm_install(
 # Load the controller-tools repository in order to build the crd generator tool
 go_repository(
     name = "io_kubernetes_sigs_controller-tools",
-    commit = "f4d9479179e084fc66c814ce0201eec3898e1b00",
-    remote = "https://github.com/munnerz/controller-tools",
-    vcs = "git",
+    commit = "538db3af1387ce55d50b93e500a49925a5768c82",
     importpath = "sigs.k8s.io/controller-tools",
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -309,6 +309,13 @@ npm_install(
     package_lock_json = "//docs/generated/reference/generate/bin:package-lock.json",
 )
 
+# Load the controller-tools repository in order to build the crd generator tool
+go_repository(
+    name = "io_kubernetes_sigs_controller-tools",
+    commit = "94656be085bdbd48c49be0a41c91e4fc5ea5b1ee",
+    importpath = "sigs.k8s.io/controller-tools",
+)
+
 # Load kubernetes-incubator/reference-docs, to be used as part of the docs
 # generation pipeline.
 # This involves quite a few dependencies, hence the long list of go_repository

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -312,7 +312,9 @@ npm_install(
 # Load the controller-tools repository in order to build the crd generator tool
 go_repository(
     name = "io_kubernetes_sigs_controller-tools",
-    commit = "94656be085bdbd48c49be0a41c91e4fc5ea5b1ee",
+    commit = "f4d9479179e084fc66c814ce0201eec3898e1b00",
+    remote = "https://github.com/munnerz/controller-tools",
+    vcs = "git",
     importpath = "sigs.k8s.io/controller-tools",
 )
 

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -42,15 +42,32 @@ spec:
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: issuers.certmanager.k8s.io
+  name: challenges.certmanager.k8s.io
   labels:
     app: cert-manager
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.dnsName
+    name: Domain
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: |-
+      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    name: Age
+    type: date
   group: certmanager.k8s.io
   version: v1alpha1
   names:
-    kind: Issuer
-    plural: issuers
+    kind: Challenge
+    plural: challenges
   scope: Namespaced
 
 ---
@@ -68,6 +85,22 @@ spec:
     kind: ClusterIssuer
     plural: clusterissuers
   scope: Cluster
+
+---
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: issuers.certmanager.k8s.io
+  labels:
+    app: cert-manager
+spec:
+  group: certmanager.k8s.io
+  version: v1alpha1
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
 
 ---
 
@@ -102,39 +135,6 @@ spec:
   names:
     kind: Order
     plural: orders
-  scope: Namespaced
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: challenges.certmanager.k8s.io
-  labels:
-    app: cert-manager
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    name: State
-    type: string
-  - JSONPath: .spec.dnsName
-    name: Domain
-    type: string
-  - JSONPath: .status.reason
-    name: Reason
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-    name: Age
-    type: date
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: Challenge
-    plural: challenges
   scope: Namespaced
 
 ---

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -1,12 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: certificates.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: certificates.certmanager.k8s.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+  - JSONPath: .status.conditions[?(@.type==\"Ready\")].status
     name: Ready
     type: string
   - JSONPath: .spec.secretName
@@ -14,37 +15,191 @@ spec:
     type: string
   - JSONPath: .spec.issuerRef.name
     name: Issuer
-    type: string
     priority: 1
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    type: string
+  - JSONPath: .status.conditions[?(@.type==\"Ready\")].message
     name: Status
-    type: string
     priority: 1
+    type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
-  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
     shortNames:
     - cert
     - certs
-
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              description: ACME contains configuration specific to ACME Certificates.
+                Notably, this contains details on how the domain names listed on this
+                Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
+                providers to DNS names.
+              properties:
+                config:
+                  items:
+                    properties:
+                      domains:
+                        description: Domains is the list of domains that this SolverConfig
+                          applies to.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - domains
+                    type: object
+                  type: array
+              required:
+              - config
+              type: object
+            commonName:
+              description: CommonName is a common name to be used on the Certificate
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: object
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'signing' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              format: int64
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: object
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+          required:
+          - secretName
+          - issuerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: challenges.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: challenges.certmanager.k8s.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -55,61 +210,530 @@ spec:
     type: string
   - JSONPath: .status.reason
     name: Reason
+    priority: 1
     type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
   names:
     kind: Challenge
     plural: challenges
   scope: Namespaced
-
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authzURL:
+              description: AuthzURL is the URL to the ACME Authorization resource
+                that this challenge is a part of.
+              type: string
+            config:
+              description: Config specifies the solver configuration for this challenge.
+              type: object
+            dnsName:
+              description: DNSName is the identifier that this challenge is for, e.g.
+                example.com.
+              type: string
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Challenge. If the Issuer does
+                not exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Challenge will be marked
+                as failed.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            key:
+              description: Key is the ACME challenge key for this challenge
+              type: string
+            token:
+              description: Token is the ACME challenge token for this challenge.
+              type: string
+            type:
+              description: Type is the type of ACME challenge this resource represents,
+                e.g. "dns01" or "http01"
+              type: string
+            url:
+              description: URL is the URL of the ACME Challenge resource for this
+                challenge. This can be used to lookup details about the status of
+                this challenge.
+              type: string
+            wildcard:
+              description: Wildcard will be true if this challenge is for a wildcard
+                identifier, for example '*.example.com'
+              type: boolean
+          required:
+          - authzURL
+          - type
+          - url
+          - dnsName
+          - token
+          - key
+          - wildcard
+          - config
+          - issuerRef
+          type: object
+        status:
+          properties:
+            presented:
+              description: Presented will be set to true if the challenge values for
+                this challenge are currently 'presented'. This *does not* imply the
+                self check is passing. Only that the values have been 'submitted'
+                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                has been presented, or the HTTP01 configuration has been configured).
+              type: boolean
+            processing:
+              description: Processing is used to denote whether this challenge should
+                be processed or not. This field will only be set to true by the 'scheduling'
+                component. It will only be set to false by the 'challenges' controller,
+                after the challenge has reached a final state or timed out. If this
+                field is set to false, the challenge controller will not take any
+                more action.
+              type: boolean
+            reason:
+              description: Reason contains human readable information on why the Challenge
+                is in the current state.
+              type: string
+            state:
+              description: State contains the current 'state' of the challenge. If
+                not set, the state of the challenge is unknown.
+              type: string
+          required:
+          - processing
+          - presented
+          - reason
+          - state
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: clusterissuers.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: clusterissuers.certmanager.k8s.io
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
   names:
     kind: ClusterIssuer
     plural: clusterissuers
   scope: Cluster
-
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  - key
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+              required:
+              - email
+              - server
+              - privateKeySecretRef
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - server
+              - path
+              type: object
+          type: object
+        status:
+          properties:
+            acme:
+              properties:
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              required:
+              - uri
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: issuers.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: issuers.certmanager.k8s.io
 spec:
   group: certmanager.k8s.io
-  version: v1alpha1
   names:
     kind: Issuer
     plural: issuers
   scope: Namespaced
-
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  - key
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+              required:
+              - email
+              - server
+              - privateKeySecretRef
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - server
+              - path
+              type: object
+          type: object
+        status:
+          properties:
+            acme:
+              properties:
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              required:
+              - uri
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: orders.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: orders.certmanager.k8s.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -117,24 +741,208 @@ spec:
     type: string
   - JSONPath: .spec.issuerRef.name
     name: Issuer
-    type: string
     priority: 1
+    type: string
   - JSONPath: .status.reason
     name: Reason
-    type: string
     priority: 1
+    type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
   names:
     kind: Order
     plural: orders
   scope: Namespaced
-
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            commonName:
+              description: CommonName is the common name as specified on the DER encoded
+                CSR. If CommonName is not specified, the first DNSName specified will
+                be used as the CommonName. At least on of CommonName or a DNSName
+                must be set. This field must match the corresponding field on the
+                DER encoded CSR.
+              type: string
+            config:
+              description: Config specifies a mapping from DNS identifiers to how
+                those identifiers should be solved when performing ACME challenges.
+                A config entry must exist for each domain listed in DNSNames and CommonName.
+              items:
+                properties:
+                  domains:
+                    description: Domains is the list of domains that this SolverConfig
+                      applies to.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - domains
+                type: object
+              type: array
+            csr:
+              description: Certificate signing request bytes in DER encoding. This
+                will be used when finalizing the order. This field must be set on
+                the order.
+              format: byte
+              type: string
+            dnsNames:
+              description: DNSNames is a list of DNS names that should be included
+                as part of the Order validation process. If CommonName is not specified,
+                the first DNSName specified will be used as the CommonName. At least
+                on of CommonName or a DNSName must be set. This field must match the
+                corresponding field on the DER encoded CSR.
+              items:
+                type: string
+              type: array
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Order. If the Issuer does not
+                exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Order will be marked as
+                failed.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - csr
+          - issuerRef
+          - config
+          type: object
+        status:
+          properties:
+            certificate:
+              description: Certificate is a copy of the PEM encoded certificate for
+                this Order. This field will be populated after the order has been
+                successfully finalized with the ACME server, and the order has transitioned
+                to the 'valid' state.
+              format: byte
+              type: string
+            challenges:
+              description: Challenges is a list of ChallengeSpecs for Challenges that
+                must be created in order to complete this Order.
+              items:
+                properties:
+                  authzURL:
+                    description: AuthzURL is the URL to the ACME Authorization resource
+                      that this challenge is a part of.
+                    type: string
+                  config:
+                    description: Config specifies the solver configuration for this
+                      challenge.
+                    type: object
+                  dnsName:
+                    description: DNSName is the identifier that this challenge is
+                      for, e.g. example.com.
+                    type: string
+                  issuerRef:
+                    description: IssuerRef references a properly configured ACME-type
+                      Issuer which should be used to create this Challenge. If the
+                      Issuer does not exist, processing will be retried. If the Issuer
+                      is not an 'ACME' Issuer, an error will be returned and the Challenge
+                      will be marked as failed.
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  key:
+                    description: Key is the ACME challenge key for this challenge
+                    type: string
+                  token:
+                    description: Token is the ACME challenge token for this challenge.
+                    type: string
+                  type:
+                    description: Type is the type of ACME challenge this resource
+                      represents, e.g. "dns01" or "http01"
+                    type: string
+                  url:
+                    description: URL is the URL of the ACME Challenge resource for
+                      this challenge. This can be used to lookup details about the
+                      status of this challenge.
+                    type: string
+                  wildcard:
+                    description: Wildcard will be true if this challenge is for a
+                      wildcard identifier, for example '*.example.com'
+                    type: boolean
+                required:
+                - authzURL
+                - type
+                - url
+                - dnsName
+                - token
+                - key
+                - wildcard
+                - config
+                - issuerRef
+                type: object
+              type: array
+            failureTime:
+              description: FailureTime stores the time that this order failed. This
+                is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+            finalizeURL:
+              description: FinalizeURL of the Order. This is used to obtain certificates
+                for this order once it has been completed.
+              type: string
+            reason:
+              description: Reason optionally provides more information about a why
+                the order is in the current state.
+              type: string
+            state:
+              description: State contains the current state of this Order resource.
+                States 'success' and 'expired' are 'final'
+              type: string
+            url:
+              description: URL of the Order. This will initially be empty when the
+                resource is first created. The Order controller will populate this
+                field when the Order is first processed. This field will be immutable
+                after it is initially set.
+              type: string
+          required:
+          - url
+          - finalizeURL
+          - certificate
+          - state
+          - reason
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -522,8 +522,6 @@ spec:
                 - message
                 type: object
               type: array
-          required:
-          - conditions
           type: object
   version: v1alpha1
 status:
@@ -716,8 +714,6 @@ spec:
                 - message
                 type: object
               type: array
-          required:
-          - conditions
           type: object
   version: v1alpha1
 status:

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -86,7 +86,7 @@ spec:
               type: array
             duration:
               description: Certificate default Duration
-              type: object
+              type: string
             ipAddresses:
               description: IPAddresses is a list of IP addresses to be used on the
                 Certificate
@@ -134,7 +134,7 @@ spec:
               type: array
             renewBefore:
               description: Certificate renew before expiration duration
-              type: object
+              type: string
             secretName:
               description: SecretName is the name of the secret resource to store
                 this secret in

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -118,6 +118,9 @@ spec:
                 either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
                 not provided, key size of 256 will be used for "ecdsa" key algorithm
                 and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
               type: string
             keySize:
               description: KeySize is the key bit size of the corresponding private
@@ -164,6 +167,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -320,6 +327,14 @@ spec:
             state:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
           required:
           - processing
@@ -379,8 +394,8 @@ spec:
                     key for this user account.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
                       type: string
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -388,7 +403,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - key
                   type: object
                 server:
                   description: Server is the ACME server URL
@@ -429,7 +443,7 @@ spec:
                         secretRef:
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description: The key of the secret to select from. Must
                                 be a valid secret key.
                               type: string
                             name:
@@ -438,7 +452,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                       required:
                       - path
@@ -449,7 +462,7 @@ spec:
                       description: This Secret contains the Vault token key
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description: The key of the secret to select from. Must
                             be a valid secret key.
                           type: string
                         name:
@@ -458,7 +471,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - key
                       type: object
                   type: object
                 caBundle:
@@ -488,8 +500,6 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
-              required:
-              - uri
               type: object
             conditions:
               items:
@@ -510,6 +520,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -571,8 +585,8 @@ spec:
                     key for this user account.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
                       type: string
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -580,7 +594,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - key
                   type: object
                 server:
                   description: Server is the ACME server URL
@@ -621,7 +634,7 @@ spec:
                         secretRef:
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description: The key of the secret to select from. Must
                                 be a valid secret key.
                               type: string
                             name:
@@ -630,7 +643,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                       required:
                       - path
@@ -641,7 +653,7 @@ spec:
                       description: This Secret contains the Vault token key
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description: The key of the secret to select from. Must
                             be a valid secret key.
                           type: string
                         name:
@@ -650,7 +662,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - key
                       type: object
                   type: object
                 caBundle:
@@ -680,8 +691,6 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
-              required:
-              - uri
               type: object
             conditions:
               items:
@@ -702,6 +711,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -775,7 +788,7 @@ spec:
             commonName:
               description: CommonName is the common name as specified on the DER encoded
                 CSR. If CommonName is not specified, the first DNSName specified will
-                be used as the CommonName. At least on of CommonName or a DNSName
+                be used as the CommonName. At least one of CommonName or a DNSNames
                 must be set. This field must match the corresponding field on the
                 DER encoded CSR.
               type: string
@@ -805,8 +818,8 @@ spec:
               description: DNSNames is a list of DNS names that should be included
                 as part of the Order validation process. If CommonName is not specified,
                 the first DNSName specified will be used as the CommonName. At least
-                on of CommonName or a DNSName must be set. This field must match the
-                corresponding field on the DER encoded CSR.
+                one of CommonName or a DNSNames must be set. This field must match
+                the corresponding field on the DER encoded CSR.
               items:
                 type: string
               type: array
@@ -916,6 +929,14 @@ spec:
             state:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
             url:
               description: URL of the Order. This will initially be empty when the
@@ -923,12 +944,6 @@ spec:
                 field when the Order is first processed. This field will be immutable
                 after it is initially set.
               type: string
-          required:
-          - url
-          - finalizeURL
-          - certificate
-          - state
-          - reason
           type: object
       required:
       - metadata

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -328,6 +328,7 @@ spec:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
               enum:
+              - ""
               - valid
               - ready
               - pending
@@ -340,7 +341,6 @@ spec:
           - processing
           - presented
           - reason
-          - state
           type: object
       required:
       - metadata
@@ -930,6 +930,7 @@ spec:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
               enum:
+              - ""
               - valid
               - ready
               - pending

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -522,8 +522,6 @@ spec:
                 - message
                 type: object
               type: array
-          required:
-          - conditions
           type: object
   version: v1alpha1
 status:
@@ -716,8 +714,6 @@ spec:
                 - message
                 type: object
               type: array
-          required:
-          - conditions
           type: object
   version: v1alpha1
 status:

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -1,12 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: certificates.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: certificates.certmanager.k8s.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+  - JSONPath: .status.conditions[?(@.type==\"Ready\")].status
     name: Ready
     type: string
   - JSONPath: .spec.secretName
@@ -14,104 +15,191 @@ spec:
     type: string
   - JSONPath: .spec.issuerRef.name
     name: Issuer
-    type: string
     priority: 1
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    type: string
+  - JSONPath: .status.conditions[?(@.type==\"Ready\")].message
     name: Status
-    type: string
     priority: 1
+    type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
-  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
     shortNames:
     - cert
     - certs
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: issuers.certmanager.k8s.io
-  labels:
-    app: cert-manager
-spec:
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: Issuer
-    plural: issuers
   scope: Namespaced
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterissuers.certmanager.k8s.io
-  labels:
-    app: cert-manager
-spec:
-  group: certmanager.k8s.io
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              description: ACME contains configuration specific to ACME Certificates.
+                Notably, this contains details on how the domain names listed on this
+                Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
+                providers to DNS names.
+              properties:
+                config:
+                  items:
+                    properties:
+                      domains:
+                        description: Domains is the list of domains that this SolverConfig
+                          applies to.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - domains
+                    type: object
+                  type: array
+              required:
+              - config
+              type: object
+            commonName:
+              description: CommonName is a common name to be used on the Certificate
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: object
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'signing' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              format: int64
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: object
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+          required:
+          - secretName
+          - issuerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
   version: v1alpha1
-  names:
-    kind: ClusterIssuer
-    plural: clusterissuers
-  scope: Cluster
-
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: orders.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    name: State
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
-    type: string
-    priority: 1
-  - JSONPath: .status.reason
-    name: Reason
-    type: string
-    priority: 1
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-    name: Age
-    type: date
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: Order
-    plural: orders
-  scope: Namespaced
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
+    controller-tools.k8s.io: "1.0"
   name: challenges.certmanager.k8s.io
-  labels:
-    app: cert-manager
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -122,21 +210,741 @@ spec:
     type: string
   - JSONPath: .status.reason
     name: Reason
+    priority: 1
     type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
   names:
     kind: Challenge
     plural: challenges
   scope: Namespaced
-
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authzURL:
+              description: AuthzURL is the URL to the ACME Authorization resource
+                that this challenge is a part of.
+              type: string
+            config:
+              description: Config specifies the solver configuration for this challenge.
+              type: object
+            dnsName:
+              description: DNSName is the identifier that this challenge is for, e.g.
+                example.com.
+              type: string
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Challenge. If the Issuer does
+                not exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Challenge will be marked
+                as failed.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            key:
+              description: Key is the ACME challenge key for this challenge
+              type: string
+            token:
+              description: Token is the ACME challenge token for this challenge.
+              type: string
+            type:
+              description: Type is the type of ACME challenge this resource represents,
+                e.g. "dns01" or "http01"
+              type: string
+            url:
+              description: URL is the URL of the ACME Challenge resource for this
+                challenge. This can be used to lookup details about the status of
+                this challenge.
+              type: string
+            wildcard:
+              description: Wildcard will be true if this challenge is for a wildcard
+                identifier, for example '*.example.com'
+              type: boolean
+          required:
+          - authzURL
+          - type
+          - url
+          - dnsName
+          - token
+          - key
+          - wildcard
+          - config
+          - issuerRef
+          type: object
+        status:
+          properties:
+            presented:
+              description: Presented will be set to true if the challenge values for
+                this challenge are currently 'presented'. This *does not* imply the
+                self check is passing. Only that the values have been 'submitted'
+                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                has been presented, or the HTTP01 configuration has been configured).
+              type: boolean
+            processing:
+              description: Processing is used to denote whether this challenge should
+                be processed or not. This field will only be set to true by the 'scheduling'
+                component. It will only be set to false by the 'challenges' controller,
+                after the challenge has reached a final state or timed out. If this
+                field is set to false, the challenge controller will not take any
+                more action.
+              type: boolean
+            reason:
+              description: Reason contains human readable information on why the Challenge
+                is in the current state.
+              type: string
+            state:
+              description: State contains the current 'state' of the challenge. If
+                not set, the state of the challenge is unknown.
+              type: string
+          required:
+          - processing
+          - presented
+          - reason
+          - state
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusterissuers.certmanager.k8s.io
+spec:
+  group: certmanager.k8s.io
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  - key
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+              required:
+              - email
+              - server
+              - privateKeySecretRef
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - server
+              - path
+              type: object
+          type: object
+        status:
+          properties:
+            acme:
+              properties:
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              required:
+              - uri
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: issuers.certmanager.k8s.io
+spec:
+  group: certmanager.k8s.io
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  - key
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+              required:
+              - email
+              - server
+              - privateKeySecretRef
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - server
+              - path
+              type: object
+          type: object
+        status:
+          properties:
+            acme:
+              properties:
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              required:
+              - uri
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: orders.certmanager.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  names:
+    kind: Order
+    plural: orders
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            commonName:
+              description: CommonName is the common name as specified on the DER encoded
+                CSR. If CommonName is not specified, the first DNSName specified will
+                be used as the CommonName. At least on of CommonName or a DNSName
+                must be set. This field must match the corresponding field on the
+                DER encoded CSR.
+              type: string
+            config:
+              description: Config specifies a mapping from DNS identifiers to how
+                those identifiers should be solved when performing ACME challenges.
+                A config entry must exist for each domain listed in DNSNames and CommonName.
+              items:
+                properties:
+                  domains:
+                    description: Domains is the list of domains that this SolverConfig
+                      applies to.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - domains
+                type: object
+              type: array
+            csr:
+              description: Certificate signing request bytes in DER encoding. This
+                will be used when finalizing the order. This field must be set on
+                the order.
+              format: byte
+              type: string
+            dnsNames:
+              description: DNSNames is a list of DNS names that should be included
+                as part of the Order validation process. If CommonName is not specified,
+                the first DNSName specified will be used as the CommonName. At least
+                on of CommonName or a DNSName must be set. This field must match the
+                corresponding field on the DER encoded CSR.
+              items:
+                type: string
+              type: array
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Order. If the Issuer does not
+                exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Order will be marked as
+                failed.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - csr
+          - issuerRef
+          - config
+          type: object
+        status:
+          properties:
+            certificate:
+              description: Certificate is a copy of the PEM encoded certificate for
+                this Order. This field will be populated after the order has been
+                successfully finalized with the ACME server, and the order has transitioned
+                to the 'valid' state.
+              format: byte
+              type: string
+            challenges:
+              description: Challenges is a list of ChallengeSpecs for Challenges that
+                must be created in order to complete this Order.
+              items:
+                properties:
+                  authzURL:
+                    description: AuthzURL is the URL to the ACME Authorization resource
+                      that this challenge is a part of.
+                    type: string
+                  config:
+                    description: Config specifies the solver configuration for this
+                      challenge.
+                    type: object
+                  dnsName:
+                    description: DNSName is the identifier that this challenge is
+                      for, e.g. example.com.
+                    type: string
+                  issuerRef:
+                    description: IssuerRef references a properly configured ACME-type
+                      Issuer which should be used to create this Challenge. If the
+                      Issuer does not exist, processing will be retried. If the Issuer
+                      is not an 'ACME' Issuer, an error will be returned and the Challenge
+                      will be marked as failed.
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  key:
+                    description: Key is the ACME challenge key for this challenge
+                    type: string
+                  token:
+                    description: Token is the ACME challenge token for this challenge.
+                    type: string
+                  type:
+                    description: Type is the type of ACME challenge this resource
+                      represents, e.g. "dns01" or "http01"
+                    type: string
+                  url:
+                    description: URL is the URL of the ACME Challenge resource for
+                      this challenge. This can be used to lookup details about the
+                      status of this challenge.
+                    type: string
+                  wildcard:
+                    description: Wildcard will be true if this challenge is for a
+                      wildcard identifier, for example '*.example.com'
+                    type: boolean
+                required:
+                - authzURL
+                - type
+                - url
+                - dnsName
+                - token
+                - key
+                - wildcard
+                - config
+                - issuerRef
+                type: object
+              type: array
+            failureTime:
+              description: FailureTime stores the time that this order failed. This
+                is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+            finalizeURL:
+              description: FinalizeURL of the Order. This is used to obtain certificates
+                for this order once it has been completed.
+              type: string
+            reason:
+              description: Reason optionally provides more information about a why
+                the order is in the current state.
+              type: string
+            state:
+              description: State contains the current state of this Order resource.
+                States 'success' and 'expired' are 'final'
+              type: string
+            url:
+              description: URL of the Order. This will initially be empty when the
+                resource is first created. The Order controller will populate this
+                field when the Order is first processed. This field will be immutable
+                after it is initially set.
+              type: string
+          required:
+          - url
+          - finalizeURL
+          - certificate
+          - state
+          - reason
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: v1
 kind: Namespace

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -86,7 +86,7 @@ spec:
               type: array
             duration:
               description: Certificate default Duration
-              type: object
+              type: string
             ipAddresses:
               description: IPAddresses is a list of IP addresses to be used on the
                 Certificate
@@ -134,7 +134,7 @@ spec:
               type: array
             renewBefore:
               description: Certificate renew before expiration duration
-              type: object
+              type: string
             secretName:
               description: SecretName is the name of the secret resource to store
                 this secret in

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -118,6 +118,9 @@ spec:
                 either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
                 not provided, key size of 256 will be used for "ecdsa" key algorithm
                 and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
               type: string
             keySize:
               description: KeySize is the key bit size of the corresponding private
@@ -164,6 +167,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -320,6 +327,14 @@ spec:
             state:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
           required:
           - processing
@@ -379,8 +394,8 @@ spec:
                     key for this user account.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
                       type: string
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -388,7 +403,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - key
                   type: object
                 server:
                   description: Server is the ACME server URL
@@ -429,7 +443,7 @@ spec:
                         secretRef:
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description: The key of the secret to select from. Must
                                 be a valid secret key.
                               type: string
                             name:
@@ -438,7 +452,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                       required:
                       - path
@@ -449,7 +462,7 @@ spec:
                       description: This Secret contains the Vault token key
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description: The key of the secret to select from. Must
                             be a valid secret key.
                           type: string
                         name:
@@ -458,7 +471,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - key
                       type: object
                   type: object
                 caBundle:
@@ -488,8 +500,6 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
-              required:
-              - uri
               type: object
             conditions:
               items:
@@ -510,6 +520,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -571,8 +585,8 @@ spec:
                     key for this user account.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
                       type: string
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -580,7 +594,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - key
                   type: object
                 server:
                   description: Server is the ACME server URL
@@ -621,7 +634,7 @@ spec:
                         secretRef:
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description: The key of the secret to select from. Must
                                 be a valid secret key.
                               type: string
                             name:
@@ -630,7 +643,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                       required:
                       - path
@@ -641,7 +653,7 @@ spec:
                       description: This Secret contains the Vault token key
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description: The key of the secret to select from. Must
                             be a valid secret key.
                           type: string
                         name:
@@ -650,7 +662,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - key
                       type: object
                   type: object
                 caBundle:
@@ -680,8 +691,6 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
-              required:
-              - uri
               type: object
             conditions:
               items:
@@ -702,6 +711,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -775,7 +788,7 @@ spec:
             commonName:
               description: CommonName is the common name as specified on the DER encoded
                 CSR. If CommonName is not specified, the first DNSName specified will
-                be used as the CommonName. At least on of CommonName or a DNSName
+                be used as the CommonName. At least one of CommonName or a DNSNames
                 must be set. This field must match the corresponding field on the
                 DER encoded CSR.
               type: string
@@ -805,8 +818,8 @@ spec:
               description: DNSNames is a list of DNS names that should be included
                 as part of the Order validation process. If CommonName is not specified,
                 the first DNSName specified will be used as the CommonName. At least
-                on of CommonName or a DNSName must be set. This field must match the
-                corresponding field on the DER encoded CSR.
+                one of CommonName or a DNSNames must be set. This field must match
+                the corresponding field on the DER encoded CSR.
               items:
                 type: string
               type: array
@@ -916,6 +929,14 @@ spec:
             state:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
             url:
               description: URL of the Order. This will initially be empty when the
@@ -923,12 +944,6 @@ spec:
                 field when the Order is first processed. This field will be immutable
                 after it is initially set.
               type: string
-          required:
-          - url
-          - finalizeURL
-          - certificate
-          - state
-          - reason
           type: object
       required:
       - metadata

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -328,6 +328,7 @@ spec:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
               enum:
+              - ""
               - valid
               - ready
               - pending
@@ -340,7 +341,6 @@ spec:
           - processing
           - presented
           - reason
-          - state
           type: object
       required:
       - metadata
@@ -930,6 +930,7 @@ spec:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
               enum:
+              - ""
               - valid
               - ready
               - pending

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -522,8 +522,6 @@ spec:
                 - message
                 type: object
               type: array
-          required:
-          - conditions
           type: object
   version: v1alpha1
 status:
@@ -716,8 +714,6 @@ spec:
                 - message
                 type: object
               type: array
-          required:
-          - conditions
           type: object
   version: v1alpha1
 status:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1,12 +1,13 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: certificates.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
+    controller-tools.k8s.io: "1.0"
+  name: certificates.certmanager.k8s.io
 spec:
   additionalPrinterColumns:
-  - JSONPath: .status.conditions[?(@.type=="Ready")].status
+  - JSONPath: .status.conditions[?(@.type==\"Ready\")].status
     name: Ready
     type: string
   - JSONPath: .spec.secretName
@@ -14,104 +15,191 @@ spec:
     type: string
   - JSONPath: .spec.issuerRef.name
     name: Issuer
-    type: string
     priority: 1
-  - JSONPath: .status.conditions[?(@.type=="Ready")].message
+    type: string
+  - JSONPath: .status.conditions[?(@.type==\"Ready\")].message
     name: Status
-    type: string
     priority: 1
+    type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
-  scope: Namespaced
   names:
     kind: Certificate
     plural: certificates
     shortNames:
     - cert
     - certs
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: issuers.certmanager.k8s.io
-  labels:
-    app: cert-manager
-spec:
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: Issuer
-    plural: issuers
   scope: Namespaced
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  name: clusterissuers.certmanager.k8s.io
-  labels:
-    app: cert-manager
-spec:
-  group: certmanager.k8s.io
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              description: ACME contains configuration specific to ACME Certificates.
+                Notably, this contains details on how the domain names listed on this
+                Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
+                providers to DNS names.
+              properties:
+                config:
+                  items:
+                    properties:
+                      domains:
+                        description: Domains is the list of domains that this SolverConfig
+                          applies to.
+                        items:
+                          type: string
+                        type: array
+                    required:
+                    - domains
+                    type: object
+                  type: array
+              required:
+              - config
+              type: object
+            commonName:
+              description: CommonName is a common name to be used on the Certificate
+              type: string
+            dnsNames:
+              description: DNSNames is a list of subject alt names to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            duration:
+              description: Certificate default Duration
+              type: object
+            ipAddresses:
+              description: IPAddresses is a list of IP addresses to be used on the
+                Certificate
+              items:
+                type: string
+              type: array
+            isCA:
+              description: IsCA will mark this Certificate as valid for signing. This
+                implies that the 'signing' usage is set
+              type: boolean
+            issuerRef:
+              description: IssuerRef is a reference to the issuer for this certificate.
+                If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+                with the given name in the same namespace as the Certificate will
+                be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            keyAlgorithm:
+              description: KeyAlgorithm is the private key algorithm of the corresponding
+                private key for this certificate. If provided, allowed values are
+                either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
+                not provided, key size of 256 will be used for "ecdsa" key algorithm
+                and key size of 2048 will be used for "rsa" key algorithm.
+              type: string
+            keySize:
+              description: KeySize is the key bit size of the corresponding private
+                key for this certificate. If provided, value must be between 2048
+                and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
+                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                to "ecdsa".
+              format: int64
+              type: integer
+            organization:
+              description: Organization is the organization to be used on the Certificate
+              items:
+                type: string
+              type: array
+            renewBefore:
+              description: Certificate renew before expiration duration
+              type: object
+            secretName:
+              description: SecretName is the name of the secret resource to store
+                this secret in
+              type: string
+          required:
+          - secretName
+          - issuerRef
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+            lastFailureTime:
+              format: date-time
+              type: string
+            notAfter:
+              description: The expiration time of the certificate stored in the secret
+                named by this resource in spec.secretName.
+              format: date-time
+              type: string
+          type: object
   version: v1alpha1
-  names:
-    kind: ClusterIssuer
-    plural: clusterissuers
-  scope: Cluster
-
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
-
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: orders.certmanager.k8s.io
+  creationTimestamp: null
   labels:
-    app: cert-manager
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.state
-    name: State
-    type: string
-  - JSONPath: .spec.issuerRef.name
-    name: Issuer
-    type: string
-    priority: 1
-  - JSONPath: .status.reason
-    name: Reason
-    type: string
-    priority: 1
-  - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
-    name: Age
-    type: date
-  group: certmanager.k8s.io
-  version: v1alpha1
-  names:
-    kind: Order
-    plural: orders
-  scope: Namespaced
-
----
-
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
+    controller-tools.k8s.io: "1.0"
   name: challenges.certmanager.k8s.io
-  labels:
-    app: cert-manager
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.state
@@ -122,21 +210,741 @@ spec:
     type: string
   - JSONPath: .status.reason
     name: Reason
+    priority: 1
     type: string
   - JSONPath: .metadata.creationTimestamp
-    description: |-
-      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
     name: Age
     type: date
   group: certmanager.k8s.io
-  version: v1alpha1
   names:
     kind: Challenge
     plural: challenges
   scope: Namespaced
-
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            authzURL:
+              description: AuthzURL is the URL to the ACME Authorization resource
+                that this challenge is a part of.
+              type: string
+            config:
+              description: Config specifies the solver configuration for this challenge.
+              type: object
+            dnsName:
+              description: DNSName is the identifier that this challenge is for, e.g.
+                example.com.
+              type: string
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Challenge. If the Issuer does
+                not exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Challenge will be marked
+                as failed.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+            key:
+              description: Key is the ACME challenge key for this challenge
+              type: string
+            token:
+              description: Token is the ACME challenge token for this challenge.
+              type: string
+            type:
+              description: Type is the type of ACME challenge this resource represents,
+                e.g. "dns01" or "http01"
+              type: string
+            url:
+              description: URL is the URL of the ACME Challenge resource for this
+                challenge. This can be used to lookup details about the status of
+                this challenge.
+              type: string
+            wildcard:
+              description: Wildcard will be true if this challenge is for a wildcard
+                identifier, for example '*.example.com'
+              type: boolean
+          required:
+          - authzURL
+          - type
+          - url
+          - dnsName
+          - token
+          - key
+          - wildcard
+          - config
+          - issuerRef
+          type: object
+        status:
+          properties:
+            presented:
+              description: Presented will be set to true if the challenge values for
+                this challenge are currently 'presented'. This *does not* imply the
+                self check is passing. Only that the values have been 'submitted'
+                for the appropriate challenge mechanism (i.e. the DNS01 TXT record
+                has been presented, or the HTTP01 configuration has been configured).
+              type: boolean
+            processing:
+              description: Processing is used to denote whether this challenge should
+                be processed or not. This field will only be set to true by the 'scheduling'
+                component. It will only be set to false by the 'challenges' controller,
+                after the challenge has reached a final state or timed out. If this
+                field is set to false, the challenge controller will not take any
+                more action.
+              type: boolean
+            reason:
+              description: Reason contains human readable information on why the Challenge
+                is in the current state.
+              type: string
+            state:
+              description: State contains the current 'state' of the challenge. If
+                not set, the state of the challenge is unknown.
+              type: string
+          required:
+          - processing
+          - presented
+          - reason
+          - state
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: clusterissuers.certmanager.k8s.io
+spec:
+  group: certmanager.k8s.io
+  names:
+    kind: ClusterIssuer
+    plural: clusterissuers
+  scope: Cluster
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  - key
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+              required:
+              - email
+              - server
+              - privateKeySecretRef
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - server
+              - path
+              type: object
+          type: object
+        status:
+          properties:
+            acme:
+              properties:
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              required:
+              - uri
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: issuers.certmanager.k8s.io
+spec:
+  group: certmanager.k8s.io
+  names:
+    kind: Issuer
+    plural: issuers
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            acme:
+              properties:
+                email:
+                  description: Email is the email for this account
+                  type: string
+                privateKeySecretRef:
+                  description: PrivateKey is the name of a secret containing the private
+                    key for this user account.
+                  properties:
+                    key:
+                      description: The key of the secret to select from.  Must be
+                        a valid secret key.
+                      type: string
+                    name:
+                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                        TODO: Add other useful fields. apiVersion, kind, uid?'
+                      type: string
+                  required:
+                  - name
+                  - key
+                  type: object
+                server:
+                  description: Server is the ACME server URL
+                  type: string
+                skipTLSVerify:
+                  description: If true, skip verifying the ACME server TLS certificate
+                  type: boolean
+              required:
+              - email
+              - server
+              - privateKeySecretRef
+              type: object
+            ca:
+              properties:
+                secretName:
+                  description: SecretName is the name of the secret used to sign Certificates
+                    issued by this Issuer.
+                  type: string
+              required:
+              - secretName
+              type: object
+            selfSigned:
+              type: object
+            vault:
+              properties:
+                auth:
+                  description: Vault authentication
+                  properties:
+                    appRole:
+                      description: This Secret contains a AppRole and Secret
+                      properties:
+                        path:
+                          description: Where the authentication path is mounted in
+                            Vault.
+                          type: string
+                        roleId:
+                          type: string
+                        secretRef:
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must
+                                be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                          required:
+                          - name
+                          - key
+                          type: object
+                      required:
+                      - path
+                      - roleId
+                      - secretRef
+                      type: object
+                    tokenSecretRef:
+                      description: This Secret contains the Vault token key
+                      properties:
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                            TODO: Add other useful fields. apiVersion, kind, uid?'
+                          type: string
+                      required:
+                      - name
+                      - key
+                      type: object
+                  type: object
+                caBundle:
+                  description: Base64 encoded CA bundle to validate Vault server certificate.
+                    Only used if the Server URL is using HTTPS protocol. This parameter
+                    is ignored for plain HTTP protocol connection. If not set the
+                    system root certificates are used to validate the TLS connection.
+                  format: byte
+                  type: string
+                path:
+                  description: Vault URL path to the certificate role
+                  type: string
+                server:
+                  description: Server is the vault connection address
+                  type: string
+              required:
+              - auth
+              - server
+              - path
+              type: object
+          type: object
+        status:
+          properties:
+            acme:
+              properties:
+                uri:
+                  description: URI is the unique account identifier, which can also
+                    be used to retrieve account details from the CA
+                  type: string
+              required:
+              - uri
+              type: object
+            conditions:
+              items:
+                properties:
+                  lastTransitionTime:
+                    description: LastTransitionTime is the timestamp corresponding
+                      to the last status change of this condition.
+                    format: date-time
+                    type: string
+                  message:
+                    description: Message is a human readable description of the details
+                      of the last transition, complementing reason.
+                    type: string
+                  reason:
+                    description: Reason is a brief machine readable explanation for
+                      the condition's last transition.
+                    type: string
+                  status:
+                    description: Status of the condition, one of ('True', 'False',
+                      'Unknown').
+                    type: string
+                  type:
+                    description: Type of the condition, currently ('Ready').
+                    type: string
+                required:
+                - type
+                - status
+                - lastTransitionTime
+                - reason
+                - message
+                type: object
+              type: array
+          required:
+          - conditions
+          type: object
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: orders.certmanager.k8s.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.state
+    name: State
+    type: string
+  - JSONPath: .spec.issuerRef.name
+    name: Issuer
+    priority: 1
+    type: string
+  - JSONPath: .status.reason
+    name: Reason
+    priority: 1
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC.
+    name: Age
+    type: date
+  group: certmanager.k8s.io
+  names:
+    kind: Order
+    plural: orders
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            commonName:
+              description: CommonName is the common name as specified on the DER encoded
+                CSR. If CommonName is not specified, the first DNSName specified will
+                be used as the CommonName. At least on of CommonName or a DNSName
+                must be set. This field must match the corresponding field on the
+                DER encoded CSR.
+              type: string
+            config:
+              description: Config specifies a mapping from DNS identifiers to how
+                those identifiers should be solved when performing ACME challenges.
+                A config entry must exist for each domain listed in DNSNames and CommonName.
+              items:
+                properties:
+                  domains:
+                    description: Domains is the list of domains that this SolverConfig
+                      applies to.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - domains
+                type: object
+              type: array
+            csr:
+              description: Certificate signing request bytes in DER encoding. This
+                will be used when finalizing the order. This field must be set on
+                the order.
+              format: byte
+              type: string
+            dnsNames:
+              description: DNSNames is a list of DNS names that should be included
+                as part of the Order validation process. If CommonName is not specified,
+                the first DNSName specified will be used as the CommonName. At least
+                on of CommonName or a DNSName must be set. This field must match the
+                corresponding field on the DER encoded CSR.
+              items:
+                type: string
+              type: array
+            issuerRef:
+              description: IssuerRef references a properly configured ACME-type Issuer
+                which should be used to create this Order. If the Issuer does not
+                exist, processing will be retried. If the Issuer is not an 'ACME'
+                Issuer, an error will be returned and the Order will be marked as
+                failed.
+              properties:
+                kind:
+                  type: string
+                name:
+                  type: string
+              required:
+              - name
+              type: object
+          required:
+          - csr
+          - issuerRef
+          - config
+          type: object
+        status:
+          properties:
+            certificate:
+              description: Certificate is a copy of the PEM encoded certificate for
+                this Order. This field will be populated after the order has been
+                successfully finalized with the ACME server, and the order has transitioned
+                to the 'valid' state.
+              format: byte
+              type: string
+            challenges:
+              description: Challenges is a list of ChallengeSpecs for Challenges that
+                must be created in order to complete this Order.
+              items:
+                properties:
+                  authzURL:
+                    description: AuthzURL is the URL to the ACME Authorization resource
+                      that this challenge is a part of.
+                    type: string
+                  config:
+                    description: Config specifies the solver configuration for this
+                      challenge.
+                    type: object
+                  dnsName:
+                    description: DNSName is the identifier that this challenge is
+                      for, e.g. example.com.
+                    type: string
+                  issuerRef:
+                    description: IssuerRef references a properly configured ACME-type
+                      Issuer which should be used to create this Challenge. If the
+                      Issuer does not exist, processing will be retried. If the Issuer
+                      is not an 'ACME' Issuer, an error will be returned and the Challenge
+                      will be marked as failed.
+                    properties:
+                      kind:
+                        type: string
+                      name:
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  key:
+                    description: Key is the ACME challenge key for this challenge
+                    type: string
+                  token:
+                    description: Token is the ACME challenge token for this challenge.
+                    type: string
+                  type:
+                    description: Type is the type of ACME challenge this resource
+                      represents, e.g. "dns01" or "http01"
+                    type: string
+                  url:
+                    description: URL is the URL of the ACME Challenge resource for
+                      this challenge. This can be used to lookup details about the
+                      status of this challenge.
+                    type: string
+                  wildcard:
+                    description: Wildcard will be true if this challenge is for a
+                      wildcard identifier, for example '*.example.com'
+                    type: boolean
+                required:
+                - authzURL
+                - type
+                - url
+                - dnsName
+                - token
+                - key
+                - wildcard
+                - config
+                - issuerRef
+                type: object
+              type: array
+            failureTime:
+              description: FailureTime stores the time that this order failed. This
+                is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
+            finalizeURL:
+              description: FinalizeURL of the Order. This is used to obtain certificates
+                for this order once it has been completed.
+              type: string
+            reason:
+              description: Reason optionally provides more information about a why
+                the order is in the current state.
+              type: string
+            state:
+              description: State contains the current state of this Order resource.
+                States 'success' and 'expired' are 'final'
+              type: string
+            url:
+              description: URL of the Order. This will initially be empty when the
+                resource is first created. The Order controller will populate this
+                field when the Order is first processed. This field will be immutable
+                after it is initially set.
+              type: string
+          required:
+          - url
+          - finalizeURL
+          - certificate
+          - state
+          - reason
+          type: object
+      required:
+      - metadata
+      - spec
+      - status
+  version: v1alpha1
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: []
+  storedVersions: []
 ---
 apiVersion: v1
 kind: Namespace

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -86,7 +86,7 @@ spec:
               type: array
             duration:
               description: Certificate default Duration
-              type: object
+              type: string
             ipAddresses:
               description: IPAddresses is a list of IP addresses to be used on the
                 Certificate
@@ -134,7 +134,7 @@ spec:
               type: array
             renewBefore:
               description: Certificate renew before expiration duration
-              type: object
+              type: string
             secretName:
               description: SecretName is the name of the secret resource to store
                 this secret in

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -118,6 +118,9 @@ spec:
                 either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
                 not provided, key size of 256 will be used for "ecdsa" key algorithm
                 and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
               type: string
             keySize:
               description: KeySize is the key bit size of the corresponding private
@@ -164,6 +167,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -320,6 +327,14 @@ spec:
             state:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
           required:
           - processing
@@ -379,8 +394,8 @@ spec:
                     key for this user account.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
                       type: string
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -388,7 +403,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - key
                   type: object
                 server:
                   description: Server is the ACME server URL
@@ -429,7 +443,7 @@ spec:
                         secretRef:
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description: The key of the secret to select from. Must
                                 be a valid secret key.
                               type: string
                             name:
@@ -438,7 +452,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                       required:
                       - path
@@ -449,7 +462,7 @@ spec:
                       description: This Secret contains the Vault token key
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description: The key of the secret to select from. Must
                             be a valid secret key.
                           type: string
                         name:
@@ -458,7 +471,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - key
                       type: object
                   type: object
                 caBundle:
@@ -488,8 +500,6 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
-              required:
-              - uri
               type: object
             conditions:
               items:
@@ -510,6 +520,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -571,8 +585,8 @@ spec:
                     key for this user account.
                   properties:
                     key:
-                      description: The key of the secret to select from.  Must be
-                        a valid secret key.
+                      description: The key of the secret to select from. Must be a
+                        valid secret key.
                       type: string
                     name:
                       description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
@@ -580,7 +594,6 @@ spec:
                       type: string
                   required:
                   - name
-                  - key
                   type: object
                 server:
                   description: Server is the ACME server URL
@@ -621,7 +634,7 @@ spec:
                         secretRef:
                           properties:
                             key:
-                              description: The key of the secret to select from.  Must
+                              description: The key of the secret to select from. Must
                                 be a valid secret key.
                               type: string
                             name:
@@ -630,7 +643,6 @@ spec:
                               type: string
                           required:
                           - name
-                          - key
                           type: object
                       required:
                       - path
@@ -641,7 +653,7 @@ spec:
                       description: This Secret contains the Vault token key
                       properties:
                         key:
-                          description: The key of the secret to select from.  Must
+                          description: The key of the secret to select from. Must
                             be a valid secret key.
                           type: string
                         name:
@@ -650,7 +662,6 @@ spec:
                           type: string
                       required:
                       - name
-                      - key
                       type: object
                   type: object
                 caBundle:
@@ -680,8 +691,6 @@ spec:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
                   type: string
-              required:
-              - uri
               type: object
             conditions:
               items:
@@ -702,6 +711,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -775,7 +788,7 @@ spec:
             commonName:
               description: CommonName is the common name as specified on the DER encoded
                 CSR. If CommonName is not specified, the first DNSName specified will
-                be used as the CommonName. At least on of CommonName or a DNSName
+                be used as the CommonName. At least one of CommonName or a DNSNames
                 must be set. This field must match the corresponding field on the
                 DER encoded CSR.
               type: string
@@ -805,8 +818,8 @@ spec:
               description: DNSNames is a list of DNS names that should be included
                 as part of the Order validation process. If CommonName is not specified,
                 the first DNSName specified will be used as the CommonName. At least
-                on of CommonName or a DNSName must be set. This field must match the
-                corresponding field on the DER encoded CSR.
+                one of CommonName or a DNSNames must be set. This field must match
+                the corresponding field on the DER encoded CSR.
               items:
                 type: string
               type: array
@@ -916,6 +929,14 @@ spec:
             state:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
             url:
               description: URL of the Order. This will initially be empty when the
@@ -923,12 +944,6 @@ spec:
                 field when the Order is first processed. This field will be immutable
                 after it is initially set.
               type: string
-          required:
-          - url
-          - finalizeURL
-          - certificate
-          - state
-          - reason
           type: object
       required:
       - metadata

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -328,6 +328,7 @@ spec:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
               enum:
+              - ""
               - valid
               - ready
               - pending
@@ -340,7 +341,6 @@ spec:
           - processing
           - presented
           - reason
-          - state
           type: object
       required:
       - metadata
@@ -930,6 +930,7 @@ spec:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
               enum:
+              - ""
               - valid
               - ready
               - pending

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -340,6 +340,7 @@ Appears In:
 </tr>
 </tbody>
 </table>
+<p>Order is a type to represent an Order with an ACME server</p>
 <table>
 <thead>
 <tr>
@@ -472,6 +473,7 @@ Appears In:
 </tr>
 </tbody>
 </table>
+<p>Challenge is a type to represent a Challenge request with an ACME server</p>
 <table>
 <thead>
 <tr>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -389,7 +389,7 @@ Appears In:
 <tbody>
 <tr>
 <td><code>commonName</code><br /> <em>string</em></td>
-<td>CommonName is the common name as specified on the DER encoded CSR. If CommonName is not specified, the first DNSName specified will be used as the CommonName. At least on of CommonName or a DNSName must be set. This field must match the corresponding field on the DER encoded CSR.</td>
+<td>CommonName is the common name as specified on the DER encoded CSR. If CommonName is not specified, the first DNSName specified will be used as the CommonName. At least one of CommonName or a DNSNames must be set. This field must match the corresponding field on the DER encoded CSR.</td>
 </tr>
 <tr>
 <td><code>config</code><br /> <em><a href="#domainsolverconfig-v1alpha1">DomainSolverConfig</a> array</em></td>
@@ -401,7 +401,7 @@ Appears In:
 </tr>
 <tr>
 <td><code>dnsNames</code><br /> <em>string array</em></td>
-<td>DNSNames is a list of DNS names that should be included as part of the Order validation process. If CommonName is not specified, the first DNSName specified will be used as the CommonName. At least on of CommonName or a DNSName must be set. This field must match the corresponding field on the DER encoded CSR.</td>
+<td>DNSNames is a list of DNS names that should be included as part of the Order validation process. If CommonName is not specified, the first DNSName specified will be used as the CommonName. At least one of CommonName or a DNSNames must be set. This field must match the corresponding field on the DER encoded CSR.</td>
 </tr>
 <tr>
 <td><code>issuerRef</code><br /> <em><a href="#objectreference-v1alpha1">ObjectReference</a></em></td>
@@ -1927,7 +1927,7 @@ Appears In:
 <tbody>
 <tr>
 <td><code>key</code><br /> <em>string</em></td>
-<td>The key of the secret to select from.  Must be a valid secret key.</td>
+<td>The key of the secret to select from. Must be a valid secret key.</td>
 </tr>
 <tr>
 <td><code>name</code><br /> <em>string</em></td>

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -150,6 +150,30 @@ sh_test(
     ],
 )
 
+sh_binary(
+    name = "update-crds",
+    srcs = ["update-crds.sh"],
+    data = [
+        ":update-deploy-gen",
+        "//hack/bin:gencrd",
+        "//pkg/apis:all-srcs",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:all-srcs",
+        "//vendor/k8s.io/apimachinery/pkg/runtime:all-srcs",
+    ],
+)
+
+sh_test(
+    name = "verify-crds",
+    srcs = ["verify-crds.sh"],
+    data = [
+        ":update-crds",
+        "//deploy:all-srcs",
+        "//hack/bin:gencrd",
+        "//pkg/apis:all-srcs",
+    ],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -63,6 +63,14 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "fetch_gencrd",
+    srcs = ["@io_kubernetes_sigs_controller-tools//cmd/crd"],
+    outs = ["gencrd"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "k8",
     values = {"host_cpu": "k8"},

--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script should be run via `bazel run //hack:update-crds`
+REPO_ROOT=${BUILD_WORKSPACE_DIRECTORY:-"$(cd "$(dirname "$0")" && pwd -P)"/..}
+runfiles="$(pwd)"
+export PATH="${runfiles}/hack/bin:${PATH}"
+cd "${REPO_ROOT}"
+
+output="$(mktemp -d)"
+gencrd generate \
+    --domain "k8s.io" \
+    --output-dir "${output}"
+
+echo "Copying files to output file"
+out="deploy/manifests/00-crds.yaml"
+rm "$out" > /dev/null 2>&1 || true
+mkdir -p "$(dirname $out)"
+touch "$out"
+for file in ${output}/*; do
+    cat "$file" >> "$out"
+    echo "---" >> "$out"
+done
+
+hack/update-deploy-gen.sh

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Copyright 2019 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+RULE_NAME="crds"
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+
+_tmp="$(mktemp -d)"
+DIFFROOT="${SCRIPT_ROOT}/"
+
+cleanup() {
+  rm -rf "${_tmp}"
+}
+trap "cleanup" EXIT SIGINT
+
+# Create a fake GOPATH
+export GOPATH="${_tmp}"
+TMP_DIFFROOT="${GOPATH}/src/github.com/jetstack/cert-manager"
+
+mkdir -p "${TMP_DIFFROOT}"
+rsync -avvL "${DIFFROOT}"/ "${TMP_DIFFROOT}" >/dev/null
+# remove __main__ directory copied to tmp
+rm -Rf "${TMP_DIFFROOT}/__main__"
+
+cd "${TMP_DIFFROOT}"
+export BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+"hack/update-${RULE_NAME}.sh"
+
+echo "diffing ${DIFFROOT} against freshly generated codegen"
+ret=0
+diff -Naupr "${DIFFROOT}/deploy/manifests/00-crds.yaml" "${TMP_DIFFROOT}/deploy/manifests/00-crds.yaml" || ret=$?
+if [[ $ret -eq 0 ]]
+then
+  echo "${DIFFROOT} up to date."
+else
+  echo "${DIFFROOT} is out of date. Please run 'bazel run //hack:update-${RULE_NAME}'"
+  exit 1
+fi

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -54,6 +54,7 @@ type LocalObjectReference struct {
 // ObjectReference is a reference to an object with a given name and kind.
 type ObjectReference struct {
 	Name string `json:"name"`
+	// +optional
 	Kind string `json:"kind,omitempty"`
 }
 
@@ -66,6 +67,7 @@ const (
 type SecretKeySelector struct {
 	// The name of the secret in the pod's namespace to select from.
 	LocalObjectReference `json:",inline"`
-	// The key of the secret to select from.  Must be a valid secret key.
-	Key string `json:"key"`
+	// The key of the secret to select from. Must be a valid secret key.
+	// +optional
+	Key string `json:"key,omitempty"`
 }

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -19,11 +19,16 @@ package v1alpha1
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // +genclient
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
-// +kubebuilder:resource:path=certificates
 // Certificate is a type to represent a Certificate from ACME
+// +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].status",description=""
+// +kubebuilder:printcolumn:name="Secret",type="string",JSONPath=".spec.secretName",description=""
+// +kubebuilder:printcolumn:name="Issuer",type="string",JSONPath=".spec.issuerRef.name",description="",priority=1
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:resource:path=certificates,shortName=cert;certs
 type Certificate struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -128,10 +128,10 @@ type ACMECertificateConfig struct {
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {
 	// +optional
-	Conditions      []CertificateCondition `json:"conditions,omitempty"`
+	Conditions []CertificateCondition `json:"conditions,omitempty"`
 
 	// +optional
-	LastFailureTime *metav1.Time           `json:"lastFailureTime,omitempty"`
+	LastFailureTime *metav1.Time `json:"lastFailureTime,omitempty"`
 
 	// The expiration time of the certificate stored in the secret named
 	// by this resource in spec.secretName.

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -57,21 +57,27 @@ const (
 // CertificateSpec defines the desired state of Certificate
 type CertificateSpec struct {
 	// CommonName is a common name to be used on the Certificate
+	// +optional
 	CommonName string `json:"commonName,omitempty"`
 
 	// Organization is the organization to be used on the Certificate
+	// +optional
 	Organization []string `json:"organization,omitempty"`
 
 	// Certificate default Duration
+	// +optional
 	Duration *metav1.Duration `json:"duration,omitempty"`
 
 	// Certificate renew before expiration duration
+	// +optional
 	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
 
 	// DNSNames is a list of subject alt names to be used on the Certificate
+	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// IPAddresses is a list of IP addresses to be used on the Certificate
+	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 
 	// SecretName is the name of the secret resource to store this secret in
@@ -87,24 +93,30 @@ type CertificateSpec struct {
 
 	// IsCA will mark this Certificate as valid for signing.
 	// This implies that the 'signing' usage is set
+	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
 	// ACME contains configuration specific to ACME Certificates.
 	// Notably, this contains details on how the domain names listed on this
 	// Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01
 	// providers to DNS names.
+	// +optional
 	ACME *ACMECertificateConfig `json:"acme,omitempty"`
 
 	// KeySize is the key bit size of the corresponding private key for this certificate.
 	// If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is
 	// empty or is set to "rsa", and value must be one of (256, 384, 521) when
 	// KeyAlgorithm is set to "ecdsa".
+	// +optional
 	KeySize int `json:"keySize,omitempty"`
+
 	// KeyAlgorithm is the private key algorithm of the corresponding private key
 	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
 	// If KeyAlgorithm is specified and KeySize is not provided,
 	// key size of 256 will be used for "ecdsa" key algorithm and
 	// key size of 2048 will be used for "rsa" key algorithm.
+	// +kubebuilder:validation:Enum=rsa,ecdsa
+	// +optional
 	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
 }
 
@@ -115,11 +127,15 @@ type ACMECertificateConfig struct {
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {
+	// +optional
 	Conditions      []CertificateCondition `json:"conditions,omitempty"`
+
+	// +optional
 	LastFailureTime *metav1.Time           `json:"lastFailureTime,omitempty"`
 
 	// The expiration time of the certificate stored in the secret named
 	// by this resource in spec.secretName.
+	// +optional
 	NotAfter *metav1.Time `json:"notAfter,omitempty"`
 }
 
@@ -129,6 +145,7 @@ type CertificateCondition struct {
 	Type CertificateConditionType `json:"type"`
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// +kubebuilder:validation:Enum=True,False,Unknown
 	Status ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -24,9 +24,14 @@ import (
 // coupling between ACME Issuers and their solver configurations (see: Solver proposal)
 
 // +genclient
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Challenge is a type to represent a Challenge request with an ACME server
+// +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Domain",type="string",JSONPath=".spec.dnsName"
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.reason",description="",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
 // +kubebuilder:resource:path=challenges
 type Challenge struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -116,7 +116,7 @@ type ChallengeStatus struct {
 
 	// State contains the current 'state' of the challenge.
 	// If not set, the state of the challenge is unknown.
-	// +kubebuilder:validation:Enum=valid,ready,pending,processing,invalid,expired,errored
+	// +kubebuilder:validation:Enum=,valid,ready,pending,processing,invalid,expired,errored
 	// +optional
-	State State `json:"state"`
+	State State `json:"state,omitempty"`
 }

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -75,6 +75,7 @@ type ChallengeSpec struct {
 
 	// Wildcard will be true if this challenge is for a wildcard identifier,
 	// for example '*.example.com'
+	// +optional
 	Wildcard bool `json:"wildcard"`
 
 	// Config specifies the solver configuration for this challenge.
@@ -96,6 +97,7 @@ type ChallengeStatus struct {
 	// challenge has reached a final state or timed out.
 	// If this field is set to false, the challenge controller will not take
 	// any more action.
+	// +optional
 	Processing bool `json:"processing"`
 
 	// Presented will be set to true if the challenge values for this challenge
@@ -104,13 +106,17 @@ type ChallengeStatus struct {
 	// have been 'submitted' for the appropriate challenge mechanism (i.e. the
 	// DNS01 TXT record has been presented, or the HTTP01 configuration has been
 	// configured).
+	// +optional
 	Presented bool `json:"presented"`
 
 	// Reason contains human readable information on why the Challenge is in the
 	// current state.
+	// +optional
 	Reason string `json:"reason"`
 
 	// State contains the current 'state' of the challenge.
 	// If not set, the state of the challenge is unknown.
+	// +kubebuilder:validation:Enum=valid,ready,pending,processing,invalid,expired,errored
+	// +optional
 	State State `json:"state"`
 }

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -75,9 +75,16 @@ type IssuerSpec struct {
 }
 
 type IssuerConfig struct {
+	// +optional
 	ACME       *ACMEIssuer       `json:"acme,omitempty"`
+
+	// +optional
 	CA         *CAIssuer         `json:"ca,omitempty"`
+
+	// +optional
 	Vault      *VaultIssuer      `json:"vault,omitempty"`
+
+	// +optional
 	SelfSigned *SelfSignedIssuer `json:"selfSigned,omitempty"`
 }
 
@@ -87,14 +94,18 @@ type SelfSignedIssuer struct {
 type VaultIssuer struct {
 	// Vault authentication
 	Auth VaultAuth `json:"auth"`
+
 	// Server is the vault connection address
 	Server string `json:"server"`
+
 	// Vault URL path to the certificate role
 	Path string `json:"path"`
+
 	// Base64 encoded CA bundle to validate Vault server certificate. Only used
 	// if the Server URL is using HTTPS protocol. This parameter is ignored for
 	// plain HTTP protocol connection. If not set the system root certificates
 	// are used to validate the TLS connection.
+	// +optional
 	CABundle []byte `json:"caBundle,omitempty"`
 }
 
@@ -104,8 +115,11 @@ type VaultIssuer struct {
 //   Vault and retrieve a token.
 type VaultAuth struct {
 	// This Secret contains the Vault token key
+	// +optional
 	TokenSecretRef SecretKeySelector `json:"tokenSecretRef,omitempty"`
+
 	// This Secret contains a AppRole and Secret
+	// +optional
 	AppRole VaultAppRole `json:"appRole,omitempty"`
 }
 
@@ -127,29 +141,39 @@ type CAIssuer struct {
 type ACMEIssuer struct {
 	// Email is the email for this account
 	Email string `json:"email"`
+
 	// Server is the ACME server URL
 	Server string `json:"server"`
+
 	// If true, skip verifying the ACME server TLS certificate
+	// +optional
 	SkipTLSVerify bool `json:"skipTLSVerify,omitempty"`
+
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
 	PrivateKey SecretKeySelector `json:"privateKeySecretRef"`
+
 	// HTTP-01 config
+	// +optional
 	HTTP01 *ACMEIssuerHTTP01Config `json:"http01,omitempty"`
+
 	// DNS-01 config
+	// +optional
 	DNS01 *ACMEIssuerDNS01Config `json:"dns01,omitempty"`
 }
 
 // ACMEIssuerHTTP01Config is a structure containing the ACME HTTP configuration options
 type ACMEIssuerHTTP01Config struct {
 	// Optional service type for Kubernetes solver service
+	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 }
 
 // ACMEIssuerDNS01Config is a structure containing the ACME DNS configuration
 // options
 type ACMEIssuerDNS01Config struct {
-	Providers []ACMEIssuerDNS01Provider `json:"providers"`
+	// +optional
+	Providers []ACMEIssuerDNS01Provider `json:"providers,omitempty"`
 }
 
 // ACMEIssuerDNS01Provider contains configuration for a DNS provider that can
@@ -161,15 +185,32 @@ type ACMEIssuerDNS01Provider struct {
 
 	// CNAMEStrategy configures how the DNS01 provider should handle CNAME
 	// records when found in DNS zones.
-	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy"`
+	// +optional
+	// +kubebuilder:validation:Enum=None,Follow
+	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy,omitempty"`
 
+	// +optional
 	Akamai       *ACMEIssuerDNS01ProviderAkamai       `json:"akamai,omitempty"`
+
+	// +optional
 	CloudDNS     *ACMEIssuerDNS01ProviderCloudDNS     `json:"clouddns,omitempty"`
+
+	// +optional
 	Cloudflare   *ACMEIssuerDNS01ProviderCloudflare   `json:"cloudflare,omitempty"`
+
+	// +optional
 	Route53      *ACMEIssuerDNS01ProviderRoute53      `json:"route53,omitempty"`
+
+	// +optional
 	AzureDNS     *ACMEIssuerDNS01ProviderAzureDNS     `json:"azuredns,omitempty"`
+
+	// +optional
 	DigitalOcean *ACMEIssuerDNS01ProviderDigitalOcean `json:"digitalocean,omitempty"`
+
+	// +optional
 	AcmeDNS      *ACMEIssuerDNS01ProviderAcmeDNS      `json:"acmedns,omitempty"`
+
+	// +optional
 	RFC2136      *ACMEIssuerDNS01ProviderRFC2136      `json:"rfc2136,omitempty"`
 }
 
@@ -224,8 +265,12 @@ type ACMEIssuerDNS01ProviderDigitalOcean struct {
 // configuration for AWS
 type ACMEIssuerDNS01ProviderRoute53 struct {
 	AccessKeyID     string            `json:"accessKeyID"`
+
 	SecretAccessKey SecretKeySelector `json:"secretAccessKeySecretRef"`
-	HostedZoneID    string            `json:"hostedZoneID"`
+
+	// +optional
+	HostedZoneID    string            `json:"hostedZoneID,omitempty"`
+
 	Region          string            `json:"region"`
 }
 
@@ -233,19 +278,24 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
 	ClientID          string            `json:"clientID"`
+
 	ClientSecret      SecretKeySelector `json:"clientSecretSecretRef"`
+
 	SubscriptionID    string            `json:"subscriptionID"`
+
 	TenantID          string            `json:"tenantID"`
+
 	ResourceGroupName string            `json:"resourceGroupName"`
 
-	// + optional
-	HostedZoneName string `json:"hostedZoneName"`
+	// +optional
+	HostedZoneName string `json:"hostedZoneName,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderAcmeDNS is a structure containing the
 // configuration for ACME-DNS servers
 type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host          string            `json:"host"`
+
 	AccountSecret SecretKeySelector `json:"accountSecretRef"`
 }
 
@@ -259,31 +309,35 @@ type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The name of the secret containing the TSIG value.
 	// If ``tsigKeyName`` is defined, this field is required.
 	// +optional
-	TSIGSecret SecretKeySelector `json:"tsigSecretSecretRef"`
+	TSIGSecret SecretKeySelector `json:"tsigSecretSecretRef,omitempty"`
 
 	// The TSIG Key name configured in the DNS.
 	// If ``tsigSecretSecretRef`` is defined, this field is required.
 	// +optional
-	TSIGKeyName string `json:"tsigKeyName"`
+	TSIGKeyName string `json:"tsigKeyName,omitempty"`
 
 	// The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
 	// when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
 	// Supported values are (case-insensitive): ``HMACMD5`` (default),
 	// ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
 	// +optional
-	TSIGAlgorithm string `json:"tsigAlgorithm"`
+	TSIGAlgorithm string `json:"tsigAlgorithm,omitempty"`
 }
 
 // IssuerStatus contains status information about an Issuer
 type IssuerStatus struct {
-	Conditions []IssuerCondition `json:"conditions"`
+	// +optional
+	Conditions []IssuerCondition `json:"conditions,omitempty"`
+
+	// +optional
 	ACME       *ACMEIssuerStatus `json:"acme,omitempty"`
 }
 
 type ACMEIssuerStatus struct {
 	// URI is the unique account identifier, which can also be used to retrieve
 	// account details from the CA
-	URI string `json:"uri"`
+	// +optional
+	URI string `json:"uri,omitempty"`
 }
 
 // IssuerCondition contains condition information for an Issuer.
@@ -292,6 +346,7 @@ type IssuerCondition struct {
 	Type IssuerConditionType `json:"type"`
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// +kubebuilder:validation:Enum=True,False,Unknown
 	Status ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -76,13 +76,13 @@ type IssuerSpec struct {
 
 type IssuerConfig struct {
 	// +optional
-	ACME       *ACMEIssuer       `json:"acme,omitempty"`
+	ACME *ACMEIssuer `json:"acme,omitempty"`
 
 	// +optional
-	CA         *CAIssuer         `json:"ca,omitempty"`
+	CA *CAIssuer `json:"ca,omitempty"`
 
 	// +optional
-	Vault      *VaultIssuer      `json:"vault,omitempty"`
+	Vault *VaultIssuer `json:"vault,omitempty"`
 
 	// +optional
 	SelfSigned *SelfSignedIssuer `json:"selfSigned,omitempty"`
@@ -190,28 +190,28 @@ type ACMEIssuerDNS01Provider struct {
 	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy,omitempty"`
 
 	// +optional
-	Akamai       *ACMEIssuerDNS01ProviderAkamai       `json:"akamai,omitempty"`
+	Akamai *ACMEIssuerDNS01ProviderAkamai `json:"akamai,omitempty"`
 
 	// +optional
-	CloudDNS     *ACMEIssuerDNS01ProviderCloudDNS     `json:"clouddns,omitempty"`
+	CloudDNS *ACMEIssuerDNS01ProviderCloudDNS `json:"clouddns,omitempty"`
 
 	// +optional
-	Cloudflare   *ACMEIssuerDNS01ProviderCloudflare   `json:"cloudflare,omitempty"`
+	Cloudflare *ACMEIssuerDNS01ProviderCloudflare `json:"cloudflare,omitempty"`
 
 	// +optional
-	Route53      *ACMEIssuerDNS01ProviderRoute53      `json:"route53,omitempty"`
+	Route53 *ACMEIssuerDNS01ProviderRoute53 `json:"route53,omitempty"`
 
 	// +optional
-	AzureDNS     *ACMEIssuerDNS01ProviderAzureDNS     `json:"azuredns,omitempty"`
+	AzureDNS *ACMEIssuerDNS01ProviderAzureDNS `json:"azuredns,omitempty"`
 
 	// +optional
 	DigitalOcean *ACMEIssuerDNS01ProviderDigitalOcean `json:"digitalocean,omitempty"`
 
 	// +optional
-	AcmeDNS      *ACMEIssuerDNS01ProviderAcmeDNS      `json:"acmedns,omitempty"`
+	AcmeDNS *ACMEIssuerDNS01ProviderAcmeDNS `json:"acmedns,omitempty"`
 
 	// +optional
-	RFC2136      *ACMEIssuerDNS01ProviderRFC2136      `json:"rfc2136,omitempty"`
+	RFC2136 *ACMEIssuerDNS01ProviderRFC2136 `json:"rfc2136,omitempty"`
 }
 
 // CNAMEStrategy configures how the DNS01 provider should handle CNAME records
@@ -264,28 +264,28 @@ type ACMEIssuerDNS01ProviderDigitalOcean struct {
 // ACMEIssuerDNS01ProviderRoute53 is a structure containing the Route 53
 // configuration for AWS
 type ACMEIssuerDNS01ProviderRoute53 struct {
-	AccessKeyID     string            `json:"accessKeyID"`
+	AccessKeyID string `json:"accessKeyID"`
 
 	SecretAccessKey SecretKeySelector `json:"secretAccessKeySecretRef"`
 
 	// +optional
-	HostedZoneID    string            `json:"hostedZoneID,omitempty"`
+	HostedZoneID string `json:"hostedZoneID,omitempty"`
 
-	Region          string            `json:"region"`
+	Region string `json:"region"`
 }
 
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
-	ClientID          string            `json:"clientID"`
+	ClientID string `json:"clientID"`
 
-	ClientSecret      SecretKeySelector `json:"clientSecretSecretRef"`
+	ClientSecret SecretKeySelector `json:"clientSecretSecretRef"`
 
-	SubscriptionID    string            `json:"subscriptionID"`
+	SubscriptionID string `json:"subscriptionID"`
 
-	TenantID          string            `json:"tenantID"`
+	TenantID string `json:"tenantID"`
 
-	ResourceGroupName string            `json:"resourceGroupName"`
+	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional
 	HostedZoneName string `json:"hostedZoneName,omitempty"`
@@ -294,7 +294,7 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 // ACMEIssuerDNS01ProviderAcmeDNS is a structure containing the
 // configuration for ACME-DNS servers
 type ACMEIssuerDNS01ProviderAcmeDNS struct {
-	Host          string            `json:"host"`
+	Host string `json:"host"`
 
 	AccountSecret SecretKeySelector `json:"accountSecretRef"`
 }
@@ -330,7 +330,7 @@ type IssuerStatus struct {
 	Conditions []IssuerCondition `json:"conditions,omitempty"`
 
 	// +optional
-	ACME       *ACMEIssuerStatus `json:"acme,omitempty"`
+	ACME *ACMEIssuerStatus `json:"acme,omitempty"`
 }
 
 type ACMEIssuerStatus struct {

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -67,16 +67,18 @@ type OrderSpec struct {
 	// CommonName is the common name as specified on the DER encoded CSR.
 	// If CommonName is not specified, the first DNSName specified will be used
 	// as the CommonName.
-	// At least on of CommonName or a DNSName must be set.
+	// At least one of CommonName or a DNSNames must be set.
 	// This field must match the corresponding field on the DER encoded CSR.
+	// +optional
 	CommonName string `json:"commonName,omitempty"`
 
 	// DNSNames is a list of DNS names that should be included as part of the Order
 	// validation process.
 	// If CommonName is not specified, the first DNSName specified will be used
 	// as the CommonName.
-	// At least on of CommonName or a DNSName must be set.
+	// At least one of CommonName or a DNSNames must be set.
 	// This field must match the corresponding field on the DER encoded CSR.
+	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// Config specifies a mapping from DNS identifiers to how those identifiers
@@ -90,32 +92,40 @@ type OrderStatus struct {
 	// This will initially be empty when the resource is first created.
 	// The Order controller will populate this field when the Order is first processed.
 	// This field will be immutable after it is initially set.
-	URL string `json:"url"`
+	// +optional
+	URL string `json:"url,omitempty"`
 
 	// FinalizeURL of the Order.
 	// This is used to obtain certificates for this order once it has been completed.
-	FinalizeURL string `json:"finalizeURL"`
+	// +optional
+	FinalizeURL string `json:"finalizeURL,omitempty"`
 
 	// Certificate is a copy of the PEM encoded certificate for this Order.
 	// This field will be populated after the order has been successfully
 	// finalized with the ACME server, and the order has transitioned to the
 	// 'valid' state.
-	Certificate []byte `json:"certificate"`
+	// +optional
+	Certificate []byte `json:"certificate,omitempty"`
 
 	// State contains the current state of this Order resource.
 	// States 'success' and 'expired' are 'final'
-	State State `json:"state"`
+	// +kubebuilder:validation:Enum=valid,ready,pending,processing,invalid,expired,errored
+	// +optional
+	State State `json:"state,omitempty"`
 
 	// Reason optionally provides more information about a why the order is in
 	// the current state.
-	Reason string `json:"reason"`
+	// +optional
+	Reason string `json:"reason,omitempty"`
 
 	// Challenges is a list of ChallengeSpecs for Challenges that must be created
 	// in order to complete this Order.
+	// +optional
 	Challenges []ChallengeSpec `json:"challenges,omitempty"`
 
 	// FailureTime stores the time that this order failed.
 	// This is used to influence garbage collection and back-off.
+	// +optional
 	FailureTime *metav1.Time `json:"failureTime,omitempty"`
 }
 
@@ -178,9 +188,11 @@ const (
 // Only one of HTTP01 or DNS01 should be non-nil.
 type SolverConfig struct {
 	// HTTP01 contains HTTP01 challenge solving configuration
+	// +optional
 	HTTP01 *HTTP01SolverConfig `json:"http01,omitempty"`
 
 	// DNS01 contains DNS01 challenge solving configuration
+	// +optional
 	DNS01 *DNS01SolverConfig `json:"dns01,omitempty"`
 }
 
@@ -190,7 +202,8 @@ type HTTP01SolverConfig struct {
 	// the ACME HTTP01 'well-known' challenge path in order to solve HTTP01
 	// challenges.
 	// If this field is specified, 'ingressClass' **must not** be specified.
-	Ingress string `json:"ingress"`
+	// +optional
+	Ingress string `json:"ingress,omitempty"`
 
 	// IngressClass is the ingress class that should be set on new ingress
 	// resources that are created in order to solve HTTP01 challenges.
@@ -200,6 +213,7 @@ type HTTP01SolverConfig struct {
 	// If this field is not set, and 'ingress' is not set, then ingresses
 	// without an ingress class set will be created to solve HTTP01 challenges.
 	// If this field is specified, 'ingress' **must not** be specified.
+	// +optional
 	IngressClass *string `json:"ingressClass,omitempty"`
 }
 

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -24,9 +24,14 @@ import (
 // coupling between ACME Issuers and their solver configurations (see: Solver proposal)
 
 // +genclient
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// Order is a type to represent an Order with an ACME server
+// +k8s:openapi-gen=true
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state"
+// +kubebuilder:printcolumn:name="Issuer",type="string",JSONPath=".spec.issuerRef.name",description="",priority=1
+// +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.reason",description="",priority=1
+// +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
 // +kubebuilder:resource:path=orders
 type Order struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -109,7 +109,7 @@ type OrderStatus struct {
 
 	// State contains the current state of this Order resource.
 	// States 'success' and 'expired' are 'final'
-	// +kubebuilder:validation:Enum=valid,ready,pending,processing,invalid,expired,errored
+	// +kubebuilder:validation:Enum=,valid,ready,pending,processing,invalid,expired,errored
 	// +optional
 	State State `json:"state,omitempty"`
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The CRD generator from kubebuilder has been extracted out into its own distinct tool, meaning we can easily re-use it in our own non-kubebuilder project.

This PR means that our CRD resources are now generated directly from our API types, including an openapi validation schema 😄 

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

~This is WIP as there are likely going to be some test fails due to misuse of field annotations such as `// + optional`~

**Release note**:
```release-note
Add validation schema to CRD resources
```
