### PR TITLE
Expose ginkgo.focus and skip-globals flags in e2e_test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,9 @@ DOCKER_REPO :=
 APP_VERSION := canary
 HACK_DIR ?= hack
 
+SKIP_GLOBALS := false
 GINKGO_SKIP :=
+GINKGO_FOCUS :=
 
 ## e2e test vars
 KUBECTL ?= kubectl
@@ -118,6 +120,8 @@ e2e_test:
 			--repo-root="$$(pwd)" \
 			--report-dir="$${ARTIFACTS:-./_artifacts}" \
 			--ginkgo.skip="$(GINKGO_SKIP)" \
+			--ginkgo.focus="$(GINKGO_FOCUS)" \
+			--skip-globals=$(SKIP_GLOBALS) \
 			--kubectl-path="$(KUBECTL)"
 
 # Generate targets

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -33,7 +33,9 @@ var (
 )
 
 var _ = ginkgo.SynchronizedBeforeSuite(func() []byte {
-	addon.InitGlobals(cfg)
+	if !cfg.Addons.SkipGlobals {
+		addon.InitGlobals(cfg)
+	}
 
 	ginkgo.By("Provisioning shared cluster addons")
 
@@ -81,9 +83,11 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {},
 			}
 		}
 
-		ginkgo.By("Cleaning up the provisioned globals")
-		err = addon.DeprovisionGlobals(cfg)
-		if err != nil {
-			framework.Failf("Error deprovisioning global addons: %v", err)
+		if !cfg.Addons.SkipGlobals {
+			ginkgo.By("Cleaning up the provisioned globals")
+			err = addon.DeprovisionGlobals(cfg)
+			if err != nil {
+				framework.Failf("Error deprovisioning global addons: %v", err)
+			}
 		}
 	})

--- a/test/e2e/framework/config/addons.go
+++ b/test/e2e/framework/config/addons.go
@@ -40,6 +40,10 @@ type Addons struct {
 	// Venafi describes global configuration variables for the Venafi tests.
 	// This includes credentials for the Venafi TPP server to use during runs.
 	Venafi Venafi
+
+	// If true, global addons will not be provisioned before running tests.
+	// This is useful when developing locally.
+	SkipGlobals bool
 }
 
 func (a *Addons) AddFlags(fs *flag.FlagSet) {
@@ -48,6 +52,9 @@ func (a *Addons) AddFlags(fs *flag.FlagSet) {
 	a.Pebble.AddFlags(fs)
 	a.Nginx.AddFlags(fs)
 	a.Venafi.AddFlags(fs)
+
+	fs.BoolVar(&a.SkipGlobals, "skip-globals", false, "If true, global addons will not be "+
+		"provisioned before running tests")
 }
 
 func (c *Addons) Validate() []error {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -152,6 +152,17 @@ func (f *Framework) AfterEach() {
 
 	f.printAddonLogs()
 
+	if !f.Config.Cleanup {
+		return
+	}
+
+	for i := len(f.requiredAddons) - 1; i >= 0; i-- {
+		a := f.requiredAddons[i]
+		By("De-provisioning test-scoped addon")
+		err := a.Deprovision()
+		Expect(err).NotTo(HaveOccurred())
+	}
+
 	By("Deleting test namespace")
 	err := f.DeleteKubeNamespace(f.Namespace.Name)
 	Expect(err).NotTo(HaveOccurred())
@@ -207,14 +218,6 @@ func (f *Framework) RequireAddon(a addon.Addon) {
 		Expect(err).NotTo(HaveOccurred())
 
 		err = a.Provision()
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	AfterEach(func() {
-		if !f.Config.Cleanup {
-			return
-		}
-		err := a.Deprovision()
 		Expect(err).NotTo(HaveOccurred())
 	})
 }

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -200,6 +200,7 @@ func (h *Helper) WaitCertificateIssuedValidTLS(ns, name string, timeout time.Dur
 	if err != nil {
 		log.Logf("Error waiting for Certificate to become Ready: %v", err)
 		h.Kubectl(ns).DescribeResource("certificate", name)
+		h.Kubectl(ns).Describe("order", "challenge")
 		return err
 	}
 
@@ -207,6 +208,7 @@ func (h *Helper) WaitCertificateIssuedValidTLS(ns, name string, timeout time.Dur
 	if err != nil {
 		log.Logf("Error validating issued certificate: %v", err)
 		h.Kubectl(ns).DescribeResource("certificate", name)
+		h.Kubectl(ns).Describe("order", "challenge")
 		return err
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Exposes more e2e test framework variables via the Makefile. This is useful for local development.

**Release note**:
```release-note
NONE
```
