### PR TITLE
Ensure managed zone picked for CloudDNS is public

### DIFF
--- a/pkg/issuer/acme/dns/clouddns/BUILD.bazel
+++ b/pkg/issuer/acme/dns/clouddns/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//vendor/golang.org/x/oauth2:go_default_library",
         "//vendor/golang.org/x/oauth2/google:go_default_library",
         "//vendor/google.golang.org/api/dns/v1:go_default_library",
+        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -217,7 +217,13 @@ func (c *DNSProvider) getHostedZone(domain string) (string, error) {
 		return "", fmt.Errorf("No matching GoogleCloud domain found for domain %s", authZone)
 	}
 
-	return zones.ManagedZones[0].Name, nil
+	for _, zone := range zones.ManagedZones {
+		if zone.Visibility == "public" {
+			return zone.Name, nil
+		}
+	}
+
+	return "", fmt.Errorf("No matching public GoogleCloud managed-zone found for domain %s", authZone)
 }
 
 func (c *DNSProvider) findTxtRecords(zone, fqdn string) ([]*dns.ResourceRecordSet, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes issue with managed zone picked being the first from the array, with may be private.

**Which issue this PR fixes**: fixes #1383 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix issue with private managed-zone being picked in CloudDNS
```
