### PR TITLE
Allows azure subdomain purely for acme-challenges

### DIFF
--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -158,5 +158,5 @@ func (c *DNSProvider) getHostedZoneName(fqdn string) (string, error) {
 }
 
 func (c *DNSProvider) trimFqdn(fqdn string) string {
-	return strings.TrimSuffix(strings.TrimSuffix(fqdn, "."), "."+c.zoneName)
+	return strings.TrimSuffix(strings.TrimSuffix(fqdn, "."), "."+strings.TrimPrefix(c.zoneName, "_acme-challenge.")
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 
In order to mitigate security concerns with allowing access to edit DNS records, we can create a dns zone purely for acme challenges and only allow this zone to be changed by cert-manager.

In order to do this we create a ClusterIssuer with the hostedZoneName of : _acme-challenge.example.com.

Currently if you set it up like this and create a certificate for test.example.com, the cert manager creates a zone of: _acme_challenge.test.example.com._acme-challenge.example.com. If we strip off `_acme-challenge.` from the hostedZoneName then the current `trimFqdn` will work correctly 

```release-note
NONE
```