### PR TITLE
Recreate dead solver pods during self-check

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -90,6 +90,13 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 }
 
 func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
+	// HTTP Present is idempotent and the state of the system may have
+	// changed since present was called by the controllers (killed pods, drained nodes)
+	// Call present again to be certain.
+	err := s.Present(ctx, issuer, ch)
+	if err != nil {
+		return err
+	}
 	ctx, cancel := context.WithTimeout(ctx, HTTP01Timeout)
 	defer cancel()
 

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -93,9 +93,13 @@ func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v
 	// HTTP Present is idempotent and the state of the system may have
 	// changed since present was called by the controllers (killed pods, drained nodes)
 	// Call present again to be certain.
-	err := s.Present(ctx, issuer, ch)
-	if err != nil {
-		return err
+	// if the listers are nil, that means we're in the present checks
+	// test
+	if s.podLister != nil && s.serviceLister != nil && s.ingressLister == nil {
+		err := s.Present(ctx, issuer, ch)
+		if err != nil {
+			return err
+		}
 	}
 	ctx, cancel := context.WithTimeout(ctx, HTTP01Timeout)
 	defer cancel()

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -95,7 +95,7 @@ func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v
 	// Call present again to be certain.
 	// if the listers are nil, that means we're in the present checks
 	// test
-	if s.podLister != nil && s.serviceLister != nil && s.ingressLister == nil {
+	if s.podLister != nil && s.serviceLister != nil && s.ingressLister != nil {
 		err := s.Present(ctx, issuer, ch)
 		if err != nil {
 			return err

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -52,13 +52,12 @@ func (s *Solver) ensurePod(ch *v1alpha1.Challenge) (*corev1.Pod, error) {
 		return existingPods[0], nil
 	}
 	if len(existingPods) > 1 {
-		errMsg := fmt.Sprintf("multiple challenge solver pods found for certificate '%s/%s'. Cleaning up existing pods.", ch.Namespace, ch.Name)
-		glog.Infof(errMsg)
+		glog.Infof("multiple challenge solver pods found for certificate '%s/%s'. Cleaning up existing pods.", ch.Namespace, ch.Name)
 		err := s.cleanupPods(ch)
 		if err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf(errMsg)
+		return s.createPod(ch)
 	}
 
 	glog.Infof("No existing HTTP01 challenge solver pod found for Certificate %q. One will be created.", ch.Namespace+"/"+ch.Name)

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -52,12 +52,13 @@ func (s *Solver) ensurePod(ch *v1alpha1.Challenge) (*corev1.Pod, error) {
 		return existingPods[0], nil
 	}
 	if len(existingPods) > 1 {
-		glog.Infof("multiple challenge solver pods found for certificate '%s/%s'. Cleaning up existing pods.", ch.Namespace, ch.Name)
+		errMsg := fmt.Sprintf("multiple challenge solver pods found for certificate '%s/%s'. Cleaning up existing pods.", ch.Namespace, ch.Name)
+		glog.Infof(errMsg)
 		err := s.cleanupPods(ch)
 		if err != nil {
 			return nil, err
 		}
-		return s.createPod(ch)
+		return nil, fmt.Errorf(errMsg)
 	}
 
 	glog.Infof("No existing HTTP01 challenge solver pod found for Certificate %q. One will be created.", ch.Namespace+"/"+ch.Name)

--- a/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
@@ -16,13 +16,16 @@ go_library(
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/pebble:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/matcher:go_default_library",
         "//test/e2e/suite/issuers/acme/dnsproviders:go_default_library",
         "//test/e2e/util:go_default_library",
         "//test/util/generate:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -227,7 +227,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	It("should obtain a signed certificate with a single CN from the ACME server after solver pod killed", func() {
+	It("should automatically recreate challenge pod and still obtain a certificate if it is manually deleted", func() {
 		certClient := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name)
 
 		By("Creating a Certificate")

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -237,7 +237,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		By("killing the solver pod")
 		podClient := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name)
 		var pod corev1.Pod
-		err = wait.PollImmediate(500*time.Millisecond, time.Minute,
+		err = wait.PollImmediate(1*time.Second, time.Minute,
 			func() (bool, error) {
 				log.Logf("Waiting for solver pod to exist")
 				podlist, err := podClient.List(metav1.ListOptions{})

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -18,11 +18,14 @@ package certificate
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	cmutil "github.com/jetstack/cert-manager/pkg/util"
@@ -30,6 +33,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/pebble"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 	. "github.com/jetstack/cert-manager/test/e2e/framework/matcher"
 	"github.com/jetstack/cert-manager/test/e2e/util"
 )
@@ -222,4 +226,49 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		err = h.WaitCertificateIssuedValid(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 	})
+
+	It("should obtain a signed certificate with a single CN from the ACME server after solver pod killed", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		_, err := certClient.Create(util.NewCertManagerACMECertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, nil, nil, acmeIngressClass, acmeIngressDomain))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("killing the solver pod")
+		podClient := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name)
+		var pod corev1.Pod
+		err = wait.PollImmediate(500*time.Millisecond, time.Minute,
+			func() (bool, error) {
+				log.Logf("Waiting for solver pod to exist")
+				podlist, err := podClient.List(metav1.ListOptions{})
+				if err != nil {
+					return false, err
+				}
+
+				for _, p := range podlist.Items {
+					log.Logf("solver pod %s", p.Name)
+					// TODO(dmo): make this cleaner instead of just going by name
+					if strings.Contains(p.Name, "http-solver") {
+						pod = p
+						return true, nil
+					}
+				}
+				return false, nil
+
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = podClient.Delete(pod.Name, &metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The pod should get remade and the certificate should be made valid.
+		// Killing the pod could potentially make the validation invalid if pebble
+		// were to ask us for the challenge after the pod was killed, but because
+		// we kill it so early, we should always be in the self-check phase
+		By("Verifying the Certificate is valid")
+		err = h.WaitCertificateIssuedValid(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
 })


### PR DESCRIPTION
**What this PR does / why we need it**:
While solver pods are fairly simple and shouldn't die, they can be terminated for a variety of reasons, like draining nodes or overzealous sysadmins. Recreate the solver pod if it goes away while we're waiting for the self-check to pass.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
fixes #1311 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
More robust handling of solver pods
```
