### PR TITLE
Bump rules_docker version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -48,17 +48,20 @@ git_repository(
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    tag = "v0.6.0",
+    tag = "v0.7.0",
 )
 
 load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
     container_repositories = "repositories",
 )
 
 container_repositories()
 
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
 load(
     "@io_bazel_rules_docker//go:image.bzl",
     _go_image_repos = "repositories",


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue that caused the `//:images.push` target to not work.

**Release note**:
```release-note
NONE
```
