### PR TITLE
docs: no need to apply 00-crds.yaml when installing with regular manifests

### DIFF
--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -50,16 +50,13 @@ cert-manager runs in:
 
 You can read more about the webhook on the :doc:`webhook document <./webhook>`.
 
-We can now go ahead and install cert-manager. This is a two-stage process where
-we first install the CustomResourceDefinition resources, and then afterwards
-install cert-manager along with the webhook component:
+We can now go ahead and install cert-manager. All resources
+(the CustomResourceDefinitions, cert-manager, and the webhook component)
+are included in a single YAML manifest file:
 
 .. code-block:: shell
 
-   # Install the CustomResourceDefinition resources
-   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
-
-   # Install cert-manager itself
+   # Install the CustomResourceDefinitions and cert-manager itself
    kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/cert-manager.yaml
 
 .. note::
@@ -75,7 +72,7 @@ install cert-manager along with the webhook component:
    'permission denied' error when creating some of these resources. This is a
    nuance of the way GKE handles RBAC and IAM permissions, and as such you
    should 'elevate' your own privileges to that of a 'cluster-admin' **before**
-   running the above commands. If you have already run the above commands, you
+   running the above command. If you have already run the above command, you
    should run them again after elevating your permissions::
 
        kubectl create clusterrolebinding cluster-admin-binding \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: updates docs to remove suggestion to apply `00-crds.yaml` before applying `cert-manager.yaml`, as the latter now includes the CRDs (since #1193).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @munnerz 