### PR TITLE
[AzureDNS] Add support for Managed Identity

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -265,11 +265,13 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", defaultClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+
-		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata.")
+		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata."+
+		"Azure - System and User Assigned Identities")
 	fs.BoolVar(&s.IssuerAmbientCredentials, "issuer-ambient-credentials", defaultIssuerAmbientCredentials, ""+
 		"Whether an issuer may make use of ambient credentials. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the Issuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+
-		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata.")
+		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata."+
+		"Azure - System and User Assigned Identities")
 	fs.DurationVar(&s.RenewBeforeExpiryDuration, "renew-before-expiry-duration", defaultRenewBeforeExpiryDuration, ""+
 		"The default 'renew before expiry' time for Certificates. "+
 		"Once a certificate is within this duration until expiry, a new Certificate "+

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -317,14 +317,22 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
+	// The ClientID of the service principal used to authenticate with the Azure API
+	// Not required if using Managed Identities
+	// +optional
 	ClientID string `json:"clientID"`
 
-	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
+	// The secret key for the service principal.
+	// Required if ClientID is configured
+	// +optional,omitempty
+	ClientSecret *cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
 
+	// The subscription containing the DNS zone
 	SubscriptionID string `json:"subscriptionID"`
 
 	TenantID string `json:"tenantID"`
 
+	// The resource group containing the DNS zone
 	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -317,14 +317,22 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
+	// The ClientID of the service principal used to authenticate with the Azure API
+	// Not required if using Managed Identities
+	// +optional
 	ClientID string `json:"clientID"`
 
-	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
+	// The secret key for the service principal.
+	// Required if ClientID is configured
+	// +optional,omitempty
+	ClientSecret *cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
 
+	// The subscription containing the DNS zone
 	SubscriptionID string `json:"subscriptionID"`
 
 	TenantID string `json:"tenantID"`
 
+	// The resource group containing the DNS zone
 	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -279,14 +279,21 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
+	// The ClientID of the service principal used to authenticate with the Azure API
+	// Not required if using Managed Identities
 	ClientID string
 
-	ClientSecret cmmeta.SecretKeySelector
+	// The secret key for the service principal.
+	// Required if ClientID is configured
+	ClientSecret *cmmeta.SecretKeySelector
 
+	// The subscription containing the DNS zone
 	SubscriptionID string
 
+	// The tenant the subscription belongs to
 	TenantID string
 
+	// The resource group containing the DNS zone
 	ResourceGroupName string
 
 	HostedZoneName string

--- a/pkg/internal/apis/certmanager/validation/issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/issuer_test.go
@@ -590,12 +590,37 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{},
 			},
 			errs: []*field.Error{
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "key"), "secret key is required"),
-				field.Required(fldPath.Child("azuredns", "clientID"), ""),
 				field.Required(fldPath.Child("azuredns", "subscriptionID"), ""),
 				field.Required(fldPath.Child("azuredns", "tenantID"), ""),
 				field.Required(fldPath.Child("azuredns", "resourceGroupName"), ""),
+			},
+		},
+		"missing azuredns client secret": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+					ClientID: "abc-123",
+					TenantID: "00000000-0000-0000-0000-000000000000",
+					SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					ResourceGroupName: "my-rg",
+					Environment: cmacme.AzurePublicCloud,
+				},
+			},
+			errs: []*field.Error{
+				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef"), "secret key selector is required"),
+			},
+		},
+		"missing azuredns client id": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+					ClientSecret: &validSecretKeyRef,
+					TenantID: "00000000-0000-0000-0000-000000000000",
+					SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					ResourceGroupName: "my-rg",
+					Environment: cmacme.AzurePublicCloud,
+				},
+			},
+			errs: []*field.Error{
+				field.Required(fldPath.Child("azuredns", "clientID"), ""),
 			},
 		},
 		"invalid azuredns environment": {
@@ -605,15 +630,23 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				},
 			},
 			errs: []*field.Error{
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "key"), "secret key is required"),
-				field.Required(fldPath.Child("azuredns", "clientID"), ""),
 				field.Required(fldPath.Child("azuredns", "subscriptionID"), ""),
 				field.Required(fldPath.Child("azuredns", "tenantID"), ""),
 				field.Required(fldPath.Child("azuredns", "resourceGroupName"), ""),
 				field.Invalid(fldPath.Child("azuredns", "environment"), cmacme.AzureDNSEnvironment("an env"),
 					"must be either empty or one of AzurePublicCloud, AzureChinaCloud, AzureGermanCloud or AzureUSGovernmentCloud"),
 			},
+		},
+		"valid azuredns managed identity": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+					TenantID: "00000000-0000-0000-0000-000000000000",
+					SubscriptionID: "00000000-0000-0000-0000-000000000000",
+					ResourceGroupName: "my-rg",
+					Environment: cmacme.AzurePublicCloud,
+				},
+			},
+			errs: []*field.Error{},
 		},
 		"missing akamai config": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{

--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -45,7 +45,7 @@ func TestLiveAzureDnsPresent(t *testing.T) {
 	if !azureLiveTest {
 		t.Skip("skipping live test")
 	}
-	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers)
+	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, false, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
 	err = provider.Present(azureDomain, "_acme-challenge."+azureDomain+".", "123d==")
@@ -59,7 +59,7 @@ func TestLiveAzureDnsCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 5)
 
-	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers)
+	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, false, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(azureDomain, "_acme-challenge."+azureDomain+".", "123d==")
@@ -69,10 +69,10 @@ func TestLiveAzureDnsCleanUp(t *testing.T) {
 func TestInvalidAzureDns(t *testing.T) {
 	validEnv := []string{"", "AzurePublicCloud", "AzureChinaCloud", "AzureGermanCloud", "AzureUSGovernmentCloud"}
 	for _, env := range validEnv {
-		_, err := NewDNSProviderCredentials(env, "cid", "secret", "", "", "", "", util.RecursiveNameservers)
+		_, err := NewDNSProviderCredentials(env, "cid", "secret", "", "", "", "", false, util.RecursiveNameservers)
 		assert.NoError(t, err)
 	}
 
-	_, err := NewDNSProviderCredentials("invalid env", "cid", "secret", "", "", "", "", util.RecursiveNameservers)
+	_, err := NewDNSProviderCredentials("invalid env", "cid", "secret", "", "", "", "",false,  util.RecursiveNameservers)
 	assert.Error(t, err)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds support for azure managed identities. It means you no longer need to add a client ID in the issuer or create a secret.

**Special notes for your reviewer**:
I'm not entirely sure if I've done the ```// +optional``` comments correctly?

**Release note**:
```release-note
Add support for Azure Managed Identity
```
