### PR TITLE
Bump files for v0.7.0-alpha.0

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.6.8
-appVersion: v0.6.1
+version: v0.7.0-alpha.0
+appVersion: v0.7.0-alpha.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -21,7 +21,7 @@ To install the chart with the release name `my-release`:
 ## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
 ## cert-manager Helm chart
 $ kubectl apply \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
 ## IMPORTANT: if you are deploying into a namespace that **already exists**,
 ## you MUST ensure the namespace has an additional label on it in order for
@@ -73,7 +73,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `global.rbac.create` | If `true`, create and use RBAC resources (includes sub-charts) | `true` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.6.1` |
+| `image.tag` | Image tag | `v0.7.0-alpha.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
@@ -107,7 +107,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.6.1` |
+| `webhook.image.tag` | Webhook image tag | `v0.7.0-alpha.0` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.caSyncImage.repository` | CA sync image repository | `quay.io/munnerz/apiextensions-ca-helper` |
 | `webhook.caSyncImage.tag` | CA sync image tag | `v0.1.0` |

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.6.5
-digest: sha256:f053fa581f15727f3e50bc78ae1e1caa05b4a61c6e842052ceb44595a28bf4cc
-generated: 2019-02-20T11:04:12.008096943Z
+  version: v0.7.0-alpha.0
+digest: sha256:1b7730e617e44e0d62529fa463ff14bc42b9ac68490acc6b53c8225c7e85c1b5
+generated: 2019-02-20T14:15:01.677169346Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.6.5"
+  version: "v0.7.0-alpha.0"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -23,7 +23,7 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.6.1
+  tag: v0.7.0-alpha.0
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,7 +1,7 @@
 name: webhook
 apiVersion: v1
-version: "v0.6.5"
-appVersion: "v0.6.1"
+version: "v0.7.0-alpha.0"
+appVersion: "v0.7.0-alpha.0"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager
 sources:

--- a/deploy/charts/cert-manager/webhook/values.yaml
+++ b/deploy/charts/cert-manager/webhook/values.yaml
@@ -30,7 +30,7 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.6.1
+  tag: v0.7.0-alpha.0
   pullPolicy: IfNotPresent
 
 caSyncImage:

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -986,7 +986,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1006,7 +1006,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1024,7 +1024,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1041,7 +1041,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1059,7 +1059,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1081,7 +1081,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.6.1"
+          image: "quay.io/jetstack/cert-manager-controller:v0.7.0-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 
@@ -988,7 +988,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -999,7 +999,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1019,7 +1019,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1037,7 +1037,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1054,7 +1054,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1075,7 +1075,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1100,7 +1100,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1121,7 +1121,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1142,7 +1142,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1164,7 +1164,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1183,7 +1183,7 @@ spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.6.1"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.7.0-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12
@@ -1216,7 +1216,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.6.8
+    chart: cert-manager-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1238,7 +1238,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.6.1"
+          image: "quay.io/jetstack/cert-manager-controller:v0.7.0-alpha.0"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -1269,7 +1269,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1312,7 +1312,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1352,7 +1352,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 data:
@@ -1385,7 +1385,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 
@@ -1396,7 +1396,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1422,7 +1422,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1441,7 +1441,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1465,7 +1465,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1481,7 +1481,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1502,7 +1502,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1519,7 +1519,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1540,7 +1540,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.6.5
+    chart: webhook-v0.7.0-alpha.0
     release: cert-manager
     heritage: Tiller
 webhooks:

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -57,7 +57,7 @@ are included in a single YAML manifest file:
 .. code-block:: shell
 
    # Install the CustomResourceDefinitions and cert-manager itself
-   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/cert-manager.yaml
+   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/cert-manager.yaml
 
 .. note::
    If you are running kubectl v1.12 or below, you will need to add the
@@ -115,7 +115,7 @@ In order to install the Helm chart, you must run:
 .. code-block:: shell
 
    # Install the CustomResourceDefinition resources separately
-   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
    # Create the namespace for cert-manager
    kubectl create namespace cert-manager
@@ -130,7 +130,7 @@ In order to install the Helm chart, you must run:
    helm install \
      --name cert-manager \
      --namespace cert-manager \
