### PR TITLE
Rectify ecdsa key size indication from 521 to 512

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -126,7 +126,7 @@ spec:
               description: KeySize is the key bit size of the corresponding private
                 key for this certificate. If provided, value must be between 2048
                 and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                and value must be one of (256, 384, 512) when KeyAlgorithm is set
                 to "ecdsa".
               format: int64
               type: integer

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -126,7 +126,7 @@ spec:
               description: KeySize is the key bit size of the corresponding private
                 key for this certificate. If provided, value must be between 2048
                 and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                and value must be one of (256, 384, 512) when KeyAlgorithm is set
                 to "ecdsa".
               format: int64
               type: integer
@@ -1283,7 +1283,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-            
+
 
 ---
 # Source: cert-manager/templates/deployment.yaml
@@ -1332,5 +1332,5 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
-            
+
 

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -126,7 +126,7 @@ spec:
               description: KeySize is the key bit size of the corresponding private
                 key for this certificate. If provided, value must be between 2048
                 and 8192 inclusive when KeyAlgorithm is empty or is set to "rsa",
-                and value must be one of (256, 384, 521) when KeyAlgorithm is set
+                and value must be one of (256, 384, 512) when KeyAlgorithm is set
                 to "ecdsa".
               format: int64
               type: integer
@@ -1388,7 +1388,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-            
+
 
 ---
 # Source: cert-manager/charts/webhook/templates/deployment.yaml
@@ -1432,7 +1432,7 @@ spec:
                 fieldPath: metadata.namespace
           resources:
             {}
-            
+
           volumeMounts:
           - name: certs
             mountPath: /certs
@@ -1488,7 +1488,7 @@ spec:
             requests:
               cpu: 10m
               memory: 32Mi
-            
+
 
 ---
 # Source: cert-manager/charts/webhook/templates/apiservice.yaml

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -105,7 +105,7 @@ type CertificateSpec struct {
 
 	// KeySize is the key bit size of the corresponding private key for this certificate.
 	// If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is
-	// empty or is set to "rsa", and value must be one of (256, 384, 521) when
+	// empty or is set to "rsa", and value must be one of (256, 384, 512) when
 	// KeyAlgorithm is set to "ecdsa".
 	// +optional
 	KeySize int `json:"keySize,omitempty"`

--- a/pkg/apis/certmanager/validation/certificate.go
+++ b/pkg/apis/certmanager/validation/certificate.go
@@ -67,8 +67,8 @@ func ValidateCertificateSpec(crt *v1alpha1.CertificateSpec, fldPath *field.Path)
 			el = append(el, field.Invalid(fldPath.Child("keySize"), crt.KeySize, "must be between 2048 & 8192 for rsa keyAlgorithm"))
 		}
 	case v1alpha1.ECDSAKeyAlgorithm:
