### PR TITLE
Ensure only the sole owner of a certificate can modify it

### DIFF
--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/testing:go_default_library",
     ],
 )

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -153,12 +153,13 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.
 			return nil, nil, err
 		}
 
+		ingOwnerRef := *metav1.NewControllerRef(ing, ingressGVK)
 		crt := &v1alpha1.Certificate{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            tls.SecretName,
 				Namespace:       ing.Namespace,
 				Labels:          ing.Labels,
-				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ing, ingressGVK)},
+				OwnerReferences: []metav1.OwnerReference{ingOwnerRef},
 			},
 			Spec: v1alpha1.CertificateSpec{
 				DNSNames:   tls.Hosts,
@@ -179,6 +180,22 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.
 		// does then skip this entry
 		if existingCrt != nil {
 			klog.Infof("Certificate %q for ingress %q already exists", tls.SecretName, ing.Name)
+
+			ownerRefs := existingCrt.GetOwnerReferences()
+			if len(ownerRefs) == 0 {
+				klog.Infof("Certificate %q has no owners and cannot be updated for ingress %q", tls.SecretName, ing.Name)
+				continue
+			}
+
+			notOwned := false
+			for _, ownerRef := range ownerRefs {
+				notOwned = notOwned || !reflect.DeepEqual(ingOwnerRef, ownerRef)
+			}
+
+			if notOwned {
+				klog.Infof("Certificate %q is not (solely) owned by ingress %q", tls.SecretName, ing.Name)
+				continue
+			}
 
 			if !certNeedsUpdate(existingCrt, crt) {
 				klog.Infof("Certificate %q for ingress %q is up to date", tls.SecretName, ing.Name)

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -145,7 +145,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -197,7 +197,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -248,7 +248,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -302,7 +302,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -356,7 +356,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -458,7 +458,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -509,7 +509,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -550,7 +550,7 @@ func TestSync(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name:            "example-com-tls",
 						Namespace:       gen.DefaultTestNamespace,
-						OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(buildIngress("ingress-name", gen.DefaultTestNamespace, nil), ingressGVK)},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
@@ -645,8 +645,9 @@ func TestSync(t *testing.T) {
 			CertificateLister: []runtime.Object{
 				&v1alpha1.Certificate{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-crt",
-						Namespace: gen.DefaultTestNamespace,
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -693,12 +694,19 @@ func TestSync(t *testing.T) {
 					},
 				},
 			},
-			CertificateLister: []runtime.Object{buildCertificate("existing-crt", gen.DefaultTestNamespace)},
+			CertificateLister: []runtime.Object{
+				buildCertificate("existing-crt",
+					gen.DefaultTestNamespace,
+					buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+				),
+			},
+
 			ExpectedUpdate: []*v1alpha1.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-crt",
-						Namespace: gen.DefaultTestNamespace,
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -749,8 +757,9 @@ func TestSync(t *testing.T) {
 			CertificateLister: []runtime.Object{
 				&v1alpha1.Certificate{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-crt",
-						Namespace: gen.DefaultTestNamespace,
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -777,8 +786,9 @@ func TestSync(t *testing.T) {
 			ExpectedUpdate: []*v1alpha1.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-crt",
-						Namespace: gen.DefaultTestNamespace,
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -830,8 +840,9 @@ func TestSync(t *testing.T) {
 			CertificateLister: []runtime.Object{
 				&v1alpha1.Certificate{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-crt",
-						Namespace: gen.DefaultTestNamespace,
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -846,8 +857,9 @@ func TestSync(t *testing.T) {
 			ExpectedUpdate: []*v1alpha1.Certificate{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "existing-crt",
-						Namespace: gen.DefaultTestNamespace,
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -1067,11 +1079,12 @@ func TestIssuerForIngress(t *testing.T) {
 	}
 }
 
-func buildCertificate(name, namespace string) *v1alpha1.Certificate {
+func buildCertificate(name, namespace string, ownerReferences []metav1.OwnerReference) *v1alpha1.Certificate {
 	return &v1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
+			Name:            name,
+			Namespace:       namespace,
+			OwnerReferences: ownerReferences,
 		},
 	}
 }
@@ -1097,5 +1110,11 @@ func buildIngress(name, namespace string, annotations map[string]string) *extv1b
 			Namespace:   namespace,
 			Annotations: annotations,
 		},
+	}
+}
+
+func buildOwnerReferences(name, namespace string) []metav1.OwnerReference {
+	return []metav1.OwnerReference{
+		*metav1.NewControllerRef(buildIngress(name, namespace, nil), ingressGVK),
 	}
 }

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -24,6 +24,7 @@ import (
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	types "k8s.io/apimachinery/pkg/types"
 	coretesting "k8s.io/client-go/testing"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -126,6 +127,7 @@ func TestSync(t *testing.T) {
 						acmeIssuerChallengeTypeAnnotation: "http01",
 						editInPlaceAnnotation:             "true",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -181,6 +183,7 @@ func TestSync(t *testing.T) {
 						clusterIssuerNameAnnotation:       "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "http01",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -232,6 +235,7 @@ func TestSync(t *testing.T) {
 						acmeIssuerChallengeTypeAnnotation: "http01",
 						ingressClassAnnotation:            "nginx-ing",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -286,6 +290,7 @@ func TestSync(t *testing.T) {
 						acmeIssuerHTTP01IngressClassAnnotation: "cert-ing",
 						ingressClassAnnotation:                 "nginx-ing",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -340,6 +345,7 @@ func TestSync(t *testing.T) {
 						ingressClassAnnotation:            "nginx-ing",
 						editInPlaceAnnotation:             "false",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -393,6 +399,7 @@ func TestSync(t *testing.T) {
 						clusterIssuerNameAnnotation:       "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "dns01",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -417,6 +424,7 @@ func TestSync(t *testing.T) {
 						clusterIssuerNameAnnotation:       "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "invalid-challenge-type",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -442,6 +450,7 @@ func TestSync(t *testing.T) {
 						acmeIssuerChallengeTypeAnnotation:     "dns01",
 						acmeIssuerDNS01ProviderNameAnnotation: "fake-dns",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -493,6 +502,7 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						clusterIssuerNameAnnotation: "issuer-name",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -535,6 +545,7 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						testAcmeTLSAnnotation: "true",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -575,6 +586,7 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						issuerNameAnnotation: "issuer-name",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -596,6 +608,7 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						issuerNameAnnotation: "issuer-name",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -617,6 +630,7 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						issuerNameAnnotation: "invalid-issuer-name",
 					},
+					UID: types.UID("ingress-name"),
 				},
 			},
 		},
@@ -632,6 +646,7 @@ func TestSync(t *testing.T) {
 						issuerNameAnnotation:              "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "http01",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -684,6 +699,7 @@ func TestSync(t *testing.T) {
 						issuerNameAnnotation:              "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "http01",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -744,6 +760,7 @@ func TestSync(t *testing.T) {
 						acmeIssuerChallengeTypeAnnotation: "http01",
 						ingressClassAnnotation:            "toot-ing",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -827,6 +844,7 @@ func TestSync(t *testing.T) {
 						acmeIssuerChallengeTypeAnnotation: "http01",
 						ingressClassAnnotation:            "toot-ing",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -959,7 +977,9 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						issuerNameAnnotation:              "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "http01",
+						ingressClassAnnotation:            "toot-ing",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -1011,7 +1031,9 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						issuerNameAnnotation:              "issuer-name",
 						acmeIssuerChallengeTypeAnnotation: "http01",
+						ingressClassAnnotation:            "toot-ing",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -1213,6 +1235,7 @@ func buildIngress(name, namespace string, annotations map[string]string) *extv1b
 			Name:        name,
 			Namespace:   namespace,
 			Annotations: annotations,
+			UID:         types.UID(name),
 		},
 	}
 }

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -917,6 +917,7 @@ func TestSync(t *testing.T) {
 					Annotations: map[string]string{
 						issuerNameAnnotation: "issuer-name",
 					},
+					UID: types.UID("ingress-name"),
 				},
 				Spec: extv1beta1.IngressSpec{
 					TLS: []extv1beta1.IngressTLS{
@@ -935,6 +936,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"a-different-value": "should be removed",
 						},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},
@@ -954,6 +956,7 @@ func TestSync(t *testing.T) {
 						Labels: map[string]string{
 							"my-test-label": "should be copied",
 						},
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
 					},
 					Spec: v1alpha1.CertificateSpec{
 						DNSNames:   []string{"example.com"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
If two ingresses are setup with the same Certificate resource, then only the first will be the owner and be allowed to modify it. Any attempts from the second ingress to modify the resource will be skipped, preventing 'flap' updates when misconfigured.

Tests are also changed to conform with this new strategy, and additional tests have been added to test the strategy.

**Which issue this PR fixes**: fixes #1520 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Ingress skips updating Certificate resource if already exists and not owned
```
