### PR TITLE
Fix RBAC for openshift and add openshift compatibility

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.8.0-alpha.0
+version: v0.8.1-alpha.0
 appVersion: v0.8.0-alpha.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -23,12 +23,20 @@ To install the chart with the release name `my-release`:
 $ kubectl apply \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
 
+## If you are installing on openshift :
+$ oc create \
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+
 ## IMPORTANT: if the cert-manager namespace **already exists**, you MUST ensure
 ## it has an additional label on it in order for the deployment to succeed
 $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true"
 
+## For openshift:
+$ oc label namespace cert-manager certmanager.k8s.io/disable-validation=true
+
 ## Add the Jetstack Helm repository
 $ helm repo add jetstack https://charts.jetstack.io
+
 
 ## Install the cert-manager helm chart
 $ helm install --name my-release --namespace cert-manager jetstack/cert-manager

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -25,7 +25,7 @@ $ kubectl apply \
 
 ## If you are installing on openshift :
 $ oc create \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.6/deploy/manifests/00-crds.yaml
+    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
 ## IMPORTANT: if the cert-manager namespace **already exists**, you MUST ensure
 ## it has an additional label on it in order for the deployment to succeed

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -4,4 +4,6 @@ dependencies:
   version: v0.8.0-alpha.0
 - name: cainjector
   repository: file://cainjector
-
+  version: v0.8.0-alpha.0
+digest: sha256:7068b0db40ed5111f1db451e89a4d78af477c8220f881f30fdd87118f71f8cc5
+generated: 2019-05-02T07:58:26.426058917+02:00

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -4,6 +4,4 @@ dependencies:
   version: v0.8.0-alpha.0
 - name: cainjector
   repository: file://cainjector
-  version: v0.8.0-alpha.0
-digest: sha256:7068b0db40ed5111f1db451e89a4d78af477c8220f881f30fdd87118f71f8cc5
-generated: 2019-05-01T16:50:17.726241574+01:00
+

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -10,14 +10,19 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "issuers/finalizers","clusterissuers", "orders", "orders/finalizers", "challenges",  "challengesi/finalizers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "events", "services", "pods"]
+    resources: ["configmaps", "secrets", "secrets/finalizers","events", "services", "services/finalizers","pods", "pods/finalizers"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
-    resources: ["ingresses"]
+    resources: ["ingresses", "ingresses/finalizers", "ingresses/status"]
     verbs: ["*"]
+{{- if .Values.global.isOpenshift }}
+  - apiGroups: ["route.openshift.io"]
+    resources: ["routes", "routes/custom-host", "routes/finalizers"]
+    verbs: ["*"]
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -10,13 +10,13 @@ metadata:
     heritage: {{ .Release.Service }}
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificates/finalizers", "issuers", "issuers/finalizers","clusterissuers", "orders", "orders/finalizers", "challenges",  "challengesi/finalizers"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges",  "challenges/finalizers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "secrets/finalizers","events", "services", "services/finalizers","pods", "pods/finalizers"]
+    resources: ["configmaps", "secrets", "events", "services","pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
-    resources: ["ingresses", "ingresses/finalizers", "ingresses/status"]
+    resources: ["ingresses", "ingresses/finalizers"]
     verbs: ["*"]
 {{- if .Values.global.isOpenshift }}
   - apiGroups: ["route.openshift.io"]

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -6,6 +6,7 @@ global:
   ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   ##
   imagePullSecrets: []
+  isOpenshift: false
   # - name: "image-pull-secret"
 
   # Optional priority class to be used for the cert-manager pods

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -1280,13 +1280,13 @@ metadata:
     heritage: Tiller
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges",  "challenges/finalizers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "events", "services", "pods"]
+    resources: ["configmaps", "secrets", "events", "services","pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
-    resources: ["ingresses"]
+    resources: ["ingresses", "ingresses/finalizers"]
     verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -1219,7 +1219,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -1275,7 +1275,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1295,7 +1295,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1313,7 +1313,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1330,7 +1330,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1390,7 +1390,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1232,7 +1232,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 ---
@@ -1288,7 +1288,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1308,7 +1308,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1326,7 +1326,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1343,7 +1343,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1546,7 +1546,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.0-alpha.0
+    chart: cert-manager-v0.8.1-alpha.0
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1293,13 +1293,13 @@ metadata:
     heritage: Tiller
 rules:
   - apiGroups: ["certmanager.k8s.io"]
-    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges"]
+    resources: ["certificates", "certificates/finalizers", "issuers", "clusterissuers", "orders", "orders/finalizers", "challenges",  "challenges/finalizers"]
     verbs: ["*"]
   - apiGroups: [""]
-    resources: ["configmaps", "secrets", "events", "services", "pods"]
+    resources: ["configmaps", "secrets", "events", "services","pods"]
     verbs: ["*"]
   - apiGroups: ["extensions"]
-    resources: ["ingresses"]
+    resources: ["ingresses", "ingresses/finalizers"]
     verbs: ["*"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR relaxes some right in order to enable this Chart to be deployed flawlessly on Openshift.

**Special notes for your reviewer**:
This helm chart have some trouble launching the webhook, after investigation, it sounded like it had some trouble creating or editing some of the needed secrets. 
Also, cert-manager needs to edit ingress. This cannot be done with the actual rights of this chart. 

```release-note
Allow Openshift to install cert-manager chart
```