### PR TITLE
Export dnsQuery function & refactor DNS01Record function

### DIFF
--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -21,7 +21,7 @@ func DNS01Record(domain, value string, nameservers []string, followCNAME bool) (
 
 	// Check if the domain has CNAME then return that
 	if followCNAME {
-		r, err := dnsQuery(fqdn, dns.TypeCNAME, nameservers, true)
+		r, err := DNSQuery(fqdn, dns.TypeCNAME, nameservers, true)
 		if err == nil && r.Rcode == dns.RcodeSuccess {
 			fqdn = updateDomainWithCName(r, fqdn)
 		}

--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -14,9 +14,10 @@ import (
 	"github.com/miekg/dns"
 )
 
-// DNS01Record returns a DNS record which will fulfill the `dns-01` challenge
-// TODO: move this into a non-generic place by resolving import cycle in dns package
-func DNS01Record(domain, value string, nameservers []string, followCNAME bool) (string, string, int, error) {
+// DNS01LookupFQDN returns a DNS name which will be updated to solve the dns-01
+// challenge
+// TODO: move this into the pkg/acme package
+func DNS01LookupFQDN(domain string, followCNAME bool, nameservers ...string) (string, error) {
 	fqdn := fmt.Sprintf("_acme-challenge.%s.", domain)
 
 	// Check if the domain has CNAME then return that
@@ -26,9 +27,9 @@ func DNS01Record(domain, value string, nameservers []string, followCNAME bool) (
 			fqdn = updateDomainWithCName(r, fqdn)
 		}
 		if err != nil {
-			return "", "", 0, err
+			return "", err
 		}
 	}
 
-	return fqdn, value, 60, nil
+	return fqdn, nil
 }

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -81,7 +81,7 @@ func updateDomainWithCName(r *dns.Msg, fqdn string) string {
 func checkDNSPropagation(fqdn, value string, nameservers []string,
 	useAuthoritative bool) (bool, error) {
 	// Initial attempt to resolve at the recursive NS
-	r, err := dnsQuery(fqdn, dns.TypeTXT, nameservers, true)
+	r, err := DNSQuery(fqdn, dns.TypeTXT, nameservers, true)
 	if err != nil {
 		return false, err
 	}
@@ -107,7 +107,7 @@ func checkDNSPropagation(fqdn, value string, nameservers []string,
 // checkAuthoritativeNss queries each of the given nameservers for the expected TXT record.
 func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, error) {
 	for _, ns := range nameservers {
-		r, err := dnsQuery(fqdn, dns.TypeTXT, []string{ns}, true)
+		r, err := DNSQuery(fqdn, dns.TypeTXT, []string{ns}, true)
 		if err != nil {
 			return false, err
 		}
@@ -136,9 +136,9 @@ func checkAuthoritativeNss(fqdn, value string, nameservers []string) (bool, erro
 	return true, nil
 }
 
-// dnsQuery will query a nameserver, iterating through the supplied servers as it retries
+// DNSQuery will query a nameserver, iterating through the supplied servers as it retries
 // The nameserver should include a port, to facilitate testing where we talk to a mock dns server.
-func dnsQuery(fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error) {
+func DNSQuery(fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error) {
 	m := new(dns.Msg)
 	m.SetQuestion(fqdn, rtype)
 	m.SetEdns0(4096, false)
@@ -196,7 +196,7 @@ func ValidateCAA(domain string, issuerID []string, iswildcard bool, nameservers 
 			for i, ans := range authNS {
 				authNS[i] = net.JoinHostPort(ans, "53")
 			}
-			msg, err = dnsQuery(queryDomain, dns.TypeCAA, authNS, false)
+			msg, err = DNSQuery(queryDomain, dns.TypeCAA, authNS, false)
 			if err != nil {
 				return fmt.Errorf("Could not validate CAA record: %s", err)
 			}
@@ -272,7 +272,7 @@ func lookupNameservers(fqdn string, nameservers []string) ([]string, error) {
 		return nil, fmt.Errorf("Could not determine the zone for %q: %v", fqdn, err)
 	}
 
-	r, err := dnsQuery(zone, dns.TypeNS, nameservers, true)
+	r, err := DNSQuery(zone, dns.TypeNS, nameservers, true)
 	if err != nil {
 		return nil, err
 	}
@@ -306,7 +306,7 @@ func FindZoneByFqdn(fqdn string, nameservers []string) (string, error) {
 	for _, index := range labelIndexes {
 		domain := fqdn[index:]
 
-		in, err := dnsQuery(domain, dns.TypeSOA, nameservers, true)
+		in, err := DNSQuery(domain, dns.TypeSOA, nameservers, true)
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

We need to export dnsQuery so that it can be used as part of the soon-to-come DNS01 test suite.

I've also refactored the DNS01Record method to be DNS01LookupFQDN, which better reflects what it does. In the process I also removed some redundant arguments and returned fields.

**Release note**:
```release-note
NONE
```

/cc @kragniz 