### PR TITLE
Bump WORKSPACE dependencies

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,15 +6,11 @@ load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
 ## Load rules_go and dependencies
 http_archive(
     name = "io_bazel_rules_go",
-    urls = ["https://github.com/bazelbuild/rules_go/releases/download/0.16.6/rules_go-0.16.6.tar.gz"],
-    sha256 = "ade51a315fa17347e5c31201fdc55aa5ffb913377aa315dceb56ee9725e620ee",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.18.2/rules_go-0.18.2.tar.gz",
+    sha256 = "31f959ecf3687f6e0bb9d01e1e7a7153367ecd82816c9c0ae149cd0e5a92bf8c",
 )
 
-load(
-    "@io_bazel_rules_go//go:def.bzl",
-    "go_rules_dependencies",
-    "go_register_toolchains",
-)
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 
 go_rules_dependencies()
 
@@ -25,8 +21,8 @@ go_register_toolchains(
 ## Load gazelle and dependencies
 http_archive(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.16.0/bazel-gazelle-0.16.0.tar.gz",
-    sha256 = "7949fc6cc17b5b191103e97481cf8889217263acf52e00b560683413af204fcb",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz",
+    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
 )
 
 load(
@@ -308,12 +304,9 @@ filegroup(
 git_repository(
     name = "build_bazel_rules_nodejs",
     remote = "https://github.com/bazelbuild/rules_nodejs.git",
-    tag = "0.26.0",  # check for the latest tag when you install
+    commit = "11271418a6bbd2529170270a7e61dcc5167bb16d",
+    shallow_since = "1554849870 -0700",
 )
-
-load("@build_bazel_rules_nodejs//:package.bzl", "rules_nodejs_dependencies")
-
-rules_nodejs_dependencies()
 
 load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
 

--- a/hack/update-bazel.sh
+++ b/hack/update-bazel.sh
@@ -26,6 +26,7 @@ cd "${REPO_ROOT}"
 
 # Generate BUILD.bazel files for golang types
 gazelle fix \
+    -exclude docs/generated/reference/generate/json_swagger \
     -external vendored \
     -build_file_name BUILD.bazel \
     -go_prefix github.com/jetstack/cert-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump workspace dependencies in prep for newer go version & remove unneeded nodejs dependency

**Release note**:
```release-note
NONE
```
