### PR TITLE
Update troubleshooting.rst

### DIFF
--- a/docs/getting-started/troubleshooting.rst
+++ b/docs/getting-started/troubleshooting.rst
@@ -28,12 +28,13 @@ following command to verify that your cert-manager namespace has the necessary
 label:
 
 .. code-block:: shell
-   :emphasize-lines: 4
 
-   kubectl get namespace
-
+   kubectl describe namespace cert-manager
+   
    Name:         cert-manager
    Labels:       certmanager.k8s.io/disable-validation=true
+   Annotations:  <none>
+   Status:       Active
    ...
 
 If you cannot see the ``certmanager.k8s.io/disable-validation=true`` label on


### PR DESCRIPTION
The example for checking the namespace has the correct label was incorrect.

It was also being hidden on the Github RST rendering, because of the `:emphasize-lines`. I suspect this is why the mistake has never been noticed previously.
I suggest having the example render in github is more important the emphasizing the line.


