### PR TITLE
Fix solver selection logic to return the selected solver rather than always returning the last one

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -476,8 +476,9 @@ func determineSolverConfigToUse(candidates []cmapi.ACMEChallengeSolver, authz *a
 	var matchAll *cmapi.ACMEChallengeSolver
 	var matchAllToSolve *acmeapi.Challenge
 
-	for _, d := range candidates {
-		acmech := challengeForSolver(&d)
+	for idx := range candidates {
+		d := &candidates[idx]
+		acmech := challengeForSolver(d)
 		if acmech == nil {
 			continue
 		}
@@ -486,14 +487,14 @@ func determineSolverConfigToUse(candidates []cmapi.ACMEChallengeSolver, authz *a
 		if d.Selector == nil {
 			if matchAll == nil {
 				matchAllDomainsNumLabels = 0
-				matchAll = &d
+				matchAll = d
 				matchAllToSolve = acmech
 			}
 			continue
 		}
 		if len(d.Selector.DNSNames) == 0 {
 			if len(d.Selector.MatchLabels) > matchAllDomainsNumLabels || matchAll == nil {
-				matchAll = &d
+				matchAll = d
 				matchAllToSolve = acmech
 			}
 		}
@@ -502,7 +503,7 @@ func determineSolverConfigToUse(candidates []cmapi.ACMEChallengeSolver, authz *a
 				continue
 			}
 			if len(d.Selector.MatchLabels) > numLabelsSpecificMatch || specificMatch == nil {
-				specificMatch = &d
+				specificMatch = d
 				specificMatchToSolve = acmech
 				break
 			}


### PR DESCRIPTION
The address of a for loop created variable does not change between loops - the variable is over-written with each new variable.  This fixes the code so that `d` references the array element instead of the local variable, which means that when `d` is assigned to `matchAll` or `specificMatch` it will work as intended.

Fixes https://github.com/jetstack/cert-manager/issues/1716 and prevents the underlying cause of https://github.com/jetstack/cert-manager/issues/1713

```release-note
Fix a bug where the logic to select a solver would always return the last solver and may return the wrong kind of solver for the challenge that it returned.
```