-     --version v0.6.1 \
+     --version v0.7.0-alpha.0 \
      stable/cert-manager
 
 The default cert-manager configuration is good for the majority of users, but a

--- a/docs/getting-started/webhook.rst
+++ b/docs/getting-started/webhook.rst
@@ -225,16 +225,16 @@ To re-install cert-manager without the webhook, run:
 
 .. code-block:: shell
 
-   kubectl delete -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/cert-manager.yaml
+   kubectl delete -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/cert-manager.yaml
 
-   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/cert-manager-no-webhook.yaml
+   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/cert-manager-no-webhook.yaml
 
 Once you have re-installed cert-manager, you should then
 :doc:`restore your configuration </tasks/backup-restore-crds>`.
 
 .. _`munnerz/apiextensions-ca-helper`: https://github.com/munnerz/apiextensions-ca-helper
-.. _`deploy directory`: https://github.com/jetstack/cert-manager/blob/release-0.6/deploy/manifests
-.. _`cert-manager.yaml`: https://github.com/jetstack/cert-manager/blob/release-0.6/deploy/manifests/cert-manager.yaml
-.. _`cert-manager-no-webhook.yaml`: https://github.com/jetstack/cert-manager/blob/release-0.6/deploy/manifests/cert-manager-no-webhook.yaml
+.. _`deploy directory`: https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/manifests
+.. _`cert-manager.yaml`: https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/manifests/cert-manager.yaml
+.. _`cert-manager-no-webhook.yaml`: https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/manifests/cert-manager-no-webhook.yaml
 .. _`GKE docs`: https://cloud.google.com/kubernetes-engine/docs/how-to/private-clusters#add_firewall_rules
 .. _`ValidatingWebhookConfiguration`: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/

--- a/docs/tasks/issuing-certificates/index.rst
+++ b/docs/tasks/issuing-certificates/index.rst
@@ -72,7 +72,7 @@ A full list of the fields supported on the Certificate resource can be found in
 the `API reference documentation`_.
 
 .. _`#1269`: https://github.com/jetstack/cert-manager/issues/1269
-.. _`API reference documentation`: https://docs.cert-manager.io/en/release-0.6/reference/api-docs/index.html#certificatespec-v1alpha1
+.. _`API reference documentation`: https://docs.cert-manager.io/en/release-0.7/reference/api-docs/index.html#certificatespec-v1alpha1
 
 Special fields on Certificate resources for ACME Issuers
 ========================================================

--- a/docs/tasks/upgrading/index.rst
+++ b/docs/tasks/upgrading/index.rst
@@ -92,5 +92,5 @@ version number you want to install:
    upgrading-0.5-0.6
 
 .. _`official Helm charts repository`: https://github.com/helm/charts
-.. _`static deployment manifests`: https://github.com/jetstack/cert-manager/blob/release-0.6/deploy/manifests
+.. _`static deployment manifests`: https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/manifests
 .. _`kubernetes/kubernetes#69590`: https://github.com/kubernetes/kubernetes/issues/69590

--- a/docs/tasks/upgrading/upgrading-0.5-0.6.rst
+++ b/docs/tasks/upgrading/upgrading-0.5-0.6.rst
@@ -76,7 +76,7 @@ Before upgrading you will need to:
 
     # Install the cert-manager CRDs
     $ kubectl apply \
-        -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+        -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
     # Update helm repository cache
     $ helm repo update
@@ -85,7 +85,7 @@ Before upgrading you will need to:
     $ helm install \
         --name cert-manager \
         --namespace cert-manager \
-        --version v0.6.1 \
+        --version v0.7.0-alpha.0 \
         stable/cert-manager
 
 4. Follow the steps in the :doc:`restore guide <../backup-restore-crds>` to

--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -352,7 +352,7 @@ install cert-manager. This example installed cert-manager into the
 
     # Install the cert-manager CRDs. We must do this before installing the Helm
     # chart in the next step
-    $ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+    $ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
     # Update your local Helm chart repositories
     $ helm repo update


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps all our manifests and files for the upcoming release-0.7. This should have probably been done nearer the cycle, but we now know for next time :smile: 

**Release note**:
```release-note
NONE
```

/cc @DanielMorsing 