### PR TITLE
Bump to Go 1.12

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.11.5",
+    go_version = "1.12",
 )
 
 ## Load gazelle and dependencies


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump to use Go 1.12

**Release note**:
```release-note
Bump to use Go 1.12
```

/area deploy