### PR TITLE
Add CLI tool to clean up old TXT records in Cloudflare

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -145,6 +145,14 @@
   revision = "4c0e84591b9aa9e6dcfdf3e020114cd81f89d5f9"
 
 [[projects]]
+  digest = "1:9b61753fc44c21c3b64bfef0b4f6c8a764d65c246e0236d64d475404824468bb"
+  name = "github.com/cloudflare/cloudflare-go"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "1f9007fbecae20711133c60519338c41cef1ffb4"
+  version = "v0.8.5"
+
+[[projects]]
   digest = "1:8c99488f6d10d92104ee155409ae42ed65badf2a745cd7709c05cb48ef540e68"
   name = "github.com/coreos/etcd"
   packages = [
@@ -1606,6 +1614,7 @@
     "github.com/aws/aws-sdk-go/aws/request",
     "github.com/aws/aws-sdk-go/aws/session",
     "github.com/aws/aws-sdk-go/service/route53",
+    "github.com/cloudflare/cloudflare-go",
     "github.com/cpu/goacmedns",
     "github.com/digitalocean/godo",
     "github.com/go-logr/logr",

--- a/test/e2e/bin/BUILD.bazel
+++ b/test/e2e/bin/BUILD.bazel
@@ -60,7 +60,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//test/e2e/bin/cloudflare-clean:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/test/e2e/bin/cloudflare-clean/BUILD.bazel
+++ b/test/e2e/bin/cloudflare-clean/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/bin/cloudflare-clean",
+    visibility = ["//visibility:private"],
+    deps = ["//vendor/github.com/cloudflare/cloudflare-go:go_default_library"],
+)
+
+go_binary(
+    name = "cloudflare-clean",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/bin/cloudflare-clean/main.go
+++ b/test/e2e/bin/cloudflare-clean/main.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"log"
+	"time"
+
+	cf "github.com/cloudflare/cloudflare-go"
+)
+
+var (
+	email            = flag.String("email", "", "Cloudflare email address to use")
+	apiKey           = flag.String("api-key", "", "Cloudflare API key to use")
+	zoneName         = flag.String("zone-name", "", "Cloudflare DNS zone to clean of old TXT records")
+	deleteOlderThan  = flag.Duration("older-than", time.Hour*24*7, "TXT records older than this duration will be deleted")
+	deleteWithPrefix = flag.String("with-prefix", "_acme-challenge.", "further filter TXT records to only delete those that begin with this prefix")
+	confirm          = flag.Bool("confirm", false, "if false, no records will actually be deleted")
+)
+
+func main() {
+	flag.Parse()
+
+	cl, err := cf.New(*apiKey, *email)
+	if err != nil {
+		log.Fatalf("error creating cloudflare client: %v", err)
+	}
+
+	zones, err := cl.ListZones(*zoneName)
+	if err != nil {
+		log.Fatalf("error listing zones: %v", err)
+	}
+	if len(zones) == 0 {
+		log.Fatalf("could not find zone with name %q", *zoneName)
+	}
+	if len(zones) > 1 {
+		log.Fatalf("found multiple zones for name %q", *zoneName)
+	}
+	zone := zones[0]
+	rrs, err := cl.DNSRecords(zone.ID, cf.DNSRecord{
+		Type: "TXT",
+	})
+	if err != nil {
+		log.Fatalf("error listing TXT records in zone: %v", err)
+	}
+
+	log.Printf("Evaluating %d records", len(rrs))
+	deleted := 0
+	skipped := 0
+	var errs []error
+	for _, rr := range rrs {
+		if !shouldDelete(rr) {
+			log.Printf("Not deleting record %q", rr.Name)
+			skipped++
+			continue
+		}
+
+		if !*confirm {
+			log.Printf("Would have deleted record %q", rr.Name)
+			deleted++
+			continue
+		}
+
+		err := cl.DeleteDNSRecord(rr.ZoneID, rr.ID)
+		if err != nil {
+			log.Printf("Error deleting record: %v", err)
+			errs = append(errs, err)
+		}
+
+		log.Printf("Deleted record %q", rr.Name)
+		deleted++
+	}
+
+	if len(errs) > 0 {
+		log.Fatalf("Encountered %d errors whilst cleaning up zone", len(errs))
+	}
+
+	log.Print()
+	log.Printf("Skipped: %d", skipped)
+	log.Printf("Deleted: %d", deleted)
+	log.Printf("Cleanup complete!")
+}
+
+func shouldDelete(rr cf.DNSRecord) bool {
+	// be extra safe about only deleting TXT records
+	if rr.Type != "TXT" {
+		return false
+	}
+	keepNewerThan := time.Now().Add(-1 * *deleteOlderThan)
+	if rr.ModifiedOn.After(keepNewerThan) ||
+		rr.CreatedOn.After(keepNewerThan) {
+		return false
+	}
+	if len(rr.Name) < len(*deleteWithPrefix) ||
+		rr.Name[0:len(*deleteWithPrefix)] != *deleteWithPrefix {
+		return false
+	}
+	return true
+}

--- a/vendor/BUILD.bazel
+++ b/vendor/BUILD.bazel
@@ -28,6 +28,7 @@ filegroup(
         "//vendor/github.com/aws/aws-sdk-go/service/route53:all-srcs",
         "//vendor/github.com/aws/aws-sdk-go/service/sts:all-srcs",
         "//vendor/github.com/beorn7/perks/quantile:all-srcs",
+        "//vendor/github.com/cloudflare/cloudflare-go:all-srcs",
         "//vendor/github.com/coreos/etcd/auth/authpb:all-srcs",
         "//vendor/github.com/coreos/etcd/clientv3:all-srcs",
         "//vendor/github.com/coreos/etcd/etcdserver/api/v3rpc/rpctypes:all-srcs",

--- a/vendor/github.com/cloudflare/cloudflare-go/.travis.yml
+++ b/vendor/github.com/cloudflare/cloudflare-go/.travis.yml
@@ -1,0 +1,46 @@
+language: go
+sudo: false
+matrix:
+  include:
+    - go: 1.x
+      env: LATEST=true
+    - go: 1.7.x
+    - go: 1.8.x
+    - go: 1.9.x
+    - go: tip
+  allow_failures:
+    - go: tip
+
+before_install:
+  - go get github.com/mitchellh/gox
+
+install:
+  - # skip
+
+script:
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d .)
+  - go vet $(go list ./... | grep -v /vendor/)
+  - go test -v -race ./...
+  # Only build binaries from the latest Go release.
+  - if [ "${LATEST}" = "true" ]; then gox -os="linux darwin windows" -arch="amd64" -output="flarectl.{{.OS}}.{{.Arch}}" -ldflags "-X main.Rev=`git rev-parse --short HEAD`" -verbose ./...; fi
+
+notifications:
+  email:
+    recipients:
+      - jamesog@cloudflare.com
+      - msilverlock@cloudflare.com
+
+deploy:
+  provider: releases
+  skip_cleanup: true
+  api_key:
+    secure: MV5fzNIUrZjIz/0Favxlni3xAjI6eMuLClN+O44Yf95KQrW+bDhaRaoxQz+/u1CraTX0f3A552is99qd5K+DbOhKjVq4YMvPimOQgJ7S03S3HNQyTl97K/1gYuss9zyWLFB6li7IDCQTaDjidjUDrYwuPE/stPQDN/JNWk9qWQWQzKwtn1PiCxcfAi//ckuxBUFxoQLLbd8zxKvUOIYha9EUrY/yF252nMHfUkYON5FEtsLXF6AA0A4NRPB2ftryg7oSgyyANO3W3NFKm1Zr2VeI89H5zVT5OA1oxcOPmMPZMQH4wp2JA6ypKQpcE5mQVdDl+t8p0t2oEPiS1ZP98/9q9B6jIvx1qAhk2z5o3uXZm5rFDL7FSq3jVYd9DG02pRq8v5zt7ZJvtHCTukHJxcxrlQ9Sp6lt+m6q3CaUWNP6IUv4Y63PQTCEIMm4tqERj+SBep/1sGVJpRxedB0dl8Ee35X31KKCZQvd8IB1N+iWqOs2ODb13XMj+ocz9m/lgGcis4DVEwFKXd2cxB13bBUzn6uiF2O154D0+kqTFdWAU4ZO9aD9MyTJ/oc4XbWFu64VgOjryak6BhzbHroj0J3htX2rXO9Mz4IN3Z6Yxcfd7F0+YH4MTFEyaiPgWf4Sc0dyP76QzwJTTwMLwVM/on5SwdGL3g+h6cRVORfbvfI=
+  file:
+  - flarectl.windows.amd64.exe
+  - flarectl.darwin.amd64
+  - flarectl.linux.amd64
+  on:
+    repo: cloudflare/cloudflare-go
+    tags: true
+    condition: $LATEST = true

