### PR TITLE
Expose metrics server on non-leader instances

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -63,14 +63,15 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) {
 		os.Exit(1)
 	}
 
-	run := func(_ context.Context) {
-		var wg sync.WaitGroup
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			metrics.Default.Start(stopCh)
-		}()
+	var wg sync.WaitGroup
+	wg.Add(1)
 
+	go func() {
+		defer wg.Done()
+		metrics.Default.Start(stopCh)
+	}()
+
+	run := func(_ context.Context) {
 		for n, fn := range controller.Known() {
 			log := log.WithValues("controller", n)
 


### PR DESCRIPTION
This makes sure all cert-manager instances have a metrics endpoint.

Fixes #1352.

```release-note
Run metrics server on cert-manager instances that have not been elected as leader
```
