### PR TITLE
Extend ACME self check to check CAA records

### DIFF
--- a/pkg/acme/client/fake.go
+++ b/pkg/acme/client/fake.go
@@ -41,6 +41,7 @@ type FakeACME struct {
 	FakeGetAccount              func(ctx context.Context) (*acme.Account, error)
 	FakeHTTP01ChallengeResponse func(token string) (string, error)
 	FakeDNS01ChallengeRecord    func(token string) (string, error)
+	FakeDiscover                func(ctx context.Context) (acme.Directory, error)
 }
 
 func (f *FakeACME) CreateOrder(ctx context.Context, order *acme.Order) (*acme.Order, error) {
@@ -132,4 +133,11 @@ func (f *FakeACME) DNS01ChallengeRecord(token string) (string, error) {
 		return f.FakeDNS01ChallengeRecord(token)
 	}
 	return "", fmt.Errorf("DNS01ChallengeRecord not implemented")
+}
+
+func (f *FakeACME) Discover(ctx context.Context) (acme.Directory, error) {
+	if f.FakeDiscover != nil {
+		return f.FakeDiscover(ctx)
+	}
+	return acme.Directory{}, fmt.Errorf("Discover not implemented")
 }

--- a/pkg/acme/client/fake.go
+++ b/pkg/acme/client/fake.go
@@ -139,5 +139,7 @@ func (f *FakeACME) Discover(ctx context.Context) (acme.Directory, error) {
 	if f.FakeDiscover != nil {
 		return f.FakeDiscover(ctx)
 	}
-	return acme.Directory{}, fmt.Errorf("Discover not implemented")
+	// We only use Discover to find CAAIdentities, so returning an
+	// empty directory here will be fine
+	return acme.Directory{}, nil
 }

--- a/pkg/acme/client/interfaces.go
+++ b/pkg/acme/client/interfaces.go
@@ -36,6 +36,7 @@ type Interface interface {
 	GetAccount(ctx context.Context) (*acme.Account, error)
 	HTTP01ChallengeResponse(token string) (string, error)
 	DNS01ChallengeRecord(token string) (string, error)
+	Discover(ctx context.Context) (acme.Directory, error)
 }
 
 var _ Interface = &acme.Client{}

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -98,3 +98,8 @@ func (l *Logger) DNS01ChallengeRecord(token string) (string, error) {
 	glog.Infof("Calling DNS01ChallengeRecord")
 	return l.baseCl.DNS01ChallengeRecord(token)
 }
+
+func (l *Logger) Discover(ctx context.Context) (acme.Directory, error) {
+	glog.Infof("Calling Discover")
+	return l.baseCl.Discover(ctx)
+}

--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/controller/acmechallenges/scheduler:go_default_library",
         "//pkg/issuer/acme/dns:go_default_library",
