### PR TITLE
Make MaxConcurrentChallenges a configurable parameter

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -224,6 +224,9 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		CertificateOptions: controller.CertificateOptions{
 			EnableOwnerRef: opts.EnableCertificateOwnerRef,
 		},
+		SchedulerOptions: controller.SchedulerOptions{
+			MaxConcurrentChallenges: opts.MaxConcurrentChallenges,
+		},
 	}, kubeCfg, nil
 }
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -71,6 +71,8 @@ type ControllerOptions struct {
 	DNS01RecursiveNameserversOnly bool
 
 	EnableCertificateOwnerRef bool
+
+	MaxConcurrentChallenges int
 }
 
 const (
@@ -95,6 +97,8 @@ const (
 	defaultEnableCertificateOwnerRef   = false
 
 	defaultDNS01RecursiveNameserversOnly = false
+
+	defaultMaxConcurrentChallenges = 60
 )
 
 func computeACMEHTTP01SolverImage(arch string) string {
@@ -240,6 +244,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.BoolVar(&s.EnableCertificateOwnerRef, "enable-certificate-owner-ref", defaultEnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+
 		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
+	fs.IntVar(&s.MaxConcurrentChallenges, "max-concurrent-challenges", defaultMaxConcurrentChallenges, ""+
+		"The maximum number of challenges that can be scheduled as 'processing' at once.")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -111,7 +111,7 @@ func New(ctx *controllerpkg.Context) (*Controller, error) {
 	if err != nil {
 		return nil, err
 	}
-	ctrl.scheduler = scheduler.New(ctrl.challengeLister)
+	ctrl.scheduler = scheduler.New(ctrl.challengeLister, ctx.SchedulerOptions.MaxConcurrentChallenges)
 	ctrl.ctx = logf.NewContext(ctx.RootContext, nil, ControllerName)
 
 	return ctrl, nil

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -32,6 +32,8 @@ import (
 	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
+const maxConcurrentChallenges = 60
+
 func randomChallenge(rand int) *cmapi.Challenge {
 	if rand == 0 {
 		rand = 10
@@ -134,9 +136,9 @@ func TestScheduleN(t *testing.T) {
 		},
 		{
 			name:       "schedule a maximum of MaxConcurrentChallenges",
-			n:          MaxConcurrentChallenges * 2,
-			challenges: ascendingChallengeN(MaxConcurrentChallenges * 2),
-			expected:   ascendingChallengeN(MaxConcurrentChallenges),
+			n:          maxConcurrentChallenges * 2,
+			challenges: ascendingChallengeN(maxConcurrentChallenges * 2),
+			expected:   ascendingChallengeN(maxConcurrentChallenges),
 		},
 		{
 			name: "schedule duplicate challenge if second challenge is in a final state",
@@ -258,7 +260,7 @@ func TestScheduleN(t *testing.T) {
 			name: "don't schedule when total number of scheduled challenges exceeds global maximum",
 			n:    5,
 			challenges: append(
-				ascendingChallengeN(MaxConcurrentChallenges, gen.SetChallengeProcessing(true)),
+				ascendingChallengeN(maxConcurrentChallenges, gen.SetChallengeProcessing(true)),
 				randomChallengeN(5, 0)...,
 			),
 		},
@@ -305,7 +307,7 @@ func TestScheduleN(t *testing.T) {
 				challengesInformer.Informer().GetIndexer().Add(ch)
 			}
 
-			s := New(challengesInformer.Lister())
+			s := New(challengesInformer.Lister(), maxConcurrentChallenges)
 
 			if test.expected == nil {
 				test.expected = []*cmapi.Challenge{}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -65,6 +65,7 @@ type Context struct {
 	ACMEOptions
 	IngressShimOptions
 	CertificateOptions
+	SchedulerOptions
 }
 
 type IssuerOptions struct {
@@ -126,4 +127,10 @@ type CertificateOptions struct {
 	// EnableOwnerRef controls wheter wheter the certificate is configured as an owner of
 	// secret where the effective TLS certificate is stored.
 	EnableOwnerRef bool
+}
+
+type SchedulerOptions struct {
+	// MaxConcurrentChallenges determines the maximum number of challenges that can be
+	// scheduled as 'processing' at once.
+	MaxConcurrentChallenges int
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Makes `MaxConcurrentChallenges` (the maximum number of challenges which can be scheduled as 'processing' at any time) a configurable parameter via the flag `--max-concurrent-challenges <int>`, with default value of `60`.

**Which issue this PR fixes**: fixes #1540 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add `MaxConcurrentChallenges` as a configurable parameter via the flag `--max-concurrent-challenges <int>`
```
