### PR TITLE
Add support for CRDs to the CA injector

### DIFF
--- a/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
@@ -24,6 +24,9 @@ rules:
   - apiGroups: ["apiregistration.k8s.io"]
     resources: ["apiservices"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/acme/webhook/apis/acme/v1alpha1:go_default_library",
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",

--- a/pkg/api/scheme.go
+++ b/pkg/api/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -37,6 +38,7 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 	whapi.AddToScheme,
 	kscheme.AddToScheme,
 	apireg.AddToScheme,
+	apiext.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/controller/cainjector/BUILD.bazel
+++ b/pkg/controller/cainjector/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/meta:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -144,6 +144,10 @@ func (r *genericInjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	// fetch the target object
 	target := r.injector.NewTarget()
 	if err := r.Client.Get(ctx, req.NamespacedName, target.AsObject()); err != nil {
+		if dropNotFound(err) == nil {
+			// don't requeue on deletions, which yield a non-found object
+			return ctrl.Result{}, nil
+		}
 		log.Error(err, "unable to fetch target object to inject into")
 		return ctrl.Result{}, err
 	}

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -21,6 +21,7 @@ import (
 
 	admissionreg "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -56,7 +57,13 @@ var (
 		listType:     &apireg.APIServiceList{},
 	}
 
-	injectorSetups  = []injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup}
+	CRDSetup = injectorSetup{
+		resourceName: "customresourcedefinition",
+		injector:     crdConversionInjector{},
+		listType:     &apiext.CustomResourceDefinitionList{},
+	}
+
+	injectorSetups  = []injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup, CRDSetup}
 	ControllerNames []string
 )
 

--- a/test/e2e/framework/BUILD.bazel
+++ b/test/e2e/framework/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//vendor/k8s.io/api/authorization/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/rbac/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
@@ -36,6 +37,7 @@ go_library(
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/controller-runtime/pkg/client:go_default_library",
     ],
 )

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -24,12 +24,14 @@ import (
 
 	"k8s.io/api/core/v1"
 	api "k8s.io/api/core/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -50,6 +52,8 @@ var Scheme = runtime.NewScheme()
 func init() {
 	kscheme.AddToScheme(Scheme)
 	certmgrscheme.AddToScheme(Scheme)
+	apiext.AddToScheme(Scheme)
+	apireg.AddToScheme(Scheme)
 }
 
 // DefaultConfig contains the default shared config the is likely parsed from

--- a/test/e2e/suite/serving/BUILD.bazel
+++ b/test/e2e/suite/serving/BUILD.bazel
@@ -14,9 +14,11 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -28,47 +28,211 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/util"
 	admissionreg "k8s.io/api/admissionregistration/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
 )
