### PR TITLE
watch TLS cert file

### DIFF
--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//pkg/apis/certmanager/validation/webhooks:go_default_library",
+        "//vendor/github.com/golang/glog:go_default_library",
         "//vendor/github.com/openshift/generic-admission-server/pkg/cmd:go_default_library",
     ],
 )

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"flag"
+	"os"
+	"time"
 
 	"github.com/openshift/generic-admission-server/pkg/cmd"
 
@@ -32,9 +34,43 @@ func main() {
 	// Avoid "logging before flag.Parse" errors from glog
 	flag.CommandLine.Parse([]string{})
 
+	// parse the command line flags to pull out the tls-cert-file
+	// argument. This flag will be parsed by code inside cmd.RunAdmissionServer
+	// so no need to pass it through the call stack or have nice errors
+	tlsflagSet := flag.NewFlagSet("tls", flag.ContinueOnError)
+	tlsflagVal := tlsflagSet.String("tls-cert-file", "", "")
+	tlsflagSet.Parse(os.Args[1:])
+	if *tlsflagVal != "" {
+		runfilewatch(*tlsflagVal)
+	}
+
 	cmd.RunAdmissionServer(
 		certHook,
 		issuerHook,
 		clusterIssuerHook,
 	)
+}
+
+func runfilewatch(filename string) {
+	info, err := os.Stat(filename)
+	if err != nil {
+		// missing TLS cert file will get turned into a proper error later
+		return
+	}
+	modtime := info.ModTime()
+	go func() {
+		for {
+			time.Sleep(1 * time.Minute)
+			info, err := os.Stat(filename)
+			if err != nil {
+				continue
+			}
+			if info.ModTime().After(modtime) {
+				// let the k8s scheduler restart us
+				// TODO(dmo): figure out if there's a way to do this with clean
+				// shutdown
+				os.Exit(0)
+			}
+		}
+	}()
 }

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/golang/glog"
 	"github.com/openshift/generic-admission-server/pkg/cmd"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/validation/webhooks"
@@ -69,6 +70,7 @@ func runfilewatch(filename string) {
 				// let the k8s scheduler restart us
 				// TODO(dmo): figure out if there's a way to do this with clean
 				// shutdown
+				glog.Info("Detected change in TLS certificate %s. Restarting to pick up new certificate", filename)
 				os.Exit(0)
 			}
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
This watches the certificate file on the webhook, restarting whenever a certificate has changed. This makes sure that we're always going to have a valid certificate

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #1340


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
