### PR TITLE
Add verify-shellcheck script

### DIFF
--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -25,11 +25,14 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-declare -r KUBE_ROOT="$(dirname "${BASH_SOURCE}")/.."
+KUBE_ROOT="$(dirname "${BASH_SOURCE[0]}")/.."
 cd "${KUBE_ROOT}"
 
-declare -r STARTINGBRANCH=$(git symbolic-ref --short HEAD)
-declare -r REBASEMAGIC="${KUBE_ROOT}/.git/rebase-apply"
+STARTINGBRANCH=$(git symbolic-ref --short HEAD)
+REBASEMAGIC="${KUBE_ROOT}/.git/rebase-apply"
+declare -r STARTINGBRANCH
+declare -r REBASEMAGIC
+
 DRY_RUN=${DRY_RUN:-""}
 REGENERATE_DOCS=${REGENERATE_DOCS:-""}
 UPSTREAM_REMOTE=${UPSTREAM_REMOTE:-upstream}
@@ -75,14 +78,17 @@ if [[ -e "${REBASEMAGIC}" ]]; then
   exit 1
 fi
 
-declare -r BRANCH="$1"
+BRANCH="$1"
 shift 1
-declare -r PULLS=( "$@" )
+PULLS=( "$@" )
+declare -r BRANCH
+declare -r PULLS
 
 function join { local IFS="$1"; shift; echo "$*"; }
-declare -r PULLDASH=$(join - "${PULLS[@]/#/#}") # Generates something like "#12345-#56789"
-declare -r PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789"
-
+PULLDASH=$(join - "${PULLS[@]/#/#}") # Generates something like "#12345-#56789"
+PULLSUBJ=$(join " " "${PULLS[@]/#/#}") # Generates something like "#12345 #56789"
+declare -r PULLDASH
+declare -r PULLSUBJ
 echo "+++ Updating remotes..."
 git remote update "${UPSTREAM_REMOTE}" "${FORK_REMOTE}"
 
@@ -92,9 +98,12 @@ if ! git log -n1 --format=%H "${BRANCH}" >/dev/null 2>&1; then
   exit 1
 fi
 
