### PR TITLE
[Azure DNS] Fixes trimming of zone inferred via zone discovery 

### DIFF
--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -129,7 +129,7 @@ func (c *DNSProvider) createRecord(fqdn, value string, ttl int) error {
 		*rparams, "", "")
 
 	if err != nil {
-		klog.Infof("Error creating TXT: %s, %v", c.zoneName, err)
+		klog.Infof("Error creating TXT: %s, %v", z, err)
 		return err
 	}
 	return nil
@@ -157,6 +157,11 @@ func (c *DNSProvider) getHostedZoneName(fqdn string) (string, error) {
 	return util.UnFqdn(z), nil
 }
 
+// Trims DNS zone from the fqdn. Defaults to DNSProvider.zoneName if it is specified.
 func (c *DNSProvider) trimFqdn(fqdn string, zone string) string {
-	return strings.TrimSuffix(strings.TrimSuffix(fqdn, "."), "."+zone)
+	z := zone
+	if len(c.zoneName) > 0 {
+		z = c.zoneName
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(fqdn, "."), "."+z)
 }

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -95,7 +95,7 @@ func (c *DNSProvider) CleanUp(domain, fqdn, value string) error {
 		context.TODO(),
 		c.resourceGroupName,
 		z,
-		c.trimFqdn(fqdn),
+		c.trimFqdn(fqdn, z),
 		dns.TXT, "")
 
 	if err != nil {
@@ -124,7 +124,7 @@ func (c *DNSProvider) createRecord(fqdn, value string, ttl int) error {
 		context.TODO(),
 		c.resourceGroupName,
 		z,
-		c.trimFqdn(fqdn),
+		c.trimFqdn(fqdn, z),
 		dns.TXT,
 		*rparams, "", "")
 
@@ -157,6 +157,6 @@ func (c *DNSProvider) getHostedZoneName(fqdn string) (string, error) {
 	return util.UnFqdn(z), nil
 }
 
-func (c *DNSProvider) trimFqdn(fqdn string) string {
-	return strings.TrimSuffix(strings.TrimSuffix(fqdn, "."), "."+c.zoneName)
+func (c *DNSProvider) trimFqdn(fqdn string, zone string) string {
+	return strings.TrimSuffix(strings.TrimSuffix(fqdn, "."), "."+zone)
 }


### PR DESCRIPTION

Signed-off-by: Aditya Sundaramurthy <aditya.sundaramurthy@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Fixes https://github.com/jetstack/cert-manager/issues/1459 . Uses inferred zone name from the Azure DNS API over the configured `hostedZoneName` param in the ClusterIssuer

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1459 

**Special notes for your reviewer**: Overrides `hostedZoneName` config param.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Removes need for `hostedZoneName` to be specified. Uses discovered DNS zone name instead.
```
