### PR TITLE
Set default acmesolver image based on arch

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -19,6 +19,7 @@ package options
 import (
 	"fmt"
 	"net"
+	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -96,8 +97,16 @@ const (
 	defaultDNS01RecursiveNameserversOnly = false
 )
 
+func computeACMEHTTP01SolverImage(arch string) string {
+	if arch == "amd64" {
+		return fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
+	} else {
+		return fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver-%s:%s", runtime.GOARCH, util.AppVersion)
+	}
+}
+
 var (
-	defaultACMEHTTP01SolverImage                 = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
+	defaultACMEHTTP01SolverImage                 = computeACMEHTTP01SolverImage(runtime.GOARCH)
 	defaultACMEHTTP01SolverResourceRequestCPU    = "10m"
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"


### PR DESCRIPTION
Signed-off-by: Lennart Jern <lennart.jern@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This detects the architecture and sets the acmesolver container image based on that.

**Which issue this PR fixes**: fixes #1470

**Special notes for your reviewer**:
I'm not sure if it's OK to use `quay.io/jetstack/cert-manager-acmesolver-amd64` instead of `quay.io/jetstack/cert-manager-acmesolver` (the case now) for the normal `amd64` arch. It makes sense in the way that all archs are treated equally but it may need changes in other places that I'm not aware of (build and push jobs?).

Please bear with me, this is my first pull request to cert-manager :smile: 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Set default acmesolver image based on arch
```
