### PR TITLE
fix(docs): updated quickstart docs

### DIFF
--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -354,12 +354,23 @@ install cert-manager. This example installed cert-manager into the
     # chart in the next step for `release-0.7` of cert-manager:
     $ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
 
-    # Update your local Helm chart repositories
+    ## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
+    ## cert-manager Helm chart
+    $ kubectl apply \
+       -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.7/deploy/manifests/00-crds.yaml
+
+    ## IMPORTANT: if the cert-manager namespace **already exists**, you MUST ensure
+    ## it has an additional label on it in order for the deployment to succeed
+    $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true"
+
+    ## Add the Jetstack Helm repository
+    $ helm repo add jetstack https://charts.jetstack.io
+    ## Updating the repo just incase it already existed
     $ helm repo update
 
-    # Install cert-manager
-    $ helm install --name cert-manager --namespace cert-manager stable/cert-manager
-
+    ## Install the cert-manager helm chart
+    $ helm install --name cert-manager --namespace cert-manager jetstack/cert-manager
+   
     NAME:   cert-manager
     LAST DEPLOYED: Wed Jan  9 13:36:13 2019
     NAMESPACE: cert-manager


### PR DESCRIPTION
Updated the quickstart documentation to use the new jetstack helm repo.

**What this PR does / why we need it**:
To fix the documentation so people don't end up pulling out their hair wondering why the stable/cert-manager chart is only pulling version 0.6.2 of the code but the CRD's are from version 0.7.0.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
fixing the quickstart documentation to use the new helm chart repo charts.jetstack.io
```
