### PR TITLE
Bump manifests for v0.7.1

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,6 +1,6 @@
 name: cert-manager
-version: v0.7.0
-appVersion: v0.7.0
+version: v0.7.1
+appVersion: v0.7.1
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 keywords:

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -75,7 +75,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `global.imagePullSecrets` | Reference to one or more secrets to be used when pulling images | `[]` |
 | `global.rbac.create` | If `true`, create and use RBAC resources (includes sub-charts) | `true` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
-| `image.tag` | Image tag | `v0.7.0` |
+| `image.tag` | Image tag | `v0.7.1` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `replicaCount`  | Number of cert-manager replicas  | `1` |
 | `clusterResourceNamespace` | Override the namespace used to store DNS provider credentials etc. for ClusterIssuer resources | Same namespace as cert-manager pod
@@ -109,7 +109,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | |
 | `webhook.image.repository` | Webhook image repository | `quay.io/jetstack/cert-manager-webhook` |
-| `webhook.image.tag` | Webhook image tag | `v0.7.0` |
+| `webhook.image.tag` | Webhook image tag | `v0.7.1` |
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.injectAPIServerCA` | if true, the apiserver's CABundle will be automatically injected into the ValidatingWebhookConfiguration resource | `true` |
 | `cainjector.enabled` | Toggles whether the cainjector component should be installed (required for the webhook component to work) | `true` |
@@ -118,7 +118,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.extraArgs` | Optional flags for cert-manager cainjector component | `[]` |
 | `cainjector.resources` | CPU/memory resource requests/limits for the cainjector pods | |
 | `cainjector.image.repository` | cainjector image repository | `quay.io/jetstack/cert-manager-cainjector` |
-| `cainjector.image.tag` | cainjector image tag | `v0.7.0` |
+| `cainjector.image.tag` | cainjector image tag | `v0.7.1` |
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.

--- a/deploy/charts/cert-manager/cainjector/Chart.yaml
+++ b/deploy/charts/cert-manager/cainjector/Chart.yaml
@@ -1,7 +1,7 @@
 name: cainjector
 apiVersion: v1
-version: "v0.7.0"
-appVersion: "v0.7.0"
+version: "v0.7.1"
+appVersion: "v0.7.1"
 description: A Helm chart for deploying the cert-manager cainjector component
 home: https://github.com/jetstack/cert-manager
 sources:

--- a/deploy/charts/cert-manager/cainjector/values.yaml
+++ b/deploy/charts/cert-manager/cainjector/values.yaml
@@ -34,5 +34,5 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-cainjector
-  tag: v0.7.0
+  tag: v0.7.1
   pullPolicy: IfNotPresent

--- a/deploy/charts/cert-manager/requirements.lock
+++ b/deploy/charts/cert-manager/requirements.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: webhook
   repository: file://webhook
-  version: v0.7.0
+  version: v0.7.1
 - name: cainjector
   repository: file://cainjector
-  version: v0.7.0
-digest: sha256:23c28c105c2ad3eacb34a1e55275933bbc3e9ce5055cb7958a61932b31254231
-generated: 2019-03-01T17:13:42.517512942Z
+  version: v0.7.1
+digest: sha256:c9c6c2fbcc0746a2cf1a40236dcf3ac15b08428718ef22c1f2d721b1add14e5b
+generated: 2019-04-23T17:32:04.886942013+01:00

--- a/deploy/charts/cert-manager/requirements.yaml
+++ b/deploy/charts/cert-manager/requirements.yaml
@@ -1,10 +1,10 @@
 # requirements.yaml
 dependencies:
 - name: webhook
-  version: "v0.7.0"
+  version: "v0.7.1"
   repository: "file://webhook"
   condition: webhook.enabled
 - name: cainjector
-  version: "v0.7.0"
+  version: "v0.7.1"
   repository: "file://cainjector"
   condition: cainjector.enabled

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -27,7 +27,7 @@ strategy: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
-  tag: v0.7.0
+  tag: v0.7.1
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer

--- a/deploy/charts/cert-manager/webhook/Chart.yaml
+++ b/deploy/charts/cert-manager/webhook/Chart.yaml
@@ -1,7 +1,7 @@
 name: webhook
 apiVersion: v1
-version: "v0.7.0"
-appVersion: "v0.7.0"
+version: "v0.7.1"
+appVersion: "v0.7.1"
 description: A Helm chart for deploying the cert-manager webhook component
 home: https://github.com/jetstack/cert-manager
 sources:

