### PR TITLE
Fix issue when migrating ingress-shim managed certificates from old to new format

### DIFF
--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -267,6 +267,7 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 			// If the HTTP01 issuer is not enabled, skip setting the ACME field
 			// on the Certificate resource.
 			if issuer.GetSpec().ACME.HTTP01 == nil {
+				crt.Spec.ACME = nil
 				return nil
 			}
 			domainCfg.HTTP01 = &v1alpha1.HTTP01SolverConfig{}
@@ -289,6 +290,7 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 			// If the DNS01 issuer is not enabled, skip setting the ACME field
 			// on the Certificate resource.
 			if issuer.GetSpec().ACME.DNS01 == nil {
+				crt.Spec.ACME = nil
 				return nil
 			}
 			dnsProvider, ok := ingAnnotations[acmeIssuerDNS01ProviderNameAnnotation]
@@ -302,6 +304,7 @@ func (c *Controller) setIssuerSpecificConfig(crt *v1alpha1.Certificate, issuer v
 		// If no challenge type is specified, don't set the ACME field at all
 		// and instead rely on the 'new API format' to provide solver config.
 		case "":
+			crt.Spec.ACME = nil
 			return nil
 		default:
 			return fmt.Errorf("invalid acme issuer challenge type specified %q", challengeType)


### PR DESCRIPTION
**What this PR does / why we need it**:

When testing out migrating my certificates & issuers to use the new format (managed by ingress-shim), it would not clear the `certificate.spec.acme` block on existing Certificate resources without me manually deleting them first, because the `setIssuerSpecificConfig` method does not actually clear the field if it is already set.

**Release note**:
```release-note
NONE
```
