### PR TITLE
Use logr in ACME HTTP01 solver

### DIFF
--- a/pkg/issuer/acme/http/BUILD.bazel
+++ b/pkg/issuer/acme/http/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/issuer/acme/http/solver:go_default_library",
+        "//pkg/logs:go_default_library",
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
@@ -25,7 +26,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/listers/extensions/v1beta1:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
 )
 
 const (
@@ -76,43 +77,61 @@ func NewSolver(ctx *controller.Context) *Solver {
 	}
 }
 
+func http01LogCtx(ctx context.Context) context.Context {
+	return logf.NewContext(ctx, nil, "http01")
+}
+
 // Present will realise the resources required to solve the given HTTP01
 // challenge validation in the apiserver. If those resources already exist, it
 // will return nil (i.e. this function is idempotent).
 func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
-	_, podErr := s.ensurePod(ch)
-	svc, svcErr := s.ensureService(issuer, ch)
+	ctx = http01LogCtx(ctx)
+
+	_, podErr := s.ensurePod(ctx, ch)
+	svc, svcErr := s.ensureService(ctx, issuer, ch)
 	if svcErr != nil {
 		return utilerrors.NewAggregate([]error{podErr, svcErr})
 	}
-	_, ingressErr := s.ensureIngress(ch, svc.Name)
+	_, ingressErr := s.ensureIngress(ctx, ch, svc.Name)
 	return utilerrors.NewAggregate([]error{podErr, svcErr, ingressErr})
 }
 
 func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
+	ctx = logf.NewContext(http01LogCtx(ctx), nil, "selfCheck")
+	log := logf.FromContext(ctx)
+
 	// HTTP Present is idempotent and the state of the system may have
 	// changed since present was called by the controllers (killed pods, drained nodes)
 	// Call present again to be certain.
 	// if the listers are nil, that means we're in the present checks
 	// test
 	if s.podLister != nil && s.serviceLister != nil && s.ingressLister != nil {
+		log.V(logf.DebugLevel).Info("calling Present function before running self check to ensure required resources exist")
 		err := s.Present(ctx, issuer, ch)
 		if err != nil {
+			log.V(logf.DebugLevel).Info("failed to call Present function", "error", err)
 			return err
 		}
 	}
+
 	ctx, cancel := context.WithTimeout(ctx, HTTP01Timeout)
 	defer cancel()
-
 	url := s.buildChallengeUrl(ch)
+	log = log.WithValues("url", url)
+	ctx = logf.NewContext(ctx, log)
 
+	log.V(logf.DebugLevel).Info("running self check multiple times to ensure challenge has propagated", "required_passes", s.requiredPasses)
 	for i := 0; i < s.requiredPasses; i++ {
 		err := s.testReachability(ctx, url, ch.Spec.Key)
 		if err != nil {
 			return err
 		}
+		log.V(logf.DebugLevel).Info("reachability test passed, re-checking in 2s time")
 		time.Sleep(time.Second * 2)
 	}
+
+	log.V(logf.DebugLevel).Info("self check succeeded")
+
 	return nil
 }
 
@@ -120,9 +139,9 @@ func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v
 // cert-manager created data.
 func (s *Solver) CleanUp(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 	var errs []error
-	errs = append(errs, s.cleanupPods(ch))
-	errs = append(errs, s.cleanupServices(ch))
-	errs = append(errs, s.cleanupIngresses(ch))
+	errs = append(errs, s.cleanupPods(ctx, ch))
+	errs = append(errs, s.cleanupServices(ctx, ch))
+	errs = append(errs, s.cleanupIngresses(ctx, ch))
 	return utilerrors.NewAggregate(errs)
 }
 