--- a/deploy/charts/cert-manager/webhook/values.yaml
+++ b/deploy/charts/cert-manager/webhook/values.yaml
@@ -30,7 +30,7 @@ resources: {}
 
 image:
   repository: quay.io/jetstack/cert-manager-webhook
-  tag: v0.7.0
+  tag: v0.7.1
   pullPolicy: IfNotPresent
 
 # if true, the apiserver's cabundle will be automatically injected into the

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -1111,7 +1111,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 
@@ -1124,7 +1124,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -1135,7 +1135,7 @@ metadata:
   name: cert-manager-cainjector
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1161,7 +1161,7 @@ metadata:
   name: cert-manager-cainjector
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1180,7 +1180,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1200,7 +1200,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1218,7 +1218,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1235,7 +1235,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1253,7 +1253,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1272,7 +1272,7 @@ spec:
       serviceAccountName: cert-manager-cainjector
       containers:
         - name: cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v0.7.0"
+          image: "quay.io/jetstack/cert-manager-cainjector:v0.7.1"
           imagePullPolicy: IfNotPresent
           args:
           - --leader-election-namespace=$(POD_NAMESPACE)
@@ -1294,7 +1294,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1316,7 +1316,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.7.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.7.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1111,7 +1111,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 
@@ -1124,7 +1124,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 
@@ -1137,7 +1137,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -1148,7 +1148,7 @@ metadata:
   name: cert-manager-cainjector
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1174,7 +1174,7 @@ metadata:
   name: cert-manager-cainjector
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1193,7 +1193,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1213,7 +1213,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1231,7 +1231,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1248,7 +1248,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1269,7 +1269,7 @@ metadata:
   name: cert-manager-webhook:auth-delegator
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1294,7 +1294,7 @@ metadata:
   namespace: kube-system
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1315,7 +1315,7 @@ metadata:
   name: cert-manager-webhook:webhook-requester
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1336,7 +1336,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1358,7 +1358,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cainjector
-    chart: cainjector-v0.7.0
+    chart: cainjector-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1377,7 +1377,7 @@ spec:
       serviceAccountName: cert-manager-cainjector
       containers:
         - name: cainjector
-          image: "quay.io/jetstack/cert-manager-cainjector:v0.7.0"
+          image: "quay.io/jetstack/cert-manager-cainjector:v0.7.1"
           imagePullPolicy: IfNotPresent
           args:
           - --leader-election-namespace=$(POD_NAMESPACE)
@@ -1399,7 +1399,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1418,7 +1418,7 @@ spec:
       serviceAccountName: cert-manager-webhook
       containers:
         - name: webhook
-          image: "quay.io/jetstack/cert-manager-webhook:v0.7.0"
+          image: "quay.io/jetstack/cert-manager-webhook:v0.7.1"
           imagePullPolicy: IfNotPresent
           args:
           - --v=12
@@ -1450,7 +1450,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.7.0
+    chart: cert-manager-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1472,7 +1472,7 @@ spec:
       serviceAccountName: cert-manager
       containers:
         - name: cert-manager
-          image: "quay.io/jetstack/cert-manager-controller:v0.7.0"
+          image: "quay.io/jetstack/cert-manager-controller:v0.7.1"
           imagePullPolicy: IfNotPresent
           args:
           - --cluster-resource-namespace=$(POD_NAMESPACE)
@@ -1498,7 +1498,7 @@ metadata:
   name: v1beta1.admission.certmanager.k8s.io
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
   annotations:
@@ -1524,7 +1524,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1540,7 +1540,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1561,7 +1561,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1578,7 +1578,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
 spec:
@@ -1599,7 +1599,7 @@ metadata:
   name: cert-manager-webhook
   labels:
     app: webhook
-    chart: webhook-v0.7.0
+    chart: webhook-v0.7.1
     release: cert-manager
     heritage: Tiller
   annotations:

--- a/docs/getting-started/install.rst
+++ b/docs/getting-started/install.rst
@@ -133,7 +133,7 @@ In order to install the Helm chart, you must run:
    helm install \
      --name cert-manager \
      --namespace cert-manager \
-     --version v0.7.0 \
+     --version v0.7.1 \
      jetstack/cert-manager
 
 The default cert-manager configuration is good for the majority of users, but a


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump manifest versions for v0.7.1

**Release note**:
```release-note
NONE
```

/cc @Evesy 