### PR TITLE
Fix redirect of ingress-shim.html page

### DIFF
--- a/docs/redirects
+++ b/docs/redirects
@@ -8,7 +8,7 @@ tutorials/ca/creating-ca-issuer.rst tasks/issuers/setup-ca.rst
 tutorials/ca/index.rst tasks/issuers/setup-ca.rst
 tutorials/vault/creating-vault-issuers.rst tasks/issuers/setup-vault.rst
 tutorials/vault/index.rst tasks/issuers/setup-vault.rst
-reference/ingress-shim.rst tasks/ingress-shim.rst
+reference/ingress-shim.rst tasks/issuing-certificates/ingress-shim.rst
 reference/issuers/acme/index.rst tasks/acme/index.rst
 reference/issuers/acme/dns01/index.rst tasks/acme/configuring-dns01/index.rst
 reference/issuers/acme/http01.rst tasks/acme/configuring-http01.rst


### PR DESCRIPTION
Signed-off-by: Mike Eves <meves23@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Fixes broken redirect of https://docs.cert-manager.io/en/latest/reference/ingress-shim.html (Link appears in search results of `shim`)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
