### PR TITLE
Validate that only one Certificate is using a secretName per namespace

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -115,9 +115,10 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 	}
 	hasDuplicate := false
 	for _, otherCrt := range otherCrts {
-		hasDuplicate = hasDuplicate ||
-			(otherCrt.Name != crtCopy.Name &&
-				otherCrt.Spec.SecretName == crtCopy.Spec.SecretName)
+		if otherCrt.Name != crtCopy.Name && otherCrt.Spec.SecretName == crtCopy.Spec.SecretName {
+			hasDuplicate = true
+			break
+		}
 	}
 	if hasDuplicate {
 		c.Recorder.Eventf(crtCopy, corev1.EventTypeWarning, errorDuplicateSecretName, "Duplicate secretName %v", crtCopy.Spec.SecretName)

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -31,7 +31,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/client-go/tools/cache"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -45,11 +47,12 @@ import (
 )
 
 const (
-	errorIssuerNotFound    = "IssuerNotFound"
-	errorIssuerNotReady    = "IssuerNotReady"
-	errorIssuerInit        = "IssuerInitError"
-	errorSavingCertificate = "SaveCertError"
-	errorConfig            = "ConfigError"
+	errorIssuerNotFound      = "IssuerNotFound"
+	errorIssuerNotReady      = "IssuerNotReady"
+	errorIssuerInit          = "IssuerInitError"
+	errorSavingCertificate   = "SaveCertError"
+	errorConfig              = "ConfigError"
+	errorDuplicateSecretName = "DuplicateSecretNameError"
 
 	reasonIssuingCertificate  = "IssueCert"
 	reasonRenewingCertificate = "RenewCert"
@@ -101,6 +104,29 @@ func (c *Controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 	el := validation.ValidateCertificate(crtCopy)
 	if len(el) > 0 {
 		c.Recorder.Eventf(crtCopy, corev1.EventTypeWarning, "BadConfig", "Resource validation failed: %v", el.ToAggregate())
+		return nil
+	}
+
+	// check that certificate secret name is unique
+	namespaceCrts := c.certificateLister.Certificates(crtCopy.Namespace)
+	otherCrts, err := namespaceCrts.List(labels.Everything())
+	if err != nil {
+		return err
+	}
+	hasDuplicate := false
+	for _, otherCrt := range otherCrts {
+		hasDuplicate = hasDuplicate ||
+			(otherCrt.Name != crtCopy.Name &&
+				otherCrt.Spec.SecretName == crtCopy.Spec.SecretName)
+	}
+	if hasDuplicate {
+		c.Recorder.Eventf(crtCopy, corev1.EventTypeWarning, errorDuplicateSecretName, "Duplicate secretName %v", crtCopy.Spec.SecretName)
+		key, err := cache.MetaNamespaceKeyFunc(crtCopy)
+		if err != nil {
+			return nil
+		}
+		c.scheduledWorkQueue.Forget(key)
+		apiutil.SetCertificateCondition(crtCopy, v1alpha1.CertificateConditionReady, v1alpha1.ConditionFalse, "DuplicateSecretName", "Another Certificate is using the same secretName")
 		return nil
 	}
 

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -118,3 +118,9 @@ func SetCertificateOrganization(orgs ...string) CertificateModifier {
 		ch.Spec.Organization = orgs
 	}
 }
+
+func SetCertificateNamespace(namespace string) CertificateModifier {
+	return func(crt *v1alpha1.Certificate) {
+		crt.ObjectMeta.Namespace = namespace
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Validates that only one Certificate is using a specific `secretName` per namespace checking that is unique before issuing, preventing multiple Certificates from updating the Secret.

**Which issue this PR fixes**: fixes #1558 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Validate that Certificates in a namespace have unique `secretName`
```
