### PR TITLE
Build under MacOS.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ generate:
 BAZEL_IMAGE_ENV := APP_VERSION=$(APP_VERSION) DOCKER_REPO=$(DOCKER_REPO) DOCKER_TAG=$(APP_VERSION)
 images:
 	$(BAZEL_IMAGE_ENV) \
-		bazel run //:images
+		bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:images
 
 images_push: images
 	# we do not use the :push target as Quay.io does not support v2.2

--- a/docs/devel/develop-with-minikube.rst
+++ b/docs/devel/develop-with-minikube.rst
@@ -41,7 +41,7 @@ You will need the following tools to build cert-manager:
 * Bazel_
 * Docker_ (and enable for non-root user)
 
-These instructions have only been tested on Linux; Windows and MacOS may
+These instructions have only been tested on Linux and MacOS; Windows may
 require further changes.
 
 If you need to add dependencies, you will additionally need:
@@ -49,8 +49,8 @@ If you need to add dependencies, you will additionally need:
 * Git_
 * Mercurial_
 
-You can then run ``bazel run //hack:update-deps`` to regenerate any
-dependencies, and ``bazel build :images`` to build the docker images.
+You can then run ``./hack/update-vendor.sh`` to regenerate any
+dependencies, and ``make build`` to build the docker images.
 
 Build a dev version of cert-manager
 ===================================


### PR DESCRIPTION
Signed-off-by: Michael FIG <michael@liveblockauctions.com>

**What this PR does / why we need it**:

Updates the build instructions and Makefile rule to allow cross-platform builds of Docker images from a MacOS host.  It probably works for Windows, too, but it is not tested.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: n/a

**Special notes for your reviewer**:

The `--platforms` flag enables Bazel rules for the Go Linux cross-compiler.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Update build instructions and enable building under MacOS.
```