@@ -138,11 +157,13 @@ func (s *Solver) buildChallengeUrl(ch *v1alpha1.Challenge) *url.URL {
 // testReachability will attempt to connect to the 'domain' with 'path' and
 // check if the returned body equals 'key'
 func testReachability(ctx context.Context, url *url.URL, key string) error {
+	log := logf.FromContext(ctx)
+	log.V(logf.DebugLevel).Info("performing HTTP01 reachability check")
+
 	req := &http.Request{
 		Method: http.MethodGet,
 		URL:    url,
 	}
-
 	req = req.WithContext(ctx)
 
 	// ACME spec says that a verifier should try
@@ -165,22 +186,28 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 
 	response, err := client.Do(req)
 	if err != nil {
-		return fmt.Errorf("failed to GET '%s': %v", url, err)
+		log.V(logf.DebugLevel).Info("failed to perform self check GET request", "error", err)
+		return fmt.Errorf("failed to perform self check GET request '%s': %v", url, err)
 	}
 
 	if response.StatusCode != http.StatusOK {
+		log.V(logf.DebugLevel).Info("received HTTP status code was not StatusOK (200)", "code", response.StatusCode)
 		return fmt.Errorf("wrong status code '%d', expected '%d'", response.StatusCode, http.StatusOK)
 	}
 
 	defer response.Body.Close()
 	presentedKey, err := ioutil.ReadAll(response.Body)
 	if err != nil {
+		log.V(logf.DebugLevel).Info("failed to decode response body", "error", err)
 		return fmt.Errorf("failed to read response body: %v", err)
 	}
 
 	if string(presentedKey) != key {
+		log.V(logf.DebugLevel).Info("key returned by server did not match expected", "actual", presentedKey, "expected", key)
 		return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey, key)
 	}
+
+	log.V(logf.DebugLevel).Info("reachability test succeeded")
 
 	return nil
 }

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"context"
 	"fmt"
 
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -26,16 +27,18 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/klog"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
 	"github.com/jetstack/cert-manager/pkg/util"
 )
 
 // getIngressesForChallenge returns a list of Ingresses that were created to solve
 // http challenges for the given domain
