### PR TITLE
fix ChallengeRequest resource creation

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -395,7 +395,7 @@ func (s *Solver) prepareChallengeRequest(issuer v1alpha1.GenericIssuer, ch *v1al
 	// construct a ChallengeRequest which can be passed to DNS solvers.
 	// The provided config will be encoded to JSON in order to avoid a coupling
 	// between cert-manager and any particular DNS provider implementation.
-	b, err := json.Marshal(cfg.Config)
+	b, err := json.Marshal(cfg)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -416,13 +416,16 @@ func (s *Solver) prepareChallengeRequest(issuer v1alpha1.GenericIssuer, ch *v1al
 
 var errNotFound = fmt.Errorf("failed to determine DNS01 solver type")
 
-func (s *Solver) dns01SolverForConfig(config *v1alpha1.ACMEChallengeSolverDNS01) (webhook.Solver, *v1alpha1.ACMEIssuerDNS01ProviderWebhook, error) {
+func (s *Solver) dns01SolverForConfig(config *v1alpha1.ACMEChallengeSolverDNS01) (webhook.Solver, interface{}, error) {
 	solverName := ""
-	var c *v1alpha1.ACMEIssuerDNS01ProviderWebhook
+	var c interface{}
 	switch {
 	case config.Webhook != nil:
 		solverName = "webhook"
 		c = config.Webhook
+	case config.RFC2136 != nil:
+		solverName = "rfc2136"
+		c = config.RFC2136
 	}
 	if solverName == "" {
 		return nil, nil, errNotFound

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -395,7 +395,7 @@ func (s *Solver) prepareChallengeRequest(issuer v1alpha1.GenericIssuer, ch *v1al
 	// construct a ChallengeRequest which can be passed to DNS solvers.
 	// The provided config will be encoded to JSON in order to avoid a coupling
 	// between cert-manager and any particular DNS provider implementation.
-	b, err := json.Marshal(cfg)
+	b, err := json.Marshal(cfg.Config)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -407,6 +407,7 @@ func (s *Solver) prepareChallengeRequest(issuer v1alpha1.GenericIssuer, ch *v1al
 		AllowAmbientCredentials: canUseAmbientCredentials,
 		ResourceNamespace:       resourceNamespace,
 		Key:                     ch.Spec.Key,
+		DNSName:                 ch.Spec.DNSName,
 		Config:                  &apiext.JSON{Raw: b},
 	}
 
@@ -415,9 +416,9 @@ func (s *Solver) prepareChallengeRequest(issuer v1alpha1.GenericIssuer, ch *v1al
 
 var errNotFound = fmt.Errorf("failed to determine DNS01 solver type")
 
-func (s *Solver) dns01SolverForConfig(config *v1alpha1.ACMEChallengeSolverDNS01) (webhook.Solver, interface{}, error) {
+func (s *Solver) dns01SolverForConfig(config *v1alpha1.ACMEChallengeSolverDNS01) (webhook.Solver, *v1alpha1.ACMEIssuerDNS01ProviderWebhook, error) {
 	solverName := ""
-	var c interface{}
+	var c *v1alpha1.ACMEIssuerDNS01ProviderWebhook
 	switch {
 	case config.Webhook != nil:
 		solverName = "webhook"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The creation of the `ChallengeRequest` resource for the webhook issuer is incorrect. The `DNSName` field is always empty (it is never set) and the `Config` field contains the wrong object (the `ACMEIssuerDNS01ProviderWebhook` containing the config).

This PR fills the `DNSName` field with the DNS name and makes `Config` contain the correct object.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes https://github.com/jetstack/cert-manager/issues/1674

**Special notes for your reviewer**:
I didn't want to dive into how to build this project, so the changes are not tested.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The `DNSName` field in the `ChallengeResource` used by the webhook issuer now contains the DNS name (was empty before)
action required: The `Config` field in the in the `ChallengeResource` used by the webhook issuer now contains the value of `issuer.spec.acme.dns01.providers.webhook.config` (contained the contents of `issuer.spec.acme.dns01.providers.webhook` before)
```
