### PR TITLE
Switch to gcr.io/distroless/static base image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,29 +66,12 @@ load(
 
 _go_image_repos()
 
-## Pull some standard base images
+## Use 'static' distroless image for all builds
 container_pull(
-    name = "alpine_linux-amd64",
-    digest = "sha256:cf2412cab4f40318e722d2604fa6c79b3d28a7cb37988d95ab2453577417359a",
-    registry = "index.docker.io",
-    repository = "munnerz/alpine",
-    tag = "3.8-amd64",
-)
-
-container_pull(
-    name = "alpine_linux-arm64",
-    digest = "sha256:4b8a5fc687674dd11ab769b8a711acba667c752b08697a03f6ffb1f1bcd123e5",
-    registry = "index.docker.io",
-    repository = "munnerz/alpine",
-    tag = "3.8-arm64",
-)
-
-container_pull(
-    name = "alpine_linux-arm",
-    digest = "sha256:185cad013588d77b0e78018b5f275a7849a63a33cd926405363825536597d9e2",
-    registry = "index.docker.io",
-    repository = "munnerz/alpine",
-    tag = "3.8-arm",
+    name = "static_base",
+    registry = "gcr.io",
+    repository = "distroless/static",
+    digest = "sha256:cd0679a54d2abaf3644829f5e290ad8a10688847475f570fddb9963318cf9390",
 )
 
 ## Fetch helm & tiller for use in template generation and testing

--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -52,7 +52,7 @@ def multiarch_image(
     for os in goos:
       go_image(
           name = "%s.app_%s-%s" % (name, os, arch),
-          base = "@alpine_%s-%s//image" % (os, arch),
+          base = "@static_base//image",
           embed = [":go_default_library"],
           goarch = arch,
           goos = os,

--- a/test/e2e/charts/pebble/BUILD.bazel
+++ b/test/e2e/charts/pebble/BUILD.bazel
@@ -2,7 +2,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_image(
     name = "image",
-    base = "@alpine_linux-amd64//image",
+    base = "@static_base//image",
     embed = ["@org_letsencrypt_pebble//cmd/pebble:go_default_library"],
     goarch = "amd64",
     goos = "linux",

--- a/test/e2e/framework/addon/samplewebhook/sample/BUILD.bazel
+++ b/test/e2e/framework/addon/samplewebhook/sample/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_image(
     name = "image",
-    base = "@alpine_linux-amd64//image",
+    base = "@static_base//image",
     embed = [":go_default_library"],
     goarch = "amd64",
     goos = "linux",


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR switches all cert-manager images to use 'gcr.io/distroless/static' as a base.

This image contains pretty much just ca-certificates, which makes it perfect for what we need.

distroless/static does not include any binaries at all, meaning the base image is by default multi-arch 😄 

Users wanting to debug from within the cert-manager pod will need to attach an additional container with their debug utilities to the pod's namespaces.

**Release note**:
```release-note
Switch to using distroless for base images
```