+
+type injectableTest struct {
+	makeInjectable func(namePrefix string) runtime.Object
+	getCAs         func(runtime.Object) [][]byte
+	subject        string
+	disabled       string
+}
 
 var _ = framework.CertManagerDescribe("CA Injector", func() {
 	f := framework.NewDefaultFramework("ca-injector")
 
 	issuerName := "inject-cert-issuer"
 
-	Context("for validating webhooks", func() {
-		var hookToCleanUp runtime.Object
-		BeforeEach(func() {
-			By("creating a self-signing issuer")
-			issuer := util.NewCertManagerSelfSignedIssuer(issuerName)
-			issuer.Namespace = f.Namespace.Name
-			Expect(f.CRClient.Create(context.Background(), issuer)).To(Succeed())
+	injectorContext := func(subj string, test *injectableTest) {
+		Context("for "+subj+"s", func() {
+			var toCleanup runtime.Object
 
-			By("Waiting for Issuer to become Ready")
-			err := util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name),
-				issuerName,
-				certmanager.IssuerCondition{
-					Type:   certmanager.IssuerConditionReady,
-					Status: certmanager.ConditionTrue,
-				})
-			Expect(err).NotTo(HaveOccurred())
-		})
+			BeforeEach(func() {
+				By("creating a self-signing issuer")
+				issuer := util.NewCertManagerSelfSignedIssuer(issuerName)
+				issuer.Namespace = f.Namespace.Name
+				Expect(f.CRClient.Create(context.Background(), issuer)).To(Succeed())
 
-		AfterEach(func() {
-			if hookToCleanUp == nil {
-				return
+				By("Waiting for Issuer to become Ready")
+				err := util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name),
+					issuerName,
+					certmanager.IssuerCondition{
+						Type:   certmanager.IssuerConditionReady,
+						Status: certmanager.ConditionTrue,
+					})
+				Expect(err).NotTo(HaveOccurred())
+			})
+
+			AfterEach(func() {
+				if toCleanup == nil {
+					return
+				}
+				Expect(f.CRClient.Delete(context.Background(), toCleanup)).To(Succeed())
+			})
+			generalSetup := func(namePrefix string) (runtime.Object, certmanager.Certificate, corev1.Secret) {
+				By("creating a " + subj + " pointing to a cert")
+				injectable := test.makeInjectable(namePrefix)
+				Expect(f.CRClient.Create(context.Background(), injectable)).To(Succeed())
+				toCleanup = injectable
+
+				By("creating a certificate")
+				secretName := types.NamespacedName{Name: "serving-certs-data", Namespace: f.Namespace.Name}
+				cert := util.NewCertManagerBasicCertificate("serving-certs", secretName.Name, issuerName, certmanager.IssuerKind, nil, nil)
+				cert.Namespace = f.Namespace.Name
+				Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
+
+				By("grabbing the corresponding secret")
+				var secret corev1.Secret
+				Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
+
+				By("checking that all webhooks have a populated CA")
+				caData := secret.Data["ca.crt"]
+				expectedLen := len(test.getCAs(injectable))
+				expectedCAs := make([][]byte, expectedLen)
+				for i := range expectedCAs {
+					expectedCAs[i] = caData
+				}
+				Eventually(func() ([][]byte, error) {
+					newInjectable := injectable.DeepCopyObject()
+					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
+						return nil, err
+					}
+					return test.getCAs(newInjectable), nil
+				}, "10s", "2s").Should(Equal(expectedCAs))
+
+				return injectable, *cert, secret
+
 			}
-			Expect(f.CRClient.Delete(context.Background(), hookToCleanUp)).To(Succeed())
-		})
 
-		setupHook := func(hookPrefix string) (admissionreg.ValidatingWebhookConfiguration, certmanager.Certificate, corev1.Secret) {
-			By("creating a validating webhook pointing to a cert")
+			It("should inject the CA data into all CA fields", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+
+				generalSetup("injected")
+			})
+
+			It("should not inject CA into non-annotated objects", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+				By("creating a validating webhook not pointing to a cert")
+				injectable := test.makeInjectable("non-injected")
+				injectable.(metav1.Object).SetAnnotations(map[string]string{}) // wipe out the inject annotation
+				Expect(f.CRClient.Create(context.Background(), injectable)).To(Succeed())
+				toCleanup = injectable
+
+				By("expecting the CA data to remain in place")
+				expectedCAs := test.getCAs(injectable)
+				Consistently(func() ([][]byte, error) {
+					newInjectable := injectable.DeepCopyObject()
+					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
+						return nil, err
+					}
+					return test.getCAs(newInjectable), nil
+				}).Should(Equal(expectedCAs))
+			})
+
+			It("should update data when the certificate changes", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+				injectable, cert, _ := generalSetup("changed")
+
+				By("grabbing the latest copy of the cert")
+				Expect(f.CRClient.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, &cert)).To(Succeed())
+
+				By("changing the name of the corresponding secret in the cert")
+				secretName := types.NamespacedName{Name: "other-data", Namespace: f.Namespace.Name}
+				cert.Spec.SecretName = secretName.Name
+				Expect(f.CRClient.Update(context.Background(), &cert)).To(Succeed())
+
+				By("grabbing the new secret")
+				var secret corev1.Secret
+				Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
+
+				By("verifying that the hooks have the new data")
+				caData := secret.Data["ca.crt"]
+				expectedLen := len(test.getCAs(injectable))
+				expectedCAs := make([][]byte, expectedLen)
+				for i := range expectedCAs {
+					expectedCAs[i] = caData
+				}
+				Eventually(func() ([][]byte, error) {
+					newInjectable := injectable.DeepCopyObject()
+					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
+						return nil, err
+					}
+					return test.getCAs(newInjectable), nil
+				}, "10s", "2s").Should(Equal(expectedCAs))
+			})
+
+			It("should ignore objects with invalid annotations", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+				By("creating a validating webhook with an invalid cert name")
+				injectable := test.makeInjectable("invalid")
+				injectable.(metav1.Object).SetAnnotations(map[string]string{
+					injctrl.WantInjectAnnotation: "serving-certs", // an invalid annotation
+				})
+				Expect(f.CRClient.Create(context.Background(), injectable)).To(Succeed())
+				toCleanup = injectable
+
+				By("expecting the CA data to remain in place")
+				expectedCAs := test.getCAs(injectable)
+				Consistently(func() ([][]byte, error) {
+					newInjectable := injectable.DeepCopyObject()
+					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
+						return nil, err
+					}
+					return test.getCAs(newInjectable), nil
+				}).Should(Equal(expectedCAs))
+			})
+
+			It("should inject the apiserver CA if the inject-apiserver-ca annotation is present", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+				if len(f.KubeClientConfig.CAData) == 0 {
+					Skip("skipping test as the kube client CA bundle is not set")
+				}
+				By("creating a vaidating webhook with the inject-apiserver-ca annotation")
+				injectable := test.makeInjectable("apiserver-ca")
+				injectable.(metav1.Object).SetAnnotations(map[string]string{
+					injctrl.WantInjectAPIServerCAAnnotation: "true",
+				})
+				Expect(f.CRClient.Create(context.Background(), injectable)).To(Succeed())
+				toCleanup = injectable
+
+				By("checking that all webhooks have a populated CA")
+				caData := f.KubeClientConfig.CAData
+				expectedLen := len(test.getCAs(injectable))
+				expectedCAs := make([][]byte, expectedLen)
+				for i := range expectedCAs {
+					expectedCAs[i] = caData
+				}
+				Eventually(func() ([][]byte, error) {
+					newInjectable := injectable.DeepCopyObject()
+					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
+						return nil, err
+					}
+					return test.getCAs(newInjectable), nil
+				}, "10s", "2s").Should(Equal(expectedCAs))
+			})
+		})
+	}
+
+	injectorContext("validating webhook", &injectableTest{
+		makeInjectable: func(namePrefix string) runtime.Object {
 			someURL := "https://localhost:8675"
-			hook := admissionreg.ValidatingWebhookConfiguration{
+			return &admissionreg.ValidatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: hookPrefix + "-hook",
+					Name: namePrefix + "-hook",
 					Annotations: map[string]string{
 						injctrl.WantInjectAnnotation: types.NamespacedName{Name: "serving-certs", Namespace: f.Namespace.Name}.String(),
 					},
@@ -91,157 +255,25 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 					},
 				},
 			}
-			Expect(f.CRClient.Create(context.Background(), &hook)).To(Succeed())
-			hookToCleanUp = &hook
-
-			By("creating a certificate")
-			secretName := types.NamespacedName{Name: "serving-certs-data", Namespace: f.Namespace.Name}
-			cert := util.NewCertManagerBasicCertificate("serving-certs", secretName.Name, issuerName, certmanager.IssuerKind, nil, nil)
-			cert.Namespace = f.Namespace.Name
-			Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
-
-			By("grabbing the corresponding secret")
-			var secret corev1.Secret
-			Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
-
-			By("checking that all webhooks have a populated CA")
-			caData := secret.Data["ca.crt"]
-			Eventually(func() ([][]byte, error) {
-				var newHook admissionreg.ValidatingWebhookConfiguration
-				if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: hook.Name}, &newHook); err != nil {
-					return nil, err
-				}
-				return [][]byte{newHook.Webhooks[0].ClientConfig.CABundle, newHook.Webhooks[1].ClientConfig.CABundle}, nil
-			}, "10s", "2s").Should(Equal([][]byte{caData, caData}))
-
-			return hook, *cert, secret
-		}
-
-		It("should inject a CA into all webhook slots", func() {
-			setupHook("injected")
-		})
-
-		It("should not inject a CA into webhooks that aren't annotated", func() {
-			By("creating a validating webhook not pointing to a cert")
-			someURL := "https://localhost:8675"
-			hook := admissionreg.ValidatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "non-injected-hook",
-				},
-				Webhooks: []admissionreg.Webhook{
-					{
-						Name: "hook1.fake.k8s.io",
-						ClientConfig: admissionreg.WebhookClientConfig{
-							URL:      &someURL,
-							CABundle: []byte("ca data 1"),
-						},
-					},
-					{
-						Name: "hook2.fake.k8s.io",
-						ClientConfig: admissionreg.WebhookClientConfig{
-							Service: &admissionreg.ServiceReference{
-								Name:      "some-svc",
-								Namespace: f.Namespace.Name,
-							},
-							CABundle: []byte("ca data 2"),
-						},
-					},
-				},
+		},
+		getCAs: func(obj runtime.Object) [][]byte {
+			hook := obj.(*admissionreg.ValidatingWebhookConfiguration)
+			res := make([][]byte, len(hook.Webhooks))
+			for i, webhook := range hook.Webhooks {
+				res[i] = webhook.ClientConfig.CABundle
 			}
-			Expect(f.CRClient.Create(context.Background(), &hook)).To(Succeed())
-			hookToCleanUp = &hook
+			return res
+		},
+	})
 
