### PR TITLE
Add support for ACMEv2 POST-as-GET

### DIFF
--- a/test/e2e/charts/pebble/templates/deployment.yaml
+++ b/test/e2e/charts/pebble/templates/deployment.yaml
@@ -21,6 +21,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
           - -config=/config/config.json
+          - -strict={{ .Values.strict }}
           volumeMounts:
           - name: config
             mountPath: /config

--- a/test/e2e/charts/pebble/values.yaml
+++ b/test/e2e/charts/pebble/values.yaml
@@ -12,3 +12,5 @@ resources:
   limits:
     cpu: 100m
     memory: 100Mi
+
+strict: "false"

--- a/test/e2e/framework/addon/pebble/pebble.go
+++ b/test/e2e/framework/addon/pebble/pebble.go
@@ -69,6 +69,12 @@ func (p *Pebble) Setup(cfg *config.Config) error {
 		ReleaseName: "chart-pebble-" + p.Name,
 		Namespace:   p.Namespace,
 		ChartName:   cfg.RepoRoot + "/test/e2e/charts/pebble",
+		Vars: []chart.StringTuple{
+			{
+				Key:   "strict",
+				Value: fmt.Sprintf("%t", cfg.Addons.Pebble.Strict),
+			},
+		},
 		// doesn't matter when installing from disk
 		ChartVersion: "0",
 	}

--- a/test/e2e/framework/config/pebble.go
+++ b/test/e2e/framework/config/pebble.go
@@ -28,9 +28,13 @@ type Pebble struct {
 
 	// // ImageTag for Pebble
 	// ImageTag string
+
+	// Strict enables Pebble's 'strict mode'
+	Strict bool
 }
 
 func (p *Pebble) AddFlags(fs *flag.FlagSet) {
+	fs.BoolVar(&p.Strict, "pebble-strict", true, "If true, tests using Pebble will have strict mode enabled")
 	// fs.StringVar(&p.ImageRepo, "pebble-image-repo", "", "The container image repository for pebble to use in e2e tests")
 	// fs.StringVar(&p.ImageTag, "pebble-image-tag", "", "The container image tag for pebble to use in e2e tests")
 }

