### PR TITLE
Add ChartVersion to helm install when running tests

### DIFF
--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -156,7 +156,8 @@ func (c *Chart) runInstall() error {
 	args := []string{"install", c.ChartName,
 		"--wait",
 		"--namespace", c.Namespace,
-		"--name", c.ReleaseName}
+		"--name", c.ReleaseName,
+		"--version", c.ChartVersion}
 
 	for _, v := range c.Values {
 		args = append(args, "--values", v)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes issue with `ChartVersion` not being set as a flag when calling `helm install` in the e2e tests, preventing the correct setup of kind pods and therefore testing.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
