### PR TITLE
Build apiextensions-ca-helper as part of cert-manager release

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -20,6 +20,7 @@ multiarch_bundle(
         "{STABLE_DOCKER_REPO}/cert-manager-controller-{arch}:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
         "{STABLE_DOCKER_REPO}/cert-manager-acmesolver-{arch}:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
         "{STABLE_DOCKER_REPO}/cert-manager-webhook-{arch}:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-ca-sync-{arch}:{STABLE_DOCKER_TAG}": "//cmd/ca-sync:image",
     },
     os = ["linux"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -274,6 +274,15 @@ http_file(
     urls = ["https://github.com/golang/dep/releases/download/v0.5.0/dep-linux-amd64"],
 )
 
+# the apiextensions-ca-helper project is bundled as part of the release build
+go_repository(
+    name = "com_github_munnerz_apiextensions-ca-helper",
+    commit = "9be50e3422109916fa939a2ef9f1f5876cc9a8b2",
+    importpath = "github.com/munnerz/apiextensions-ca-helper",
+    # Expose the generated go_default_library as 'public' visibility
+    patch_cmds = ["sed -i -e 's/private/public/g' 'BUILD.bazel'"],
+)
+
 ## Brodocs and associated dependencies
 new_git_repository(
     name = "brodocs",

--- a/cmd/ca-sync/BUILD.bazel
+++ b/cmd/ca-sync/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
+load("//hack:def.bzl", "multiarch_image")
+
+# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
+multiarch_image(
+    name = "image",
+    embed = ["@com_github_munnerz_apiextensions-ca-helper//:go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "ca-sync",
+    embed = ["@com_github_munnerz_apiextensions-ca-helper//:go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.6.7
+version: v0.6.8
 appVersion: v0.6.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -109,8 +109,8 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
 | `webhook.image.tag` | Webhook image tag | `v0.6.1` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
-| `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
-| `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |
+| `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/jetstack/cert-manager-ca-sync` |
+| `webhook.caSyncImage.tag` | CA sync image tag | `v0.6.1` |
 | `webhook.caSyncImage.pullPolicy` | CA sync image pull policy | `IfNotPresent` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.4
-digest: sha256:a0af88ca014f7195e521457f22c31d8bf28c7c90b0c9a088bfc5cb8ab188b769
-generated: 2019-02-07T16:38:55.664017-07:00
+  version: v0.6.5
+digest: sha256:f053fa581f15727f3e50bc78ae1e1caa05b4a61c6e842052ceb44595a28bf4cc
+generated: 2019-02-19T18:31:38.574694658Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.4"
+  version: "v0.6.5"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.4"
+version: "v0.6.5"
 appVersion: "v0.6.1"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/webhook/values.yaml
+++ b/deploy/charts/cert-manager/webhook/values.yaml
@@ -34,6 +34,6 @@ image:
   pullPolicy: IfNotPresent
 
 caSyncImage:
-  repository: quay.io/munnerz/apiextensions-ca-helper
-  tag: v0.1.0
+  repository: quay.io/jetstack/cert-manager-ca-sync
+  tag: v0.6.1
   pullPolicy: IfNotPresent

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 ---
@@ -986,7 +986,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1006,7 +1006,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1024,7 +1024,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1041,7 +1041,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1059,7 +1059,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 
@@ -988,7 +988,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 ---
@@ -999,7 +999,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1019,7 +1019,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1037,7 +1037,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1054,7 +1054,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1075,7 +1075,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1100,7 +1100,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1121,7 +1121,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1142,7 +1142,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1164,7 +1164,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1216,7 +1216,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.7
+    chart: cert-manager-v0.6.8
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1264,7 +1264,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1281,7 +1281,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: ca-helper
-            image: quay.io/munnerz/apiextensions-ca-helper:v0.1.0
+            image: quay.io/jetstack/cert-manager-ca-sync:v0.6.1
             imagePullPolicy: IfNotPresent
             args:
             - -config=/config/config
@@ -1307,7 +1307,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1321,7 +1321,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: ca-helper
-        image: quay.io/munnerz/apiextensions-ca-helper:v0.1.0
+        image: quay.io/jetstack/cert-manager-ca-sync:v0.6.1
         imagePullPolicy: IfNotPresent
         args:
         - -config=/config/config
@@ -1347,7 +1347,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 data:
@@ -1380,7 +1380,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 
@@ -1391,7 +1391,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1417,7 +1417,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1436,7 +1436,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1460,7 +1460,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1476,7 +1476,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1497,7 +1497,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1514,7 +1514,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1535,7 +1535,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.4
+    chart: webhook-v0.6.5
     release: cert-manager
     heritage: Tiller
 webhooks:

--- a/hack/ci/lib/build_images.sh
+++ b/hack/ci/lib/build_images.sh
@@ -41,6 +41,7 @@ build_images() {
         "${DOCKER_REPO}"/cert-manager-controller:"${DOCKER_TAG}" \
         "${DOCKER_REPO}"/cert-manager-acmesolver:"${DOCKER_TAG}" \
         "${DOCKER_REPO}"/cert-manager-webhook:"${DOCKER_TAG}" \
+        "${DOCKER_REPO}"/cert-manager-ca-sync:"${DOCKER_TAG}" \
         "pebble:bazel" \
         "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.21.0" \
         "k8s.gcr.io/defaultbackend:bazel" \

--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -41,6 +41,7 @@ def stamped_image(
 
 def multiarch_image(
     name,
+    embed = [":go_default_library"],
     goarch = ["amd64", "arm64", "arm"],
     goos = ["linux"],
     user = "1000",
@@ -52,7 +53,7 @@ def multiarch_image(
       go_image(
           name = "%s.app_%s-%s" % (name, os, arch),
           base = "@alpine_%s-%s//image" % (os, arch),
-          embed = [":go_default_library"],
+          embed = embed,
           goarch = arch,
           goos = os,
           pure = "on",

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -74,7 +74,7 @@ export ALLOW_OVERWRITE=${ALLOW_OVERWRITE:-}
 export CHART_PATH=${CHART_PATH:-deploy/charts/cert-manager}
 # remove trailing `/` if present
 export DOCKER_REPO=${DOCKER_REPO%/}
-COMPONENTS=( acmesolver controller webhook )
+COMPONENTS=( acmesolver controller webhook ca-sync )
 SKIP_REF_TAG=${SKIP_REF_TAG:-}
 GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "dirty" || echo "clean")
 if [ -z "$ALLOW_DIRTY" -a "$GIT_DIRTY" != "clean" ]; then

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -13,6 +13,7 @@ container_bundle(
         "{STABLE_DOCKER_REPO}/cert-manager-controller:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
         "{STABLE_DOCKER_REPO}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
         "{STABLE_DOCKER_REPO}/cert-manager-webhook:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-ca-sync:{STABLE_DOCKER_TAG}": "//cmd/ca-sync:image",
     },
 )
 

--- a/test/fixtures/cert-manager-values.yaml
+++ b/test/fixtures/cert-manager-values.yaml
@@ -23,6 +23,9 @@ webhook:
   image:
     tag: build
     pullPolicy: Never
+  caSyncImage:
+    tag: build
+    pullPolicy: Never
   resources:
     requests:
       cpu: 100m


### PR DESCRIPTION
**What this PR does / why we need it**:

This will also enable multiarch builds of the ca-helper

**Release note**:
```release-note
Build multiarch images of the ca-sync component
```

/area deploy
