### PR TITLE
Copy labels from Ingress to Certificate resource in ingress-shim

### DIFF
--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -191,6 +191,7 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.
 			updateCrt.Spec.SecretName = tls.SecretName
 			updateCrt.Spec.IssuerRef.Name = issuer.GetObjectMeta().Name
 			updateCrt.Spec.IssuerRef.Kind = issuerKind
+			updateCrt.Labels = ing.Labels
 			err = c.setIssuerSpecificConfig(updateCrt, issuer, ing, tls)
 			if err != nil {
 				return nil, nil, err
@@ -206,6 +207,14 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.
 // certNeedsUpdate checks and returns true if two Certificates differ
 func certNeedsUpdate(a, b *v1alpha1.Certificate) bool {
 	if a.Name != b.Name {
+		return true
+	}
+
+	// TODO: we may need to allow users to edit the managed Certificate resources
+	// to add their own labels directly.
+	// Right now, we'll reset/remove the label values back automatically.
+	// Let's hope no other controllers do this automatically, else we'll start fighting...
+	if !reflect.DeepEqual(a.Labels, b.Labels) {
 		return true
 	}
 

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -99,15 +99,19 @@ func (b *Builder) Start() {
 	// read all events out of the recorder and just log for now
 	// TODO: validate logged events
 	go func() {
-		r, ok := b.Recorder.(*record.FakeRecorder)
-		if !ok {
-			return
-		}
+		// Skip logging event messages due to a race/timing issue in the test
+		// framework that needs investigating, where log is called after the
+		// test has finished
+
+		//r, ok := b.Recorder.(*record.FakeRecorder)
+		//if !ok {
+		//	return
+		//}
 
 		// exits when r.Events is closed in Finish
-		for e := range r.Events {
-			b.logf("Event logged: %v", e)
-		}
+		//for e := range r.Events {
+		//	b.logf("Event logged: %v", e)
+		//}
 	}()
 
 	b.FakeKubeClient().PrependReactor("create", "*", b.generateNameReactor)


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates ingress-shim to copy labels across from Ingress resources to Certificates.

This *may* causing 'fighting' between controllers as it is, however it depends if other controllers utilise labels on resources to track things.

We should probably revisit this soon to see if there's a more optimal way we can co-exist with other controllers.

This is needed to make the new ACME solver selector code work well with ingress-shim.

**Release note**:
```release-note
Copy labels from Ingress resources to Certificates
```