-declare -r NEWBRANCHREQ="automated-cherry-pick-of-${PULLDASH}" # "Required" portion for tools.
-declare -r NEWBRANCH="$(echo "${NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
-declare -r NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
+NEWBRANCHREQ="automated-cherry-pick-of-${PULLDASH}" # "Required" portion for tools.
+NEWBRANCH="$(echo "${NEWBRANCHREQ}-${BRANCH}" | sed 's/\//-/g')"
+NEWBRANCHUNIQ="${NEWBRANCH}-$(date +%s)"
+declare -r NEWBRANCHREQ
+declare -r NEWBRANCH
+declare -r NEWBRANCHUNIQ
 echo "+++ Creating local branch ${NEWBRANCHUNIQ}"
 
 cleanbranch=""
@@ -124,7 +133,8 @@ trap return_to_kansas EXIT
 
 SUBJECTS=()
 function make-a-pr() {
-  local rel="$(basename "${BRANCH}")"
+  rel="$(basename "${BRANCH}")"
+  local rel
   echo
   echo "+++ Creating a pull request on GitHub at ${GITHUB_USER}:${NEWBRANCH}"
 
@@ -212,7 +222,7 @@ if [[ -n "${DRY_RUN}" ]]; then
   exit 0
 fi
 
-if git remote -v | grep ^${FORK_REMOTE} | grep kubernetes/kubernetes.git; then
+if git remote -v | grep "^${FORK_REMOTE}" | grep kubernetes/kubernetes.git; then
   echo "!!! You have ${FORK_REMOTE} configured as your kubernetes/kubernetes.git"
   echo "This isn't normal. Leaving you with push instructions:"
   echo

--- a/hack/ci/lib/build_images.sh
+++ b/hack/ci/lib/build_images.sh
@@ -22,7 +22,7 @@ set -o pipefail
 # It will transfer them to the 'kind' docker container so they are available
 # in a testing environment.
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
 source "${SCRIPT_ROOT}/lib.sh"
 
 build_images() {

--- a/hack/ci/lib/cluster_create.sh
+++ b/hack/ci/lib/cluster_create.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
 source "${SCRIPT_ROOT}/lib.sh"
 
 # deploy_kind will deploy a kubernetes-in-docker cluster
@@ -27,10 +27,10 @@ deploy_kind() {
     bazel run "${KIND_IMAGE_TARGET}"
 
     function kubeVersion() {
-        echo $(docker run \
+        docker run \
             --entrypoint="cat" \
             "${KIND_IMAGE}" \
-            /kind/version)
+            /kind/version
     }
 
     # default to v1beta1, if 1.12.x then use v1alpha3, if 1.11.x then use v1alpha2

--- a/hack/ci/lib/cluster_destroy.sh
+++ b/hack/ci/lib/cluster_destroy.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
 source "${SCRIPT_ROOT}/lib.sh"
 
 "${KIND}" delete cluster --name="${KIND_CLUSTER_NAME}"

--- a/hack/ci/lib/lib.sh
+++ b/hack/ci/lib/lib.sh
@@ -19,14 +19,12 @@ set -o nounset
 set -o pipefail
 
 _SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
-REPO_ROOT="${_SCRIPT_ROOT}/../../.."
+export REPO_ROOT="${_SCRIPT_ROOT}/../../.."
 
 # This file contains common definitions that are re-used in other scripts
-
 export K8S_VERSION="${K8S_VERSION:-1.11}"
-KUBECTL_TARGET="${KUBECTL_TARGET:-//test/e2e/bin:kubectl-${K8S_VERSION}}"
-KIND_IMAGE_TARGET="${KIND_IMAGE_TARGET:-@kind-${K8S_VERSION}//image}"
-
+export KUBECTL_TARGET="${KUBECTL_TARGET:-//test/e2e/bin:kubectl-${K8S_VERSION}}"
+export KIND_IMAGE_TARGET="${KIND_IMAGE_TARGET:-@kind-${K8S_VERSION}//image}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-cm-local-cluster}"
 export KIND_CONTAINER_NAME="kind-${KIND_CLUSTER_NAME}-control-plane"
 

--- a/hack/ci/run-dev-kind.sh
+++ b/hack/ci/run-dev-kind.sh
@@ -22,7 +22,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
 source "${SCRIPT_ROOT}/lib/lib.sh"
 
 echo "+++ Creating cluster using kind"

--- a/hack/ci/run-e2e-kind.sh
+++ b/hack/ci/run-e2e-kind.sh
@@ -24,7 +24,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")
 source "${SCRIPT_ROOT}/lib/lib.sh"
 
 cleanup() {
@@ -44,5 +44,5 @@ echo "Testing kind apiserver connectivity"
 "${SCRIPT_ROOT}/lib/build_images.sh"
 
 make e2e_test \
-    KUBECONFIG=${KUBECONFIG} \
-    KUBECTL=${KUBECTL}
+    KUBECONFIG="${KUBECONFIG}" \
+    KUBECTL="${KUBECTL}"

--- a/hack/print-workspace-status.sh
+++ b/hack/print-workspace-status.sh
@@ -20,8 +20,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/../..
-
 # AppVersion is set as the AppVersion to be compiled into the controller binary.
 # It's used as the default version of the 'acmesolver' image to use for ACME
 # challenge requests, and any other future provider that requires additional
@@ -31,7 +29,7 @@ if [ -z "${APP_VERSION:-}" ]; then
 fi
 APP_GIT_COMMIT=${APP_GIT_COMMIT:-$(git rev-parse HEAD)}
 GIT_STATE=""
-if [ ! -z "$(git status --porcelain)" ]; then
+if [ -n "$(git status --porcelain)" ]; then
     GIT_STATE="dirty"
 fi
 

--- a/hack/verify-bazel.sh
+++ b/hack/verify-bazel.sh
@@ -26,7 +26,7 @@ set -o pipefail
 
 RULE_NAME="bazel"
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 _tmp="$(mktemp -d)"
 DIFFROOT="${SCRIPT_ROOT}/"
@@ -45,7 +45,8 @@ rsync -avvL "${DIFFROOT}"/ "${TMP_DIFFROOT}" >/dev/null
 rm -Rf "${TMP_DIFFROOT}/__main__"
 
 cd "${TMP_DIFFROOT}"
-export BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+export BUILD_WORKSPACE_DIRECTORY
 "hack/update-${RULE_NAME}.sh"
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 RULE_NAME="codegen"
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 _tmp="$(mktemp -d)"
 DIFFROOT="${SCRIPT_ROOT}/"
@@ -40,7 +40,8 @@ rsync -avvL "${DIFFROOT}"/ "${TMP_DIFFROOT}" >/dev/null
 rm -Rf "${TMP_DIFFROOT}/__main__"
 
 cd "${TMP_DIFFROOT}"
-export BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+export BUILD_WORKSPACE_DIRECTORY
 "hack/update-${RULE_NAME}.sh"
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"

--- a/hack/verify-crds.sh
+++ b/hack/verify-crds.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 RULE_NAME="crds"
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 _tmp="$(mktemp -d)"
 DIFFROOT="${SCRIPT_ROOT}/"
@@ -40,7 +40,8 @@ rsync -avvL "${DIFFROOT}"/ "${TMP_DIFFROOT}" >/dev/null
 rm -Rf "${TMP_DIFFROOT}/__main__"
 
 cd "${TMP_DIFFROOT}"
-export BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+export BUILD_WORKSPACE_DIRECTORY
 "hack/update-${RULE_NAME}.sh"
 
 echo "diffing ${DIFFROOT} against freshly generated codegen"

--- a/hack/verify-errexit.sh
+++ b/hack/verify-errexit.sh
@@ -26,7 +26,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-REPO_ROOT=$(dirname "${BASH_SOURCE}")/..
+REPO_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 if [ "$*" != "" ]; then
   args="$*"
@@ -36,22 +36,22 @@ fi
 
 # Gather the list of files that appear to be shell scripts.
 # Meaning they have some form of "#!...sh" as a line in them.
-shFiles=$(grep -Rrl '^#!.*sh$' $args)
+shFiles=$(grep -Rrl '^#!.*sh$' "$args")
 
 tmp=$(mktemp)
 # Delete the temporary file as it should only exist if errors have occurred.
-rm $tmp
+rm "$tmp"
 
 for file in ${shFiles}; do
-  grep "set -o errexit" $file > /dev/null 2>&1 && continue
-  grep "set -[a-z]*e" $file > /dev/null 2>&1 && continue
+  grep "set -o errexit" "$file" > /dev/null 2>&1 && continue
+  grep "set -[a-z]*e" "$file" > /dev/null 2>&1 && continue
 
-  echo $file: appears to be missing \"set -o errexit\" | tee -a $tmp
+  echo "$file: appears to be missing \"set -o errexit\"" | tee -a "$tmp"
 done
 
 rc="0"
 if [ -e "$tmp" ]; then
   rc="1"
 fi
-rm -f $tmp
-exit $rc
+rm -f "$tmp"
+exit "$rc"

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -18,7 +18,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
 # This script should be run via `bazel run //hack:update-deps`
 runfiles="$(pwd)"
 export PATH="${runfiles}/hack/bin:${PATH}"
@@ -32,13 +31,13 @@ trap "cleanup" EXIT SIGINT
 # Create a fake GOPATH
 export GOPATH="${_tmp}"
 TMP_DIFFROOT="${GOPATH}/src/github.com/jetstack/cert-manager"
-mkdir -p "$(dirname ${TMP_DIFFROOT})"
+mkdir -p "$(dirname "${TMP_DIFFROOT}")"
 ln -s "$(pwd)" "${TMP_DIFFROOT}"
 cd "${TMP_DIFFROOT}"
 
 echo "+++ Running gofmt"
 output=$(find . -name '*.go' | grep -v 'vendor/' | xargs gofmt -s -d)
-if [ ! -z "${output}" ]; then
+if [ -n "${output}" ]; then
     echo "${output}"
     echo "Please run 'bazel run //hack:update-gofmt'"
     exit 1

--- a/hack/verify-reference-docs.sh
+++ b/hack/verify-reference-docs.sh
@@ -20,7 +20,7 @@ set -o pipefail
 
 RULE_NAME="reference-docs"
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")/..
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
 
 _tmp="$(mktemp -d)"
 DIFFROOT="${SCRIPT_ROOT}/"
@@ -37,9 +37,11 @@ TMP_DIFFROOT="${GOPATH}/src/github.com/jetstack/cert-manager"
 mkdir -p "${TMP_DIFFROOT}"
 rsync -avvL "${DIFFROOT}"/ "${TMP_DIFFROOT}" >/dev/null
 
-export runfiles="$(pwd)"
+runfiles="$(pwd)"
+export runfiles
 cd "${TMP_DIFFROOT}"
-export BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+BUILD_WORKSPACE_DIRECTORY="$(pwd)"
+export BUILD_WORKSPACE_DIRECTORY
 "hack/update-${RULE_NAME}.sh"
 
 echo "diffing ${DIFFROOT} against freshly generated ${RULE_NAME}"

--- a/hack/verify-shellcheck.sh
+++ b/hack/verify-shellcheck.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd -P)"/..
+
+# required version for this script, if not installed on the host we will
+# use the official docker image instead. keep this in sync with SHELLCHECK_IMAGE
+SHELLCHECK_VERSION="0.6.0"
+# upstream shellcheck latest stable image as of January 10th, 2019
+SHELLCHECK_IMAGE="koalaman/shellcheck-alpine:v0.6.0@sha256:7d4d712a2686da99d37580b4e2f45eb658b74e4b01caf67c1099adc294b96b52"
+
+# fixed name for the shellcheck docker container so we can reliably clean it up
+SHELLCHECK_CONTAINER="k8s-shellcheck"
+
+# disabled lints
+disabled=(
+  # this lint disallows non-constant source, which we use extensively without
+  # any known bugs
+  1090
+  # this lint prefers command -v to which, they are not the same
+  2230
+)
+# comma separate for passing to shellcheck
+join_by() {
+  local IFS="$1";
+  shift;
+  echo "$*";
+}
+SHELLCHECK_DISABLED="$(join_by , "${disabled[@]}")"
+readonly SHELLCHECK_DISABLED
+
+# creates the shellcheck container for later use
+create_container () {
+  # TODO(bentheelder): this is a performance hack, we create the container with
+  # a sleep MAX_INT32 so that it is effectively paused.
+  # We then repeatedly exec to it to run each shellcheck, and later rm it when
+  # we're done.
+  # This is incredibly much faster than creating a container for each shellcheck
+  # call ...
+  docker run --name "${SHELLCHECK_CONTAINER}" -d --rm -v "${REPO_ROOT}:${REPO_ROOT}" -w "${REPO_ROOT}" --entrypoint="sleep" "${SHELLCHECK_IMAGE}" 2147483647
+}
+# removes the shellcheck container
+remove_container () {
+  docker rm -f "${SHELLCHECK_CONTAINER}" &> /dev/null || true
+}
+
+# ensure we're linting the k8s source tree
+cd "${REPO_ROOT}"
+
+# find all shell scripts excluding ./_*, ./.git/*, ./vendor*,
+# and anything git-ignored
+all_shell_scripts=()
+while IFS=$'\n' read -r script;
+  do git check-ignore -q "$script" || all_shell_scripts+=("$script");
+done < <(find . -name "*.sh" \
+  -not \( \
+    -path ./_\*      -o \
+    -path ./.git\*   -o \
+    -path ./vendor\*    \
+  \))
+
+# make sure known failures are sorted
+failure_file="${REPO_ROOT}/hack/.shellcheck_failures"
+if ! diff -u "${failure_file}" <(LC_ALL=C sort "${failure_file}"); then
+  {
+    echo
+    echo "hack/.shellcheck_failures is not in alphabetical order. Please sort it:"
+    echo
+    echo "  LC_ALL=C sort -o hack/.shellcheck_failures hack/.shellcheck_failures"
+    echo
+  } >&2
+  false
+fi
+
+# load known failure files
+failing_files=()
+while IFS=$'\n' read -r script;
+  do failing_files+=("$script");
+done < <(cat "${failure_file}")
+
+# TODO(bentheelder): we should probably move this and the copy in verify-golint.sh
+# to one of the bash libs
+array_contains () {
+  local seeking=$1; shift # shift will iterate through the array
+  local in=1 # in holds the exit status for the function
+  for element; do
+    if [[ "$element" == "$seeking" ]]; then
+      in=0 # set in to 0 since we found it
+      break
+    fi
+  done
+  return $in
+}
+
+# detect if the host machine has the required shellcheck version installed
+# if so, we will use that instead.
+HAVE_SHELLCHECK=false
+if which shellcheck &>/dev/null; then
+  detected_version="$(shellcheck --version | grep 'version: .*')"
+  if [[ "${detected_version}" = "version: ${SHELLCHECK_VERSION}" ]]; then
+    HAVE_SHELLCHECK=true
+  fi
+fi
+
+# tell the user which we've selected and possibly set up the container
+if ${HAVE_SHELLCHECK}; then
+  echo "Using host shellcheck ${SHELLCHECK_VERSION} binary."
+else
+  echo "Using shellcheck ${SHELLCHECK_VERSION} docker image."
+  # remove any previous container, ensure we will attempt to cleanup on exit,
+  # and create the container
+  remove_container
+  trap 'remove_container' EXIT
+  if ! output="$(create_container 2>&1)"; then
+      {
+        echo "Failed to create shellcheck container with output: "
+        echo ""
+        echo "${output}"
+      } >&2
+      exit 1
+  fi
+fi
+
+# lint each script, tracking failures
+errors=()
+not_failing=()
+for f in "${all_shell_scripts[@]}"; do
+  set +o errexit
+  if ${HAVE_SHELLCHECK}; then
+    failedLint=$(shellcheck --exclude="${SHELLCHECK_DISABLED}" "${f}")
+  else
+    failedLint=$(docker exec -t ${SHELLCHECK_CONTAINER} \
+                 shellcheck --exclude="${SHELLCHECK_DISABLED}" "${f}")
+  fi
+  set -o errexit
+  array_contains "${f}" "${failing_files[@]}" && in_failing=$? || in_failing=$?
+  if [[ -n "${failedLint}" ]] && [[ "${in_failing}" -ne "0" ]]; then
+    errors+=( "${failedLint}" )
+  fi
+  if [[ -z "${failedLint}" ]] && [[ "${in_failing}" -eq "0" ]]; then
+    not_failing+=( "${f}" )
+  fi
+done
+
+# Check to be sure all the packages that should pass lint are.
+if [ ${#errors[@]} -eq 0 ]; then
+  echo 'Congratulations! All shell files are passing lint (excluding those in hack/.shellcheck_failures).'
+else
+  {
+    echo "Errors from shellcheck:"
+    for err in "${errors[@]}"; do
+      echo "$err"
+    done
+    echo
+    echo 'Please review the above warnings. You can test via "./hack/verify-shellcheck"'
+    echo 'If the above warnings do not make sense, you can exempt this package from shellcheck'
+    echo 'checking by adding it to hack/.shellcheck_failures (if your reviewer is okay with it).'
+    echo
+  } >&2
+  false
+fi
+
+if [[ ${#not_failing[@]} -gt 0 ]]; then
+  {
+    echo "Some packages in hack/.shellcheck_failures are passing shellcheck. Please remove them."
+    echo
+    for f in "${not_failing[@]}"; do
+      echo "  $f"
+    done
+    echo
+  } >&2
+  false
+fi
+
+# Check that all failing_packages actually still exist
+gone=()
+for f in "${failing_files[@]}"; do
+  array_contains "$f" "${all_shell_scripts[@]}" || gone+=( "$f" )
+done
+
+if [[ ${#gone[@]} -gt 0 ]]; then
+  {
+    echo "Some files in hack/.shellcheck_failures do not exist anymore. Please remove them."
+    echo
+    for f in "${gone[@]}"; do
+      echo "  $f"
+    done
+    echo
+  } >&2
+  false
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a verify-shellcheck.sh script to verify our :bash_fire: is somewhat sane.

I've not set this up to automatically run as part of CI, but it's useful to have it around in the repo so we can manually test.

I've also fixed up a number of shellcheck failures with this PR!

**Release note**:
```release-note
NONE
```