-func (s *Solver) getIngressesForChallenge(ch *v1alpha1.Challenge) ([]*extv1beta1.Ingress, error) {
+func (s *Solver) getIngressesForChallenge(ctx context.Context, ch *v1alpha1.Challenge) ([]*extv1beta1.Ingress, error) {
+	log := logf.FromContext(ctx)
+
 	podLabels := podLabels(ch)
 	selector := labels.NewSelector()
 	for key, val := range podLabels {
@@ -46,7 +49,7 @@ func (s *Solver) getIngressesForChallenge(ch *v1alpha1.Challenge) ([]*extv1beta1
 		selector = selector.Add(*req)
 	}
 
-	klog.Infof("Looking up Ingresses for selector %v", selector)
+	log.V(logf.DebugLevel).Info("checking for existing HTTP01 solver ingresses")
 	ingressList, err := s.ingressLister.Ingresses(ch.Namespace).List(selector)
 	if err != nil {
 		return nil, err
@@ -55,8 +58,8 @@ func (s *Solver) getIngressesForChallenge(ch *v1alpha1.Challenge) ([]*extv1beta1
 	var relevantIngresses []*extv1beta1.Ingress
 	for _, ingress := range ingressList {
 		if !metav1.IsControlledBy(ingress, ch) {
-			klog.Infof("Found ingress %q with acme-order-url annotation set to that of Challenge %q "+
-				"but it is not owned by the Challenge resource, so skipping it.", ingress.Namespace+"/"+ingress.Name, ch.Namespace+"/"+ch.Name)
+			logf.WithRelatedResource(log, ingress).Info("found existing solver ingress for this challenge resource, however " +
+				"it does not have an appropriate OwnerReference referencing this challenge. Skipping it altogether.")
 			continue
 		}
 		relevantIngresses = append(relevantIngresses, ingress)
@@ -68,34 +71,38 @@ func (s *Solver) getIngressesForChallenge(ch *v1alpha1.Challenge) ([]*extv1beta1
 // ensureIngress will ensure the ingress required to solve this challenge
 // exists, or if an existing ingress is specified on the secret will ensure
 // that the ingress has an appropriate challenge path configured
-func (s *Solver) ensureIngress(ch *v1alpha1.Challenge, svcName string) (ing *extv1beta1.Ingress, err error) {
+func (s *Solver) ensureIngress(ctx context.Context, ch *v1alpha1.Challenge, svcName string) (ing *extv1beta1.Ingress, err error) {
+	log := logf.FromContext(ctx).WithName("ensureIngress")
+
 	httpDomainCfg := ch.Spec.Config.HTTP01
 	if httpDomainCfg == nil {
 		httpDomainCfg = &v1alpha1.HTTP01SolverConfig{}
 	}
 	if httpDomainCfg != nil &&
 		httpDomainCfg.Ingress != "" {
-
-		return s.addChallengePathToIngress(ch, svcName)
+		log := logf.WithRelatedResourceName(log, httpDomainCfg.Ingress, ch.Namespace, "Ingress")
+		ctx := logf.NewContext(ctx, log)
+		log.Info("adding solver paths to existing ingress resource")
+		return s.addChallengePathToIngress(ctx, ch, svcName)
 	}
-	existingIngresses, err := s.getIngressesForChallenge(ch)
+	existingIngresses, err := s.getIngressesForChallenge(ctx, ch)
 	if err != nil {
 		return nil, err
 	}
 	if len(existingIngresses) == 1 {
+		logf.WithRelatedResource(log, existingIngresses[0]).Info("found one existing HTTP01 solver ingress")
 		return existingIngresses[0], nil
 	}
 	if len(existingIngresses) > 1 {
-		errMsg := fmt.Sprintf("multiple challenge solver ingresses found for Challenge '%s/%s'. Cleaning up existing pods.", ch.Namespace, ch.Name)
-		klog.Infof(errMsg)
-		err := s.cleanupIngresses(ch)
+		log.Info("multiple challenge solver ingresses found for challenge. cleaning up all existing ingresses.")
+		err := s.cleanupIngresses(ctx, ch)
 		if err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf(errMsg)
+		return nil, fmt.Errorf("multiple existing challenge solver ingresses found and cleaned up. retrying challenge sync")
 	}
 
-	klog.Infof("No existing HTTP01 challenge solver ingress found for Challenge %q. One will be created.", ch.Namespace+"/"+ch.Name)
+	log.Info("creating HTTP01 challenge solver ingress")
 	return s.createIngress(ch, svcName)
 }
 
@@ -145,7 +152,7 @@ func buildIngressResource(ch *v1alpha1.Challenge, svcName string) *extv1beta1.In
 	}
 }
 
-func (s *Solver) addChallengePathToIngress(ch *v1alpha1.Challenge, svcName string) (*extv1beta1.Ingress, error) {
+func (s *Solver) addChallengePathToIngress(ctx context.Context, ch *v1alpha1.Challenge, svcName string) (*extv1beta1.Ingress, error) {
 	ingressName := ch.Spec.Config.HTTP01.Ingress
 
 	ing, err := s.ingressLister.Ingresses(ch.Namespace).Get(ingressName)
@@ -193,7 +200,9 @@ func (s *Solver) addChallengePathToIngress(ch *v1alpha1.Challenge, svcName strin
 // cleanupIngresses will remove the rules added by cert-manager to an existing
 // ingress, or delete the ingress if an existing ingress name is not specified
 // on the certificate.
-func (s *Solver) cleanupIngresses(ch *v1alpha1.Challenge) error {
+func (s *Solver) cleanupIngresses(ctx context.Context, ch *v1alpha1.Challenge) error {
+	log := logf.FromContext(ctx, "cleanupPods")
+
 	httpDomainCfg := ch.Spec.Config.HTTP01
 	if httpDomainCfg == nil {
 		httpDomainCfg = &v1alpha1.HTTP01SolverConfig{}
@@ -203,19 +212,22 @@ func (s *Solver) cleanupIngresses(ch *v1alpha1.Challenge) error {
 	// if the 'ingress' field on the domain config is not set, we need to delete
 	// the ingress resources that cert-manager has created to solve the challenge
 	if existingIngressName == "" {
-		ingresses, err := s.getIngressesForChallenge(ch)
+		ingresses, err := s.getIngressesForChallenge(ctx, ch)
 		if err != nil {
 			return err
 		}
-		klog.V(4).Infof("Found %d ingresses to clean up for certificate %q", len(ingresses), ch.Namespace+"/"+ch.Name)
 		var errs []error
 		for _, ingress := range ingresses {
-			// TODO: should we call DeleteCollection here? We'd need to somehow
-			// also ensure ownership as part of that request using a FieldSelector.
+			log := logf.WithRelatedResource(log, ingress).V(logf.DebugLevel)
+
+			log.Info("deleting ingress resource")
 			err := s.Client.ExtensionsV1beta1().Ingresses(ingress.Namespace).Delete(ingress.Name, nil)
 			if err != nil {
+				log.Info("failed to delete ingress resource", "error", err)
 				errs = append(errs, err)
+				continue
 			}
+			log.Info("successfully deleted ingress resource")
 		}
 		return utilerrors.NewAggregate(errs)
 	}
@@ -223,13 +235,15 @@ func (s *Solver) cleanupIngresses(ch *v1alpha1.Challenge) error {
 	// otherwise, we need to remove any cert-manager added rules from the ingress resource
 	ing, err := s.Client.ExtensionsV1beta1().Ingresses(ch.Namespace).Get(existingIngressName, metav1.GetOptions{})
 	if k8sErrors.IsNotFound(err) {
-		klog.Infof("attempt to cleanup Ingress %q of ACME challenge path failed: %v", ch.Namespace+"/"+existingIngressName, err)
+		log.Error(err, "named ingress resource not found, skipping cleanup")
 		return nil
 	}
 	if err != nil {
 		return err
 	}
+	log = logf.WithRelatedResource(log, ing)
 
+	log.Info("attempting to clean up automatically added solver paths on ingress resource")
 	ingPathToDel := solverPathFn(ch.Spec.Token)
 	var ingRules []extv1beta1.IngressRule
 	for _, rule := range ing.Spec.Rules {
@@ -249,6 +263,7 @@ func (s *Solver) cleanupIngresses(ch *v1alpha1.Challenge) error {
 		// delete here, delete it
 		for i, path := range rule.HTTP.Paths {
 			if path.Path == ingPathToDel {
+				log.Info("deleting challenge solver path on ingress resource", "host", rule.Host, "path", path.Path)
 				rule.HTTP.Paths = append(rule.HTTP.Paths[:i], rule.HTTP.Paths[i+1:]...)
 			}
 		}
@@ -265,6 +280,8 @@ func (s *Solver) cleanupIngresses(ch *v1alpha1.Challenge) error {
 	if err != nil {
 		return err
 	}
+
+	log.Info("cleaned up all challenge solver paths on ingress resource")
 
 	return nil
 }

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -96,7 +97,7 @@ func TestGetIngressesForChallenge(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.getIngressesForChallenge(test.Challenge)
+			resp, err := test.Solver.getIngressesForChallenge(context.TODO(), test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}
@@ -349,7 +350,7 @@ func TestCleanupIngresses(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			err := test.Solver.cleanupIngresses(test.Challenge)
+			err := test.Solver.cleanupIngresses(context.TODO(), test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"context"
 	"fmt"
 	"hash/adler32"
 
@@ -25,9 +26,9 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
-	"k8s.io/klog"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
 )
 
 func podLabels(ch *v1alpha1.Challenge) map[string]string {
@@ -43,31 +44,36 @@ func podLabels(ch *v1alpha1.Challenge) map[string]string {
 	}
 }
 
-func (s *Solver) ensurePod(ch *v1alpha1.Challenge) (*corev1.Pod, error) {
-	existingPods, err := s.getPodsForChallenge(ch)
+func (s *Solver) ensurePod(ctx context.Context, ch *v1alpha1.Challenge) (*corev1.Pod, error) {
+	log := logf.FromContext(ctx).WithName("ensurePod")
+
+	log.V(logf.DebugLevel).Info("checking for existing HTTP01 solver pods")
+	existingPods, err := s.getPodsForChallenge(ctx, ch)
 	if err != nil {
 		return nil, err
 	}
 	if len(existingPods) == 1 {
+		logf.WithRelatedResource(log, existingPods[0]).Info("found one existing HTTP01 solver pod")
 		return existingPods[0], nil
 	}
 	if len(existingPods) > 1 {
-		errMsg := fmt.Sprintf("multiple challenge solver pods found for certificate '%s/%s'. Cleaning up existing pods.", ch.Namespace, ch.Name)
-		klog.Infof(errMsg)
-		err := s.cleanupPods(ch)
+		log.Info("multiple challenge solver pods found for challenge. cleaning up all existing pods.")
+		err := s.cleanupPods(ctx, ch)
 		if err != nil {
 			return nil, err
 		}
-		return nil, fmt.Errorf(errMsg)
+		return nil, fmt.Errorf("multiple existing challenge solver pods found and cleaned up. retrying challenge sync")
 	}
 
-	klog.Infof("No existing HTTP01 challenge solver pod found for Certificate %q. One will be created.", ch.Namespace+"/"+ch.Name)
+	log.Info("creating HTTP01 challenge solver pod")
 	return s.createPod(ch)
 }
 
 // getPodsForChallenge returns a list of pods that were created to solve
 // the given challenge
-func (s *Solver) getPodsForChallenge(ch *v1alpha1.Challenge) ([]*corev1.Pod, error) {
+func (s *Solver) getPodsForChallenge(ctx context.Context, ch *v1alpha1.Challenge) ([]*corev1.Pod, error) {
+	log := logf.FromContext(ctx)
+
 	podLabels := podLabels(ch)
 	orderSelector := labels.NewSelector()
 	for key, val := range podLabels {
@@ -86,8 +92,8 @@ func (s *Solver) getPodsForChallenge(ch *v1alpha1.Challenge) ([]*corev1.Pod, err
 	var relevantPods []*corev1.Pod
 	for _, pod := range podList {
 		if !metav1.IsControlledBy(pod, ch) {
-			klog.Infof("Found pod %q with acme-order-url annotation set to that of Certificate %q"+
-				"but it is not owned by the Certificate resource, so skipping it.", pod.Namespace+"/"+pod.Name, ch.Namespace+"/"+ch.Name)
+			logf.WithRelatedResource(log, pod).Info("found existing solver pod for this challenge resource, however " +
+				"it does not have an appropriate OwnerReference referencing this challenge. Skipping it altogether.")
 			continue
 		}
 		relevantPods = append(relevantPods, pod)
@@ -96,20 +102,27 @@ func (s *Solver) getPodsForChallenge(ch *v1alpha1.Challenge) ([]*corev1.Pod, err
 	return relevantPods, nil
 }
 
-func (s *Solver) cleanupPods(ch *v1alpha1.Challenge) error {
-	pods, err := s.getPodsForChallenge(ch)
+func (s *Solver) cleanupPods(ctx context.Context, ch *v1alpha1.Challenge) error {
+	log := logf.FromContext(ctx, "cleanupPods")
+
+	pods, err := s.getPodsForChallenge(ctx, ch)
 	if err != nil {
 		return err
 	}
 	var errs []error
 	for _, pod := range pods {
-		// TODO: should we call DeleteCollection here? We'd need to somehow
-		// also ensure ownership as part of that request using a FieldSelector.
+		log := logf.WithRelatedResource(log, pod).V(logf.DebugLevel)
+		log.Info("deleting pod resource")
+
 		err := s.Client.CoreV1().Pods(pod.Namespace).Delete(pod.Name, nil)
 		if err != nil {
+			log.Info("failed to delete pod resource", "error", err)
 			errs = append(errs, err)
+			continue
 		}
+		log.Info("successfully deleted pod resource")
 	}
+
 	return utilerrors.NewAggregate(errs)
 }
 

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -162,7 +163,7 @@ func TestEnsurePod(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.ensurePod(test.Challenge)
+			resp, err := test.Solver.ensurePod(context.TODO(), test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}
@@ -240,7 +241,7 @@ func TestGetPodsForCertificate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.getPodsForChallenge(test.Challenge)
+			resp, err := test.Solver.getPodsForChallenge(context.TODO(), test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package http
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -156,7 +157,7 @@ func TestEnsureService(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.ensureService(test.Issuer, test.Challenge)
+			resp, err := test.Solver.ensureService(context.TODO(), test.Issuer, test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}
@@ -234,7 +235,7 @@ func TestGetServicesForCertificate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.getServicesForChallenge(test.Challenge)
+			resp, err := test.Solver.getServicesForChallenge(context.TODO(), test.Challenge)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds additional debug logging and switches the HTTP01 solver to use the logr interface

**Release note**:
```release-note
Improve logging in ACME HTTP01 solver
```
