### PR TITLE
Update references to Helm chart repo with charts.jetstack.io

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.7.0-beta.0
+version: v0.7.0-beta.1
 appVersion: v0.7.0-beta.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -23,13 +23,15 @@ To install the chart with the release name `my-release`:
 $ kubectl apply \
     -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
-## IMPORTANT: if you are deploying into a namespace that **already exists**,
-## you MUST ensure the namespace has an additional label on it in order for
-## the deployment to succeed
-$ kubectl label namespace <deployment-namespace> certmanager.k8s.io/disable-validation="true"
+## IMPORTANT: if the cert-manager namespace **already exists**, you MUST ensure
+## it has an additional label on it in order for the deployment to succeed
+$ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true"
+
+## Add the Jetstack Helm repository
+$ helm repo add jetstack https://charts.jetstack.io
 
 ## Install the cert-manager helm chart
-$ helm install --name my-release stable/cert-manager
+$ helm install --name my-release --namespace cert-manager jetstack/cert-manager
 ```
 
 In order to begin issuing certificates, you will need to set up a ClusterIssuer
@@ -38,20 +40,20 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://docs.cert-manager.io/en/latest/reference/issuers.html
+https://docs.cert-manager.io/en/latest/tasks/issuers/index.html
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://docs.cert-manager.io/en/latest/reference/ingress-shim.html
+https://docs.cert-manager.io/en/latest/tasks/issuing-certificates/ingress-shim.html
 
 > **Tip**: List all releases using `helm list`
 
 ## Upgrading the Chart
 
 Special considerations may be required when upgrading the Helm chart, and these
-are documented in our full [upgrading guide](https://docs.cert-manager.io/en/latest/admin/upgrading/index.html).
+are documented in our full [upgrading guide](https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html).
 Please check here before perform upgrades!
 
 ## Uninstalling the Chart

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -1124,7 +1124,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -1180,7 +1180,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1200,7 +1200,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1218,7 +1218,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1235,7 +1235,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1294,7 +1294,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1137,7 +1137,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -1193,7 +1193,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1213,7 +1213,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1231,7 +1231,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1248,7 +1248,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1450,7 +1450,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0-beta.0
+    chart: cert-manager-v0.7.0-beta.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -123,6 +123,9 @@ In order to install the Helm chart, you must run:
    # Label the cert-manager namespace to disable resource validation
    kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 
+   # Add the Jetstack Helm repository
+   helm repo add jetstack https://charts.jetstack.io
+
    # Update your local Helm chart repository cache
    helm repo update
 
@@ -131,7 +134,7 @@ In order to install the Helm chart, you must run:
      --name cert-manager \
      --namespace cert-manager \
      --version v0.7.0-beta.0 \
-     stable/cert-manager
+     jetstack/cert-manager
 
 The default cert-manager configuration is good for the majority of users, but a
 full list of the available options can be found in the `Helm chart README`_.
@@ -263,7 +266,7 @@ If you have any issues with your installation, please refer to the
 :doc:`troubleshooting guide <./troubleshooting>`.
 
 .. _`CustomResourceDefinitions`: https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/
-.. _`Helm chart README`: https://github.com/helm/charts/blob/master/stable/cert-manager/README.md
+.. _`Helm chart README`: https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/charts/cert-manager/README.md
 .. _`kubernetes/kubernetes#69590`: https://github.com/kubernetes/kubernetes/issues/69590
 .. _`ValidatingWebhookConfiguration`: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
 .. _`Helm`: https://helm.sh/

--- a/docs/tasks/upgrading/index.rst
+++ b/docs/tasks/upgrading/index.rst
@@ -43,10 +43,10 @@ version number you want to install:
    # can provision correctly.
    kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 
-   helm upgrade --version <version> <release_name> stable/cert-manager
+   helm upgrade --version <version> <release_name> jetstack/cert-manager
 
 This will upgrade you to the latest version of cert-manager, as listed in the
-`official Helm charts repository`_.
+`Jetstack Helm chart repository`_.
 
 .. note::
    You can find out your release name using ``helm list | grep cert-manager``.
@@ -91,6 +91,6 @@ version number you want to install:
    upgrading-0.4-0.5
    upgrading-0.5-0.6
 
-.. _`official Helm charts repository`: https://github.com/helm/charts
+.. _`official Helm charts repository`: https://hub.helm.sh/charts/jetstack
 .. _`static deployment manifests`: https://github.com/jetstack/cert-manager/blob/release-0.7/deploy/manifests
 .. _`kubernetes/kubernetes#69590`: https://github.com/kubernetes/kubernetes/issues/69590


### PR DESCRIPTION
**What this PR does / why we need it**:

Update the installation instructions to refer to the new charts.jetstack.io repo

**Release note**:
```release-note
NONE
```

/milestone v0.7
/cc @DanielMorsing 