### PR TITLE
Add the removal of unrequired certificates

### DIFF
--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -26,6 +26,7 @@ import (
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/klog"
 
@@ -115,6 +116,19 @@ func (c *Controller) Sync(ctx context.Context, ing *extv1beta1.Ingress) error {
 			return err
 		}
 		c.Recorder.Eventf(ing, corev1.EventTypeNormal, "UpdateCertificate", "Successfully updated Certificate %q", crt.Name)
+	}
+
+	unrequiredCrts, err := c.findUnrequiredCertificates(ing)
+	if err != nil {
+		return err
+	}
+
+	for _, crt := range unrequiredCrts {
+		err = c.CMClient.CertmanagerV1alpha1().Certificates(crt.Namespace).Delete(crt.Name, nil)
+		if err != nil {
+			return err
+		}
+		c.Recorder.Eventf(ing, corev1.EventTypeNormal, "DeleteCertificate", "Successfully deleted unrequired Certificate %q", crt.Name)
 	}
 
 	return nil
@@ -215,6 +229,35 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.
 		}
 	}
 	return newCrts, updateCrts, nil
+}
+
+func (c *Controller) findUnrequiredCertificates(ing *extv1beta1.Ingress) ([]*v1alpha1.Certificate, error) {
+	var unrequired []*v1alpha1.Certificate
+	crts, err := c.certificateLister.Certificates(ing.Namespace).List(labels.Everything())
+	if err != nil {
+		return nil, err
+	}
+
+	for _, crt := range crts {
+		if isUnrequiredCertificate(crt, ing) {
+			unrequired = append(unrequired, crt)
+		}
+	}
+
+	return unrequired, nil
+}
+
+func isUnrequiredCertificate(crt *v1alpha1.Certificate, ing *extv1beta1.Ingress) bool {
+	if !metav1.IsControlledBy(crt, ing) {
+		return false
+	}
+
+	for _, tls := range ing.Spec.TLS {
+		if crt.Spec.SecretName == tls.SecretName {
+			return false
+		}
+	}
+	return true
 }
 
 // certNeedsUpdate checks and returns true if two Certificates differ

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -233,6 +233,7 @@ func (c *Controller) buildCertificates(ing *extv1beta1.Ingress, issuer v1alpha1.
 
 func (c *Controller) findUnrequiredCertificates(ing *extv1beta1.Ingress) ([]*v1alpha1.Certificate, error) {
 	var unrequired []*v1alpha1.Certificate
+	// TODO: investigate selector which filters for certificates controlled by the ingress
 	crts, err := c.certificateLister.Certificates(ing.Namespace).List(labels.Everything())
 	if err != nil {
 		return nil, err

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -110,6 +110,7 @@ func TestSync(t *testing.T) {
 		Err                 bool
 		ExpectedCreate      []*v1alpha1.Certificate
 		ExpectedUpdate      []*v1alpha1.Certificate
+		ExpectedDelete      []*v1alpha1.Certificate
 	}
 	tests := []testT{
 		{
@@ -1077,6 +1078,80 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:         "should delete a Certificate if its SecretName is not present in the ingress",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			Ingress: &extv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						issuerNameAnnotation:              "issuer-name",
+						acmeIssuerChallengeTypeAnnotation: "http01",
+					},
+					UID: types.UID("ingress-name"),
+				},
+			},
+			CertificateLister: []runtime.Object{
+				&v1alpha1.Certificate{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.DomainSolverConfig{
+								{
+									Domains: []string{"example.com"},
+									SolverConfig: v1alpha1.SolverConfig{
+										HTTP01: &v1alpha1.HTTP01SolverConfig{
+											Ingress: "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedDelete: []*v1alpha1.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "existing-crt",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+					},
+					Spec: v1alpha1.CertificateSpec{
+						DNSNames:   []string{"example.com"},
+						SecretName: "existing-crt",
+						IssuerRef: v1alpha1.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+						ACME: &v1alpha1.ACMECertificateConfig{
+							Config: []v1alpha1.DomainSolverConfig{
+								{
+									Domains: []string{"example.com"},
+									SolverConfig: v1alpha1.SolverConfig{
+										HTTP01: &v1alpha1.HTTP01SolverConfig{
+											Ingress: "",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	testFn := func(test testT) func(t *testing.T) {
 		return func(t *testing.T) {
@@ -1102,6 +1177,14 @@ func TestSync(t *testing.T) {
 						cr,
 					)),
 				)
+			}
+			for _, cr := range test.ExpectedDelete {
+				expectedActions = append(expectedActions,
+					testpkg.NewAction(coretesting.NewDeleteAction(
+						v1alpha1.SchemeGroupVersion.WithResource("certificates"),
+						cr.Namespace,
+						cr.Name,
+					)))
 			}
 			b := &testpkg.Builder{
 				T:                  t,
@@ -1214,6 +1297,9 @@ func buildCertificate(name, namespace string, ownerReferences []metav1.OwnerRefe
 			Name:            name,
 			Namespace:       namespace,
 			OwnerReferences: ownerReferences,
+		},
+		Spec: v1alpha1.CertificateSpec{
+			SecretName: name,
 		},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When the `SecretName` of a TLS entry in an ingress is changed/modified, the previous certificate is deleted.
This fixes issues with work queues being filled with unrequired certificates.

**Which issue this PR fixes**: fixes #912 

**Special notes for your reviewer**:
The change to `sync_test.go` will need to be modified for simplicity to follow the changes in pull request #1670 (w.r.t. owner references).

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add the removal of certificates when no longer required by the owner ingress
```