--- a/third_party/crypto/acme/acme.go
+++ b/third_party/crypto/acme/acme.go
@@ -255,7 +255,7 @@ func (c *Client) FinalizeOrder(ctx context.Context, finalizeURL string, csr []by
 // If a caller needs to poll an order until its status is final,
 // see the WaitOrder method.
 func (c *Client) GetOrder(ctx context.Context, url string) (*Order, error) {
-	res, err := c.get(ctx, url)
+	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -373,7 +373,7 @@ func (c *Client) UpdateAccount(ctx context.Context, a *Account) (*Account, error
 // If a caller needs to poll an authorization until its status is final,
 // see the WaitAuthorization method.
 func (c *Client) GetAuthorization(ctx context.Context, url string) (*Authorization, error) {
-	res, err := c.get(ctx, url)
+	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -419,7 +419,7 @@ func (c *Client) DeactivateAuthorization(ctx context.Context, url string) error 
 func (c *Client) WaitAuthorization(ctx context.Context, url string) (*Authorization, error) {
 	sleep := sleeper(ctx)
 	for {
-		res, err := c.get(ctx, url)
+		res, err := c.postWithJWSAccount(ctx, url, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -463,7 +463,7 @@ func (c *Client) WaitAuthorization(ctx context.Context, url string) (*Authorizat
 //
 // A client typically polls a challenge status using this method.
 func (c *Client) GetChallenge(ctx context.Context, url string) (*Challenge, error) {
-	res, err := c.get(ctx, url)
+	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -488,15 +488,7 @@ func (c *Client) AcceptChallenge(ctx context.Context, chal *Challenge) (*Challen
 		return nil, err
 	}
 
-	auth, err := keyAuth(c.Key.Public(), chal.Token)
-	if err != nil {
-		return nil, err
-	}
-
-	req := struct {
-		Auth string `json:"keyAuthorization"`
-	}{auth}
-	res, err := c.postWithJWSAccount(ctx, chal.URL, req)
+	res, err := c.postWithJWSAccount(ctx, chal.URL, json.RawMessage(`{}`))
 	if err != nil {
 		return nil, err
 	}
@@ -819,7 +811,7 @@ func nonceFromHeader(h http.Header) string {
 }
 
 func (c *Client) GetCertificate(ctx context.Context, url string) ([][]byte, error) {
-	res, err := c.get(ctx, url)
+	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/third_party/crypto/acme/acme.go
+++ b/third_party/crypto/acme/acme.go
@@ -255,6 +255,10 @@ func (c *Client) FinalizeOrder(ctx context.Context, finalizeURL string, csr []by
 // If a caller needs to poll an order until its status is final,
 // see the WaitOrder method.
 func (c *Client) GetOrder(ctx context.Context, url string) (*Order, error) {
+	if _, err := c.Discover(ctx); err != nil {
+		return nil, err
+	}
+
 	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
@@ -373,6 +377,10 @@ func (c *Client) UpdateAccount(ctx context.Context, a *Account) (*Account, error
 // If a caller needs to poll an authorization until its status is final,
 // see the WaitAuthorization method.
 func (c *Client) GetAuthorization(ctx context.Context, url string) (*Authorization, error) {
+	if _, err := c.Discover(ctx); err != nil {
+		return nil, err
+	}
+
 	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
@@ -397,6 +405,10 @@ func (c *Client) GetAuthorization(ctx context.Context, url string) (*Authorizati
 //
 // It does not revoke existing certificates.
 func (c *Client) DeactivateAuthorization(ctx context.Context, url string) error {
+	if _, err := c.Discover(ctx); err != nil {
+		return err
+	}
+
 	res, err := c.postWithJWSAccount(ctx, url, json.RawMessage(`{"status":"deactivated"}`))
 	if err != nil {
 		return err
@@ -417,6 +429,10 @@ func (c *Client) DeactivateAuthorization(ctx context.Context, url string) error 
 // If the Status is StatusInvalid, StatusDeactivated, or StatusRevoked the
 // returned error will be of type AuthorizationError.
 func (c *Client) WaitAuthorization(ctx context.Context, url string) (*Authorization, error) {
+	if _, err := c.Discover(ctx); err != nil {
+		return nil, err
+	}
+
 	sleep := sleeper(ctx)
 	for {
 		res, err := c.postWithJWSAccount(ctx, url, nil)
@@ -463,6 +479,10 @@ func (c *Client) WaitAuthorization(ctx context.Context, url string) (*Authorizat
 //
 // A client typically polls a challenge status using this method.
 func (c *Client) GetChallenge(ctx context.Context, url string) (*Challenge, error) {
+	if _, err := c.Discover(ctx); err != nil {
+		return nil, err
+	}
+
 	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err
@@ -811,6 +831,10 @@ func nonceFromHeader(h http.Header) string {
 }
 
 func (c *Client) GetCertificate(ctx context.Context, url string) ([][]byte, error) {
+	if _, err := c.Discover(ctx); err != nil {
+		return nil, err
+	}
+
 	res, err := c.postWithJWSAccount(ctx, url, nil)
 	if err != nil {
 		return nil, err

--- a/third_party/crypto/acme/jws.go
+++ b/third_party/crypto/acme/jws.go
@@ -36,11 +36,14 @@ func jwsEncodeJSON(claimset interface{}, key crypto.Signer, accountURL, url, non
 		phead = fmt.Sprintf(`{"alg":%q,"kid":%q,"nonce":%q,"url":%q}`, alg, accountURL, nonce, url)
 	}
 	phead = base64.RawURLEncoding.EncodeToString([]byte(phead))
-	cs, err := json.Marshal(claimset)
-	if err != nil {
-		return nil, err
+	payload := ""
+	if claimset != nil {
+		cs, err := json.Marshal(claimset)
+		if err != nil {
+			return nil, err
+		}
+		payload = base64.RawURLEncoding.EncodeToString(cs)
 	}
-	payload := base64.RawURLEncoding.EncodeToString(cs)
 	hash := sha.New()
 	hash.Write([]byte(phead + "." + payload))
 	sig, err := jwsSign(key, sha, hash.Sum(nil))


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for ACME POST-as-GET to the ACME client.

Thanks to @bluecmd for this patch.

**Which issue this PR fixes**: fixes #1341 

**Special notes for your reviewer**:

I'm holding this patch until v0.9, as this probably shouldn't be included this late in v0.8.

**Release note**:
```release-note
Add support for ACMEv2 POST-as-GET
```

/hold
/milestone v0.9
