### PR TITLE
Add acme dns01 webhook provider e2e test case

### DIFF
--- a/hack/ci/lib/build_images.sh
+++ b/hack/ci/lib/build_images.sh
@@ -43,6 +43,7 @@ build_images() {
         "pebble:bazel" \
         "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.23.0" \
         "k8s.gcr.io/defaultbackend:bazel" \
+        "sample-webhook:bazel" \
         "vault:bazel" \
         "gcr.io/kubernetes-helm/tiller:bazel" \
     ; do

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -9,6 +9,7 @@ container_bundle(
         "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.23.0": "@io_kubernetes_ingress-nginx//image",
         "k8s.gcr.io/defaultbackend:bazel": "@io_gcr_k8s_defaultbackend//image",
         "vault:bazel": "@com_hashicorp_vault//image",
+        "sample-webhook:bazel": "//test/e2e/framework/addon/samplewebhook/sample:image",
         "gcr.io/kubernetes-helm/tiller:bazel": "@io_gcr_helm_tiller//image",
         "{STABLE_DOCKER_REPO}/cert-manager-controller:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
         "{STABLE_DOCKER_REPO}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",

--- a/test/e2e/framework/addon/BUILD.bazel
+++ b/test/e2e/framework/addon/BUILD.bazel
@@ -33,6 +33,7 @@ filegroup(
         "//test/e2e/framework/addon/chart:all-srcs",
         "//test/e2e/framework/addon/nginxingress:all-srcs",
         "//test/e2e/framework/addon/pebble:all-srcs",
+        "//test/e2e/framework/addon/samplewebhook:all-srcs",
         "//test/e2e/framework/addon/tiller:all-srcs",
         "//test/e2e/framework/addon/vault:all-srcs",
     ],

--- a/test/e2e/framework/addon/certmanager/addon.go
+++ b/test/e2e/framework/addon/certmanager/addon.go
@@ -48,6 +48,7 @@ type Certmanager struct {
 // Details return the details about the certmanager instance deployed
 type Details struct {
 	ClusterResourceNamespace string
+	ServiceAccountName       string
 }
 
 func (p *Certmanager) Setup(cfg *config.Config) error {
@@ -78,6 +79,9 @@ func (p *Certmanager) Setup(cfg *config.Config) error {
 		ChartName:   cfg.RepoRoot + "/deploy/charts/cert-manager",
 		// TODO: move resource requests/limits into Vars so they are always set
 		Values: []string{cfg.RepoRoot + "/test/fixtures/cert-manager-values.yaml"},
+		Vars: []chart.StringTuple{
+			{Key: "serviceAccount.name", Value: "chart-certmanager-cert-manager"},
+		},
 		// doesn't matter when installing from disk
 		ChartVersion: "0",
 		UpdateDeps:   true,
@@ -92,7 +96,7 @@ func (p *Certmanager) Setup(cfg *config.Config) error {
 // Provision will actually deploy this instance of Pebble-ingress to the cluster.
 func (p *Certmanager) Provision() error {
 	if err := exec.Command(p.config.Kubectl, "apply", "-f", p.config.RepoRoot+"/deploy/manifests/00-crds.yaml").Run(); err != nil {
-		return fmt.Errorf("Error install cert-manager CRD manifests: %v", err)
+		return fmt.Errorf("error install cert-manager CRD manifests: %v", err)
 	}
 
 	return p.chart.Provision()
@@ -102,6 +106,7 @@ func (p *Certmanager) Provision() error {
 func (p *Certmanager) Details() *Details {
 	return &Details{
 		ClusterResourceNamespace: p.Namespace,
+		ServiceAccountName:       "chart-certmanager-cert-manager",
 	}
 }
 

--- a/test/e2e/framework/addon/samplewebhook/BUILD.bazel
+++ b/test/e2e/framework/addon/samplewebhook/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["addon.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/framework/addon/samplewebhook",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//test/e2e/framework/addon/certmanager:go_default_library",
+        "//test/e2e/framework/addon/chart:go_default_library",
+        "//test/e2e/framework/addon/tiller:go_default_library",
+        "//test/e2e/framework/config:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//test/e2e/framework/addon/samplewebhook/sample:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/addon/samplewebhook/addon.go
+++ b/test/e2e/framework/addon/samplewebhook/addon.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package samplewebhook
+
+import (
+	"fmt"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/certmanager"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/chart"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
+	"github.com/jetstack/cert-manager/test/e2e/framework/config"
+)
+
+// CertmanagerWebhook defines an addon that installs a cert-manager DNS01
+// webhook
+type CertmanagerWebhook struct {
+	config        *config.Config
+	chart         *chart.Chart
+	tillerDetails *tiller.Details
+
+	// Tiller is the tiller instance used to deploy the chart
+	Tiller *tiller.Tiller
+
+	Certmanager *certmanager.Certmanager
+
+	Name string
+
+	// Required namespace to deploy the webhook into.
+	Namespace string
+
+	// Optional override for the group name to use for the webhook
+	GroupName string
+}
+
+// Details return the details about the webhook instance deployed
+type Details struct {
+	GroupName string
+	SolverName string
+}
+
+func (p *CertmanagerWebhook) Setup(cfg *config.Config) error {
+	p.config = cfg
+	if p.Name == "" {
+		return fmt.Errorf("name field must be set")
+	}
+	if p.Namespace == "" {
+		return fmt.Errorf("namespace name must be specified")
+	}
+	if p.Tiller == nil {
+		return fmt.Errorf("tiller field must be set")
+	}
+	if p.Certmanager == nil {
+		return fmt.Errorf("certmanager field must be set")
+	}
+	if p.config.Kubectl == "" {
+		return fmt.Errorf("path to kubectl must be provided")
+	}
+	if p.GroupName == "" {
+		p.GroupName = p.Name + ".acme.example.com"
+	}
+	var err error
+	p.tillerDetails, err = p.Tiller.Details()
+	if err != nil {
+		return err
+	}
+	p.chart = &chart.Chart{
+		Tiller:      p.Tiller,
+		ReleaseName: "wh-" + p.Name,
+		Namespace:   p.Namespace,
+		ChartName:   cfg.RepoRoot + "/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook",
+		Vars: []chart.StringTuple{
+			{Key: "certManager.namespace", Value: p.Certmanager.Namespace},
+			{Key: "image.repository", Value: "sample-webhook"},
+			{Key: "image.tag", Value: "bazel"},
+			{Key: "groupName", Value: "acme.example.com"},
+		},
+		Values: []string{cfg.RepoRoot + "/test/fixtures/example-webhook-values.yaml"},
+		// doesn't matter when installing from disk
+		ChartVersion: "0",
+		UpdateDeps:   true,
+	}
+	err = p.chart.Setup(cfg)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Provision will actually deploy this instance of Pebble-ingress to the cluster.
+func (p *CertmanagerWebhook) Provision() error {
+	return p.chart.Provision()
+}
+
+// Details returns details that can be used to utilise the instance of Pebble.
+func (p *CertmanagerWebhook) Details() *Details {
+	return &Details{
+		GroupName: p.GroupName,
+		SolverName: "my-custom-solver",
+	}
+}
+
+// Deprovision will destroy this instance of Pebble
+func (p *CertmanagerWebhook) Deprovision() error {
+	return p.chart.Deprovision()
+}
+
+func (p *CertmanagerWebhook) SupportsGlobal() bool {
+	return false
+}
+
+func (p *CertmanagerWebhook) Logs() (map[string]string, error) {
+	return p.chart.Logs()
+}

--- a/test/e2e/framework/addon/samplewebhook/addon.go
+++ b/test/e2e/framework/addon/samplewebhook/addon.go
@@ -47,7 +47,7 @@ type CertmanagerWebhook struct {
 
 // Details return the details about the webhook instance deployed
 type Details struct {
-	GroupName string
+	GroupName  string
 	SolverName string
 }
 
@@ -83,9 +83,10 @@ func (p *CertmanagerWebhook) Setup(cfg *config.Config) error {
 		ChartName:   cfg.RepoRoot + "/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook",
 		Vars: []chart.StringTuple{
 			{Key: "certManager.namespace", Value: p.Certmanager.Namespace},
+			{Key: "certManager.serviceAccountName", Value: p.Certmanager.Details().ServiceAccountName},
 			{Key: "image.repository", Value: "sample-webhook"},
 			{Key: "image.tag", Value: "bazel"},
-			{Key: "groupName", Value: "acme.example.com"},
+			{Key: "groupName", Value: p.GroupName},
 		},
 		Values: []string{cfg.RepoRoot + "/test/fixtures/example-webhook-values.yaml"},
 		// doesn't matter when installing from disk
@@ -107,7 +108,7 @@ func (p *CertmanagerWebhook) Provision() error {
 // Details returns details that can be used to utilise the instance of Pebble.
 func (p *CertmanagerWebhook) Details() *Details {
 	return &Details{
-		GroupName: p.GroupName,
+		GroupName:  p.GroupName,
 		SolverName: "my-custom-solver",
 	}
 }

--- a/test/e2e/framework/addon/samplewebhook/sample/BUILD.bazel
+++ b/test/e2e/framework/addon/samplewebhook/sample/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+go_image(
+    name = "image",
+    base = "@alpine_linux-amd64//image",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/framework/addon/samplewebhook/sample",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//pkg/acme/webhook/apis/acme/v1alpha1:go_default_library",
+        "//pkg/acme/webhook/cmd:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "sample",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/.helmignore
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/Chart.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart for Kubernetes
+name: example-webhook
+version: 0.1.0

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/_helpers.tpl
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "example-webhook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "example-webhook.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "example-webhook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "example-webhook.selfSignedIssuer" -}}
+{{ printf "%s-selfsign" (include "example-webhook.fullname" .) }}
+{{- end -}}
+
+{{- define "example-webhook.rootCAIssuer" -}}
+{{ printf "%s-ca" (include "example-webhook.fullname" .) }}
+{{- end -}}
+
+{{- define "example-webhook.rootCACertificate" -}}
+{{ printf "%s-ca" (include "example-webhook.fullname" .) }}
+{{- end -}}
+
+{{- define "example-webhook.servingCertificate" -}}
+{{ printf "%s-webhook-tls" (include "example-webhook.fullname" .) }}
+{{- end -}}

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/apiservice.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/apiservice.yaml
@@ -1,0 +1,19 @@
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.{{ .Values.groupName }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
+spec:
+  group: {{ .Values.groupName }}
+  groupPriorityMinimum: 1000
+  versionPriority: 15
+  service:
+    name: {{ include "example-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+  version: v1alpha1

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/deployment.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "example-webhook.fullname" . }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "example-webhook.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "example-webhook.name" . }}
+        release: {{ .Release.Name }}
+    spec:
+      serviceAccountName: {{ include "example-webhook.fullname" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - --tls-cert-file=/tls/tls.crt
+            - --tls-private-key-file=/tls/tls.key
+          env:
+            - name: GROUP_NAME
+              value: {{ .Values.groupName | quote }}
+          ports:
+            - name: https
+              containerPort: 443
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          readinessProbe:
+            httpGet:
+              scheme: HTTPS
+              path: /healthz
+              port: https
+          volumeMounts:
+            - name: certs
+              mountPath: /tls
+              readOnly: true
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: certs
+          secret:
+            secretName: {{ include "example-webhook.servingCertificate" . }}
+    {{- with .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/pki.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/pki.yaml
@@ -1,0 +1,76 @@
+---
+# Create a selfsigned Issuer, in order to create a root CA certificate for
+# signing webhook serving certificates
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: {{ include "example-webhook.selfSignedIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selfSigned: {}
+
+---
+
+# Generate a CA Certificate used to sign certificates for the webhook
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "example-webhook.rootCACertificate" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  secretName: {{ include "example-webhook.rootCACertificate" . }}
+  duration: 43800h # 5y
+  issuerRef:
+    name: {{ include "example-webhook.selfSignedIssuer" . }}
+  commonName: "ca.example-webhook.cert-manager"
+  isCA: true
+
+---
+
+# Create an Issuer that uses the above generated CA certificate to issue certs
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Issuer
+metadata:
+  name: {{ include "example-webhook.rootCAIssuer" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ca:
+    secretName: {{ include "example-webhook.rootCACertificate" . }}
+
+---
+
+# Finally, generate a serving certificate for the webhook to use
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: {{ include "example-webhook.servingCertificate" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  secretName: {{ include "example-webhook.servingCertificate" . }}
+  duration: 8760h # 1y
+  issuerRef:
+    name: {{ include "example-webhook.rootCAIssuer" . }}
+  dnsNames:
+  - {{ include "example-webhook.fullname" . }}
+  - {{ include "example-webhook.fullname" . }}.{{ .Release.Namespace }}
+  - {{ include "example-webhook.fullname" . }}.{{ .Release.Namespace }}.svc

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/rbac.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/rbac.yaml
@@ -82,7 +82,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: cert-manager:domain-solver
+  name: {{ include "example-webhook.fullname" . }}:domain-solver
 subjects:
   - apiGroup: ""
     kind: ServiceAccount

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/rbac.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/rbac.yaml
@@ -1,0 +1,90 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "example-webhook.fullname" . }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+---
+# Grant the webhook permission to read the ConfigMap containing the Kubernetes
+# apiserver's requestheader-ca-certificate.
+# This ConfigMap is automatically created by the Kubernetes apiserver.
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ include "example-webhook.fullname" . }}:webhook-authentication-reader
+  namespace: kube-system
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "example-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+---
+# apiserver gets the auth-delegator role to delegate auth decisions to
+# the core apiserver
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "example-webhook.fullname" . }}:auth-delegator
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "example-webhook.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+---
+# Grant cert-manager permission to validate using our apiserver
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ include "example-webhook.fullname" . }}:domain-solver
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+rules:
+  - apiGroups:
+      - {{ .Values.groupName }}
+    resources:
+      - '*'
+    verbs:
+      - 'create'
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "example-webhook.fullname" . }}:domain-solver
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cert-manager:domain-solver
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ .Values.certManager.serviceAccountName }}
+    namespace: {{ .Values.certManager.namespace }}

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/service.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "example-webhook.fullname" . }}
+  labels:
+    app: {{ include "example-webhook.name" . }}
+    chart: {{ include "example-webhook.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+  selector:
+    app: {{ include "example-webhook.name" . }}
+    release: {{ .Release.Name }}

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/values.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/values.yaml
@@ -1,0 +1,43 @@
+# The GroupName here is used to identify your company or business unit that
+# created this webhook.
+# For example, this may be "acme.mycompany.com".
+# This name will need to be referenced in each Issuer's `webhook` stanza to
+# inform cert-manager of where to send ChallengePayload resources in order to
+# solve the DNS01 challenge.
+# This group name should be **unique**, hence using your own company's domain
+# here is recommended.
+groupName: acme.mycompany.com
+
+certManager:
+  namespace: cert-manager
+  serviceAccountName: cert-manager
+
+image:
+  repository: mycompany/webhook-image
+  tag: latest
+  pullPolicy: IfNotPresent
+
+nameOverride: ""
+fullnameOverride: ""
+
+service:
+  type: ClusterIP
+  port: 443
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/test/e2e/framework/addon/samplewebhook/sample/main.go
+++ b/test/e2e/framework/addon/samplewebhook/sample/main.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package main
 
 import (

--- a/test/e2e/framework/addon/samplewebhook/sample/main.go
+++ b/test/e2e/framework/addon/samplewebhook/sample/main.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	//"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+
+	"github.com/jetstack/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/acme/webhook/cmd"
+)
+
+var GroupName = os.Getenv("GROUP_NAME")
+
+func main() {
+	if GroupName == "" {
+		panic("GROUP_NAME must be specified")
+	}
+
+	// This will register our custom DNS provider with the webhook serving
+	// library, making it available as an API under the provided GroupName.
+	// You can register multiple DNS provider implementations with a single
+	// webhook, where the Name() method will be used to disambiguate between
+	// the different implementations.
+	cmd.RunWebhookServer(GroupName,
+		&customDNSProviderSolver{},
+	)
+}
+
+// customDNSProviderSolver implements the provider-specific logic needed to
+// 'present' an ACME challenge TXT record for your own DNS provider.
+// To do so, it must implement the `github.com/jetstack/cert-manager/pkg/acme/webhook.Solver`
+// interface.
+type customDNSProviderSolver struct {
+	// If a Kubernetes 'clientset' is needed, you must:
+	// 1. uncomment the additional `client` field in this structure below
+	// 2. uncomment the "k8s.io/client-go/kubernetes" import at the top of the file
+	// 3. uncomment the relevant code in the Initialize method below
+	// 4. ensure your webhook's service account has the required RBAC role
+	//    assigned to it for interacting with the Kubernetes APIs you need.
+	//client kubernetes.Clientset
+}
+
+// customDNSProviderConfig is a structure that is used to decode into when
+// solving a DNS01 challenge.
+// This information is provided by cert-manager, and may be a reference to
+// additional configuration that's needed to solve the challenge for this
+// particular certificate or issuer.
+// This typically includes references to Secret resources containing DNS
+// provider credentials, in cases where a 'multi-tenant' DNS solver is being
+// created.
+// If you do *not* require per-issuer or per-certificate configuration to be
+// provided to your webhook, you can skip decoding altogether in favour of
+// using CLI flags or similar to provide configuration.
+// You should not include sensitive information here. If credentials need to
+// be used by your provider here, you should reference a Kubernetes Secret
+// resource and fetch these credentials using a Kubernetes clientset.
+type customDNSProviderConfig struct {
+	// Change the two fields below according to the format of the configuration
+	// to be decoded.
+	// These fields will be set by users in the
+	// `issuer.spec.acme.dns01.providers.webhook.config` field.
+
+	//Email           string `json:"email"`
+	//APIKeySecretRef v1alpha1.SecretKeySelector `json:"apiKeySecretRef"`
+}
+
+// Name is used as the name for this DNS solver when referencing it on the ACME
+// Issuer resource.
+// This should be unique **within the group name**, i.e. you can have two
+// solvers configured with the same Name() **so long as they do not co-exist
+// within a single webhook deployment**.
+// For example, `cloudflare` may be used as the name of a solver.
+func (c *customDNSProviderSolver) Name() string {
+	return "my-custom-solver"
+}
+
+// Present is responsible for actually presenting the DNS record with the
+// DNS provider.
+// This method should tolerate being called multiple times with the same value.
+// cert-manager itself will later perform a self check to ensure that the
+// solver has correctly configured the DNS provider.
+func (c *customDNSProviderSolver) Present(ch *v1alpha1.ChallengeRequest) error {
+	cfg, err := loadConfig(ch.Config)
+	if err != nil {
+		return err
+	}
+
+	// TODO: do something more useful with the decoded configuration
+	fmt.Printf("Decoded configuration %v", cfg)
+
+	// TODO: add code that sets a record in the DNS provider's console
+	return nil
+}
+
+// CleanUp should delete the relevant TXT record from the DNS provider console.
+// If multiple TXT records exist with the same record name (e.g.
+// _acme-challenge.example.com) then **only** the record with the same `key`
+// value provided on the ChallengeRequest should be cleaned up.
+// This is in order to facilitate multiple DNS validations for the same domain
+// concurrently.
+func (c *customDNSProviderSolver) CleanUp(ch *v1alpha1.ChallengeRequest) error {
+	// TODO: add code that deletes a record from the DNS provider's console
+	return nil
+}
+
+// Initialize will be called when the webhook first starts.
+// This method can be used to instantiate the webhook, i.e. initialising
+// connections or warming up caches.
+// Typically, the kubeClientConfig parameter is used to build a Kubernetes
+// client that can be used to fetch resources from the Kubernetes API, e.g.
+// Secret resources containing credentials used to authenticate with DNS
+// provider accounts.
+// The stopCh can be used to handle early termination of the webhook, in cases
+// where a SIGTERM or similar signal is sent to the webhook process.
+func (c *customDNSProviderSolver) Initialize(kubeClientConfig *rest.Config, stopCh <-chan struct{}) error {
+	///// UNCOMMENT THE BELOW CODE TO MAKE A KUBERNETES CLIENTSET AVAILABLE TO
+	///// YOUR CUSTOM DNS PROVIDER
+
+	//cl, err := kubernetes.NewForConfig(kubeClientConfig)
+	//if err != nil {
+	//	return err
+	//}
+	//
+	//c.client = cl
+
+	///// END OF CODE TO MAKE KUBERNETES CLIENTSET AVAILABLE
+	return nil
+}
+
+// loadConfig is a small helper function that decodes JSON configuration into
+// the typed config struct.
+func loadConfig(cfgJSON *extapi.JSON) (customDNSProviderConfig, error) {
+	cfg := customDNSProviderConfig{}
+	// handle the 'base case' where no configuration has been provided
+	if cfgJSON == nil {
+		return cfg, nil
+	}
+	if err := json.Unmarshal(cfgJSON.Raw, &cfg); err != nil {
+		return cfg, fmt.Errorf("error decoding solver config: %v", err)
+	}
+
+	return cfg, nil
+}

--- a/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dns01.go",
         "http01.go",
+        "webhook.go",
     ],
     importpath = "github.com/jetstack/cert-manager/test/e2e/suite/issuers/acme/certificate",
     tags = ["manual"],
@@ -15,6 +16,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/pebble:go_default_library",
+        "//test/e2e/framework/addon/samplewebhook:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/log:go_default_library",
         "//test/e2e/framework/matcher:go_default_library",
@@ -25,6 +27,7 @@ go_library(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/pebble"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/samplewebhook"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
+	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/util/generate"
+)
+
+var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
+	f := framework.NewDefaultFramework("acme-dns01-sample-webhook")
+	//h := f.Helper()
+
+	Context("with the sample webhook solver deployed", func() {
+		// TODO: add additional DNS provider configs here
+		//cf := &dnsproviders.Cloudflare{}
+
+		var (
+			tiller = &tiller.Tiller{
+				Name:               "tiller-deploy-sample-webhook",
+				ClusterPermissions: true,
+			}
+			pebble = &pebble.Pebble{
+				Tiller: tiller,
+				Name:   "cm-e2e-acme-dns01-sample-webhook",
+			}
+			webhook = &samplewebhook.CertmanagerWebhook{
+				Name: "cm-e2e-acme-dns01-sample-webhook",
+				Tiller: tiller,
+				Certmanager: addon.CertManager,
+			}
+		)
+
+		BeforeEach(func() {
+			tiller.Namespace = f.Namespace.Name
+			pebble.Namespace = f.Namespace.Name
+			webhook.Namespace = f.Namespace.Name
+		})
+
+		f.RequireGlobalAddon(addon.CertManager)
+		f.RequireAddon(tiller)
+		f.RequireAddon(pebble)
+		f.RequireAddon(webhook)
+
+		issuerName := "test-acme-issuer"
+		//certificateName := "test-acme-certificate"
+		certificateSecretName := "test-acme-certificate"
+		dnsDomain := ""
+
+		BeforeEach(func() {
+			dnsDomain = "example.com"
+
+			By("Creating an Issuer")
+			issuer := generate.Issuer(generate.IssuerConfig{
+				Name:              issuerName,
+				Namespace:         f.Namespace.Name,
+				ACMESkipTLSVerify: true,
+				ACMEServer: pebble.Details().Host,
+				ACMEEmail:          testingACMEEmail,
+				ACMEPrivateKeyName: testingACMEPrivateKey,
+				DNS01: &v1alpha1.ACMEIssuerDNS01Config{
+					Providers: []v1alpha1.ACMEIssuerDNS01Provider{
+						{
+							Name: "default",
+							Webhook: &v1alpha1.ACMEIssuerDNS01ProviderWebhook{
+								GroupName: webhook.Details().GroupName,
+								SolverName: webhook.Details().SolverName,
+								Config: &v1beta1.JSON{
+									Raw: []byte(`{}`),
+								},
+							},
+						},
+					},
+				},
+			})
+			issuer, err := f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Create(issuer)
+			Expect(err).NotTo(HaveOccurred())
+			By("Waiting for Issuer to become Ready")
+			err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name),
+				issuerName,
+				v1alpha1.IssuerCondition{
+					Type:   v1alpha1.IssuerConditionReady,
+					Status: v1alpha1.ConditionTrue,
+				})
+			Expect(err).NotTo(HaveOccurred())
+			By("Verifying the ACME account URI is set")
+			err = util.WaitForIssuerStatusFunc(f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name),
+				issuerName,
+				func(i *v1alpha1.Issuer) (bool, error) {
+					if i.GetStatus().ACMEStatus().URI == "" {
+						return false, nil
+					}
+					return true, nil
+				})
+			Expect(err).NotTo(HaveOccurred())
+			By("Verifying ACME account private key exists")
+			secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(testingACMEPrivateKey, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if len(secret.Data) != 1 {
+				Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
+			}
+		})
+
+		AfterEach(func() {
+			By("Cleaning up")
+			f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Delete(issuerName, nil)
+			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(testingACMEPrivateKey, nil)
+			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(certificateSecretName, nil)
+		})
+
+		It("should run before and after each", func() {
+
+		})
+	})
+})

--- a/test/e2e/suite/issuers/acme/certificate/webhook.go
+++ b/test/e2e/suite/issuers/acme/certificate/webhook.go
@@ -195,7 +195,7 @@ var _ = framework.CertManagerDescribe("ACME webhook DNS provider", func() {
 						log.Logf("Found challenge named %q", ch.Name)
 
 						if ch.Status.Presented == false {
-							log.Logf("Challenge %q has not been 'Presented'")
+							log.Logf("Challenge %q has not been 'Presented'", ch.Name)
 							allPresented = false
 						}
 					}

--- a/test/fixtures/example-webhook-values.yaml
+++ b/test/fixtures/example-webhook-values.yaml
@@ -1,0 +1,7 @@
+resources:
+  requests:
+    cpu: 50m
+    memory: 50Mi
+  limits:
+    cpu: 100m
+    memory: 200Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a DNS test that creates a certificate and waits to ensure that cert-manager marks the certificate as presented, by calling the provisioned 'dummy' DNS01 webhook (this webhook will *always* return success, so long as it can decode the ChallengePayload).

This is currently using a copy of the helm chart taken from the [example repo](https://github.com/munnerz/cert-manager-webhook-example).

**Release note**:
```release-note
NONE
```
