### PR TITLE
Fix wrong helm repo reference in "Migrating from kube-lego"

### DIFF
--- a/docs/tutorials/acme/migrating-from-kube-lego.rst
+++ b/docs/tutorials/acme/migrating-from-kube-lego.rst
@@ -223,7 +223,7 @@ run:
 .. code-block:: shell
 
    helm upgrade cert-manager \
-       stable/cert-manager \
+       jetstack/cert-manager \
        --namespace kube-system \
        --set ingressShim.defaultIssuerName=letsencrypt-staging \
        --set ingressShim.defaultIssuerKind=ClusterIssuer


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The migration docs reference `stable/cert-manager` whcih when applied installs the wrong version of cert-manager which leads to a whole bunch of problems.


