### PR TITLE
Set global.logLevel to 4 during e2e tests

### DIFF
--- a/test/fixtures/cert-manager-values.yaml
+++ b/test/fixtures/cert-manager-values.yaml
@@ -1,5 +1,8 @@
 replicaCount: 1
 
+global:
+  logLevel: "4"
+
 image:
   tag: build
   pullPolicy: Never
@@ -13,7 +16,6 @@ resources:
     memory: 200Mi
 
 extraArgs:
-- --v=10
 - --leader-election-lease-duration=10s
 - --leader-election-renew-deadline=3s
 - --leader-election-retry-period=2s


### PR DESCRIPTION
**What this PR does / why we need it**:

This should make reading logs easier 😄 

**Release note**:
```release-note
NONE
```
