### PR TITLE
Don't return errors if retrieving pod logs fails

### DIFF
--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -266,16 +266,17 @@ func (c *Chart) Logs() (map[string]string, error) {
 
 		err := resp.Error()
 		if err != nil {
-			return nil, err
+			continue
 		}
 
 		logs, err := resp.Raw()
 		if err != nil {
-			return nil, err
+			continue
 		}
 
 		outPath := path.Join(c.Namespace, pod.Name)
 		out[outPath] = string(logs)
 	}
+
 	return out, nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

When cert-manager is deploying and the controller is in a crash loop, the webhook sometimes does not start which means errors get returned when retrieving the pod logs so the log messages don't get printed.

This PR ignores errors when retrieving pod logs, in favour of returning as many logs as can be retrieved.

**Release note**:
```release-note
NONE
```
