### PR TITLE
WIP: Restarting pods

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -203,7 +203,8 @@ func buildControllerContext(opts *options.ControllerOptions) (*controller.Contex
 			DefaultACMEIssuerDNS01ProviderName: opts.DefaultACMEIssuerDNS01ProviderName,
 		},
 		CertificateOptions: controller.CertificateOptions{
-			EnableOwnerRef: opts.EnableCertificateOwnerRef,
+			EnableOwnerRef: 	opts.EnableCertificateOwnerRef,
+			EnablePodRefresh: 	opts.EnablePodRefresh,
 		},
 	}, kubeCfg, nil
 }

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -70,6 +70,8 @@ type ControllerOptions struct {
 	DNS01RecursiveNameserversOnly bool
 
 	EnableCertificateOwnerRef bool
+
+	EnablePodRefresh bool
 }
 
 const (
@@ -94,6 +96,8 @@ const (
 	defaultEnableCertificateOwnerRef   = false
 
 	defaultDNS01RecursiveNameserversOnly = false
+
+	defaultEnablePodRefresh	= false
 )
 
 var (
@@ -137,6 +141,7 @@ func NewControllerOptions() *ControllerOptions {
 		DNS01RecursiveNameservers:          []string{},
 		DNS01RecursiveNameserversOnly:      defaultDNS01RecursiveNameserversOnly,
 		EnableCertificateOwnerRef:          defaultEnableCertificateOwnerRef,
+		EnablePodRefresh:					defaultEnablePodRefresh,
 	}
 }
 
@@ -231,6 +236,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableCertificateOwnerRef, "enable-certificate-owner-ref", defaultEnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+
 		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
+	fs.BoolVar(&s.EnablePodRefresh, "enable-pod-refresh", defaultEnablePodRefresh, "When true, anytime a certificate is regnerated " +
+		"the pods that mount that certificate will be restarted so the services can pick up the new certificate.")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -116,4 +116,7 @@ type CertificateOptions struct {
 	// EnableOwnerRef controls wheter wheter the certificate is configured as an owner of
 	// secret where the effective TLS certificate is stored.
 	EnableOwnerRef bool
+	// EnablePodRefresh controls whether renewing this certificate will cause all the pods that
+	// mount its secret to be refreshed by cert-manager.
+	EnablePodRefresh bool
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR allows cert-manager to restart pods that mount a secret with a refreshed certificate. 

The use case for this is when a certificate expires and cert-manager refreshes the certificate, the service running inside the pod may not be able to pick up the certificate. Having the pod be restarted when a certificate is refreshed allows the service running within the pod to pick up the new certificate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1440 

**Special notes for your reviewer**:
This adds an additional command line flag `--enable-pod-restart` to allow this feature to be turned on. This feature is turned off by default.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
When a certificate is refreshed, it allows cert-manager to refresh pods that mount that certificate.
```
