### PR TITLE
Fix chart version accidentally being ahead

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,5 +1,5 @@
 name: cert-manager
-version: v0.8.1-alpha.0
+version: v0.8.0-alpha.1
 appVersion: v0.8.0-alpha.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager

--- a/deploy/manifests/cert-manager-no-webhook.yaml
+++ b/deploy/manifests/cert-manager-no-webhook.yaml
@@ -1219,7 +1219,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -1275,7 +1275,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1295,7 +1295,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1313,7 +1313,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1330,7 +1330,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1390,7 +1390,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:

--- a/deploy/manifests/cert-manager.yaml
+++ b/deploy/manifests/cert-manager.yaml
@@ -1232,7 +1232,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 ---
@@ -1288,7 +1288,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 rules:
@@ -1308,7 +1308,7 @@ metadata:
   name: cert-manager
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 roleRef:
@@ -1326,7 +1326,7 @@ metadata:
   name: cert-manager-view
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-view: "true"
@@ -1343,7 +1343,7 @@ metadata:
   name: cert-manager-edit
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
@@ -1546,7 +1546,7 @@ metadata:
   namespace: "cert-manager"
   labels:
     app: cert-manager
-    chart: cert-manager-v0.8.1-alpha.0
+    chart: cert-manager-v0.8.0-alpha.1
     release: cert-manager
     heritage: Tiller
 spec:


### PR DESCRIPTION
**What this PR does / why we need it**:

The patch version here was accidentally bumped instead of the revision number.

This PR will require manual overriding of the chart job to merge 😄 

**Release note**:
```release-note
NONE
```
