### PR TITLE
Add Support for email and URI base Subject Alternative Names

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -72,6 +72,9 @@ type CertificateSpec struct {
 	// +optional
 	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
 
+	// Do not automatically add the common name as an Subject Alternative Name
+	ExcludeCommonNameFromSANs bool `json:"excludeCommonNameFromSANs,omitempty"`
+
 	// DNSNames is a list of subject alt names to be used on the Certificate
 	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`
@@ -79,6 +82,12 @@ type CertificateSpec struct {
 	// IPAddresses is a list of IP addresses to be used on the Certificate
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
+
+	// EmailAddresses is a list of email addresses to use in the Subject Alternative Names (SANs)
+	EmailAddresses []string `json:"emailAddresses,omitempty"`
+
+	// URIs is a list of URIs to use in the Subject Alternative Names (SANs)
+	URIs []string `json:"uris,omitempty"`
 
 	// SecretName is the name of the secret resource to store this secret in
 	SecretName string `json:"secretName"`

--- a/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
@@ -645,6 +645,16 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.EmailAddresses != nil {
+		in, out := &in.EmailAddresses, &out.EmailAddresses
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.URIs != nil {
+		in, out := &in.URIs, &out.URIs
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	out.IssuerRef = in.IssuerRef
 	if in.ACME != nil {
 		in, out := &in.ACME, &out.ACME

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -237,6 +237,17 @@ func (c *Controller) certificateMatchesSpec(crt *v1alpha1.Certificate, key crypt
 		errs = append(errs, fmt.Sprintf("DNS names on TLS certificate not up to date: %q", cert.DNSNames))
 	}
 
+	// validate the email SANs are correct
+	expectedEmailAddresses := pki.EMailAddressesForCertificate(crt)
+	if !util.EqualUnsorted(cert.EmailAddresses, expectedEmailAddresses) {
+		errs = append(errs, fmt.Sprintf("Email SANs on TLS certificate not up to date: %q", cert.EmailAddresses))
+	}
+
+	// validate the URI SANs are correct
+	if !util.EqualUnsorted(pki.URIsToString(cert.URIs), crt.Spec.URIs) {
+		errs = append(errs, fmt.Sprintf("URI SANs on TLS certificate not up to date: %q", cert.URIs))
+	}
+
 	// validate the ip addresses are correct
 	if !util.EqualUnsorted(pki.IPAddressesToString(cert.IPAddresses), crt.Spec.IPAddresses) {
 		errs = append(errs, fmt.Sprintf("IP addresses on TLS certificate not up to date: %q", pki.IPAddressesToString(cert.IPAddresses)))

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -99,7 +99,7 @@ func TestDNSNamesForCertificate(t *testing.T) {
 			name:           "certificate with both common name and dnsName set",
 			crtCN:          "cn",
 			crtDNSNames:    []string{"dnsname"},
-			expectDNSNames: []string{"cn", "dnsname"},
+			expectDNSNames: []string{"dnsname", "cn"},
 		},
 		{
 			name:           "certificate with multiple dns names set",
@@ -116,7 +116,7 @@ func TestDNSNamesForCertificate(t *testing.T) {
 			name:           "certificate with a dnsName equal to cn",
 			crtCN:          "cn",
 			crtDNSNames:    []string{"dnsname", "cn"},
-			expectDNSNames: []string{"cn", "dnsname"},
+			expectDNSNames: []string{"dnsname", "cn"},
 		},
 	}
 	testFn := func(test testT) func(*testing.T) {


### PR DESCRIPTION

**What this PR does / why we need it**:
* Allows to configure email / URI Subject Alternative Names
* Explicitly use these SANs in the Vault issuer
* Makes it possible to exclude the common name from the SANs (was inconsistent w.r.t. Vault) 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1356

**Special notes for your reviewer**:

This is WIP in the sense that I would like feedback before investing more time. I also did not add any additional tests (yet) though the build passed locally and I did some initial tests in our cluster.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
When using the Vault issuer, the `exclude_cn_from_sans` parameter of the Vault PKI API now defaults to false to make it consistent in how conformance to the certificate spec is validated. This can now be explicitly configured on the `Certificate` resource (ExcludeCommonNameFromSANs)
```
