### PR TITLE
[docs] Fix Venafi link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -39,3 +39,4 @@ a source of references when seeking help with the project.
 .. _kube-cert-manager: https://github.com/PalmStoneGames/kube-cert-manager
 .. _`Let's Encrypt`: https://letsencrypt.org
 .. _`HashiCorp Vault`: https://www.vaultproject.io
+.. _`Venafi`: https://www.venafi.com/


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes the Venafi link on https://docs.cert-manager.io/en/latest/