### PR TITLE
Run helm init -c in release.sh

### DIFF
--- a/hack/release.sh
+++ b/hack/release.sh
@@ -152,6 +152,8 @@ else
     HELM="$(bazel info bazel-genfiles)/hack/bin/helm"
     CHART_OUT="$(mktemp -d)"
 
+    "${HELM}" init --client-only
+
     "${HELM}" package \
         --dependency-update \
         --destination "${CHART_OUT}" \


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes an issue with the release script on environments that haven't run `helm init` before.

**Release note**:
```release-note
NONE
```
