### PR TITLE
make email address an optional field in ACME issuers

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -457,7 +457,6 @@ spec:
                     type: object
                   type: array
               required:
-              - email
               - server
               - privateKeySecretRef
               type: object
@@ -737,7 +736,6 @@ spec:
                     type: object
                   type: array
               required:
-              - email
               - server
               - privateKeySecretRef
               type: object

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -191,7 +191,8 @@ type CAIssuer struct {
 // ACMEIssuer contains the specification for an ACME issuer
 type ACMEIssuer struct {
 	// Email is the email for this account
-	Email string `json:"email"`
+	// +optional
+	Email string `json:"email,omitempty"`
 
 	// Server is the ACME server URL
 	Server string `json:"server"`

--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -94,9 +94,6 @@ func ValidateIssuerConfig(iss *v1alpha1.IssuerConfig, fldPath *field.Path) field
 
 func ValidateACMEIssuerConfig(iss *v1alpha1.ACMEIssuer, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
-	if len(iss.Email) == 0 {
-		el = append(el, field.Required(fldPath.Child("email"), "email address is a required field"))
-	}
 	if len(iss.PrivateKey.Name) == 0 {
 		el = append(el, field.Required(fldPath.Child("privateKeySecretRef", "name"), "private key secret name is a required field"))
 	}

--- a/pkg/apis/certmanager/validation/issuer_test.go
+++ b/pkg/apis/certmanager/validation/issuer_test.go
@@ -112,7 +112,6 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 		"acme issuer with missing fields": {
 			spec: &v1alpha1.ACMEIssuer{},
 			errs: []*field.Error{
-				field.Required(fldPath.Child("email"), "email address is a required field"),
 				field.Required(fldPath.Child("privateKeySecretRef", "name"), "private key secret name is a required field"),
 				field.Required(fldPath.Child("server"), "acme server URL is a required field"),
 			},

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -217,8 +217,13 @@ func (a *Acme) registerAccount(ctx context.Context, cl client.Interface) (*acmea
 		return nil, err
 	}
 
+	emailurl := []string(nil)
+	if a.issuer.GetSpec().ACME.Email != "" {
+		emailurl = []string{fmt.Sprintf("mailto:%s", strings.ToLower(a.issuer.GetSpec().ACME.Email))}
+	}
+
 	acc = &acmeapi.Account{
-		Contact:     []string{fmt.Sprintf("mailto:%s", strings.ToLower(a.issuer.GetSpec().ACME.Email))},
+		Contact:     emailurl,
 		TermsAgreed: true,
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Email addresses aren't required by the acme standard. Bring the configuration into line with the spec

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #1428

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Make ACME email addresses optional
```
