### PR TITLE
Use Helm appVersion as image tag by default

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.7.0-alpha.1
+version: v0.7.0-alpha.2
 appVersion: v0.7.0-alpha.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.7.0-alpha.1
-digest: sha256:cf86c328530ade83d1b5bb11f1230bb01231bccaf39676cb36397513accf7a03
-generated: 2019-02-22T12:49:26.767885234Z
+  version: v0.7.0-alpha.2
+digest: sha256:c3840a25965f2d6332bb16dae8fcb3d8b74d6380df0e3aef1199217f04353886
+generated: 2019-02-22T18:26:36.818101631Z

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,6 +1,6 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.7.0-alpha.1"
+  version: "v0.7.0-alpha.2"
   repository: "file://webhook"
   condition: webhook.enabled

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -45,7 +45,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
         {{- if .Values.clusterResourceNamespace }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -23,7 +23,9 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.7.0-alpha.0
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion will be used.
+  # tag: canary
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,6 +1,6 @@
 name: webhook
 apiVersion: v1
-version: "v0.7.0-alpha.1"
+version: "v0.7.0-alpha.2"
 appVersion: "v0.7.0-alpha.0"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/webhook/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/webhook/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - --v=12

--- a/deploy/charts/cert-manager/webhook/values.yaml
+++ b/deploy/charts/cert-manager/webhook/values.yaml
@@ -30,7 +30,9 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.7.0-alpha.0
+  # Override the image tag to deploy by setting this variable.
+  # If no value is set, the chart's appVersion will be used.
+  # tag: canary
   pullPolicy: IfNotPresent
 
 caSyncImage:

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -986,7 +986,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1006,7 +1006,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1024,7 +1024,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1041,7 +1041,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1059,7 +1059,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -975,7 +975,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 
@@ -988,7 +988,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 ---
@@ -999,7 +999,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1019,7 +1019,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1037,7 +1037,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1054,7 +1054,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1075,7 +1075,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1100,7 +1100,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1121,7 +1121,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1142,7 +1142,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1164,7 +1164,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1215,7 +1215,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-alpha.1
+    chart: cert-manager-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1268,7 +1268,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1311,7 +1311,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1351,7 +1351,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 data:
@@ -1384,7 +1384,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 
@@ -1395,7 +1395,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1421,7 +1421,7 @@ metadata:
   name: cert-manager-webhook-ca-sync
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1440,7 +1440,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1464,7 +1464,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1480,7 +1480,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1501,7 +1501,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1518,7 +1518,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1539,7 +1539,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.7.0-alpha.1
+    chart: webhook-v0.7.0-alpha.2
     release: cert-manager
     heritage: Tiller
 webhooks:


### PR DESCRIPTION
**What this PR does / why we need it**:

Use the Chart's appVersion field as the image tag as part of the Helm chart.
This will make future chart/release manifest version handling easier in future.

**Release note**:
```release-note
NONE
```