+        "//pkg/issuer/acme/dns/util:go_default_library",
         "//pkg/issuer/acme/http:go_default_library",
         "//pkg/util:go_default_library",
         "//third_party/crypto/acme:go_default_library",

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -146,7 +146,7 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 	// means no CAA check is performed by ACME server or if any valid
 	// CAA would stop issuance (strongly suspect the former)
 	if len(dir.CAA) != 0 {
-		err := dnsutil.ValidateCAA(ch.Spec.DNSName, dir.CAA, ch.Spec.Wildcard)
+		err := dnsutil.ValidateCAA(ch.Spec.DNSName, dir.CAA, ch.Spec.Wildcard, c.Context.DNS01Nameservers)
 		if err != nil {
 			ch.Status.Reason = fmt.Sprintf("CAA self-check failed: %s", err)
 			return err

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -31,6 +31,8 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
 	acmeapi "github.com/jetstack/cert-manager/third_party/crypto/acme"
+
+	dnsutil "github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 const (
@@ -129,6 +131,26 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 		// due to the http01 solver creating resources that this controller
 		// watches/syncs on
 		return nil
+	}
+
+	// check for CAA records.
+	// CAA records are static, so we don't have to present anything
+	// before we check for them.
+
+	// Find out which identity the ACME server says it will use.
+	dir, err := cl.Discover(ctx)
+	if err != nil {
+		return err
+	}
+	// TODO(dmo): figure out if missing CAA identity in directory
+	// means no CAA check is performed by ACME server or if any valid
+	// CAA would stop issuance (strongly suspect the former)
+	if len(dir.CAA) != 0 {
+		err := dnsutil.ValidateCAA(ch.Spec.DNSName, dir.CAA, ch.Spec.Wildcard)
+		if err != nil {
+			ch.Status.Reason = fmt.Sprintf("CAA self-check failed: %s", err)
+			return err
+		}
 	}
 
 	solver, err := c.solverFor(ch.Spec.Type)

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -168,7 +168,7 @@ func dnsQuery(fqdn string, rtype uint16, nameservers []string, recursive bool) (
 	return
 }
 
-func ValidateCAA(domain string, issuerID []string, iswildcard bool) error {
+func ValidateCAA(domain string, issuerID []string, iswildcard bool, nameservers []string) error {
 	// see https://tools.ietf.org/html/rfc6844#section-4
 	// for more information about how CAA lookup is performed
 	fqdn := ToFqdn(domain)
@@ -186,7 +186,7 @@ func ValidateCAA(domain string, issuerID []string, iswildcard bool) error {
 		var err error
 		for i := 0; i < 8; i++ {
 			//TODO(dmo): figure out if we need these servers to be configurable as well
-			msg, err = dnsQuery(queryDomain, dns.TypeCAA, RecursiveNameservers, true)
+			msg, err = dnsQuery(queryDomain, dns.TypeCAA, nameservers, true)
 			if err != nil {
 				return fmt.Errorf("Could not validate CAA record: %s", err)
 			}

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -177,3 +177,24 @@ func TestResolveConfServers(t *testing.T) {
 		}
 	}
 }
+
+func TestValidateCAA(t *testing.T) {
+	// google installs a CAA record at google.com
+	// ask for the www.google.com record to test that
+	// we recurse up the labels
+	err := ValidateCAA("www.google.com", []string{"letsencrypt", "pki.goog"}, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
+	}
+	// now ask, expecting a CA that wont match
+	err = ValidateCAA("www.google.com", []string{"daniel.homebrew.ca"}, false)
+	if err == nil {
+		t.Fatalf("expected err, got success")
+	}
+	// ask for a domain you know does not have CAA records.
+	// it should succeed
+	err = ValidateCAA("www.example.org", []string{"daniel.homebrew.ca"}, false)
+	if err != nil {
+		t.Fatalf("expected err, got %s", err)
+	}
+}

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -182,18 +182,18 @@ func TestValidateCAA(t *testing.T) {
 	// google installs a CAA record at google.com
 	// ask for the www.google.com record to test that
 	// we recurse up the labels
-	err := ValidateCAA("www.google.com", []string{"letsencrypt", "pki.goog"}, false)
+	err := ValidateCAA("www.google.com", []string{"letsencrypt", "pki.goog"}, false, RecursiveNameservers)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}
 	// now ask, expecting a CA that wont match
-	err = ValidateCAA("www.google.com", []string{"daniel.homebrew.ca"}, false)
+	err = ValidateCAA("www.google.com", []string{"daniel.homebrew.ca"}, false, RecursiveNameservers)
 	if err == nil {
 		t.Fatalf("expected err, got success")
 	}
 	// ask for a domain you know does not have CAA records.
 	// it should succeed
-	err = ValidateCAA("www.example.org", []string{"daniel.homebrew.ca"}, false)
+	err = ValidateCAA("www.example.org", []string{"daniel.homebrew.ca"}, false, RecursiveNameservers)
 	if err != nil {
 		t.Fatalf("expected err, got %s", err)
 	}

--- a/third_party/crypto/acme/acme.go
+++ b/third_party/crypto/acme/acme.go
@@ -90,15 +90,6 @@ type Client struct {
 	accountURL string
 }
 
-// SetAccountURL will set the account URL cached by the client.
-// This should be used with caution, in order to reduce the number of calls
-// made to the 'new-acct' endpoint in 'cacheAccountURL'
-func (c *Client) SetAccountURL(url string) {
-	c.urlMu.Lock()
-	defer c.urlMu.Unlock()
-	c.accountURL = url
-}
-
 // Discover performs ACME server discovery using c.DirectoryURL.
 //
 // It caches successful result. So, subsequent calls will not result in


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR implements a rudimentary CAA check for ACME clients, making sure that users don't run into LE rate limits with improperly set up DNS

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #211

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Check for CAA records during ACME issuance
```