--- a/vendor/github.com/cloudflare/cloudflare-go/BUILD.bazel
+++ b/vendor/github.com/cloudflare/cloudflare-go/BUILD.bazel
@@ -1,0 +1,51 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cloudflare.go",
+        "cpage.go",
+        "custom_hostname.go",
+        "dns.go",
+        "errors.go",
+        "firewall.go",
+        "ips.go",
+        "keyless.go",
+        "load_balancing.go",
+        "lockdown.go",
+        "options.go",
+        "organizations.go",
+        "origin_ca.go",
+        "page_rules.go",
+        "railgun.go",
+        "rate_limiting.go",
+        "ssl.go",
+        "user.go",
+        "user_agent.go",
+        "virtualdns.go",
+        "waf.go",
+        "zone.go",
+    ],
+    importmap = "github.com/jetstack/cert-manager/vendor/github.com/cloudflare/cloudflare-go",
+    importpath = "github.com/cloudflare/cloudflare-go",
+    tags = ["manual"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//vendor/github.com/pkg/errors:go_default_library",
+        "//vendor/golang.org/x/time/rate:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/vendor/github.com/cloudflare/cloudflare-go/LICENSE
+++ b/vendor/github.com/cloudflare/cloudflare-go/LICENSE
@@ -1,0 +1,26 @@
+Copyright (c) 2015-2016, Cloudflare. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimer in the documentation and/or
+other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+may be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/cloudflare/cloudflare-go/README.md
+++ b/vendor/github.com/cloudflare/cloudflare-go/README.md
@@ -1,0 +1,106 @@
+# cloudflare-go
+
+[![GoDoc](https://img.shields.io/badge/godoc-reference-5673AF.svg?style=flat-square)](https://godoc.org/github.com/cloudflare/cloudflare-go)
+[![Build Status](https://img.shields.io/travis/cloudflare/cloudflare-go/master.svg?style=flat-square)](https://travis-ci.org/cloudflare/cloudflare-go)
+[![Go Report Card](https://goreportcard.com/badge/github.com/cloudflare/cloudflare-go?style=flat-square)](https://goreportcard.com/report/github.com/cloudflare/cloudflare-go)
+
+> **Note**: This library is under active development as we expand it to cover
+> our (expanding!) API. Consider the public API of this package a little
+> unstable as we work towards a v1.0.
+
+A Go library for interacting with
+[Cloudflare's API v4](https://api.cloudflare.com/). This library allows you to:
+
+* Manage and automate changes to your DNS records within Cloudflare
+* Manage and automate changes to your zones (domains) on Cloudflare, including
+  adding new zones to your account
+* List and modify the status of WAF (Web Application Firewall) rules for your
+  zones
+* Fetch Cloudflare's IP ranges for automating your firewall whitelisting
+
+A command-line client, [flarectl](cmd/flarectl), is also available as part of
+this project.
+
+## Features
+
+The current feature list includes:
+
+* [x] DNS Records
+* [x] Zones
+* [x] Web Application Firewall (WAF)
+* [x] Cloudflare IPs
+* [x] User Administration (partial)
+* [x] Virtual DNS Management
+* [x] Custom hostnames
+* [x] Zone Lockdown and User-Agent Block rules
+* [x] Cache purging
+* [ ] Organization Administration
+* [x] [Railgun](https://www.cloudflare.com/railgun/) administration
+* [ ] [Keyless SSL](https://blog.cloudflare.com/keyless-ssl-the-nitty-gritty-technical-details/)
+* [x] [Origin CA](https://blog.cloudflare.com/universal-ssl-encryption-all-the-way-to-the-origin-for-free/)
+* [x] [Load Balancing](https://blog.cloudflare.com/introducing-load-balancing-intelligent-failover-with-cloudflare/)
+* [x] Firewall (partial)
+* [x] Rate Limiting
+
+Pull Requests are welcome, but please open an issue (or comment in an existing
+issue) to discuss any non-trivial changes before submitting code.
+
+## Installation
+
+You need a working Go environment.
+
+```
+go get github.com/cloudflare/cloudflare-go
+```
+
+## Getting Started
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/cloudflare/cloudflare-go"
+)
+
+func main() {
+	// Construct a new API object
+	api, err := cloudflare.New(os.Getenv("CF_API_KEY"), os.Getenv("CF_API_EMAIL"))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Fetch user details on the account
+	u, err := api.UserDetails()
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print user details
+	fmt.Println(u)
+
+	// Fetch the zone ID
+	id, err := api.ZoneIDByName("example.com") // Assuming example.com exists in your Cloudflare account already
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Fetch zone details
+	zone, err := api.ZoneDetails(id)
+	if err != nil {
+		log.Fatal(err)
+	}
+	// Print zone details
+	fmt.Println(zone)
+}
+```
+
+Also refer to the
+[API documentation](https://godoc.org/github.com/cloudflare/cloudflare-go) for
+how to use this package in-depth.
+
+# License
+
+BSD licensed. See the [LICENSE](LICENSE) file for details.

--- a/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/cloudflare.go
@@ -1,0 +1,318 @@
+// Package cloudflare implements the Cloudflare v4 API.
+package cloudflare
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"io/ioutil"
+	"log"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/pkg/errors"
+	"golang.org/x/time/rate"
+)
+
+const apiURL = "https://api.cloudflare.com/client/v4"
+const (
+	// AuthKeyEmail specifies that we should authenticate with API key and email address
+	AuthKeyEmail = 1 << iota
+	// AuthUserService specifies that we should authenticate with a User-Service key
+	AuthUserService
+)
+
+// API holds the configuration for the current API client. A client should not
+// be modified concurrently.
+type API struct {
+	APIKey            string
+	APIEmail          string
+	APIUserServiceKey string
+	BaseURL           string
+	organizationID    string
+	headers           http.Header
+	httpClient        *http.Client
+	authType          int
+	rateLimiter       *rate.Limiter
+	retryPolicy       RetryPolicy
+	logger            Logger
+}
+
+// New creates a new Cloudflare v4 API client.
+func New(key, email string, opts ...Option) (*API, error) {
+	if key == "" || email == "" {
+		return nil, errors.New(errEmptyCredentials)
+	}
+
+	silentLogger := log.New(ioutil.Discard, "", log.LstdFlags)
+
+	api := &API{
+		APIKey:      key,
+		APIEmail:    email,
+		BaseURL:     apiURL,
+		headers:     make(http.Header),
+		authType:    AuthKeyEmail,
+		rateLimiter: rate.NewLimiter(rate.Limit(4), 1), // 4rps equates to default api limit (1200 req/5 min)
+		retryPolicy: RetryPolicy{
+			MaxRetries:    3,
+			MinRetryDelay: time.Duration(1) * time.Second,
+			MaxRetryDelay: time.Duration(30) * time.Second,
+		},
+		logger: silentLogger,
+	}
+
+	err := api.parseOptions(opts...)
+	if err != nil {
+		return nil, errors.Wrap(err, "options parsing failed")
+	}
+
+	// Fall back to http.DefaultClient if the package user does not provide
+	// their own.
+	if api.httpClient == nil {
+		api.httpClient = http.DefaultClient
+	}
+
+	return api, nil
+}
+
+// SetAuthType sets the authentication method (AuthyKeyEmail or AuthUserService).
+func (api *API) SetAuthType(authType int) {
+	api.authType = authType
+}
+
+// ZoneIDByName retrieves a zone's ID from the name.
+func (api *API) ZoneIDByName(zoneName string) (string, error) {
+	res, err := api.ListZones(zoneName)
+	if err != nil {
+		return "", errors.Wrap(err, "ListZones command failed")
+	}
+	for _, zone := range res {
+		if zone.Name == zoneName {
+			return zone.ID, nil
+		}
+	}
+	return "", errors.New("Zone could not be found")
+}
+
+// makeRequest makes a HTTP request and returns the body as a byte slice,
+// closing it before returnng. params will be serialized to JSON.
+func (api *API) makeRequest(method, uri string, params interface{}) ([]byte, error) {
+	return api.makeRequestWithAuthType(method, uri, params, api.authType)
+}
+
+func (api *API) makeRequestWithAuthType(method, uri string, params interface{}, authType int) ([]byte, error) {
+	// Replace nil with a JSON object if needed
+	var jsonBody []byte
+	var err error
+	if params != nil {
+		jsonBody, err = json.Marshal(params)
+		if err != nil {
+			return nil, errors.Wrap(err, "error marshalling params to JSON")
+		}
+	} else {
+		jsonBody = nil
+	}
+
+	var resp *http.Response
+	var respErr error
+	var reqBody io.Reader
+	var respBody []byte
+	for i := 0; i <= api.retryPolicy.MaxRetries; i++ {
+		if jsonBody != nil {
+			reqBody = bytes.NewReader(jsonBody)
+		}
+
+		if i > 0 {
+			// expect the backoff introduced here on errored requests to dominate the effect of rate limiting
+			// dont need a random component here as the rate limiter should do something similar
+			// nb time duration could truncate an arbitrary float. Since our inputs are all ints, we should be ok
+			sleepDuration := time.Duration(math.Pow(2, float64(i-1)) * float64(api.retryPolicy.MinRetryDelay))
+
+			if sleepDuration > api.retryPolicy.MaxRetryDelay {
+				sleepDuration = api.retryPolicy.MaxRetryDelay
+			}
+			// useful to do some simple logging here, maybe introduce levels later
+			api.logger.Printf("Sleeping %s before retry attempt number %d for request %s %s", sleepDuration.String(), i, method, uri)
+			time.Sleep(sleepDuration)
+		}
+		api.rateLimiter.Wait(context.TODO())
+		if err != nil {
+			return nil, errors.Wrap(err, "Error caused by request rate limiting")
+		}
+		resp, respErr = api.request(method, uri, reqBody, authType)
+
+		// retry if the server is rate limiting us or if it failed
+		// assumes server operations are rolled back on failure
+		if respErr != nil || resp.StatusCode == http.StatusTooManyRequests || resp.StatusCode >= 500 {
+			// if we got a valid http response, try to read body so we can reuse the connection
+			// see https://golang.org/pkg/net/http/#Client.Do
+			if respErr == nil {
+				respBody, err = ioutil.ReadAll(resp.Body)
+				resp.Body.Close()
+
+				respErr = errors.Wrap(err, "could not read response body")
+
+				api.logger.Printf("Request: %s %s got an error response %d: %s\n", method, uri, resp.StatusCode,
+					strings.Replace(strings.Replace(string(respBody), "\n", "", -1), "\t", "", -1))
+			} else {
+				api.logger.Printf("Error performing request: %s %s : %s \n", method, uri, respErr.Error())
+			}
+			continue
+		} else {
+			respBody, err = ioutil.ReadAll(resp.Body)
+			defer resp.Body.Close()
+			if err != nil {
+				return nil, errors.Wrap(err, "could not read response body")
+			}
+			break
+		}
+	}
+	if respErr != nil {
+		return nil, respErr
+	}
+
+	switch {
+	case resp.StatusCode >= http.StatusOK && resp.StatusCode < http.StatusMultipleChoices:
+	case resp.StatusCode == http.StatusUnauthorized:
+		return nil, errors.Errorf("HTTP status %d: invalid credentials", resp.StatusCode)
+	case resp.StatusCode == http.StatusForbidden:
+		return nil, errors.Errorf("HTTP status %d: insufficient permissions", resp.StatusCode)
+	case resp.StatusCode == http.StatusServiceUnavailable,
+		resp.StatusCode == http.StatusBadGateway,
+		resp.StatusCode == http.StatusGatewayTimeout,
+		resp.StatusCode == 522,
+		resp.StatusCode == 523,
+		resp.StatusCode == 524:
+		return nil, errors.Errorf("HTTP status %d: service failure", resp.StatusCode)
+	default:
+		var s string
+		if respBody != nil {
+			s = string(respBody)
+		}
+		return nil, errors.Errorf("HTTP status %d: content %q", resp.StatusCode, s)
+	}
+
+	return respBody, nil
+}
+
+// request makes a HTTP request to the given API endpoint, returning the raw
+// *http.Response, or an error if one occurred. The caller is responsible for
+// closing the response body.
+func (api *API) request(method, uri string, reqBody io.Reader, authType int) (*http.Response, error) {
+	req, err := http.NewRequest(method, api.BaseURL+uri, reqBody)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request creation failed")
+	}
+
+	// Apply any user-defined headers first.
+	req.Header = cloneHeader(api.headers)
+	if authType&AuthKeyEmail != 0 {
+		req.Header.Set("X-Auth-Key", api.APIKey)
+		req.Header.Set("X-Auth-Email", api.APIEmail)
+	}
+	if authType&AuthUserService != 0 {
+		req.Header.Set("X-Auth-User-Service-Key", api.APIUserServiceKey)
+	}
+
+	if req.Header.Get("Content-Type") == "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := api.httpClient.Do(req)
+	if err != nil {
+		return nil, errors.Wrap(err, "HTTP request failed")
+	}
+
+	return resp, nil
+}
+
+// Returns the base URL to use for API endpoints that exist for both accounts and organizations.
+// If an Organization option was used when creating the API instance, returns the org URL.
+//
+// accountBase is the base URL for endpoints referring to the current user. It exists as a
+// parameter because it is not consistent across APIs.
+func (api *API) userBaseURL(accountBase string) string {
+	if api.organizationID != "" {
+		return "/organizations/" + api.organizationID
+	}
+	return accountBase
+}
+
+// cloneHeader returns a shallow copy of the header.
+// copied from https://godoc.org/github.com/golang/gddo/httputil/header#Copy
+func cloneHeader(header http.Header) http.Header {
+	h := make(http.Header)
+	for k, vs := range header {
+		h[k] = vs
+	}
+	return h
+}
+
+// ResponseInfo contains a code and message returned by the API as errors or
+// informational messages inside the response.
+type ResponseInfo struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Response is a template.  There will also be a result struct.  There will be a
+// unique response type for each response, which will include this type.
+type Response struct {
+	Success  bool           `json:"success"`
+	Errors   []ResponseInfo `json:"errors"`
+	Messages []ResponseInfo `json:"messages"`
+}
+
+// ResultInfo contains metadata about the Response.
+type ResultInfo struct {
+	Page       int `json:"page"`
+	PerPage    int `json:"per_page"`
+	TotalPages int `json:"total_pages"`
+	Count      int `json:"count"`
+	Total      int `json:"total_count"`
+}
+
+// RawResponse keeps the result as JSON form
+type RawResponse struct {
+	Response
+	Result json.RawMessage `json:"result"`
+}
+
+// Raw makes a HTTP request with user provided params and returns the
+// result as untouched JSON.
+func (api *API) Raw(method, endpoint string, data interface{}) (json.RawMessage, error) {
+	res, err := api.makeRequest(method, endpoint, data)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r RawResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// PaginationOptions can be passed to a list request to configure paging
+// These values will be defaulted if omitted, and PerPage has min/max limits set by resource
+type PaginationOptions struct {
+	Page    int `json:"page,omitempty"`
+	PerPage int `json:"per_page,omitempty"`
+}
+
+// RetryPolicy specifies number of retries and min/max retry delays
+// This config is used when the client exponentially backs off after errored requests
+type RetryPolicy struct {
+	MaxRetries    int
+	MinRetryDelay time.Duration
+	MaxRetryDelay time.Duration
+}
+
+// Logger defines the interface this library needs to use logging
+// This is a subset of the methods implemented in the log package
+type Logger interface {
+	Printf(format string, v ...interface{})
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/cpage.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/cpage.go
@@ -1,0 +1,29 @@
+package cloudflare
+
+import "time"
+
+// CustomPage represents a custom page configuration.
+type CustomPage struct {
+	CreatedOn      string    `json:"created_on"`
+	ModifiedOn     time.Time `json:"modified_on"`
+	URL            string    `json:"url"`
+	State          string    `json:"state"`
+	RequiredTokens []string  `json:"required_tokens"`
+	PreviewTarget  string    `json:"preview_target"`
+	Description    string    `json:"description"`
+}
+
+// CustomPageResponse represents the response from the custom pages endpoint.
+type CustomPageResponse struct {
+	Response
+	Result []CustomPage `json:"result"`
+}
+
+// https://api.cloudflare.com/#custom-pages-for-a-zone-available-custom-pages
+// GET /zones/:zone_identifier/custom_pages
+
+// https://api.cloudflare.com/#custom-pages-for-a-zone-custom-page-details
+// GET /zones/:zone_identifier/custom_pages/:identifier
+
+// https://api.cloudflare.com/#custom-pages-for-a-zone-update-custom-page-url
+// PUT /zones/:zone_identifier/custom_pages/:identifier

--- a/vendor/github.com/cloudflare/cloudflare-go/custom_hostname.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/custom_hostname.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// CustomHostnameSSL represents the SSL section in a given custom hostname.
+type CustomHostnameSSL struct {
+	Status      string `json:"status,omitempty"`
+	Method      string `json:"method,omitempty"`
+	Type        string `json:"type,omitempty"`
+	CnameTarget string `json:"cname_target,omitempty"`
+	CnameName   string `json:"cname_name,omitempty"`
+}
+
+// CustomMetadata defines custom metadata for the hostname. This requires logic to be implemented by Cloudflare to act on the data provided.
+type CustomMetadata map[string]interface{}
+
+// CustomHostname represents a custom hostname in a zone.
+type CustomHostname struct {
+	ID             string            `json:"id,omitempty"`
+	Hostname       string            `json:"hostname,omitempty"`
+	SSL            CustomHostnameSSL `json:"ssl,omitempty"`
+	CustomMetadata CustomMetadata    `json:"custom_metadata,omitempty"`
+}
+
+// CustomHostNameResponse represents a response from the Custom Hostnames endpoints.
+type CustomHostnameResponse struct {
+	Result CustomHostname `json:"result"`
+	Response
+}
+
+// CustomHostnameListResponse represents a response from the Custom Hostnames endpoints.
+type CustomHostnameListResponse struct {
+	Result []CustomHostname `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// Modify SSL configuration for the given custom hostname in the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-update-custom-hostname-configuration
+func (api *API) UpdateCustomHostnameSSL(zoneID string, customHostnameID string, ssl CustomHostnameSSL) (CustomHostname, error) {
+	return CustomHostname{}, errors.New("Not implemented")
+}
+
+// Delete a custom hostname (and any issued SSL certificates)
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-delete-a-custom-hostname-and-any-issued-ssl-certificates-
+func (api *API) DeleteCustomHostname(zoneID string, customHostnameID string) error {
+	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// CreateCustomHostname creates a new custom hostname and requests that an SSL certificate be issued for it.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-create-custom-hostname
+func (api *API) CreateCustomHostname(zoneID string, ch CustomHostname) (*CustomHostnameResponse, error) {
+	uri := "/zones/" + zoneID + "/custom_hostnames"
+	res, err := api.makeRequest("POST", uri, ch)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response *CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// CustomHostnames fetches custom hostnames for the given zone,
+// by applying filter.Hostname if not empty and scoping the result to page'th 50 items.
+//
+// The returned ResultInfo can be used to implement pagination.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-list-custom-hostnames
+func (api *API) CustomHostnames(zoneID string, page int, filter CustomHostname) ([]CustomHostname, ResultInfo, error) {
+	v := url.Values{}
+	v.Set("per_page", "50")
+	v.Set("page", strconv.Itoa(page))
+	if filter.Hostname != "" {
+		v.Set("hostname", filter.Hostname)
+	}
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/custom_hostnames" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []CustomHostname{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var customHostnameListResponse CustomHostnameListResponse
+	err = json.Unmarshal(res, &customHostnameListResponse)
+	if err != nil {
+		return []CustomHostname{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	return customHostnameListResponse.Result, customHostnameListResponse.ResultInfo, nil
+}
+
+// CustomHostname inspects the given custom hostname in the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-hostname-for-a-zone-custom-hostname-configuration-details
+func (api *API) CustomHostname(zoneID string, customHostnameID string) (CustomHostname, error) {
+	uri := "/zones/" + zoneID + "/custom_hostnames/" + customHostnameID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return CustomHostname{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var response CustomHostnameResponse
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return CustomHostname{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// CustomHostnameIDByName retrieves the ID for the given hostname in the given zone.
+func (api *API) CustomHostnameIDByName(zoneID string, hostname string) (string, error) {
+	customHostnames, _, err := api.CustomHostnames(zoneID, 1, CustomHostname{Hostname: hostname})
+	if err != nil {
+		return "", errors.Wrap(err, "CustomHostnames command failed")
+	}
+	for _, ch := range customHostnames {
+		if ch.Hostname == hostname {
+			return ch.ID, nil
+		}
+	}
+	return "", errors.New("CustomHostname could not be found")
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/dns.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/dns.go
@@ -1,0 +1,174 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// DNSRecord represents a DNS record in a zone.
+type DNSRecord struct {
+	ID         string      `json:"id,omitempty"`
+	Type       string      `json:"type,omitempty"`
+	Name       string      `json:"name,omitempty"`
+	Content    string      `json:"content,omitempty"`
+	Proxiable  bool        `json:"proxiable,omitempty"`
+	Proxied    bool        `json:"proxied,omitempty"`
+	TTL        int         `json:"ttl,omitempty"`
+	Locked     bool        `json:"locked,omitempty"`
+	ZoneID     string      `json:"zone_id,omitempty"`
+	ZoneName   string      `json:"zone_name,omitempty"`
+	CreatedOn  time.Time   `json:"created_on,omitempty"`
+	ModifiedOn time.Time   `json:"modified_on,omitempty"`
+	Data       interface{} `json:"data,omitempty"` // data returned by: SRV, LOC
+	Meta       interface{} `json:"meta,omitempty"`
+	Priority   int         `json:"priority,omitempty"`
+}
+
+// DNSRecordResponse represents the response from the DNS endpoint.
+type DNSRecordResponse struct {
+	Result DNSRecord `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// DNSListResponse represents the response from the list DNS records endpoint.
+type DNSListResponse struct {
+	Result []DNSRecord `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateDNSRecord creates a DNS record for the zone identifier.
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-create-dns-record
+func (api *API) CreateDNSRecord(zoneID string, rr DNSRecord) (*DNSRecordResponse, error) {
+	uri := "/zones/" + zoneID + "/dns_records"
+	res, err := api.makeRequest("POST", uri, rr)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var recordResp *DNSRecordResponse
+	err = json.Unmarshal(res, &recordResp)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return recordResp, nil
+}
+
+// DNSRecords returns a slice of DNS records for the given zone identifier.
+//
+// This takes a DNSRecord to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-list-dns-records
+func (api *API) DNSRecords(zoneID string, rr DNSRecord) ([]DNSRecord, error) {
+	// Construct a query string
+	v := url.Values{}
+	// Request as many records as possible per page - API max is 50
+	v.Set("per_page", "50")
+	if rr.Name != "" {
+		v.Set("name", rr.Name)
+	}
+	if rr.Type != "" {
+		v.Set("type", rr.Type)
+	}
+	if rr.Content != "" {
+		v.Set("content", rr.Content)
+	}
+
+	var query string
+	var records []DNSRecord
+	page := 1
+
+	// Loop over makeRequest until what we've fetched all records
+	for {
+		v.Set("page", strconv.Itoa(page))
+		query = "?" + v.Encode()
+		uri := "/zones/" + zoneID + "/dns_records" + query
+		res, err := api.makeRequest("GET", uri, nil)
+		if err != nil {
+			return []DNSRecord{}, errors.Wrap(err, errMakeRequestError)
+		}
+		var r DNSListResponse
+		err = json.Unmarshal(res, &r)
+		if err != nil {
+			return []DNSRecord{}, errors.Wrap(err, errUnmarshalError)
+		}
+		records = append(records, r.Result...)
+		if r.ResultInfo.Page >= r.ResultInfo.TotalPages {
+			break
+		}
+		// Loop around and fetch the next page
+		page++
+	}
+	return records, nil
+}
+
+// DNSRecord returns a single DNS record for the given zone & record
+// identifiers.
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-dns-record-details
+func (api *API) DNSRecord(zoneID, recordID string) (DNSRecord, error) {
+	uri := "/zones/" + zoneID + "/dns_records/" + recordID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return DNSRecord{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r DNSRecordResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return DNSRecord{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// UpdateDNSRecord updates a single DNS record for the given zone & record
+// identifiers.
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-update-dns-record
+func (api *API) UpdateDNSRecord(zoneID, recordID string, rr DNSRecord) error {
+	rec, err := api.DNSRecord(zoneID, recordID)
+	if err != nil {
+		return err
+	}
+	// Populate the record name from the existing one if the update didn't
+	// specify it.
+	if rr.Name == "" {
+		rr.Name = rec.Name
+	}
+	rr.Type = rec.Type
+	uri := "/zones/" + zoneID + "/dns_records/" + recordID
+	res, err := api.makeRequest("PUT", uri, rr)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r DNSRecordResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}
+
+// DeleteDNSRecord deletes a single DNS record for the given zone & record
+// identifiers.
+//
+// API reference: https://api.cloudflare.com/#dns-records-for-a-zone-delete-dns-record
+func (api *API) DeleteDNSRecord(zoneID, recordID string) error {
+	uri := "/zones/" + zoneID + "/dns_records/" + recordID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r DNSRecordResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/errors.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/errors.go
@@ -1,0 +1,48 @@
+package cloudflare
+
+// Error messages
+const (
+	errEmptyCredentials     = "invalid credentials: key & email must not be empty"
+	errMakeRequestError     = "error from makeRequest"
+	errUnmarshalError       = "error unmarshalling the JSON response"
+	errRequestNotSuccessful = "error reported by API"
+)
+
+var _ Error = &UserError{}
+
+// Error represents an error returned from this library.
+type Error interface {
+	error
+	// Raised when user credentials or configuration is invalid.
+	User() bool
+	// Raised when a parsing error (e.g. JSON) occurs.
+	Parse() bool
+	// Raised when a network error occurs.
+	Network() bool
+	// Contains the most recent error.
+}
+
+// UserError represents a user-generated error.
+type UserError struct {
+	Err error
+}
+
+// User is a user-caused error.
+func (e *UserError) User() bool {
+	return true
+}
+
+// Network error.
+func (e *UserError) Network() bool {
+	return false
+}
+
+// Parse error.
+func (e *UserError) Parse() bool {
+	return true
+}
+
+// Error wraps the underlying error.
+func (e *UserError) Error() string {
+	return e.Err.Error()
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/firewall.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/firewall.go
@@ -1,0 +1,241 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// AccessRule represents a firewall access rule.
+type AccessRule struct {
+	ID            string                  `json:"id,omitempty"`
+	Notes         string                  `json:"notes,omitempty"`
+	AllowedModes  []string                `json:"allowed_modes,omitempty"`
+	Mode          string                  `json:"mode,omitempty"`
+	Configuration AccessRuleConfiguration `json:"configuration,omitempty"`
+	Scope         AccessRuleScope         `json:"scope,omitempty"`
+	CreatedOn     time.Time               `json:"created_on,omitempty"`
+	ModifiedOn    time.Time               `json:"modified_on,omitempty"`
+}
+
+// AccessRuleConfiguration represents the configuration of a firewall
+// access rule.
+type AccessRuleConfiguration struct {
+	Target string `json:"target,omitempty"`
+	Value  string `json:"value,omitempty"`
+}
+
+// AccessRuleScope represents the scope of a firewall access rule.
+type AccessRuleScope struct {
+	ID    string `json:"id,omitempty"`
+	Email string `json:"email,omitempty"`
+	Name  string `json:"name,omitempty"`
+	Type  string `json:"type,omitempty"`
+}
+
+// AccessRuleResponse represents the response from the firewall access
+// rule endpoint.
+type AccessRuleResponse struct {
+	Result AccessRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// AccessRuleListResponse represents the response from the list access rules
+// endpoint.
+type AccessRuleListResponse struct {
+	Result []AccessRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// ListUserAccessRules returns a slice of access rules for the logged-in user.
+//
+// This takes an AccessRule to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-list-access-rules
+func (api *API) ListUserAccessRules(accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	return api.listAccessRules("/user", accessRule, page)
+}
+
+// CreateUserAccessRule creates a firewall access rule for the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-create-access-rule
+func (api *API) CreateUserAccessRule(accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.createAccessRule("/user", accessRule)
+}
+
+// UpdateUserAccessRule updates a single access rule for the logged-in user &
+// given access rule identifier.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-update-access-rule
+func (api *API) UpdateUserAccessRule(accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.updateAccessRule("/user", accessRuleID, accessRule)
+}
+
+// DeleteUserAccessRule deletes a single access rule for the logged-in user and
+// access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#user-level-firewall-access-rule-update-access-rule
+func (api *API) DeleteUserAccessRule(accessRuleID string) (*AccessRuleResponse, error) {
+	return api.deleteAccessRule("/user", accessRuleID)
+}
+
+// ListZoneAccessRules returns a slice of access rules for the given zone
+// identifier.
+//
+// This takes an AccessRule to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-list-access-rules
+func (api *API) ListZoneAccessRules(zoneID string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	return api.listAccessRules("/zones/"+zoneID, accessRule, page)
+}
+
+// CreateZoneAccessRule creates a firewall access rule for the given zone
+// identifier.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-create-access-rule
+func (api *API) CreateZoneAccessRule(zoneID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.createAccessRule("/zones/"+zoneID, accessRule)
+}
+
+// UpdateZoneAccessRule updates a single access rule for the given zone &
+// access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-update-access-rule
+func (api *API) UpdateZoneAccessRule(zoneID, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.updateAccessRule("/zones/"+zoneID, accessRuleID, accessRule)
+}
+
+// DeleteZoneAccessRule deletes a single access rule for the given zone and
+// access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#firewall-access-rule-for-a-zone-delete-access-rule
+func (api *API) DeleteZoneAccessRule(zoneID, accessRuleID string) (*AccessRuleResponse, error) {
+	return api.deleteAccessRule("/zones/"+zoneID, accessRuleID)
+}
+
+// ListOrganizationAccessRules returns a slice of access rules for the given
+// organization identifier.
+//
+// This takes an AccessRule to allow filtering of the results returned.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-list-access-rules
+func (api *API) ListOrganizationAccessRules(organizationID string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	return api.listAccessRules("/organizations/"+organizationID, accessRule, page)
+}
+
+// CreateOrganizationAccessRule creates a firewall access rule for the given
+// organization identifier.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-create-access-rule
+func (api *API) CreateOrganizationAccessRule(organizationID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.createAccessRule("/organizations/"+organizationID, accessRule)
+}
+
+// UpdateOrganizationAccessRule updates a single access rule for the given
+// organization & access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-update-access-rule
+func (api *API) UpdateOrganizationAccessRule(organizationID, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	return api.updateAccessRule("/organizations/"+organizationID, accessRuleID, accessRule)
+}
+
+// DeleteOrganizationAccessRule deletes a single access rule for the given
+// organization and access rule identifiers.
+//
+// API reference: https://api.cloudflare.com/#organization-level-firewall-access-rule-delete-access-rule
+func (api *API) DeleteOrganizationAccessRule(organizationID, accessRuleID string) (*AccessRuleResponse, error) {
+	return api.deleteAccessRule("/organizations/"+organizationID, accessRuleID)
+}
+
+func (api *API) listAccessRules(prefix string, accessRule AccessRule, page int) (*AccessRuleListResponse, error) {
+	// Construct a query string
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+	v.Set("page", strconv.Itoa(page))
+	// Request as many rules as possible per page - API max is 100
+	v.Set("per_page", "100")
+	if accessRule.Notes != "" {
+		v.Set("notes", accessRule.Notes)
+	}
+	if accessRule.Mode != "" {
+		v.Set("mode", accessRule.Mode)
+	}
+	if accessRule.Scope.Type != "" {
+		v.Set("scope_type", accessRule.Scope.Type)
+	}
+	if accessRule.Configuration.Value != "" {
+		v.Set("configuration_value", accessRule.Configuration.Value)
+	}
+	if accessRule.Configuration.Target != "" {
+		v.Set("configuration_target", accessRule.Configuration.Target)
+	}
+	v.Set("page", strconv.Itoa(page))
+	query := "?" + v.Encode()
+
+	uri := prefix + "/firewall/access_rules/rules" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return response, nil
+}
+
+func (api *API) createAccessRule(prefix string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	uri := prefix + "/firewall/access_rules/rules"
+	res, err := api.makeRequest("POST", uri, accessRule)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+func (api *API) updateAccessRule(prefix, accessRuleID string, accessRule AccessRule) (*AccessRuleResponse, error) {
+	uri := prefix + "/firewall/access_rules/rules/" + accessRuleID
+	res, err := api.makeRequest("PATCH", uri, accessRule)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return response, nil
+}
+
+func (api *API) deleteAccessRule(prefix, accessRuleID string) (*AccessRuleResponse, error) {
+	uri := prefix + "/firewall/access_rules/rules/" + accessRuleID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &AccessRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/ips.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/ips.go
@@ -1,0 +1,44 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
+	"github.com/pkg/errors"
+)
+
+// IPRanges contains lists of IPv4 and IPv6 CIDRs.
+type IPRanges struct {
+	IPv4CIDRs []string `json:"ipv4_cidrs"`
+	IPv6CIDRs []string `json:"ipv6_cidrs"`
+}
+
+// IPsResponse is the API response containing a list of IPs.
+type IPsResponse struct {
+	Response
+	Result IPRanges `json:"result"`
+}
+
+// IPs gets a list of Cloudflare's IP ranges.
+//
+// This does not require logging in to the API.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ips
+func IPs() (IPRanges, error) {
+	resp, err := http.Get(apiURL + "/ips")
+	if err != nil {
+		return IPRanges{}, errors.Wrap(err, "HTTP request failed")
+	}
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return IPRanges{}, errors.Wrap(err, "Response body could not be read")
+	}
+	var r IPsResponse
+	err = json.Unmarshal(body, &r)
+	if err != nil {
+		return IPRanges{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/keyless.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/keyless.go
@@ -1,0 +1,52 @@
+package cloudflare
+
+import "time"
+
+// KeylessSSL represents Keyless SSL configuration.
+type KeylessSSL struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	Host        string    `json:"host"`
+	Port        int       `json:"port"`
+	Status      string    `json:"success"`
+	Enabled     bool      `json:"enabled"`
+	Permissions []string  `json:"permissions"`
+	CreatedOn   time.Time `json:"created_on"`
+	ModifiedOn  time.Time `json:"modifed_on"`
+}
+
+// KeylessSSLResponse represents the response from the Keyless SSL endpoint.
+type KeylessSSLResponse struct {
+	Response
+	Result []KeylessSSL `json:"result"`
+}
+
+// CreateKeyless creates a new Keyless SSL configuration for the zone.
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-create-a-keyless-ssl-configuration
+func (api *API) CreateKeyless() {
+}
+
+// ListKeyless lists Keyless SSL configurations for a zone.
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-list-keyless-ssls
+func (api *API) ListKeyless() {
+}
+
+// Keyless provides the configuration for a given Keyless SSL identifier.
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-keyless-ssl-details
+func (api *API) Keyless() {
+}
+
+// UpdateKeyless updates an existing Keyless SSL configuration.
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-update-keyless-configuration
+func (api *API) UpdateKeyless() {
+}
+
+// DeleteKeyless deletes an existing Keyless SSL configuration.
+//
+// API reference: https://api.cloudflare.com/#keyless-ssl-for-a-zone-delete-keyless-configuration
+func (api *API) DeleteKeyless() {
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/load_balancing.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/load_balancing.go
@@ -1,0 +1,330 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// LoadBalancerPool represents a load balancer pool's properties.
+type LoadBalancerPool struct {
+	ID                string               `json:"id,omitempty"`
+	CreatedOn         *time.Time           `json:"created_on,omitempty"`
+	ModifiedOn        *time.Time           `json:"modified_on,omitempty"`
+	Description       string               `json:"description"`
+	Name              string               `json:"name"`
+	Enabled           bool                 `json:"enabled"`
+	MinimumOrigins    int                  `json:"minimum_origins,omitempty"`
+	Monitor           string               `json:"monitor,omitempty"`
+	Origins           []LoadBalancerOrigin `json:"origins"`
+	NotificationEmail string               `json:"notification_email,omitempty"`
+
+	// CheckRegions defines the geographic region(s) from where to run health-checks from - e.g. "WNAM", "WEU", "SAF", "SAM".
+	// Providing a null/empty value means "all regions", which may not be available to all plan types.
+	CheckRegions []string `json:"check_regions"`
+}
+
+type LoadBalancerOrigin struct {
+	Name    string  `json:"name"`
+	Address string  `json:"address"`
+	Enabled bool    `json:"enabled"`
+	Weight  float64 `json:"weight"`
+}
+
+// LoadBalancerMonitor represents a load balancer monitor's properties.
+type LoadBalancerMonitor struct {
+	ID            string              `json:"id,omitempty"`
+	CreatedOn     *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn    *time.Time          `json:"modified_on,omitempty"`
+	Type          string              `json:"type"`
+	Description   string              `json:"description"`
+	Method        string              `json:"method"`
+	Path          string              `json:"path"`
+	Header        map[string][]string `json:"header"`
+	Timeout       int                 `json:"timeout"`
+	Retries       int                 `json:"retries"`
+	Interval      int                 `json:"interval"`
+	ExpectedBody  string              `json:"expected_body"`
+	ExpectedCodes string              `json:"expected_codes"`
+}
+
+// LoadBalancer represents a load balancer's properties.
+type LoadBalancer struct {
+	ID           string              `json:"id,omitempty"`
+	CreatedOn    *time.Time          `json:"created_on,omitempty"`
+	ModifiedOn   *time.Time          `json:"modified_on,omitempty"`
+	Description  string              `json:"description"`
+	Name         string              `json:"name"`
+	TTL          int                 `json:"ttl,omitempty"`
+	FallbackPool string              `json:"fallback_pool"`
+	DefaultPools []string            `json:"default_pools"`
+	RegionPools  map[string][]string `json:"region_pools"`
+	PopPools     map[string][]string `json:"pop_pools"`
+	Proxied      bool                `json:"proxied"`
+	Persistence  string              `json:"session_affinity,omitempty"`
+}
+
+// loadBalancerPoolResponse represents the response from the load balancer pool endpoints.
+type loadBalancerPoolResponse struct {
+	Response
+	Result LoadBalancerPool `json:"result"`
+}
+
+// loadBalancerPoolListResponse represents the response from the List Pools endpoint.
+type loadBalancerPoolListResponse struct {
+	Response
+	Result     []LoadBalancerPool `json:"result"`
+	ResultInfo ResultInfo         `json:"result_info"`
+}
+
+// loadBalancerMonitorResponse represents the response from the load balancer monitor endpoints.
+type loadBalancerMonitorResponse struct {
+	Response
+	Result LoadBalancerMonitor `json:"result"`
+}
+
+// loadBalancerMonitorListResponse represents the response from the List Monitors endpoint.
+type loadBalancerMonitorListResponse struct {
+	Response
+	Result     []LoadBalancerMonitor `json:"result"`
+	ResultInfo ResultInfo            `json:"result_info"`
+}
+
+// loadBalancerResponse represents the response from the load balancer endpoints.
+type loadBalancerResponse struct {
+	Response
+	Result LoadBalancer `json:"result"`
+}
+
+// loadBalancerListResponse represents the response from the List Load Balancers endpoint.
+type loadBalancerListResponse struct {
+	Response
+	Result     []LoadBalancer `json:"result"`
+	ResultInfo ResultInfo     `json:"result_info"`
+}
+
+// CreateLoadBalancerPool creates a new load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-create-a-pool
+func (api *API) CreateLoadBalancerPool(pool LoadBalancerPool) (LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools"
+	res, err := api.makeRequest("POST", uri, pool)
+	if err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListLoadBalancerPools lists load balancer pools connected to an account.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-list-pools
+func (api *API) ListLoadBalancerPools() ([]LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolListResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LoadBalancerPoolDetails returns the details for a load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-pool-details
+func (api *API) LoadBalancerPoolDetails(poolID string) (LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools/" + poolID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteLoadBalancerPool disables and deletes a load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-delete-a-pool
+func (api *API) DeleteLoadBalancerPool(poolID string) error {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools/" + poolID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ModifyLoadBalancerPool modifies a configured load balancer pool.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-pools-modify-a-pool
+func (api *API) ModifyLoadBalancerPool(pool LoadBalancerPool) (LoadBalancerPool, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/pools/" + pool.ID
+	res, err := api.makeRequest("PUT", uri, pool)
+	if err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerPoolResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerPool{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// CreateLoadBalancerMonitor creates a new load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-create-a-monitor
+func (api *API) CreateLoadBalancerMonitor(monitor LoadBalancerMonitor) (LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors"
+	res, err := api.makeRequest("POST", uri, monitor)
+	if err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListLoadBalancerMonitors lists load balancer monitors connected to an account.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-list-monitors
+func (api *API) ListLoadBalancerMonitors() ([]LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorListResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LoadBalancerMonitorDetails returns the details for a load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-monitor-details
+func (api *API) LoadBalancerMonitorDetails(monitorID string) (LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors/" + monitorID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteLoadBalancerMonitor disables and deletes a load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-delete-a-monitor
+func (api *API) DeleteLoadBalancerMonitor(monitorID string) error {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors/" + monitorID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ModifyLoadBalancerMonitor modifies a configured load balancer monitor.
+//
+// API reference: https://api.cloudflare.com/#load-balancer-monitors-modify-a-monitor
+func (api *API) ModifyLoadBalancerMonitor(monitor LoadBalancerMonitor) (LoadBalancerMonitor, error) {
+	uri := api.userBaseURL("/user") + "/load_balancers/monitors/" + monitor.ID
+	res, err := api.makeRequest("PUT", uri, monitor)
+	if err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerMonitorResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancerMonitor{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// CreateLoadBalancer creates a new load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-create-a-load-balancer
+func (api *API) CreateLoadBalancer(zoneID string, lb LoadBalancer) (LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers"
+	res, err := api.makeRequest("POST", uri, lb)
+	if err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListLoadBalancers lists load balancers configured on a zone.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-list-load-balancers
+func (api *API) ListLoadBalancers(zoneID string) ([]LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerListResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// LoadBalancerDetails returns the details for a load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-load-balancer-details
+func (api *API) LoadBalancerDetails(zoneID, lbID string) (LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers/" + lbID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteLoadBalancer disables and deletes a load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-delete-a-load-balancer
+func (api *API) DeleteLoadBalancer(zoneID, lbID string) error {
+	uri := "/zones/" + zoneID + "/load_balancers/" + lbID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ModifyLoadBalancer modifies a configured load balancer.
+//
+// API reference: https://api.cloudflare.com/#load-balancers-modify-a-load-balancer
+func (api *API) ModifyLoadBalancer(zoneID string, lb LoadBalancer) (LoadBalancer, error) {
+	uri := "/zones/" + zoneID + "/load_balancers/" + lb.ID
+	res, err := api.makeRequest("PUT", uri, lb)
+	if err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r loadBalancerResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return LoadBalancer{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/lockdown.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/lockdown.go
@@ -1,0 +1,150 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// ZoneLockdown represents a Zone Lockdown rule. A rule only permits access to
+// the provided URL pattern(s) from the given IP address(es) or subnet(s).
+type ZoneLockdown struct {
+	ID             string               `json:"id"`
+	Description    string               `json:"description"`
+	URLs           []string             `json:"urls"`
+	Configurations []ZoneLockdownConfig `json:"configurations"`
+	Paused         bool                 `json:"paused"`
+}
+
+// ZoneLockdownConfig represents a Zone Lockdown config, which comprises
+// a Target ("ip" or "ip_range") and a Value (an IP address or IP+mask,
+// respectively.)
+type ZoneLockdownConfig struct {
+	Target string `json:"target"`
+	Value  string `json:"value"`
+}
+
+// ZoneLockdownResponse represents a response from the Zone Lockdown endpoint.
+type ZoneLockdownResponse struct {
+	Result ZoneLockdown `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// ZoneLockdownListResponse represents a response from the List Zone Lockdown
+// endpoint.
+type ZoneLockdownListResponse struct {
+	Result []ZoneLockdown `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateZoneLockdown creates a Zone ZoneLockdown rule for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-create-a-ZoneLockdown-rule
+func (api *API) CreateZoneLockdown(zoneID string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns"
+	res, err := api.makeRequest("POST", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateZoneLockdown updates a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-update-ZoneLockdown-rule
+func (api *API) UpdateZoneLockdown(zoneID string, id string, ld ZoneLockdown) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns"
+	res, err := api.makeRequest("PUT", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// DeleteZoneLockdown deletes a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-delete-ZoneLockdown-rule
+func (api *API) DeleteZoneLockdown(zoneID string, id string) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns/" + id
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ZoneLockdown retrieves a Zone ZoneLockdown rule (based on the ID) for the
+// given zone ID.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-ZoneLockdown-rule-details
+func (api *API) ZoneLockdown(zoneID string, id string) (*ZoneLockdownResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/lockdowns/" + id
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ListZoneLockdowns retrieves a list of Zone ZoneLockdown rules for a given
+// zone ID by page number.
+//
+// API reference: https://api.cloudflare.com/#zone-ZoneLockdown-list-ZoneLockdown-rules
+func (api *API) ListZoneLockdowns(zoneID string, page int) (*ZoneLockdownListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/lockdowns" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneLockdownListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/options.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/options.go
@@ -1,0 +1,90 @@
+package cloudflare
+
+import (
+	"net/http"
+
+	"time"
+
+	"golang.org/x/time/rate"
+)
+
+// Option is a functional option for configuring the API client.
+type Option func(*API) error
+
+// HTTPClient accepts a custom *http.Client for making API calls.
+func HTTPClient(client *http.Client) Option {
+	return func(api *API) error {
+		api.httpClient = client
+		return nil
+	}
+}
+
+// Headers allows you to set custom HTTP headers when making API calls (e.g. for
+// satisfying HTTP proxies, or for debugging).
+func Headers(headers http.Header) Option {
+	return func(api *API) error {
+		api.headers = headers
+		return nil
+	}
+}
+
+// Organization allows you to apply account-level changes (Load Balancing, Railguns)
+// to an organization instead.
+func UsingOrganization(orgID string) Option {
+	return func(api *API) error {
+		api.organizationID = orgID
+		return nil
+	}
+}
+
+// UsingRateLimit applies a non-default rate limit to client API requests
+// If not specified the default of 4rps will be applied
+func UsingRateLimit(rps float64) Option {
+	return func(api *API) error {
+		// because ratelimiter doesnt do any windowing
+		// setting burst makes it difficult to enforce a fixed rate
+		// so setting it equal to 1 this effectively disables bursting
+		// this doesn't check for sensible values, ultimately the api will enforce that the value is ok
+		api.rateLimiter = rate.NewLimiter(rate.Limit(rps), 1)
+		return nil
+	}
+}
+
+// UsingRetryPolicy applies a non-default number of retries and min/max retry delays
+// This will be used when the client exponentially backs off after errored requests
+func UsingRetryPolicy(maxRetries int, minRetryDelaySecs int, maxRetryDelaySecs int) Option {
+	// seconds is very granular for a minimum delay - but this is only in case of failure
+	return func(api *API) error {
+		api.retryPolicy = RetryPolicy{
+			MaxRetries:    maxRetries,
+			MinRetryDelay: time.Duration(minRetryDelaySecs) * time.Second,
+			MaxRetryDelay: time.Duration(maxRetryDelaySecs) * time.Second,
+		}
+		return nil
+	}
+}
+
+// UsingLogger can be set if you want to get log output from this API instance
+// By default no log output is emitted
+func UsingLogger(logger Logger) Option {
+	return func(api *API) error {
+		api.logger = logger
+		return nil
+	}
+}
+
+// parseOptions parses the supplied options functions and returns a configured
+// *API instance.
+func (api *API) parseOptions(opts ...Option) error {
+	// Range over each options function and apply it to our API type to
+	// configure it. Options functions are applied in order, with any
+	// conflicting options overriding earlier calls.
+	for _, option := range opts {
+		err := option(api)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/organizations.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/organizations.go
@@ -1,0 +1,185 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Organization represents a multi-user organization.
+type Organization struct {
+	ID          string   `json:"id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Status      string   `json:"status,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+	Roles       []string `json:"roles,omitempty"`
+}
+
+// organizationResponse represents the response from the Organization endpoint.
+type organizationResponse struct {
+	Response
+	Result     []Organization `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationMember has details on a member.
+type OrganizationMember struct {
+	ID     string             `json:"id,omitempty"`
+	Name   string             `json:"name,omitempty"`
+	Email  string             `json:"email,omitempty"`
+	Status string             `json:"status,omitempty"`
+	Roles  []OrganizationRole `json:"roles,omitempty"`
+}
+
+// OrganizationInvite has details on an invite.
+type OrganizationInvite struct {
+	ID                 string             `json:"id,omitempty"`
+	InvitedMemberID    string             `json:"invited_member_id,omitempty"`
+	InvitedMemberEmail string             `json:"invited_member_email,omitempty"`
+	OrganizationID     string             `json:"organization_id,omitempty"`
+	OrganizationName   string             `json:"organization_name,omitempty"`
+	Roles              []OrganizationRole `json:"roles,omitempty"`
+	InvitedBy          string             `json:"invited_by,omitempty"`
+	InvitedOn          *time.Time         `json:"invited_on,omitempty"`
+	ExpiresOn          *time.Time         `json:"expires_on,omitempty"`
+	Status             string             `json:"status,omitempty"`
+}
+
+// OrganizationRole has details on a role.
+type OrganizationRole struct {
+	ID          string   `json:"id,omitempty"`
+	Name        string   `json:"name,omitempty"`
+	Description string   `json:"description,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+// OrganizationDetails represents details of an organization.
+type OrganizationDetails struct {
+	ID      string               `json:"id,omitempty"`
+	Name    string               `json:"name,omitempty"`
+	Members []OrganizationMember `json:"members"`
+	Invites []OrganizationInvite `json:"invites"`
+	Roles   []OrganizationRole   `json:"roles,omitempty"`
+}
+
+// organizationDetailsResponse represents the response from the OrganizationDetails endpoint.
+type organizationDetailsResponse struct {
+	Response
+	Result OrganizationDetails `json:"result"`
+}
+
+// ListOrganizations lists organizations of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#user-s-organizations-list-organizations
+func (api *API) ListOrganizations() ([]Organization, ResultInfo, error) {
+	var r organizationResponse
+	res, err := api.makeRequest("GET", "/user/organizations", nil)
+	if err != nil {
+		return []Organization{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []Organization{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
+// OrganizationDetails returns details for the specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organizations-organization-details
+func (api *API) OrganizationDetails(organizationID string) (OrganizationDetails, error) {
+	var r organizationDetailsResponse
+	uri := "/organizations/" + organizationID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return OrganizationDetails{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return OrganizationDetails{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// organizationMembersResponse represents the response from the Organization members endpoint.
+type organizationMembersResponse struct {
+	Response
+	Result     []OrganizationMember `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationMembers returns list of members for specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-members-list-members
+func (api *API) OrganizationMembers(organizationID string) ([]OrganizationMember, ResultInfo, error) {
+	var r organizationMembersResponse
+	uri := "/organizations/" + organizationID + "/members"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []OrganizationMember{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationMember{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
+// organizationInvitesResponse represents the response from the Organization invites endpoint.
+type organizationInvitesResponse struct {
+	Response
+	Result     []OrganizationInvite `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationMembers returns list of invites for specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-invites
+func (api *API) OrganizationInvites(organizationID string) ([]OrganizationInvite, ResultInfo, error) {
+	var r organizationInvitesResponse
+	uri := "/organizations/" + organizationID + "/invites"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []OrganizationInvite{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationInvite{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}
+
+// organizationRolesResponse represents the response from the Organization roles endpoint.
+type organizationRolesResponse struct {
+	Response
+	Result     []OrganizationRole `json:"result"`
+	ResultInfo `json:"result_info"`
+}
+
+// OrganizationRoles returns list of roles for specified organization of the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#organization-roles-list-roles
+func (api *API) OrganizationRoles(organizationID string) ([]OrganizationRole, ResultInfo, error) {
+	var r organizationRolesResponse
+	uri := "/organizations/" + organizationID + "/roles"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []OrganizationRole{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []OrganizationRole{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, r.ResultInfo, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/origin_ca.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/origin_ca.go
@@ -1,0 +1,168 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// OriginCACertificate represents a Cloudflare-issued certificate.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca
+type OriginCACertificate struct {
+	ID              string    `json:"id"`
+	Certificate     string    `json:"certificate"`
+	Hostnames       []string  `json:"hostnames"`
+	ExpiresOn       time.Time `json:"expires_on"`
+	RequestType     string    `json:"request_type"`
+	RequestValidity int       `json:"requested_validity"`
+	CSR             string    `json:"csr"`
+}
+
+// OriginCACertificateListOptions represents the parameters used to list Cloudflare-issued certificates.
+type OriginCACertificateListOptions struct {
+	ZoneID string
+}
+
+// OriginCACertificateID represents the ID of the revoked certificate from the Revoke Certificate endpoint.
+type OriginCACertificateID struct {
+	ID string `json:"id"`
+}
+
+// originCACertificateResponse represents the response from the Create Certificate and the Certificate Details endpoints.
+type originCACertificateResponse struct {
+	Response
+	Result OriginCACertificate `json:"result"`
+}
+
+// originCACertificateResponseList represents the response from the List Certificates endpoint.
+type originCACertificateResponseList struct {
+	Response
+	Result     []OriginCACertificate `json:"result"`
+	ResultInfo ResultInfo            `json:"result_info"`
+}
+
+// originCACertificateResponseRevoke represents the response from the Revoke Certificate endpoint.
+type originCACertificateResponseRevoke struct {
+	Response
+	Result OriginCACertificateID `json:"result"`
+}
+
+// CreateOriginCertificate creates a Cloudflare-signed certificate.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-create-certificate
+func (api *API) CreateOriginCertificate(certificate OriginCACertificate) (*OriginCACertificate, error) {
+	uri := "/certificates"
+	res, err := api.makeRequestWithAuthType("POST", uri, certificate, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponse
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return &originResponse.Result, nil
+}
+
+// OriginCertificates lists all Cloudflare-issued certificates.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-list-certificates
+func (api *API) OriginCertificates(options OriginCACertificateListOptions) ([]OriginCACertificate, error) {
+	v := url.Values{}
+	if options.ZoneID != "" {
+		v.Set("zone_id", options.ZoneID)
+	}
+	uri := "/certificates" + "?" + v.Encode()
+	res, err := api.makeRequestWithAuthType("GET", uri, nil, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponseList
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return originResponse.Result, nil
+}
+
+// OriginCertificate returns the details for a Cloudflare-issued certificate.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-certificate-details
+func (api *API) OriginCertificate(certificateID string) (*OriginCACertificate, error) {
+	uri := "/certificates/" + certificateID
+	res, err := api.makeRequestWithAuthType("GET", uri, nil, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponse
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return &originResponse.Result, nil
+}
+
+// RevokeOriginCertificate revokes a created certificate for a zone.
+//
+// This function requires api.APIUserServiceKey be set to your Certificates API key.
+//
+// API reference: https://api.cloudflare.com/#cloudflare-ca-revoke-certificate
+func (api *API) RevokeOriginCertificate(certificateID string) (*OriginCACertificateID, error) {
+	uri := "/certificates/" + certificateID
+	res, err := api.makeRequestWithAuthType("DELETE", uri, nil, AuthUserService)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var originResponse *originCACertificateResponseRevoke
+
+	err = json.Unmarshal(res, &originResponse)
+
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	if !originResponse.Success {
+		return nil, errors.New(errRequestNotSuccessful)
+	}
+
+	return &originResponse.Result, nil
+
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/page_rules.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/page_rules.go
@@ -1,0 +1,206 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// PageRuleTarget is the target to evaluate on a request.
+//
+// Currently Target must always be "url" and Operator must be "matches". Value
+// is the URL pattern to match against.
+type PageRuleTarget struct {
+	Target     string `json:"target"`
+	Constraint struct {
+		Operator string `json:"operator"`
+		Value    string `json:"value"`
+	} `json:"constraint"`
+}
+
+/*
+PageRuleAction is the action to take when the target is matched.
+
+Valid IDs are:
+
+  always_online
+  always_use_https
+  browser_cache_ttl
+  browser_check
+  cache_level
+  disable_apps
+  disable_performance
+  disable_railgun
+  disable_security
+  edge_cache_ttl
+  email_obfuscation
+  forwarding_url
+  ip_geolocation
+  mirage
+  rocket_loader
+  security_level
+  server_side_exclude
+  smart_errors
+  ssl
+  waf
+*/
+type PageRuleAction struct {
+	ID    string      `json:"id"`
+	Value interface{} `json:"value"`
+}
+
+// PageRuleActions maps API action IDs to human-readable strings.
+var PageRuleActions = map[string]string{
+	"always_online":       "Always Online",            // Value of type string
+	"always_use_https":    "Always Use HTTPS",         // Value of type interface{}
+	"browser_cache_ttl":   "Browser Cache TTL",        // Value of type int
+	"browser_check":       "Browser Integrity Check",  // Value of type string
+	"cache_level":         "Cache Level",              // Value of type string
+	"disable_apps":        "Disable Apps",             // Value of type interface{}
+	"disable_performance": "Disable Performance",      // Value of type interface{}
+	"disable_railgun":     "Disable Railgun",          // Value of type string
+	"disable_security":    "Disable Security",         // Value of type interface{}
+	"edge_cache_ttl":      "Edge Cache TTL",           // Value of type int
+	"email_obfuscation":   "Email Obfuscation",        // Value of type string
+	"forwarding_url":      "Forwarding URL",           // Value of type map[string]interface
+	"ip_geolocation":      "IP Geolocation Header",    // Value of type string
+	"mirage":              "Mirage",                   // Value of type string
+	"rocket_loader":       "Rocker Loader",            // Value of type string
+	"security_level":      "Security Level",           // Value of type string
+	"server_side_exclude": "Server Side Excludes",     // Value of type string
+	"smart_errors":        "Smart Errors",             // Value of type string
+	"ssl":                 "SSL",                      // Value of type string
+	"waf":                 "Web Application Firewall", // Value of type string
+}
+
+// PageRule describes a Page Rule.
+type PageRule struct {
+	ID         string           `json:"id,omitempty"`
+	Targets    []PageRuleTarget `json:"targets"`
+	Actions    []PageRuleAction `json:"actions"`
+	Priority   int              `json:"priority"`
+	Status     string           `json:"status"` // can be: active, paused
+	ModifiedOn time.Time        `json:"modified_on,omitempty"`
+	CreatedOn  time.Time        `json:"created_on,omitempty"`
+}
+
+// PageRuleDetailResponse is the API response, containing a single PageRule.
+type PageRuleDetailResponse struct {
+	Success  bool     `json:"success"`
+	Errors   []string `json:"errors"`
+	Messages []string `json:"messages"`
+	Result   PageRule `json:"result"`
+}
+
+// PageRulesResponse is the API response, containing an array of PageRules.
+type PageRulesResponse struct {
+	Success  bool       `json:"success"`
+	Errors   []string   `json:"errors"`
+	Messages []string   `json:"messages"`
+	Result   []PageRule `json:"result"`
+}
+
+// CreatePageRule creates a new Page Rule for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-create-a-page-rule
+func (api *API) CreatePageRule(zoneID string, rule PageRule) (*PageRule, error) {
+	uri := "/zones/" + zoneID + "/pagerules"
+	res, err := api.makeRequest("POST", uri, rule)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PageRuleDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return &r.Result, nil
+}
+
+// ListPageRules returns all Page Rules for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-list-page-rules
+func (api *API) ListPageRules(zoneID string) ([]PageRule, error) {
+	uri := "/zones/" + zoneID + "/pagerules"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []PageRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PageRulesResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []PageRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// PageRule fetches detail about one Page Rule for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-page-rule-details
+func (api *API) PageRule(zoneID, ruleID string) (PageRule, error) {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return PageRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PageRuleDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return PageRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ChangePageRule lets you change individual settings for a Page Rule. This is
+// in contrast to UpdatePageRule which replaces the entire Page Rule.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-change-a-page-rule
+func (api *API) ChangePageRule(zoneID, ruleID string, rule PageRule) error {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
+	res, err := api.makeRequest("PATCH", uri, rule)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r PageRuleDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}
+
+// UpdatePageRule lets you replace a Page Rule. This is in contrast to
+// ChangePageRule which lets you change individual settings.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-update-a-page-rule
+func (api *API) UpdatePageRule(zoneID, ruleID string, rule PageRule) error {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
+	res, err := api.makeRequest("PUT", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r PageRuleDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}
+
+// DeletePageRule deletes a Page Rule for a zone.
+//
+// API reference: https://api.cloudflare.com/#page-rules-for-a-zone-delete-a-page-rule
+func (api *API) DeletePageRule(zoneID, ruleID string) error {
+	uri := "/zones/" + zoneID + "/pagerules/" + ruleID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r PageRuleDetailResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/railgun.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/railgun.go
@@ -1,0 +1,297 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Railgun represents a Railgun's properties.
+type Railgun struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Status         string    `json:"status"`
+	Enabled        bool      `json:"enabled"`
+	ZonesConnected int       `json:"zones_connected"`
+	Build          string    `json:"build"`
+	Version        string    `json:"version"`
+	Revision       string    `json:"revision"`
+	ActivationKey  string    `json:"activation_key"`
+	ActivatedOn    time.Time `json:"activated_on"`
+	CreatedOn      time.Time `json:"created_on"`
+	ModifiedOn     time.Time `json:"modified_on"`
+	UpgradeInfo    struct {
+		LatestVersion string `json:"latest_version"`
+		DownloadLink  string `json:"download_link"`
+	} `json:"upgrade_info"`
+}
+
+// RailgunListOptions represents the parameters used to list railguns.
+type RailgunListOptions struct {
+	Direction string
+}
+
+// railgunResponse represents the response from the Create Railgun and the Railgun Details endpoints.
+type railgunResponse struct {
+	Response
+	Result Railgun `json:"result"`
+}
+
+// railgunsResponse represents the response from the List Railguns endpoint.
+type railgunsResponse struct {
+	Response
+	Result []Railgun `json:"result"`
+}
+
+// CreateRailgun creates a new Railgun.
+//
+// API reference: https://api.cloudflare.com/#railgun-create-railgun
+func (api *API) CreateRailgun(name string) (Railgun, error) {
+	uri := api.userBaseURL("") + "/railguns"
+	params := struct {
+		Name string `json:"name"`
+	}{
+		Name: name,
+	}
+	res, err := api.makeRequest("POST", uri, params)
+	if err != nil {
+		return Railgun{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r railgunResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return Railgun{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListRailguns lists Railguns connected to an account.
+//
+// API reference: https://api.cloudflare.com/#railgun-list-railguns
+func (api *API) ListRailguns(options RailgunListOptions) ([]Railgun, error) {
+	v := url.Values{}
+	if options.Direction != "" {
+		v.Set("direction", options.Direction)
+	}
+	uri := api.userBaseURL("") + "/railguns" + "?" + v.Encode()
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r railgunsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// RailgunDetails returns the details for a Railgun.
+//
+// API reference: https://api.cloudflare.com/#railgun-railgun-details
+func (api *API) RailgunDetails(railgunID string) (Railgun, error) {
+	uri := api.userBaseURL("") + "/railguns/" + railgunID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return Railgun{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r railgunResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return Railgun{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// RailgunZones returns the zones that are currently using a Railgun.
+//
+// API reference: https://api.cloudflare.com/#railgun-get-zones-connected-to-a-railgun
+func (api *API) RailgunZones(railgunID string) ([]Zone, error) {
+	uri := api.userBaseURL("") + "/railguns/" + railgunID + "/zones"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZonesResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// enableRailgun enables (true) or disables (false) a Railgun for all zones connected to it.
+//
+// API reference: https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
+func (api *API) enableRailgun(railgunID string, enable bool) (Railgun, error) {
+	uri := api.userBaseURL("") + "/railguns/" + railgunID
+	params := struct {
+		Enabled bool `json:"enabled"`
+	}{
+		Enabled: enable,
+	}
+	res, err := api.makeRequest("PATCH", uri, params)
+	if err != nil {
+		return Railgun{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r railgunResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return Railgun{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// EnableRailgun enables a Railgun for all zones connected to it.
+//
+// API reference: https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
+func (api *API) EnableRailgun(railgunID string) (Railgun, error) {
+	return api.enableRailgun(railgunID, true)
+}
+
+// DisableRailgun enables a Railgun for all zones connected to it.
+//
+// API reference: https://api.cloudflare.com/#railgun-enable-or-disable-a-railgun
+func (api *API) DisableRailgun(railgunID string) (Railgun, error) {
+	return api.enableRailgun(railgunID, false)
+}
+
+// DeleteRailgun disables and deletes a Railgun.
+//
+// API reference: https://api.cloudflare.com/#railgun-delete-railgun
+func (api *API) DeleteRailgun(railgunID string) error {
+	uri := api.userBaseURL("") + "/railguns/" + railgunID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}
+
+// ZoneRailgun represents the status of a Railgun on a zone.
+type ZoneRailgun struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	Enabled   bool   `json:"enabled"`
+	Connected bool   `json:"connected"`
+}
+
+// zoneRailgunResponse represents the response from the Zone Railgun Details endpoint.
+type zoneRailgunResponse struct {
+	Response
+	Result ZoneRailgun `json:"result"`
+}
+
+// zoneRailgunsResponse represents the response from the Zone Railgun endpoint.
+type zoneRailgunsResponse struct {
+	Response
+	Result []ZoneRailgun `json:"result"`
+}
+
+// RailgunDiagnosis represents the test results from testing railgun connections
+// to a zone.
+type RailgunDiagnosis struct {
+	Method          string `json:"method"`
+	HostName        string `json:"host_name"`
+	HTTPStatus      int    `json:"http_status"`
+	Railgun         string `json:"railgun"`
+	URL             string `json:"url"`
+	ResponseStatus  string `json:"response_status"`
+	Protocol        string `json:"protocol"`
+	ElapsedTime     string `json:"elapsed_time"`
+	BodySize        string `json:"body_size"`
+	BodyHash        string `json:"body_hash"`
+	MissingHeaders  string `json:"missing_headers"`
+	ConnectionClose bool   `json:"connection_close"`
+	Cloudflare      string `json:"cloudflare"`
+	CFRay           string `json:"cf-ray"`
+	// NOTE: Cloudflare's online API documentation does not yet have definitions
+	// for the following fields. See: https://api.cloudflare.com/#railgun-connections-for-a-zone-test-railgun-connection/
+	CFWANError    string `json:"cf-wan-error"`
+	CFCacheStatus string `json:"cf-cache-status"`
+}
+
+// railgunDiagnosisResponse represents the response from the Test Railgun Connection enpoint.
+type railgunDiagnosisResponse struct {
+	Response
+	Result RailgunDiagnosis `json:"result"`
+}
+
+// ZoneRailguns returns the available Railguns for a zone.
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-get-available-railguns
+func (api *API) ZoneRailguns(zoneID string) ([]ZoneRailgun, error) {
+	uri := "/zones/" + zoneID + "/railguns"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneRailgunsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ZoneRailgunDetails returns the configuration for a given Railgun.
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-get-railgun-details
+func (api *API) ZoneRailgunDetails(zoneID, railgunID string) (ZoneRailgun, error) {
+	uri := "/zones/" + zoneID + "/railguns/" + railgunID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ZoneRailgun{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneRailgunResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return ZoneRailgun{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// TestRailgunConnection tests a Railgun connection for a given zone.
+//
+// API reference: https://api.cloudflare.com/#railgun-connections-for-a-zone-test-railgun-connection
+func (api *API) TestRailgunConnection(zoneID, railgunID string) (RailgunDiagnosis, error) {
+	uri := "/zones/" + zoneID + "/railguns/" + railgunID + "/diagnose"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return RailgunDiagnosis{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r railgunDiagnosisResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return RailgunDiagnosis{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// connectZoneRailgun connects (true) or disconnects (false) a Railgun for a given zone.
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
+func (api *API) connectZoneRailgun(zoneID, railgunID string, connect bool) (ZoneRailgun, error) {
+	uri := "/zones/" + zoneID + "/railguns/" + railgunID
+	params := struct {
+		Connected bool `json:"connected"`
+	}{
+		Connected: connect,
+	}
+	res, err := api.makeRequest("PATCH", uri, params)
+	if err != nil {
+		return ZoneRailgun{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneRailgunResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return ZoneRailgun{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ConnectZoneRailgun connects a Railgun for a given zone.
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
+func (api *API) ConnectZoneRailgun(zoneID, railgunID string) (ZoneRailgun, error) {
+	return api.connectZoneRailgun(zoneID, railgunID, true)
+}
+
+// DisconnectZoneRailgun disconnects a Railgun for a given zone.
+//
+// API reference: https://api.cloudflare.com/#railguns-for-a-zone-connect-or-disconnect-a-railgun
+func (api *API) DisconnectZoneRailgun(zoneID, railgunID string) (ZoneRailgun, error) {
+	return api.connectZoneRailgun(zoneID, railgunID, false)
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/rate_limiting.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/rate_limiting.go
@@ -1,0 +1,195 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// RateLimit is a policy than can be applied to limit traffic within a customer domain
+type RateLimit struct {
+	ID          string                  `json:"id,omitempty"`
+	Disabled    bool                    `json:"disabled,omitempty"`
+	Description string                  `json:"description,omitempty"`
+	Match       RateLimitTrafficMatcher `json:"match"`
+	Bypass      []RateLimitKeyValue     `json:"bypass,omitempty"`
+	Threshold   int                     `json:"threshold"`
+	Period      int                     `json:"period"`
+	Action      RateLimitAction         `json:"action"`
+}
+
+// RateLimitTrafficMatcher contains the rules that will be used to apply a rate limit to traffic
+type RateLimitTrafficMatcher struct {
+	Request  RateLimitRequestMatcher  `json:"request"`
+	Response RateLimitResponseMatcher `json:"response"`
+}
+
+// RateLimitRequestMatcher contains the matching rules pertaining to requests
+type RateLimitRequestMatcher struct {
+	Methods    []string `json:"methods,omitempty"`
+	Schemes    []string `json:"schemes,omitempty"`
+	URLPattern string   `json:"url,omitempty"`
+}
+
+// RateLimitResponseMatcher contains the matching rules pertaining to responses
+type RateLimitResponseMatcher struct {
+	Statuses      []int `json:"status,omitempty"`
+	OriginTraffic *bool `json:"origin_traffic,omitempty"` // api defaults to true so we need an explicit empty value
+}
+
+// RateLimitKeyValue is k-v formatted as expected in the rate limit description
+type RateLimitKeyValue struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
+}
+
+// RateLimitAction is the action that will be taken when the rate limit threshold is reached
+type RateLimitAction struct {
+	Mode     string                   `json:"mode"`
+	Timeout  int                      `json:"timeout"`
+	Response *RateLimitActionResponse `json:"response"`
+}
+
+// RateLimitActionResponse is the response that will be returned when rate limit action is triggered
+type RateLimitActionResponse struct {
+	ContentType string `json:"content_type"`
+	Body        string `json:"body"`
+}
+
+type rateLimitResponse struct {
+	Response
+	Result RateLimit `json:"result"`
+}
+
+type rateLimitListResponse struct {
+	Response
+	Result     []RateLimit `json:"result"`
+	ResultInfo ResultInfo  `json:"result_info"`
+}
+
+// CreateRateLimit creates a new rate limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-create-a-ratelimit
+func (api *API) CreateRateLimit(zoneID string, limit RateLimit) (RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits"
+	res, err := api.makeRequest("POST", uri, limit)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListRateLimits returns Rate Limits for a zone, paginated according to the provided options
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-list-rate-limits
+func (api *API) ListRateLimits(zoneID string, pageOpts PaginationOptions) ([]RateLimit, ResultInfo, error) {
+	v := url.Values{}
+	if pageOpts.PerPage > 0 {
+		v.Set("per_page", strconv.Itoa(pageOpts.PerPage))
+	}
+	if pageOpts.Page > 0 {
+		v.Set("page", strconv.Itoa(pageOpts.Page))
+	}
+
+	uri := "/zones/" + zoneID + "/rate_limits"
+	if len(v) > 0 {
+		uri = uri + "?" + v.Encode()
+	}
+
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []RateLimit{}, ResultInfo{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r rateLimitListResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []RateLimit{}, ResultInfo{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, r.ResultInfo, nil
+}
+
+// ListAllRateLimits returns all Rate Limits for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-list-rate-limits
+func (api *API) ListAllRateLimits(zoneID string) ([]RateLimit, error) {
+	pageOpts := PaginationOptions{
+		PerPage: 100, // this is the max page size allowed
+		Page:    1,
+	}
+
+	allRateLimits := make([]RateLimit, 0)
+	for {
+		rateLimits, resultInfo, err := api.ListRateLimits(zoneID, pageOpts)
+		if err != nil {
+			return []RateLimit{}, err
+		}
+		allRateLimits = append(allRateLimits, rateLimits...)
+		// total pages is not returned on this call
+		// if number of records is less than the max, this must be the last page
+		// in case TotalCount % PerPage = 0, the last request will return an empty list
+		if resultInfo.Count < resultInfo.PerPage {
+			break
+		}
+		// continue with the next page
+		pageOpts.Page = pageOpts.Page + 1
+	}
+
+	return allRateLimits, nil
+}
+
+// RateLimit fetches detail about one Rate Limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-rate-limit-details
+func (api *API) RateLimit(zoneID, limitID string) (RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits/" + limitID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// UpdateRateLimit lets you replace a Rate Limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-update-rate-limit
+func (api *API) UpdateRateLimit(zoneID, limitID string, limit RateLimit) (RateLimit, error) {
+	uri := "/zones/" + zoneID + "/rate_limits/" + limitID
+	res, err := api.makeRequest("PUT", uri, limit)
+	if err != nil {
+		return RateLimit{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return RateLimit{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteRateLimit deletes a Rate Limit for a zone.
+//
+// API reference: https://api.cloudflare.com/#rate-limits-for-a-zone-delete-rate-limit
+func (api *API) DeleteRateLimit(zoneID, limitID string) error {
+	uri := "/zones/" + zoneID + "/rate_limits/" + limitID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	var r rateLimitResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+	return nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/ssl.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/ssl.go
@@ -1,0 +1,148 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// ZoneCustomSSL represents custom SSL certificate metadata.
+type ZoneCustomSSL struct {
+	ID            string     `json:"id"`
+	Hosts         []string   `json:"hosts"`
+	Issuer        string     `json:"issuer"`
+	Signature     string     `json:"signature"`
+	Status        string     `json:"status"`
+	BundleMethod  string     `json:"bundle_method"`
+	ZoneID        string     `json:"zone_id"`
+	UploadedOn    time.Time  `json:"uploaded_on"`
+	ModifiedOn    time.Time  `json:"modified_on"`
+	ExpiresOn     time.Time  `json:"expires_on"`
+	Priority      int        `json:"priority"`
+	KeylessServer KeylessSSL `json:"keyless_server"`
+}
+
+// zoneCustomSSLResponse represents the response from the zone SSL details endpoint.
+type zoneCustomSSLResponse struct {
+	Response
+	Result ZoneCustomSSL `json:"result"`
+}
+
+// zoneCustomSSLsResponse represents the response from the zone SSL list endpoint.
+type zoneCustomSSLsResponse struct {
+	Response
+	Result []ZoneCustomSSL `json:"result"`
+}
+
+// ZoneCustomSSLOptions represents the parameters to create or update an existing
+// custom SSL configuration.
+type ZoneCustomSSLOptions struct {
+	Certificate  string `json:"certificate"`
+	PrivateKey   string `json:"private_key"`
+	BundleMethod string `json:"bundle_method,omitempty"`
+}
+
+// ZoneCustomSSLPriority represents a certificate's ID and priority. It is a
+// subset of ZoneCustomSSL used for patch requests.
+type ZoneCustomSSLPriority struct {
+	ID       string `json:"ID"`
+	Priority int    `json:"priority"`
+}
+
+// CreateSSL allows you to add a custom SSL certificate to the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-create-ssl-configuration
+func (api *API) CreateSSL(zoneID string, options ZoneCustomSSLOptions) (ZoneCustomSSL, error) {
+	uri := "/zones/" + zoneID + "/custom_certificates"
+	res, err := api.makeRequest("POST", uri, options)
+	if err != nil {
+		return ZoneCustomSSL{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneCustomSSLResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return ZoneCustomSSL{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ListSSL lists the custom certificates for the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-list-ssl-configurations
+func (api *API) ListSSL(zoneID string) ([]ZoneCustomSSL, error) {
+	uri := "/zones/" + zoneID + "/custom_certificates"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneCustomSSLsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// SSLDetails returns the configuration details for a custom SSL certificate.
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-ssl-configuration-details
+func (api *API) SSLDetails(zoneID, certificateID string) (ZoneCustomSSL, error) {
+	uri := "/zones/" + zoneID + "/custom_certificates/" + certificateID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ZoneCustomSSL{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneCustomSSLResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return ZoneCustomSSL{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// UpdateSSL updates (replaces) a custom SSL certificate.
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-update-ssl-configuration
+func (api *API) UpdateSSL(zoneID, certificateID string, options ZoneCustomSSLOptions) (ZoneCustomSSL, error) {
+	uri := "/zones/" + zoneID + "/custom_certificates/" + certificateID
+	res, err := api.makeRequest("PATCH", uri, options)
+	if err != nil {
+		return ZoneCustomSSL{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneCustomSSLResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return ZoneCustomSSL{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ReprioritizeSSL allows you to change the priority (which is served for a given
+// request) of custom SSL certificates associated with the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-re-prioritize-ssl-certificates
+func (api *API) ReprioritizeSSL(zoneID string, p []ZoneCustomSSLPriority) ([]ZoneCustomSSL, error) {
+	uri := "/zones/" + zoneID + "/custom_certificates/prioritize"
+	params := struct {
+		Certificates []ZoneCustomSSLPriority `json:"certificates"`
+	}{
+		Certificates: p,
+	}
+	res, err := api.makeRequest("PUT", uri, params)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneCustomSSLsResponse
+	if err := json.Unmarshal(res, &r); err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// DeleteSSL deletes a custom SSL certificate from the given zone.
+//
+// API reference: https://api.cloudflare.com/#custom-ssl-for-a-zone-delete-an-ssl-certificate
+func (api *API) DeleteSSL(zoneID, certificateID string) error {
+	uri := "/zones/" + zoneID + "/custom_certificates/" + certificateID
+	if _, err := api.makeRequest("DELETE", uri, nil); err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+	return nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/user.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/user.go
@@ -1,0 +1,113 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// User describes a user account.
+type User struct {
+	ID            string         `json:"id,omitempty"`
+	Email         string         `json:"email,omitempty"`
+	FirstName     string         `json:"first_name,omitempty"`
+	LastName      string         `json:"last_name,omitempty"`
+	Username      string         `json:"username,omitempty"`
+	Telephone     string         `json:"telephone,omitempty"`
+	Country       string         `json:"country,omitempty"`
+	Zipcode       string         `json:"zipcode,omitempty"`
+	CreatedOn     *time.Time     `json:"created_on,omitempty"`
+	ModifiedOn    *time.Time     `json:"modified_on,omitempty"`
+	APIKey        string         `json:"api_key,omitempty"`
+	TwoFA         bool           `json:"two_factor_authentication_enabled,omitempty"`
+	Betas         []string       `json:"betas,omitempty"`
+	Organizations []Organization `json:"organizations,omitempty"`
+}
+
+// UserResponse wraps a response containing User accounts.
+type UserResponse struct {
+	Response
+	Result User `json:"result"`
+}
+
+// userBillingProfileResponse wraps a response containing Billing Profile information.
+type userBillingProfileResponse struct {
+	Response
+	Result UserBillingProfile
+}
+
+// UserBillingProfile contains Billing Profile information.
+type UserBillingProfile struct {
+	ID              string     `json:"id,omitempty"`
+	FirstName       string     `json:"first_name,omitempty"`
+	LastName        string     `json:"last_name,omitempty"`
+	Address         string     `json:"address,omitempty"`
+	Address2        string     `json:"address2,omitempty"`
+	Company         string     `json:"company,omitempty"`
+	City            string     `json:"city,omitempty"`
+	State           string     `json:"state,omitempty"`
+	ZipCode         string     `json:"zipcode,omitempty"`
+	Country         string     `json:"country,omitempty"`
+	Telephone       string     `json:"telephone,omitempty"`
+	CardNumber      string     `json:"card_number,omitempty"`
+	CardExpiryYear  int        `json:"card_expiry_year,omitempty"`
+	CardExpiryMonth int        `json:"card_expiry_month,omitempty"`
+	VAT             string     `json:"vat,omitempty"`
+	CreatedOn       *time.Time `json:"created_on,omitempty"`
+	EditedOn        *time.Time `json:"edited_on,omitempty"`
+}
+
+// UserDetails provides information about the logged-in user.
+//
+// API reference: https://api.cloudflare.com/#user-user-details
+func (api *API) UserDetails() (User, error) {
+	var r UserResponse
+	res, err := api.makeRequest("GET", "/user", nil)
+	if err != nil {
+		return User{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return User{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// UpdateUser updates the properties of the given user.
+//
+// API reference: https://api.cloudflare.com/#user-update-user
+func (api *API) UpdateUser(user *User) (User, error) {
+	var r UserResponse
+	res, err := api.makeRequest("PATCH", "/user", user)
+	if err != nil {
+		return User{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return User{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// UserBillingProfile returns the billing profile of the user.
+//
+// API reference: https://api.cloudflare.com/#user-billing-profile
+func (api *API) UserBillingProfile() (UserBillingProfile, error) {
+	var r userBillingProfileResponse
+	res, err := api.makeRequest("GET", "/user/billing/profile", nil)
+	if err != nil {
+		return UserBillingProfile{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return UserBillingProfile{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/user_agent.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/user_agent.go
@@ -1,0 +1,149 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"net/url"
+	"strconv"
+
+	"github.com/pkg/errors"
+)
+
+// UserAgentRule represents a User-Agent Block. These rules can be used to
+// challenge, block or whitelist specific User-Agents for a given zone.
+type UserAgentRule struct {
+	ID            string              `json:"id"`
+	Description   string              `json:"description"`
+	Mode          string              `json:"mode"`
+	Configuration UserAgentRuleConfig `json:"configuration"`
+	Paused        bool                `json:"paused"`
+}
+
+// UserAgentRuleConfig represents a Zone Lockdown config, which comprises
+// a Target ("ip" or "ip_range") and a Value (an IP address or IP+mask,
+// respectively.)
+type UserAgentRuleConfig ZoneLockdownConfig
+
+// UserAgentRuleResponse represents a response from the Zone Lockdown endpoint.
+type UserAgentRuleResponse struct {
+	Result UserAgentRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// UserAgentRuleListResponse represents a response from the List Zone Lockdown endpoint.
+type UserAgentRuleListResponse struct {
+	Result []UserAgentRule `json:"result"`
+	Response
+	ResultInfo `json:"result_info"`
+}
+
+// CreateUserAgentRule creates a User-Agent Block rule for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-create-a-useragent-rule
+func (api *API) CreateUserAgentRule(zoneID string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
+	switch ld.Mode {
+	case "block", "challenge", "js_challenge", "whitelist":
+		break
+	default:
+		return nil, errors.New(`the User-Agent Block rule mode must be one of "block", "challenge", "js_challenge", "whitelist"`)
+	}
+
+	uri := "/zones/" + zoneID + "/firewall/ua_rules"
+	res, err := api.makeRequest("POST", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateUserAgentRule updates a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-update-useragent-rule
+func (api *API) UpdateUserAgentRule(zoneID string, id string, ld UserAgentRule) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("PUT", uri, ld)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// DeleteUserAgentRule deletes a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-delete-useragent-rule
+func (api *API) DeleteUserAgentRule(zoneID string, id string) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UserAgentRule retrieves a User-Agent Block rule (based on the ID) for the given zone ID.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-useragent-rule-details
+func (api *API) UserAgentRule(zoneID string, id string) (*UserAgentRuleResponse, error) {
+	uri := "/zones/" + zoneID + "/firewall/ua_rules/" + id
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ListUserAgentRules retrieves a list of User-Agent Block rules for a given zone ID by page number.
+//
+// API reference: https://api.cloudflare.com/#user-agent-blocking-rules-list-useragent-rules
+func (api *API) ListUserAgentRules(zoneID string, page int) (*UserAgentRuleListResponse, error) {
+	v := url.Values{}
+	if page <= 0 {
+		page = 1
+	}
+
+	v.Set("page", strconv.Itoa(page))
+	v.Set("per_page", strconv.Itoa(100))
+	query := "?" + v.Encode()
+
+	uri := "/zones/" + zoneID + "/firewall/ua_rules" + query
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &UserAgentRuleListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/virtualdns.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/virtualdns.go
@@ -1,0 +1,125 @@
+package cloudflare
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// VirtualDNS represents a Virtual DNS configuration.
+type VirtualDNS struct {
+	ID                   string   `json:"id"`
+	Name                 string   `json:"name"`
+	OriginIPs            []string `json:"origin_ips"`
+	VirtualDNSIPs        []string `json:"virtual_dns_ips"`
+	MinimumCacheTTL      uint     `json:"minimum_cache_ttl"`
+	MaximumCacheTTL      uint     `json:"maximum_cache_ttl"`
+	DeprecateAnyRequests bool     `json:"deprecate_any_requests"`
+	ModifiedOn           string   `json:"modified_on"`
+}
+
+// VirtualDNSResponse represents a Virtual DNS response.
+type VirtualDNSResponse struct {
+	Response
+	Result *VirtualDNS `json:"result"`
+}
+
+// VirtualDNSListResponse represents an array of Virtual DNS responses.
+type VirtualDNSListResponse struct {
+	Response
+	Result []*VirtualDNS `json:"result"`
+}
+
+// CreateVirtualDNS creates a new Virtual DNS cluster.
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--create-a-virtual-dns-cluster
+func (api *API) CreateVirtualDNS(v *VirtualDNS) (*VirtualDNS, error) {
+	res, err := api.makeRequest("POST", "/user/virtual_dns", v)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &VirtualDNSResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// VirtualDNS fetches a single virtual DNS cluster.
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--get-a-virtual-dns-cluster
+func (api *API) VirtualDNS(virtualDNSID string) (*VirtualDNS, error) {
+	uri := "/user/virtual_dns/" + virtualDNSID
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &VirtualDNSResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// ListVirtualDNS lists the virtual DNS clusters associated with an account.
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--get-virtual-dns-clusters
+func (api *API) ListVirtualDNS() ([]*VirtualDNS, error) {
+	res, err := api.makeRequest("GET", "/user/virtual_dns", nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &VirtualDNSListResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response.Result, nil
+}
+
+// UpdateVirtualDNS updates a Virtual DNS cluster.
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--modify-a-virtual-dns-cluster
+func (api *API) UpdateVirtualDNS(virtualDNSID string, vv VirtualDNS) error {
+	uri := "/user/virtual_dns/" + virtualDNSID
+	res, err := api.makeRequest("PUT", uri, vv)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &VirtualDNSResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}
+
+// DeleteVirtualDNS deletes a Virtual DNS cluster. Note that this cannot be
+// undone, and will stop all traffic to that cluster.
+//
+// API reference: https://api.cloudflare.com/#virtual-dns-users--delete-a-virtual-dns-cluster
+func (api *API) DeleteVirtualDNS(virtualDNSID string) error {
+	uri := "/user/virtual_dns/" + virtualDNSID
+	res, err := api.makeRequest("DELETE", uri, nil)
+	if err != nil {
+		return errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &VirtualDNSResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return errors.Wrap(err, errUnmarshalError)
+	}
+
+	return nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/waf.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/waf.go
@@ -1,0 +1,97 @@
+package cloudflare
+
+import (
+	"encoding/json"
+
+	"github.com/pkg/errors"
+)
+
+// WAFPackage represents a WAF package configuration.
+type WAFPackage struct {
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Description   string `json:"description"`
+	ZoneID        string `json:"zone_id"`
+	DetectionMode string `json:"detection_mode"`
+	Sensitivity   string `json:"sensitivity"`
+	ActionMode    string `json:"action_mode"`
+}
+
+// WAFPackagesResponse represents the response from the WAF packages endpoint.
+type WAFPackagesResponse struct {
+	Response
+	Result     []WAFPackage `json:"result"`
+	ResultInfo ResultInfo   `json:"result_info"`
+}
+
+// WAFRule represents a WAF rule.
+type WAFRule struct {
+	ID          string `json:"id"`
+	Description string `json:"description"`
+	Priority    string `json:"priority"`
+	PackageID   string `json:"package_id"`
+	Group       struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"group"`
+	Mode         string   `json:"mode"`
+	DefaultMode  string   `json:"default_mode"`
+	AllowedModes []string `json:"allowed_modes"`
+}
+
+// WAFRulesResponse represents the response from the WAF rule endpoint.
+type WAFRulesResponse struct {
+	Response
+	Result     []WAFRule  `json:"result"`
+	ResultInfo ResultInfo `json:"result_info"`
+}
+
+// ListWAFPackages returns a slice of the WAF packages for the given zone.
+func (api *API) ListWAFPackages(zoneID string) ([]WAFPackage, error) {
+	var p WAFPackagesResponse
+	var packages []WAFPackage
+	var res []byte
+	var err error
+	uri := "/zones/" + zoneID + "/firewall/waf/packages"
+	res, err = api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []WAFPackage{}, errors.Wrap(err, errMakeRequestError)
+	}
+	err = json.Unmarshal(res, &p)
+	if err != nil {
+		return []WAFPackage{}, errors.Wrap(err, errUnmarshalError)
+	}
+	if !p.Success {
+		// TODO: Provide an actual error message instead of always returning nil
+		return []WAFPackage{}, err
+	}
+	for pi := range p.Result {
+		packages = append(packages, p.Result[pi])
+	}
+	return packages, nil
+}
+
+// ListWAFRules returns a slice of the WAF rules for the given WAF package.
+func (api *API) ListWAFRules(zoneID, packageID string) ([]WAFRule, error) {
+	var r WAFRulesResponse
+	var rules []WAFRule
+	var res []byte
+	var err error
+	uri := "/zones/" + zoneID + "/firewall/waf/packages/" + packageID + "/rules"
+	res, err = api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []WAFRule{}, errors.Wrap(err, errMakeRequestError)
+	}
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []WAFRule{}, errors.Wrap(err, errUnmarshalError)
+	}
+	if !r.Success {
+		// TODO: Provide an actual error message instead of always returning nil
+		return []WAFRule{}, err
+	}
+	for ri := range r.Result {
+		rules = append(rules, r.Result[ri])
+	}
+	return rules, nil
+}

--- a/vendor/github.com/cloudflare/cloudflare-go/zone.go
+++ b/vendor/github.com/cloudflare/cloudflare-go/zone.go
@@ -1,0 +1,587 @@
+package cloudflare
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+)
+
+// Owner describes the resource owner.
+type Owner struct {
+	ID        string `json:"id"`
+	Email     string `json:"email"`
+	OwnerType string `json:"owner_type"`
+}
+
+// Zone describes a Cloudflare zone.
+type Zone struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	// DevMode contains the time in seconds until development expires (if
+	// positive) or since it expired (if negative). It will be 0 if never used.
+	DevMode           int          `json:"development_mode"`
+	OriginalNS        []string     `json:"original_name_servers"`
+	OriginalRegistrar string       `json:"original_registrar"`
+	OriginalDNSHost   string       `json:"original_dnshost"`
+	CreatedOn         time.Time    `json:"created_on"`
+	ModifiedOn        time.Time    `json:"modified_on"`
+	NameServers       []string     `json:"name_servers"`
+	Owner             Owner        `json:"owner"`
+	Permissions       []string     `json:"permissions"`
+	Plan              ZoneRatePlan `json:"plan"`
+	PlanPending       ZoneRatePlan `json:"plan_pending,omitempty"`
+	Status            string       `json:"status"`
+	Paused            bool         `json:"paused"`
+	Type              string       `json:"type"`
+	Host              struct {
+		Name    string
+		Website string
+	} `json:"host"`
+	VanityNS    []string `json:"vanity_name_servers"`
+	Betas       []string `json:"betas"`
+	DeactReason string   `json:"deactivation_reason"`
+	Meta        ZoneMeta `json:"meta"`
+}
+
+// ZoneMeta describes metadata about a zone.
+type ZoneMeta struct {
+	// custom_certificate_quota is broken - sometimes it's a string, sometimes a number!
+	// CustCertQuota     int    `json:"custom_certificate_quota"`
+	PageRuleQuota     int  `json:"page_rule_quota"`
+	WildcardProxiable bool `json:"wildcard_proxiable"`
+	PhishingDetected  bool `json:"phishing_detected"`
+}
+
+// ZoneRatePlan contains the plan information for a zone.
+type ZoneRatePlan struct {
+	ID         string                   `json:"id"`
+	Name       string                   `json:"name,omitempty"`
+	Price      int                      `json:"price,omitempty"`
+	Currency   string                   `json:"currency,omitempty"`
+	Duration   int                      `json:"duration,omitempty"`
+	Frequency  string                   `json:"frequency,omitempty"`
+	Components []zoneRatePlanComponents `json:"components,omitempty"`
+}
+
+type zoneRatePlanComponents struct {
+	Name      string `json:"name"`
+	Default   int    `json:"Default"`
+	UnitPrice int    `json:"unit_price"`
+}
+
+// ZoneID contains only the zone ID.
+type ZoneID struct {
+	ID string `json:"id"`
+}
+
+// ZoneResponse represents the response from the Zone endpoint containing a single zone.
+type ZoneResponse struct {
+	Response
+	Result Zone `json:"result"`
+}
+
+// ZonesResponse represents the response from the Zone endpoint containing an array of zones.
+type ZonesResponse struct {
+	Response
+	Result []Zone `json:"result"`
+}
+
+// ZoneIDResponse represents the response from the Zone endpoint, containing only a zone ID.
+type ZoneIDResponse struct {
+	Response
+	Result ZoneID `json:"result"`
+}
+
+// AvailableZoneRatePlansResponse represents the response from the Available Rate Plans endpoint.
+type AvailableZoneRatePlansResponse struct {
+	Response
+	Result []ZoneRatePlan `json:"result"`
+	ResultInfo
+}
+
+// ZoneRatePlanResponse represents the response from the Plan Details endpoint.
+type ZoneRatePlanResponse struct {
+	Response
+	Result ZoneRatePlan `json:"result"`
+}
+
+// ZoneSetting contains settings for a zone.
+type ZoneSetting struct {
+	ID            string      `json:"id"`
+	Editable      bool        `json:"editable"`
+	ModifiedOn    string      `json:"modified_on"`
+	Value         interface{} `json:"value"`
+	TimeRemaining int         `json:"time_remaining"`
+}
+
+// ZoneSettingResponse represents the response from the Zone Setting endpoint.
+type ZoneSettingResponse struct {
+	Response
+	Result []ZoneSetting `json:"result"`
+}
+
+// ZoneSSLSetting contains ssl setting for a zone.
+type ZoneSSLSetting struct {
+	ID                string `json:"id"`
+	Editable          bool   `json:"editable"`
+	ModifiedOn        string `json:"modified_on"`
+	Value             string `json:"value"`
+	CertificateStatus string `json:"certificate_status"`
+}
+
+// ZoneSettingResponse represents the response from the Zone SSL Setting endpoint.
+type ZoneSSLSettingResponse struct {
+	Response
+	Result ZoneSSLSetting `json:"result"`
+}
+
+// ZoneAnalyticsData contains totals and timeseries analytics data for a zone.
+type ZoneAnalyticsData struct {
+	Totals     ZoneAnalytics   `json:"totals"`
+	Timeseries []ZoneAnalytics `json:"timeseries"`
+}
+
+// zoneAnalyticsDataResponse represents the response from the Zone Analytics Dashboard endpoint.
+type zoneAnalyticsDataResponse struct {
+	Response
+	Result ZoneAnalyticsData `json:"result"`
+}
+
+// ZoneAnalyticsColocation contains analytics data by datacenter.
+type ZoneAnalyticsColocation struct {
+	ColocationID string          `json:"colo_id"`
+	Timeseries   []ZoneAnalytics `json:"timeseries"`
+}
+
+// zoneAnalyticsColocationResponse represents the response from the Zone Analytics By Co-location endpoint.
+type zoneAnalyticsColocationResponse struct {
+	Response
+	Result []ZoneAnalyticsColocation `json:"result"`
+}
+
+// ZoneAnalytics contains analytics data for a zone.
+type ZoneAnalytics struct {
+	Since    time.Time `json:"since"`
+	Until    time.Time `json:"until"`
+	Requests struct {
+		All         int            `json:"all"`
+		Cached      int            `json:"cached"`
+		Uncached    int            `json:"uncached"`
+		ContentType map[string]int `json:"content_type"`
+		Country     map[string]int `json:"country"`
+		SSL         struct {
+			Encrypted   int `json:"encrypted"`
+			Unencrypted int `json:"unencrypted"`
+		} `json:"ssl"`
+		HTTPStatus map[string]int `json:"http_status"`
+	} `json:"requests"`
+	Bandwidth struct {
+		All         int            `json:"all"`
+		Cached      int            `json:"cached"`
+		Uncached    int            `json:"uncached"`
+		ContentType map[string]int `json:"content_type"`
+		Country     map[string]int `json:"country"`
+		SSL         struct {
+			Encrypted   int `json:"encrypted"`
+			Unencrypted int `json:"unencrypted"`
+		} `json:"ssl"`
+	} `json:"bandwidth"`
+	Threats struct {
+		All     int            `json:"all"`
+		Country map[string]int `json:"country"`
+		Type    map[string]int `json:"type"`
+	} `json:"threats"`
+	Pageviews struct {
+		All           int            `json:"all"`
+		SearchEngines map[string]int `json:"search_engines"`
+	} `json:"pageviews"`
+	Uniques struct {
+		All int `json:"all"`
+	}
+}
+
+// ZoneAnalyticsOptions represents the optional parameters in Zone Analytics
+// endpoint requests.
+type ZoneAnalyticsOptions struct {
+	Since      *time.Time
+	Until      *time.Time
+	Continuous *bool
+}
+
+// PurgeCacheRequest represents the request format made to the purge endpoint.
+type PurgeCacheRequest struct {
+	Everything bool `json:"purge_everything,omitempty"`
+	// Purge by filepath (exact match). Limit of 30
+	Files []string `json:"files,omitempty"`
+	// Purge by Tag (Enterprise only):
+	// https://support.cloudflare.com/hc/en-us/articles/206596608-How-to-Purge-Cache-Using-Cache-Tags-Enterprise-only-
+	Tags []string `json:"tags,omitempty"`
+	// Purge by hostname - e.g. "assets.example.com"
+	Hosts []string `json:"hosts,omitempty"`
+}
+
+// PurgeCacheResponse represents the response from the purge endpoint.
+type PurgeCacheResponse struct {
+	Response
+	Result struct {
+		ID string `json:"id"`
+	} `json:"result"`
+}
+
+// newZone describes a new zone.
+type newZone struct {
+	Name      string `json:"name"`
+	JumpStart bool   `json:"jump_start"`
+	// We use a pointer to get a nil type when the field is empty.
+	// This allows us to completely omit this with json.Marshal().
+	Organization *Organization `json:"organization,omitempty"`
+}
+
+// CreateZone creates a zone on an account.
+//
+// Setting jumpstart to true will attempt to automatically scan for existing
+// DNS records. Setting this to false will create the zone with no DNS records.
+//
+// If Organization is non-empty, it must have at least the ID field populated.
+// This will add the new zone to the specified multi-user organization.
+//
+// API reference: https://api.cloudflare.com/#zone-create-a-zone
+func (api *API) CreateZone(name string, jumpstart bool, org Organization) (Zone, error) {
+	var newzone newZone
+	newzone.Name = name
+	newzone.JumpStart = jumpstart
+	if org.ID != "" {
+		newzone.Organization = &org
+	}
+
+	res, err := api.makeRequest("POST", "/zones", newzone)
+	if err != nil {
+		return Zone{}, errors.Wrap(err, errMakeRequestError)
+	}
+
+	var r ZoneResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return Zone{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ZoneActivationCheck initiates another zone activation check for newly-created zones.
+//
+// API reference: https://api.cloudflare.com/#zone-initiate-another-zone-activation-check
+func (api *API) ZoneActivationCheck(zoneID string) (Response, error) {
+	res, err := api.makeRequest("PUT", "/zones/"+zoneID+"/activation_check", nil)
+	if err != nil {
+		return Response{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r Response
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return Response{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r, nil
+}
+
+// ListZones lists zones on an account. Optionally takes a list of zone names
+// to filter against.
+//
+// API reference: https://api.cloudflare.com/#zone-list-zones
+func (api *API) ListZones(z ...string) ([]Zone, error) {
+	v := url.Values{}
+	var res []byte
+	var r ZonesResponse
+	var zones []Zone
+	var err error
+	if len(z) > 0 {
+		for _, zone := range z {
+			v.Set("name", zone)
+			res, err = api.makeRequest("GET", "/zones?"+v.Encode(), nil)
+			if err != nil {
+				return []Zone{}, errors.Wrap(err, errMakeRequestError)
+			}
+			err = json.Unmarshal(res, &r)
+			if err != nil {
+				return []Zone{}, errors.Wrap(err, errUnmarshalError)
+			}
+			if !r.Success {
+				// TODO: Provide an actual error message instead of always returning nil
+				return []Zone{}, err
+			}
+			for zi := range r.Result {
+				zones = append(zones, r.Result[zi])
+			}
+		}
+	} else {
+		// TODO: Paginate here. We only grab the first page of results.
+		// Could do this concurrently after the first request by creating a
+		// sync.WaitGroup or just a channel + workers.
+		res, err = api.makeRequest("GET", "/zones", nil)
+		if err != nil {
+			return []Zone{}, errors.Wrap(err, errMakeRequestError)
+		}
+		err = json.Unmarshal(res, &r)
+		if err != nil {
+			return []Zone{}, errors.Wrap(err, errUnmarshalError)
+		}
+		zones = r.Result
+	}
+
+	return zones, nil
+}
+
+// ZoneDetails fetches information about a zone.
+//
+// API reference: https://api.cloudflare.com/#zone-zone-details
+func (api *API) ZoneDetails(zoneID string) (Zone, error) {
+	res, err := api.makeRequest("GET", "/zones/"+zoneID, nil)
+	if err != nil {
+		return Zone{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return Zone{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ZoneOptions is a subset of Zone, for editable options.
+type ZoneOptions struct {
+	Paused   *bool         `json:"paused,omitempty"`
+	VanityNS []string      `json:"vanity_name_servers,omitempty"`
+	Plan     *ZoneRatePlan `json:"plan,omitempty"`
+}
+
+// ZoneSetPaused pauses Cloudflare service for the entire zone, sending all
+// traffic direct to the origin.
+func (api *API) ZoneSetPaused(zoneID string, paused bool) (Zone, error) {
+	zoneopts := ZoneOptions{Paused: &paused}
+	zone, err := api.EditZone(zoneID, zoneopts)
+	if err != nil {
+		return Zone{}, err
+	}
+
+	return zone, nil
+}
+
+// ZoneSetVanityNS sets custom nameservers for the zone.
+// These names must be within the same zone.
+func (api *API) ZoneSetVanityNS(zoneID string, ns []string) (Zone, error) {
+	zoneopts := ZoneOptions{VanityNS: ns}
+	zone, err := api.EditZone(zoneID, zoneopts)
+	if err != nil {
+		return Zone{}, err
+	}
+
+	return zone, nil
+}
+
+// ZoneSetRatePlan changes the zone plan.
+func (api *API) ZoneSetRatePlan(zoneID string, plan ZoneRatePlan) (Zone, error) {
+	zoneopts := ZoneOptions{Plan: &plan}
+	zone, err := api.EditZone(zoneID, zoneopts)
+	if err != nil {
+		return Zone{}, err
+	}
+
+	return zone, nil
+}
+
+// EditZone edits the given zone.
+//
+// This is usually called by ZoneSetPaused, ZoneSetVanityNS or ZoneSetPlan.
+//
+// API reference: https://api.cloudflare.com/#zone-edit-zone-properties
+func (api *API) EditZone(zoneID string, zoneOpts ZoneOptions) (Zone, error) {
+	res, err := api.makeRequest("PATCH", "/zones/"+zoneID, zoneOpts)
+	if err != nil {
+		return Zone{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return Zone{}, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return r.Result, nil
+}
+
+// PurgeEverything purges the cache for the given zone.
+//
+// Note: this will substantially increase load on the origin server for that
+// zone if there is a high cached vs. uncached request ratio.
+//
+// API reference: https://api.cloudflare.com/#zone-purge-all-files
+func (api *API) PurgeEverything(zoneID string) (PurgeCacheResponse, error) {
+	uri := "/zones/" + zoneID + "/purge_cache"
+	res, err := api.makeRequest("DELETE", uri, PurgeCacheRequest{true, nil, nil, nil})
+	if err != nil {
+		return PurgeCacheResponse{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PurgeCacheResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return PurgeCacheResponse{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r, nil
+}
+
+// PurgeCache purges the cache using the given PurgeCacheRequest (zone/url/tag).
+//
+// API reference: https://api.cloudflare.com/#zone-purge-individual-files-by-url-and-cache-tags
+func (api *API) PurgeCache(zoneID string, pcr PurgeCacheRequest) (PurgeCacheResponse, error) {
+	uri := "/zones/" + zoneID + "/purge_cache"
+	res, err := api.makeRequest("DELETE", uri, pcr)
+	if err != nil {
+		return PurgeCacheResponse{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r PurgeCacheResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return PurgeCacheResponse{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r, nil
+}
+
+// DeleteZone deletes the given zone.
+//
+// API reference: https://api.cloudflare.com/#zone-delete-a-zone
+func (api *API) DeleteZone(zoneID string) (ZoneID, error) {
+	res, err := api.makeRequest("DELETE", "/zones/"+zoneID, nil)
+	if err != nil {
+		return ZoneID{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneIDResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return ZoneID{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// AvailableZoneRatePlans returns information about all plans available to the specified zone.
+//
+// API reference: https://api.cloudflare.com/#zone-plan-available-plans
+func (api *API) AvailableZoneRatePlans(zoneID string) ([]ZoneRatePlan, error) {
+	uri := "/zones/" + zoneID + "/available_rate_plans"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return []ZoneRatePlan{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r AvailableZoneRatePlansResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return []ZoneRatePlan{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// encode encodes non-nil fields into URL encoded form.
+func (o ZoneAnalyticsOptions) encode() string {
+	v := url.Values{}
+	if o.Since != nil {
+		v.Set("since", (*o.Since).Format(time.RFC3339))
+	}
+	if o.Until != nil {
+		v.Set("until", (*o.Until).Format(time.RFC3339))
+	}
+	if o.Continuous != nil {
+		v.Set("continuous", fmt.Sprintf("%t", *o.Continuous))
+	}
+	return v.Encode()
+}
+
+// ZoneAnalyticsDashboard returns zone analytics information.
+//
+// API reference: https://api.cloudflare.com/#zone-analytics-dashboard
+func (api *API) ZoneAnalyticsDashboard(zoneID string, options ZoneAnalyticsOptions) (ZoneAnalyticsData, error) {
+	uri := "/zones/" + zoneID + "/analytics/dashboard" + "?" + options.encode()
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ZoneAnalyticsData{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneAnalyticsDataResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return ZoneAnalyticsData{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ZoneAnalyticsByColocation returns zone analytics information by datacenter.
+//
+// API reference: https://api.cloudflare.com/#zone-analytics-analytics-by-co-locations
+func (api *API) ZoneAnalyticsByColocation(zoneID string, options ZoneAnalyticsOptions) ([]ZoneAnalyticsColocation, error) {
+	uri := "/zones/" + zoneID + "/analytics/colos" + "?" + options.encode()
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+	var r zoneAnalyticsColocationResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}
+
+// ZoneSettings returns all of the settings for a given zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-get-all-zone-settings
+func (api *API) ZoneSettings(zoneID string) (*ZoneSettingResponse, error) {
+	uri := "/zones/" + zoneID + "/settings"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneSettingResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// UpdateZoneSettings updates the settings for a given zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-edit-zone-settings-info
+func (api *API) UpdateZoneSettings(zoneID string, settings []ZoneSetting) (*ZoneSettingResponse, error) {
+	uri := "/zones/" + zoneID + "/settings"
+	res, err := api.makeRequest("PATCH", uri, struct {
+		Items []ZoneSetting `json:"items"`
+	}{settings})
+	if err != nil {
+		return nil, errors.Wrap(err, errMakeRequestError)
+	}
+
+	response := &ZoneSettingResponse{}
+	err = json.Unmarshal(res, &response)
+	if err != nil {
+		return nil, errors.Wrap(err, errUnmarshalError)
+	}
+
+	return response, nil
+}
+
+// ZoneSSLSettings returns information about SSL setting to the specified zone.
+//
+// API reference: https://api.cloudflare.com/#zone-settings-get-ssl-setting
+func (api *API) ZoneSSLSettings(zoneID string) (ZoneSSLSetting, error) {
+	uri := "/zones/" + zoneID + "/settings/ssl"
+	res, err := api.makeRequest("GET", uri, nil)
+	if err != nil {
+		return ZoneSSLSetting{}, errors.Wrap(err, errMakeRequestError)
+	}
+	var r ZoneSSLSettingResponse
+	err = json.Unmarshal(res, &r)
+	if err != nil {
+		return ZoneSSLSetting{}, errors.Wrap(err, errUnmarshalError)
+	}
+	return r.Result, nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When an e2e test fails, it can leave TXT records around as cert-manager is torn down before they have a chance to be deleted. This can cause a build-up of records.

This tool will list all TXT records in a cloudflare zone older than a provided time (and matching a prefix), and delete them.

This can be configured as a periodic job on our cluster.

**Release note**:
```release-note
NONE
```

/area testing