### PR TITLE
Fix update loop due to changing notAfter struct

### DIFF
--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/util/errors:go_default_library",
         "//pkg/util/kube:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "//vendor/github.com/kr/pretty:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

It seems that the metav1.Time that we read from the x509 certificate changes between calls to read the certificate.

This PR updates the acmechallenges controller to first encode to json before comparing the encoded bytes, which should resolve the issue.

There's probably a cleaner way to handle this comparison, but for now this fixes a known bug 🙈 

**Which issue this PR fixes**: fixes #TODO

**Release note**:
```release-note
Fix update loop in certificates controller and add additional debug logging 
```