-			By("expecting the CA data to remain in place")
-			Consistently(func() ([][]byte, error) {
-				var newHook admissionreg.ValidatingWebhookConfiguration
-				if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: hook.Name}, &newHook); err != nil {
-					return nil, err
-				}
-				return [][]byte{newHook.Webhooks[0].ClientConfig.CABundle, newHook.Webhooks[1].ClientConfig.CABundle}, nil
-			}).Should(Equal([][]byte{hook.Webhooks[0].ClientConfig.CABundle, hook.Webhooks[1].ClientConfig.CABundle}))
-		})
-
-		It("should update the webhooks when the certificate is changed", func() {
-			hook, cert, _ := setupHook("changed")
-
-			By("grabbing the latest copy of the cert")
-			Expect(f.CRClient.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, &cert)).To(Succeed())
-
-			By("changing the name of the corresponding secret in the cert")
-			secretName := types.NamespacedName{Name: "other-data", Namespace: f.Namespace.Name}
-			cert.Spec.SecretName = secretName.Name
-			Expect(f.CRClient.Update(context.Background(), &cert)).To(Succeed())
-
-			By("grabbing the new secret")
-			var secret corev1.Secret
-			Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
-
-			By("verifying that the hooks have the new data")
-			caData := secret.Data["ca.crt"]
-			Eventually(func() ([][]byte, error) {
-				var newHook admissionreg.ValidatingWebhookConfiguration
-				if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: hook.Name}, &newHook); err != nil {
-					return nil, err
-				}
-				return [][]byte{newHook.Webhooks[0].ClientConfig.CABundle, newHook.Webhooks[1].ClientConfig.CABundle}, nil
-			}, "10s", "2s").Should(Equal([][]byte{caData, caData}))
-		})
-
-		It("should ignore webhooks with invalid annotations", func() {
-			By("creating a validating webhook with an invalid cert name")
+	injectorContext("mutating webhook", &injectableTest{
+		makeInjectable: func(namePrefix string) runtime.Object {
 			someURL := "https://localhost:8675"
-			hook := admissionreg.ValidatingWebhookConfiguration{
+			return &admissionreg.MutatingWebhookConfiguration{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "invalid-hook",
+					Name: namePrefix + "-hook",
 					Annotations: map[string]string{
-						injctrl.WantInjectAnnotation: "serving-certs",
-					},
-				},
-				Webhooks: []admissionreg.Webhook{
-					{
-						Name: "hook1.fake.k8s.io",
-						ClientConfig: admissionreg.WebhookClientConfig{
-							URL:      &someURL,
-							CABundle: []byte("ca data 1"),
-						},
-					},
-					{
-						Name: "hook2.fake.k8s.io",
-						ClientConfig: admissionreg.WebhookClientConfig{
-							Service: &admissionreg.ServiceReference{
-								Name:      "some-svc",
-								Namespace: f.Namespace.Name,
-							},
-							CABundle: []byte("ca data 2"),
-						},
-					},
-				},
-			}
-			Expect(f.CRClient.Create(context.Background(), &hook)).To(Succeed())
-			hookToCleanUp = &hook
-
-			By("expecting the CA data to remain in place")
-			Consistently(func() ([][]byte, error) {
-				var newHook admissionreg.ValidatingWebhookConfiguration
-				if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: hook.Name}, &newHook); err != nil {
-					return nil, err
-				}
-				return [][]byte{newHook.Webhooks[0].ClientConfig.CABundle, newHook.Webhooks[1].ClientConfig.CABundle}, nil
-			}).Should(Equal([][]byte{hook.Webhooks[0].ClientConfig.CABundle, hook.Webhooks[1].ClientConfig.CABundle}))
-
-		})
-
-		It("should inject the apiserver CA if the webhook as the inject-apiserver-ca annotation", func() {
-			if len(f.KubeClientConfig.CAData) == 0 {
-				Skip("skipping test as the kube client CA bundle is not set")
-			}
-			By("creating a vaidating webhook with the inject-apiserver-ca annotation")
-			someURL := "https://localhost:8675"
-			hook := admissionreg.ValidatingWebhookConfiguration{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "apiserver-ca-hook",
-					Annotations: map[string]string{
-						injctrl.WantInjectAPIServerCAAnnotation: "true",
+						injctrl.WantInjectAnnotation: types.NamespacedName{Name: "serving-certs", Namespace: f.Namespace.Name}.String(),
 					},
 				},
 				Webhooks: []admissionreg.Webhook{
@@ -262,18 +294,79 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 					},
 				},
 			}
-			Expect(f.CRClient.Create(context.Background(), &hook)).To(Succeed())
-			hookToCleanUp = &hook
+		},
+		getCAs: func(obj runtime.Object) [][]byte {
+			hook := obj.(*admissionreg.MutatingWebhookConfiguration)
+			res := make([][]byte, len(hook.Webhooks))
+			for i, webhook := range hook.Webhooks {
+				res[i] = webhook.ClientConfig.CABundle
+			}
+			return res
+		},
+	})
 
