### PR TITLE
bazel: use update instead of + for dict

### DIFF
--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -92,7 +92,7 @@ def multiarch_bundle(
             images = oa_images,
             **kwargs)
 
-        all_images += oa_images
+        all_images.update(oa_images)
 
     container_bundle(
         name = name,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Updates bazel syntax to work with newest version.
In bazel 0.24.0 the flag `--incompatible_disallow_dict_plus` is enabled by default, which means that cert-manager won't build without this change.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: I could not find an issue for this.

**Special notes for your reviewer**:
You can find the flag mentioned above in the [release notes](https://github.com/bazelbuild/bazel/releases). I'm not sure if the "dict plus" is used some place else, but with this change I was able to `make build` successfully.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
