### PR TITLE
Add omitempty to fields on conditions

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -178,9 +178,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
             lastFailureTime:
@@ -599,9 +596,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
           type: object
@@ -858,9 +852,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
           type: object

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -178,9 +178,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
             lastFailureTime:
@@ -599,9 +596,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
           type: object
@@ -858,9 +852,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
           type: object

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -178,9 +178,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
             lastFailureTime:
@@ -599,9 +596,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
           type: object
@@ -858,9 +852,6 @@ spec:
                 required:
                 - type
                 - status
-                - lastTransitionTime
-                - reason
-                - message
                 type: object
               type: array
           type: object

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -150,15 +150,18 @@ type CertificateCondition struct {
 
 	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
-	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// Reason is a brief machine readable explanation for the condition's last
 	// transition.
-	Reason string `json:"reason"`
+	// +optional
+	Reason string `json:"reason,omitempty"`
 
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
-	Message string `json:"message"`
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -431,15 +431,18 @@ type IssuerCondition struct {
 
 	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
-	LastTransitionTime metav1.Time `json:"lastTransitionTime"`
+	// +optional
+	LastTransitionTime metav1.Time `json:"lastTransitionTime,omitempty"`
 
 	// Reason is a brief machine readable explanation for the condition's last
 	// transition.
-	Reason string `json:"reason"`
+	// +optional
+	Reason string `json:"reason,omitempty"`
 
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
-	Message string `json:"message"`
+	// +optional
+	Message string `json:"message,omitempty"`
 }
 
 // IssuerConditionType represents an Issuer condition value.


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the standard in upstream k8s, and prevents errors
when malformed 'condition' stanzas are included in resources.

**Which issue this PR fixes**: fixes #1509 

**Special notes for your reviewer**:

I'm also intending to cherry pick this into v0.7

**Release note**:
```release-note
Fix upgrade bug where lastTransitionTime may be set to nil, rendering cert-manager inoperable without manual intervention
```