-		if crt.KeySize > 0 && crt.KeySize != 256 && crt.KeySize != 384 && crt.KeySize != 521 {
-			el = append(el, field.NotSupported(fldPath.Child("keySize"), crt.KeySize, []string{"256", "384", "521"}))
+		if crt.KeySize > 0 && crt.KeySize != 256 && crt.KeySize != 384 && crt.KeySize != 512 {
+			el = append(el, field.NotSupported(fldPath.Child("keySize"), crt.KeySize, []string{"256", "384", "512"}))
 		}
 	default:
 		el = append(el, field.Invalid(fldPath.Child("keyAlgorithm"), crt.KeyAlgorithm, "must be either empty or one of rsa or ecdsa"))

--- a/pkg/apis/certmanager/validation/certificate_test.go
+++ b/pkg/apis/certmanager/validation/certificate_test.go
@@ -283,14 +283,14 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 		},
-		"valid certificate with ecdsa keyAlgorithm specified with keySize 521": {
+		"valid certificate with ecdsa keyAlgorithm specified with keySize 512": {
 			cfg: &v1alpha1.Certificate{
 				Spec: v1alpha1.CertificateSpec{
 					CommonName:   "testcn",
 					SecretName:   "abc",
 					IssuerRef:    validIssuerRef,
 					KeyAlgorithm: v1alpha1.ECDSAKeyAlgorithm,
-					KeySize:      521,
+					KeySize:      512,
 				},
 			},
 		},
@@ -356,7 +356,7 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 			errs: []*field.Error{
-				field.NotSupported(fldPath.Child("keySize"), 100, []string{"256", "384", "521"}),
+				field.NotSupported(fldPath.Child("keySize"), 100, []string{"256", "384", "512"}),
 			},
 		},
 		"certificate with invalid keyAlgorithm": {

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -486,7 +486,7 @@ func generateSelfSignedTemporaryCertificate(crt *v1alpha1.Certificate, pk []byte
 // In practice, this shouldn't really be a concern anyway.
 func generateLocallySignedTemporaryCertificate(crt *v1alpha1.Certificate, pk []byte) ([]byte, error) {
 	// generate a throwaway self-signed root CA
-	caPk, err := pki.GenerateECPrivateKey(pki.ECCurve521)
+	caPk, err := pki.GenerateECPrivateKey(pki.ECCurve512)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/issuer/ca/issue_test.go
+++ b/pkg/issuer/ca/issue_test.go
@@ -166,7 +166,7 @@ func TestIssue(t *testing.T) {
 				gen.SetCertificateSecretName("crt-output"),
 				gen.SetCertificateCommonName("testing-cn"),
 				gen.SetCertificateKeyAlgorithm(v1alpha1.ECDSAKeyAlgorithm),
-				gen.SetCertificateKeySize(521),
+				gen.SetCertificateKeySize(512),
 			),
 			Builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{rootRSACASecret},

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -289,7 +289,7 @@ func SignatureAlgorithm(crt *v1alpha1.Certificate) (x509.PublicKeyAlgorithm, x50
 	case v1alpha1.ECDSAKeyAlgorithm:
 		pubKeyAlgo = x509.ECDSA
 		switch crt.Spec.KeySize {
-		case 521:
+		case 512:
 			sigAlgo = x509.ECDSAWithSHA512
 		case 384:
 			sigAlgo = x509.ECDSAWithSHA384

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -210,9 +210,9 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 			expectedKeyType: x509.ECDSA,
 		},
 		{
-			name:            "certificate with KeyAlgorithm ecdsa and size 521",
+			name:            "certificate with KeyAlgorithm ecdsa and size 512",
 			keyAlgo:         v1alpha1.ECDSAKeyAlgorithm,
-			keySize:         521,
+			keySize:         512,
 			expectedSigAlgo: x509.ECDSAWithSHA512,
 			expectedKeyType: x509.ECDSA,
 		},

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -42,8 +42,8 @@ const (
 	ECCurve256 = 256
 	// ECCurve384 represents a 384bit ECDSA key.
 	ECCurve384 = 384
-	// ECCurve521 represents a 521bit ECDSA key.
-	ECCurve521 = 521
+	// ECCurve512 represents a 512bit ECDSA key.
+	ECCurve512 = 512
 )
 
 // GeneratePrivateKeyForCertificate will generate a private key suitable for
@@ -89,7 +89,7 @@ func GenerateRSAPrivateKey(keySize int) (*rsa.PrivateKey, error) {
 }
 
 // GenerateECPrivateKey will generate an ECDSA private key of the given size.
-// It can be used to generate 256, 384 and 521 sized keys.
+// It can be used to generate 256, 384 and 512 sized keys.
 func GenerateECPrivateKey(keySize int) (*ecdsa.PrivateKey, error) {
 	var ecCurve elliptic.Curve
 
@@ -98,8 +98,8 @@ func GenerateECPrivateKey(keySize int) (*ecdsa.PrivateKey, error) {
 		ecCurve = elliptic.P256()
 	case ECCurve384:
 		ecCurve = elliptic.P384()
-	case ECCurve521:
-		ecCurve = elliptic.P521()
+	case ECCurve512:
+		ecCurve = elliptic.P512()
 	default:
 		return nil, fmt.Errorf("unsupported ecdsa key size specified: %d", keySize)
 	}

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -49,8 +49,8 @@ func ecCurveForKeySize(keySize int) (elliptic.Curve, error) {
 		return elliptic.P256(), nil
 	case ECCurve384:
 		return elliptic.P384(), nil
-	case ECCurve521:
-		return elliptic.P521(), nil
+	case ECCurve512:
+		return elliptic.P512(), nil
 	default:
 		return nil, fmt.Errorf("unknown ecdsa key size specified: %d", keySize)
 	}
@@ -119,9 +119,9 @@ func TestGeneratePrivateKeyForCertificate(t *testing.T) {
 			expectErr: false,
 		},
 		{
-			name:      "ecdsa key with keysize 521",
+			name:      "ecdsa key with keysize 512",
 			keyAlgo:   v1alpha1.ECDSAKeyAlgorithm,
-			keySize:   521,
+			keySize:   512,
 			expectErr: false,
 		},
 		{

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -80,7 +80,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 			crt := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, nil, nil)
 			crt.Spec.KeyAlgorithm = v1alpha1.ECDSAKeyAlgorithm
-			crt.Spec.KeySize = 521
+			crt.Spec.KeySize = 512
 
 			By("Creating a Certificate")
 			_, err := certClient.Create(crt)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR intends to rectify a typo in the key size indication for ECDSA keys. Currently, the allowed sizes for ECDSA keys are `256`, `384` and `521`, however, the `521` actually maps to using 512 bits in the code.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
