### PR TITLE
Fix logic to select the solver that has the most labels

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -495,6 +495,7 @@ func determineSolverConfigToUse(candidates []cmapi.ACMEChallengeSolver, authz *a
 			if len(d.Selector.MatchLabels) > matchAllDomainsNumLabels || matchAll == nil {
 				matchAll = &d
 				matchAllToSolve = acmech
+				matchAllDomainsNumLabels = len(d.Selector.MatchLabels)
 			}
 		}
 		for _, dom := range d.Selector.DNSNames {
@@ -504,6 +505,7 @@ func determineSolverConfigToUse(candidates []cmapi.ACMEChallengeSolver, authz *a
 			if len(d.Selector.MatchLabels) > numLabelsSpecificMatch || specificMatch == nil {
 				specificMatch = &d
 				specificMatchToSolve = acmech
+				numLabelsSpecificMatch = len(d.Selector.MatchLabels)
 				break
 			}
 		}


### PR DESCRIPTION
These variables seem like they should be updated when updating the thing they are supposed to be derived from.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

https://github.com/jetstack/cert-manager/issues/1714

**Special notes for your reviewer**:

**Release note**:

```release-note
Fix a the logic to select the most specific solver from an issuer if multiple matched
```
