### PR TITLE
Concurrentdns01

### DIFF
--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -64,6 +64,9 @@ func NewDNSProviderHostBytes(host string, accountJson []byte, dns01Nameservers [
 
 // Present creates a TXT record to fulfil the dns-01 challenge
 func (c *DNSProvider) Present(domain, fqdn, value string) error {
+	// NOTE: acme-dns doesn't allow setting multiple TXT records
+	// via the HTTP interface. If multiple domains are validated
+	// on the same label, it will fail
 	if account, exists := c.accounts[domain]; exists {
 		// Update the acme-dns TXT record.
 		return c.client.UpdateTXTRecord(account, value)

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136.go
@@ -192,8 +192,6 @@ func (r *DNSProvider) changeRecord(action, fqdn, value string, ttl int) error {
 	m.SetUpdate(zone)
 	switch action {
 	case "INSERT":
-		// Always remove old challenge left over from who knows what.
-		m.RemoveRRset(rrs)
 		m.Insert(rrs)
 	case "REMOVE":
 		m.Remove(rrs)


### PR DESCRIPTION
**What this PR does / why we need it**:
The challenge scheduler tries to keep DNS01 validations from happening concurrently on a given domain. This keeps multiple validations from happening concurrently, making only one TXT record appear.

However, if multiple domains are CNAMEd onto a single domain, we can end up having multiple challenges out for a single domain. Our DNS providers have previously assumed that only one challenge can be answered per domain and trampled over other TXT records.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #1181

**Special notes for your reviewer**:
At writing time, I have yet to update Azure and Route53

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Handle multiple challenges on same domain more gracefully
```
