### PR TITLE
Clean up Prometheus metrics for deleted Certificates

### DIFF
--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -136,6 +136,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
 		// TODO (@munnerz): make time.Second duration configurable
 		go wait.Until(func() { c.worker(ctx) }, time.Second, stopCh)
 	}
+	go wait.Until(func() { c.metrics.CleanUp(c.certificateLister, c.secretLister) }, time.Minute*5, stopCh)
 	<-stopCh
 	log.V(logf.DebugLevel).Info("shutting down queue as workqueue signaled shutdown")
 	c.queue.ShutDown()

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -136,7 +136,7 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
 		// TODO (@munnerz): make time.Second duration configurable
 		go wait.Until(func() { c.worker(ctx) }, time.Second, stopCh)
 	}
-	go wait.Until(func() { c.metrics.CleanUp(c.certificateLister, c.secretLister) }, time.Minute*5, stopCh)
+	go wait.Until(func() { c.metrics.CleanUp(c.certificateLister) }, time.Minute, stopCh)
 	<-stopCh
 	log.V(logf.DebugLevel).Info("shutting down queue as workqueue signaled shutdown")
 	c.queue.ShutDown()

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -109,6 +109,7 @@ func New(ctx *controllerpkg.Context) *Controller {
 
 	ctrl.helper = issuer.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 	ctrl.metrics = metrics.Default
+	ctrl.metrics.SetActiveCertificates(ctrl.certificateLister)
 	ctrl.helper = issuer.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 	ctrl.issuerFactory = issuer.NewIssuerFactory(ctx)
 	ctrl.clock = clock.RealClock{}
@@ -136,7 +137,6 @@ func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
 		// TODO (@munnerz): make time.Second duration configurable
 		go wait.Until(func() { c.worker(ctx) }, time.Second, stopCh)
 	}
-	go wait.Until(func() { c.metrics.CleanUp(c.certificateLister) }, time.Minute, stopCh)
 	<-stopCh
 	log.V(logf.DebugLevel).Info("shutting down queue as workqueue signaled shutdown")
 	c.queue.ShutDown()

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -16,7 +16,9 @@ go_library(
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )
 

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -10,11 +10,13 @@ go_library(
         "//pkg/logs:go_default_library",
         "//pkg/util/errors:go_default_library",
         "//pkg/util/kube:go_default_library",
+        "//pkg/client/listers/certmanager/v1alpha1:go_default_library",
         "//vendor/github.com/gorilla/mux:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
     ],
 )
 

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -7,16 +7,16 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/client/listers/certmanager/v1alpha1:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util/errors:go_default_library",
         "//pkg/util/kube:go_default_library",
-        "//pkg/client/listers/certmanager/v1alpha1:go_default_library",
         "//vendor/github.com/gorilla/mux:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus:go_default_library",
         "//vendor/github.com/prometheus/client_golang/prometheus/promhttp:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
+        "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
     ],
 )
 
@@ -38,5 +38,9 @@ go_test(
     name = "go_default_test",
     srcs = ["metrics_test.go"],
     embed = [":go_default_library"],
-    deps = ["//vendor/github.com/prometheus/client_golang/prometheus/testutil:go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//vendor/github.com/prometheus/client_golang/prometheus/testutil:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -85,23 +85,23 @@ func TestCleanUp(t *testing.T) {
 	tests := map[string]testT{
 		"active and inactive": {
 			active: map[*v1alpha1.Certificate]*x509.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "something",
 						Namespace: "default",
 					},
-				}: &x509.Certificate{
+				}: {
 					// fixed expiry time for testing
 					NotAfter: time.Unix(2208988804, 0),
 				},
 			},
 			inactive: map[*v1alpha1.Certificate]*x509.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "something-else",
 						Namespace: "default",
 					},
-				}: &x509.Certificate{
+				}: {
 					// fixed expiry time for testing
 					NotAfter: time.Unix(2208988804, 0),
 				},
@@ -112,21 +112,21 @@ func TestCleanUp(t *testing.T) {
 		},
 		"only active": {
 			active: map[*v1alpha1.Certificate]*x509.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "something",
 						Namespace: "default",
 					},
-				}: &x509.Certificate{
+				}: {
 					// fixed expiry time for testing
 					NotAfter: time.Unix(2208988804, 0),
 				},
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "something-else",
 						Namespace: "default",
 					},
-				}: &x509.Certificate{
+				}: {
 					// fixed expiry time for testing
 					NotAfter: time.Unix(2208988804, 0),
 				},
@@ -140,21 +140,21 @@ func TestCleanUp(t *testing.T) {
 		"only inactive": {
 			active: map[*v1alpha1.Certificate]*x509.Certificate{},
 			inactive: map[*v1alpha1.Certificate]*x509.Certificate{
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "something",
 						Namespace: "default",
 					},
-				}: &x509.Certificate{
+				}: {
 					// fixed expiry time for testing
 					NotAfter: time.Unix(2208988804, 0),
 				},
-				&v1alpha1.Certificate{
+				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "something-else",
 						Namespace: "default",
 					},
-				}: &x509.Certificate{
+				}: {
 					// fixed expiry time for testing
 					NotAfter: time.Unix(2208988804, 0),
 				},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Prometheus metrics for Certificates will be cleaned up by deleting entries for deleted Certificates, and keeping track of which Certificates are currently registered by Prometheus.
This prevents metrics for deleted Certificates from being exposed past their use.

**Which issue this PR fixes**: fixes #1332 

**Special notes for your reviewer**:
The metrics are currently cleaned up every minute via a goroutine in the certificate controller - I would be happy to discuss a more refined garbage collection scheme to implement.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Prometheus metrics for deleted Certificates are cleaned up
```