-			By("checking that all webhooks have a populated CA")
-			caData := f.KubeClientConfig.CAData
-			Eventually(func() ([][]byte, error) {
-				var newHook admissionreg.ValidatingWebhookConfiguration
-				if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: hook.Name}, &newHook); err != nil {
-					return nil, err
-				}
-				return [][]byte{newHook.Webhooks[0].ClientConfig.CABundle, newHook.Webhooks[1].ClientConfig.CABundle}, nil
-			}, "10s", "2s").Should(Equal([][]byte{caData, caData}))
-		})
+	// TODO(directxman12): enable ConversionWebhook feature on the test infra,
+	// re-enable this.
+	injectorContext("conversion webhook", &injectableTest{
+		makeInjectable: func(namePrefix string) runtime.Object {
+			someURL := "https://localhost:8675"
+			return &apiext.CustomResourceDefinition{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "objs." + namePrefix + ".testing.certmanager.k8s.io",
+					Annotations: map[string]string{
+						injctrl.WantInjectAnnotation: types.NamespacedName{Name: "serving-certs", Namespace: f.Namespace.Name}.String(),
+					},
+				},
+				Spec: apiext.CustomResourceDefinitionSpec{
+					Group:   namePrefix + ".testing.certmanager.k8s.io",
+					Version: "v1",
+					Conversion: &apiext.CustomResourceConversion{
+						Strategy: apiext.WebhookConverter,
+						WebhookClientConfig: &apiext.WebhookClientConfig{
+							URL: &someURL,
+						},
+					},
+					Names: apiext.CustomResourceDefinitionNames{
+						Kind:     "Obj",
+						ListKind: "ObjList",
+					},
+				},
+			}
+		},
+		getCAs: func(obj runtime.Object) [][]byte {
+			crd := obj.(*apiext.CustomResourceDefinition)
+			if crd.Spec.Conversion == nil || crd.Spec.Conversion.WebhookClientConfig == nil {
+				return nil
+			}
+			return [][]byte{crd.Spec.Conversion.WebhookClientConfig.CABundle}
+		},
+		disabled: "ConversionWebhook feature not yet enabled on test infra",
+	})
+
+	injectorContext("api service", &injectableTest{
+		makeInjectable: func(namePrefix string) runtime.Object {
+			return &apireg.APIService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "v1." + namePrefix + ".testing.certmanager.k8s.io",
+					Annotations: map[string]string{
+						injctrl.WantInjectAnnotation: types.NamespacedName{Name: "serving-certs", Namespace: f.Namespace.Name}.String(),
+					},
+				},
+				Spec: apireg.APIServiceSpec{
+					Service: &apireg.ServiceReference{
+						Name:      "does-not-exit",
+						Namespace: "default",
+					},
+					Group:                namePrefix + ".testing.certmanager.k8s.io",
+					Version:              "v1",
+					GroupPriorityMinimum: 1,
+					VersionPriority:      1,
+				},
+			}
+		},
+		getCAs: func(obj runtime.Object) [][]byte {
+			apiSvc := obj.(*apireg.APIService)
+			return [][]byte{apiSvc.Spec.CABundle}
+		},
 	})
 })


### PR DESCRIPTION
This adds support for the CRD conversion webhook configuration to the CA
injector controller.  This allows you to configure injection conversion webhooks much the same way that you can for validating/mutating webhooks and API services.


**Release note**:
```release-note
Support CRD conversion webhooks in the CA injector controller.
```
