### PR TITLE
Add BaseController as a refactoring of common controller code

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "go_default_library",
     srcs = [
+        "base_controller.go",
         "context.go",
         "helper.go",
         "register.go",
@@ -14,8 +15,10 @@ go_library(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
+        "//pkg/logs:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/informers:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/rest:go_default_library",

--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/apiserver/pkg/util/feature:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -187,7 +187,7 @@ func (c *Controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 		}
 
 		// retry after 10s
-		c.queue.AddAfter(key, time.Second*10)
+		c.BaseController.Queue.AddAfter(key, time.Second*10)
 
 		return nil
 	}

--- a/pkg/controller/acmeorders/BUILD.bazel
+++ b/pkg/controller/acmeorders/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/sets:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -42,7 +42,7 @@ func (c *Controller) handleGenericIssuer(obj interface{}) {
 			runtime.HandleError(err)
 			continue
 		}
-		c.queue.Add(key)
+		c.BaseController.Queue.Add(key)
 	}
 }
 

--- a/pkg/controller/base_controller.go
+++ b/pkg/controller/base_controller.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+)
+
+type BaseController struct {
+	// the controllers root context, containing a controller scoped logger
+	Ctx context.Context
+	*Context
+
+	// To allow injection for testing.
+	syncHandler func(ctx context.Context, key string) error
+
+	watchedInformers []cache.InformerSynced
+	Queue            workqueue.RateLimitingInterface
+}
+
+func New(ctx *Context, controllerName string, syncHandler func(ctx context.Context, key string) error) *BaseController {
+	bctrl := &BaseController{Context: ctx}
+	bctrl.syncHandler = syncHandler
+	bctrl.Ctx = logf.NewContext(ctx.RootContext, nil, controllerName)
+	return bctrl
+}
+
+func (bctrl *BaseController) AddQueuing(rateLimiter workqueue.RateLimiter, name string, informer cache.SharedIndexInformer) {
+	bctrl.Queue = workqueue.NewNamedRateLimitingQueue(rateLimiter, name)
+	informer.AddEventHandler(&QueuingEventHandler{Queue: bctrl.Queue})
+	bctrl.watchedInformers = append(bctrl.watchedInformers, informer.HasSynced)
+}
+
+func (bctrl *BaseController) AddHandled(informer cache.SharedIndexInformer, handler cache.ResourceEventHandler) {
+	informer.AddEventHandler(handler)
+	bctrl.watchedInformers = append(bctrl.watchedInformers, informer.HasSynced)
+}
+
+func (bctrl *BaseController) AddWatched(informers ...cache.SharedIndexInformer) {
+	for _, informer := range informers {
+		bctrl.watchedInformers = append(bctrl.watchedInformers, informer.HasSynced)
+	}
+}
+
+func (bc *BaseController) Run(workers int, stopCh <-chan struct{}) error {
+	ctx, cancel := context.WithCancel(bc.Ctx)
+	defer cancel()
+	log := logf.FromContext(ctx)
+
+	log.Info("starting control loop")
+	// wait for all the informer caches we depend on are synced
+	if !cache.WaitForCacheSync(stopCh, bc.watchedInformers...) {
+		// TODO: replace with Errorf call to glog
+		return fmt.Errorf("error waiting for informer caches to sync")
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		// TODO (@munnerz): make time.Second duration configurable
+		go wait.Until(func() {
+			defer wg.Done()
+			bc.worker(ctx)
+		}, time.Second, stopCh)
+	}
+	<-stopCh
+	log.Info("shutting down queue as workqueue signaled shutdown")
+	bc.Queue.ShutDown()
+	log.V(logf.DebugLevel).Info("waiting for workers to exit...")
+	wg.Wait()
+	log.V(logf.DebugLevel).Info("workers exited")
+	return nil
+}
+
+func (bc *BaseController) worker(ctx context.Context) {
+	log := logf.FromContext(bc.Ctx)
+
+	log.V(logf.DebugLevel).Info("starting worker")
+	for {
+		obj, shutdown := bc.Queue.Get()
+		if shutdown {
+			break
+		}
+
+		var key string
+		// use an inlined function so we can use defer
+		func() {
+			defer bc.Queue.Done(obj)
+			var ok bool
+			if key, ok = obj.(string); !ok {
+				return
+			}
+			log := log.WithValues("key", key)
+			log.Info("syncing item")
+			if err := bc.syncHandler(ctx, key); err != nil {
+				log.Error(err, "re-queuing item  due to error processing")
+				bc.Queue.AddRateLimited(obj)
+				return
+			}
+			log.Info("finished processing work item")
+			bc.Queue.Forget(obj)
+		}()
+	}
+	log.V(logf.DebugLevel).Info("exiting worker loop")
+}

--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -30,10 +30,8 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )

--- a/pkg/controller/certificates/checks.go
+++ b/pkg/controller/certificates/checks.go
@@ -29,7 +29,7 @@ import (
 )
 
 func (c *Controller) handleGenericIssuer(obj interface{}) {
-	log := logf.FromContext(c.ctx, "handleGenericIssuer")
+	log := logf.FromContext(c.BaseController.Ctx, "handleGenericIssuer")
 
 	iss, ok := obj.(cmapi.GenericIssuer)
 	if !ok {
@@ -50,12 +50,12 @@ func (c *Controller) handleGenericIssuer(obj interface{}) {
 			log.Error(err, "error computing key for resource")
 			continue
 		}
-		c.queue.Add(key)
+		c.BaseController.Queue.Add(key)
 	}
 }
 
 func (c *Controller) handleSecretResource(obj interface{}) {
-	log := logf.FromContext(c.ctx, "handleSecretResource")
+	log := logf.FromContext(c.BaseController.Ctx, "handleSecretResource")
 
 	secret, ok := obj.(*corev1.Secret)
 	if !ok {
@@ -76,7 +76,7 @@ func (c *Controller) handleSecretResource(obj interface{}) {
 			log.Error(err, "error computing key for resource")
 			continue
 		}
-		c.queue.Add(key)
+		c.BaseController.Queue.Add(key)
 	}
 }
 
@@ -129,7 +129,7 @@ func (c *Controller) certificatesForGenericIssuer(iss cmapi.GenericIssuer) ([]*c
 }
 
 func (c *Controller) handleOwnedResource(obj interface{}) {
-	log := logf.FromContext(c.ctx, "handleOwnedResource")
+	log := logf.FromContext(c.BaseController.Ctx, "handleOwnedResource")
 
 	metaobj, ok := obj.(metav1.Object)
 	if !ok {
@@ -168,7 +168,7 @@ func (c *Controller) handleOwnedResource(obj interface{}) {
 				log.Error(err, "error computing key for resource")
 				continue
 			}
-			c.queue.Add(objKey)
+			c.BaseController.Queue.Add(objKey)
 		}
 	}
 }

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -18,7 +18,6 @@ package certificates
 
 import (
 	"context"
-	"sync"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
@@ -46,7 +45,6 @@ type Controller struct {
 	secretLister        corelisters.SecretLister
 
 	scheduledWorkQueue scheduler.ScheduledWorkQueue
-	workerWg           sync.WaitGroup
 	metrics            *metrics.Metrics
 
 	// used for testing

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -18,15 +18,11 @@ package certificates
 
 import (
 	"context"
-	"fmt"
 	"sync"
-	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 	"k8s.io/utils/clock"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -39,26 +35,18 @@ import (
 )
 
 type Controller struct {
-	// the controllers root context, containing a controller scoped logger
-	ctx context.Context
-
-	*controllerpkg.Context
+	*controllerpkg.BaseController
 
 	helper        issuer.Helper
 	issuerFactory issuer.IssuerFactory
-
-	// To allow injection for testing.
-	syncHandler func(ctx context.Context, key string) error
 
 	issuerLister        cmlisters.IssuerLister
 	clusterIssuerLister cmlisters.ClusterIssuerLister
 	certificateLister   cmlisters.CertificateLister
 	secretLister        corelisters.SecretLister
 
-	queue              workqueue.RateLimitingInterface
 	scheduledWorkQueue scheduler.ScheduledWorkQueue
 	workerWg           sync.WaitGroup
-	syncedFuncs        []cache.InformerSynced
 	metrics            *metrics.Metrics
 
 	// used for testing
@@ -71,110 +59,45 @@ type Controller struct {
 // New returns a new Certificates controller. It sets up the informer handler
 // functions for all the types it watches.
 func New(ctx *controllerpkg.Context) *Controller {
-	ctrl := &Controller{Context: ctx}
-	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), "certificates")
+	ctrl := &Controller{}
+	bctrl := controllerpkg.New(ctx, ControllerName, ctrl.processNextWorkItem)
+
+	certificateInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().Certificates()
+	bctrl.AddQueuing(controllerpkg.DefaultItemBasedRateLimiter(), "certificates", certificateInformer.Informer())
+	ctrl.certificateLister = certificateInformer.Lister()
 
 	// Create a scheduled work queue that calls the ctrl.queue.Add method for
 	// each object in the queue. This is used to schedule re-checks of
 	// Certificate resources when they get near to expiry
-	ctrl.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(ctrl.queue.AddRateLimited)
+	ctrl.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(bctrl.Queue.AddRateLimited)
 
-	certificateInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().Certificates()
-	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})
-	ctrl.certificateLister = certificateInformer.Lister()
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, certificateInformer.Informer().HasSynced)
-
-	issuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
-	issuerInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleGenericIssuer})
+	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
+	bctrl.AddHandled(issuerInformer.Informer(), &controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleGenericIssuer})
 	ctrl.issuerLister = issuerInformer.Lister()
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, issuerInformer.Informer().HasSynced)
 
 	// if scoped to a single namespace
 	if ctx.Namespace == "" {
-		clusterIssuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers()
-		clusterIssuerInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleGenericIssuer})
+		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers()
+		bctrl.AddHandled(clusterIssuerInformer.Informer(), &controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleGenericIssuer})
 		ctrl.clusterIssuerLister = clusterIssuerInformer.Lister()
-		ctrl.syncedFuncs = append(ctrl.syncedFuncs, clusterIssuerInformer.Informer().HasSynced)
 	}
 
-	secretsInformer := ctrl.KubeSharedInformerFactory.Core().V1().Secrets()
-	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleSecretResource})
+	secretsInformer := ctx.KubeSharedInformerFactory.Core().V1().Secrets()
+	bctrl.AddHandled(secretsInformer.Informer(), &controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleSecretResource})
 	ctrl.secretLister = secretsInformer.Lister()
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, secretsInformer.Informer().HasSynced)
 
-	ordersInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().Orders()
-	ordersInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleOwnedResource})
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, ordersInformer.Informer().HasSynced)
+	ordersInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().Orders()
+	bctrl.AddHandled(ordersInformer.Informer(), &controllerpkg.BlockingEventHandler{WorkFunc: ctrl.handleOwnedResource})
 
+	ctrl.BaseController = bctrl
 	ctrl.helper = issuer.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 	ctrl.metrics = metrics.Default
 	ctrl.helper = issuer.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 	ctrl.issuerFactory = issuer.NewIssuerFactory(ctx)
 	ctrl.clock = clock.RealClock{}
 	ctrl.localTemporarySigner = generateLocallySignedTemporaryCertificate
-	ctrl.ctx = logf.NewContext(ctx.RootContext, nil, ControllerName)
 
 	return ctrl
-}
-
-func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
-	ctx, cancel := context.WithCancel(c.ctx)
-	defer cancel()
-	log := logf.FromContext(ctx)
-
-	log.Info("starting control loop")
-	// wait for all the informer caches we depend to sync
-	if !cache.WaitForCacheSync(stopCh, c.syncedFuncs...) {
-		return fmt.Errorf("error waiting for informer caches to sync")
-	}
-
-	log.Info("synced all caches for control loop")
-
-	for i := 0; i < workers; i++ {
-		c.workerWg.Add(1)
-		// TODO (@munnerz): make time.Second duration configurable
-		go wait.Until(func() { c.worker(ctx) }, time.Second, stopCh)
-	}
-	<-stopCh
-	log.V(logf.DebugLevel).Info("shutting down queue as workqueue signaled shutdown")
-	c.queue.ShutDown()
-	log.V(logf.DebugLevel).Info("waiting for workers to exit...")
-	c.workerWg.Wait()
-	log.V(logf.DebugLevel).Info("workers exited")
-	return nil
-}
-
-func (c *Controller) worker(ctx context.Context) {
-	log := logf.FromContext(ctx)
-	defer c.workerWg.Done()
-	log.V(logf.DebugLevel).Info("starting worker")
-	for {
-		obj, shutdown := c.queue.Get()
-		if shutdown {
-			break
-		}
-
-		var key string
-		// use an inlined function so we can use defer
-		func() {
-			defer c.queue.Done(obj)
-			var ok bool
-			if key, ok = obj.(string); !ok {
-				return
-			}
-			log := log.WithValues("key", key)
-			log.Info("syncing resource")
-			if err := c.syncHandler(ctx, key); err != nil {
-				log.Error(err, "re-queuing item  due to error processing")
-				c.queue.AddRateLimited(obj)
-				return
-			}
-			log.Info("finished processing work item")
-			c.queue.Forget(obj)
-		}()
-	}
-	log.V(logf.DebugLevel).Info("exiting worker loop")
 }
 
 func (c *Controller) processNextWorkItem(ctx context.Context, key string) error {

--- a/pkg/controller/clusterissuers/BUILD.bazel
+++ b/pkg/controller/clusterissuers/BUILD.bazel
@@ -21,10 +21,8 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
     ],
 )
 

--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
-        "//pkg/client/informers/externalversions/certmanager/v1alpha1:go_default_library",
         "//pkg/client/listers/certmanager/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/issuer:go_default_library",
@@ -24,13 +23,10 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
-        "//vendor/k8s.io/client-go/informers/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/listers/extensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",
     ],
 )

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -20,26 +20,19 @@ import (
 	"context"
 	"fmt"
 	"sync"
-	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	extlisters "k8s.io/client-go/listers/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/client-go/util/workqueue"
-	"k8s.io/klog"
 
 	cmv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/issuer"
-	"github.com/jetstack/cert-manager/pkg/util"
-	extinformers "k8s.io/client-go/informers/extensions/v1beta1"
 )
 
 const (
@@ -54,58 +47,57 @@ type defaults struct {
 }
 
 type Controller struct {
+	*controllerpkg.BaseController
+
 	Client   kubernetes.Interface
 	CMClient clientset.Interface
 	Recorder record.EventRecorder
 
 	helper issuer.Helper
 
-	// To allow injection for testing.
-	syncHandler func(ctx context.Context, key string) error
-
 	ingressLister       extlisters.IngressLister
 	certificateLister   cmlisters.CertificateLister
 	issuerLister        cmlisters.IssuerLister
 	clusterIssuerLister cmlisters.ClusterIssuerLister
 
-	queue       workqueue.RateLimitingInterface
-	workerWg    sync.WaitGroup
-	syncedFuncs []cache.InformerSynced
-	defaults    defaults
+	workerWg sync.WaitGroup
+	defaults defaults
 }
 
-// New returns a new Certificates controller. It sets up the informer handler
-// functions for all the types it watches.
-func New(
-	certificatesInformer cminformers.CertificateInformer,
-	ingressInformer extinformers.IngressInformer,
-	issuerInformer cminformers.IssuerInformer,
-	clusterIssuerInformer cminformers.ClusterIssuerInformer,
-	client kubernetes.Interface,
-	cmClient clientset.Interface,
-	recorder record.EventRecorder,
-	defaults defaults,
-) *Controller {
-	ctrl := &Controller{Client: client, CMClient: cmClient, Recorder: recorder, defaults: defaults}
-	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), "ingresses")
+func New(ctx *controllerpkg.Context) *Controller {
+	ctrl := &Controller{
+		Client:   ctx.Client,
+		CMClient: ctx.CMClient,
+		Recorder: ctx.Recorder,
+		defaults: defaults{
+			ctx.DefaultAutoCertificateAnnotations,
+			ctx.DefaultIssuerName,
+			ctx.DefaultIssuerKind,
+			ctx.DefaultACMEIssuerChallengeType,
+			ctx.DefaultACMEIssuerDNS01ProviderName,
+		},
+	}
+	bctrl := controllerpkg.New(ctx, ControllerName, ctrl.processNextWorkItem)
 
-	ingressInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})
+	ingressInformer := ctx.KubeSharedInformerFactory.Extensions().V1beta1().Ingresses()
+	bctrl.AddQueuing(controllerpkg.DefaultItemBasedRateLimiter(), "ingresses", ingressInformer.Informer())
 	ctrl.ingressLister = ingressInformer.Lister()
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, ingressInformer.Informer().HasSynced)
 
-	certificatesInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.certificateDeleted})
+	certificatesInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().Certificates()
+	bctrl.AddHandled(certificatesInformer.Informer(), &controllerpkg.BlockingEventHandler{WorkFunc: ctrl.certificateDeleted})
 	ctrl.certificateLister = certificatesInformer.Lister()
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, certificatesInformer.Informer().HasSynced)
 
+	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
+	bctrl.AddWatched(issuerInformer.Informer())
 	ctrl.issuerLister = issuerInformer.Lister()
-	ctrl.syncedFuncs = append(ctrl.syncedFuncs, issuerInformer.Informer().HasSynced)
 
-	if clusterIssuerInformer != nil {
+	if ctx.Namespace == "" {
+		clusterIssuerInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers()
+		bctrl.AddWatched(clusterIssuerInformer.Informer())
 		ctrl.clusterIssuerLister = clusterIssuerInformer.Lister()
-		ctrl.syncedFuncs = append(ctrl.syncedFuncs, clusterIssuerInformer.Informer().HasSynced)
 	}
 
+	ctrl.BaseController = bctrl
 	ctrl.helper = issuer.NewHelper(ctrl.issuerLister, ctrl.clusterIssuerLister)
 
 	return ctrl
@@ -128,64 +120,8 @@ func (c *Controller) certificateDeleted(obj interface{}) {
 			runtime.HandleError(err)
 			continue
 		}
-		c.queue.Add(key)
+		c.BaseController.Queue.Add(key)
 	}
-}
-
-func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
-	klog.V(4).Infof("Starting %s control loop", ControllerName)
-	// wait for all the informer caches we depend to sync
-	if !cache.WaitForCacheSync(stopCh, c.syncedFuncs...) {
-		return fmt.Errorf("error waiting for informer caches to sync")
-	}
-
-	klog.V(4).Infof("Synced all caches for %s control loop", ControllerName)
-
-	for i := 0; i < workers; i++ {
-		c.workerWg.Add(1)
-		// TODO (@munnerz): make time.Second duration configurable
-		go wait.Until(func() { c.worker(stopCh) }, time.Second, stopCh)
-	}
-	<-stopCh
-	klog.V(4).Infof("Shutting down queue as workqueue signaled shutdown")
-	c.queue.ShutDown()
-	klog.V(4).Infof("Waiting for workers to exit...")
-	c.workerWg.Wait()
-	klog.V(4).Infof("Workers exited.")
-	return nil
-}
-
-func (c *Controller) worker(stopCh <-chan struct{}) {
-	defer c.workerWg.Done()
-	klog.V(4).Infof("Starting %q worker", ControllerName)
-	for {
-		obj, shutdown := c.queue.Get()
-		if shutdown {
-			break
-		}
-
-		var key string
-		// use an inlined function so we can use defer
-		func() {
-			defer c.queue.Done(obj)
-			var ok bool
-			if key, ok = obj.(string); !ok {
-				return
-			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			ctx = util.ContextWithStopCh(ctx, stopCh)
-			klog.Infof("%s controller: syncing item '%s'", ControllerName, key)
-			if err := c.syncHandler(ctx, key); err != nil {
-				klog.Errorf("%s controller: Re-queuing item %q due to error processing: %s", ControllerName, key, err.Error())
-				c.queue.AddRateLimited(obj)
-				return
-			}
-			klog.Infof("%s controller: Finished processing work item %q", ControllerName, key)
-			c.queue.Forget(obj)
-		}()
-	}
-	klog.V(4).Infof("Exiting %q worker loop", ControllerName)
 }
 
 func (c *Controller) processNextWorkItem(ctx context.Context, key string) error {
@@ -213,19 +149,6 @@ var keyFunc = controllerpkg.KeyFunc
 
 func init() {
 	controllerpkg.Register(ControllerName, func(ctx *controllerpkg.Context) (controllerpkg.Interface, error) {
-		var clusterIssuerInformer cminformers.ClusterIssuerInformer
-		if ctx.Namespace == "" {
-			clusterIssuerInformer = ctx.SharedInformerFactory.Certmanager().V1alpha1().ClusterIssuers()
-		}
-		return New(
-			ctx.SharedInformerFactory.Certmanager().V1alpha1().Certificates(),
-			ctx.KubeSharedInformerFactory.Extensions().V1beta1().Ingresses(),
-			ctx.SharedInformerFactory.Certmanager().V1alpha1().Issuers(),
-			clusterIssuerInformer,
-			ctx.Client,
-			ctx.CMClient,
-			ctx.Recorder,
-			defaults{ctx.DefaultAutoCertificateAnnotations, ctx.DefaultIssuerName, ctx.DefaultIssuerKind, ctx.DefaultACMEIssuerChallengeType, ctx.DefaultACMEIssuerDNS01ProviderName},
-		).Run, nil
+		return New(ctx).BaseController.Run, nil
 	})
 }

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"sync"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/runtime"
@@ -60,7 +59,6 @@ type Controller struct {
 	issuerLister        cmlisters.IssuerLister
 	clusterIssuerLister cmlisters.ClusterIssuerLister
 
-	workerWg sync.WaitGroup
 	defaults defaults
 }
 

--- a/pkg/controller/issuers/BUILD.bazel
+++ b/pkg/controller/issuers/BUILD.bazel
@@ -21,10 +21,8 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
-        "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
     ],
 )
 

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -18,16 +18,11 @@ package issuers
 
 import (
 	"context"
-	"fmt"
-	"sync"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/workqueue"
 
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
@@ -36,47 +31,35 @@ import (
 )
 
 type Controller struct {
-	// the controllers root context, containing a controller scoped logger
-	ctx context.Context
-	*controllerpkg.Context
-	issuerFactory issuer.IssuerFactory
+	*controllerpkg.BaseController
 
-	// To allow injection for testing.
-	syncHandler func(ctx context.Context, key string) error
+	issuerFactory issuer.IssuerFactory
 
 	issuerLister cmlisters.IssuerLister
 	secretLister corelisters.SecretLister
-
-	watchedInformers []cache.InformerSynced
-	queue            workqueue.RateLimitingInterface
 }
 
 func New(ctx *controllerpkg.Context) *Controller {
-	ctrl := &Controller{
-		Context: ctx,
-	}
+	ctrl := &Controller{}
+	bctrl := controllerpkg.New(ctx, ControllerName, ctrl.processNextWorkItem)
 
-	ctrl.syncHandler = ctrl.processNextWorkItem
-	ctrl.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), "issuers")
-
-	issuerInformer := ctrl.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
-	issuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: ctrl.queue})
-	ctrl.watchedInformers = append(ctrl.watchedInformers, issuerInformer.Informer().HasSynced)
+	issuerInformer := ctx.SharedInformerFactory.Certmanager().V1alpha1().Issuers()
+	bctrl.AddQueuing(controllerpkg.DefaultItemBasedRateLimiter(), "issuers", issuerInformer.Informer())
 	ctrl.issuerLister = issuerInformer.Lister()
 
-	secretsInformer := ctrl.KubeSharedInformerFactory.Core().V1().Secrets()
-	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: ctrl.secretDeleted})
-	ctrl.watchedInformers = append(ctrl.watchedInformers, secretsInformer.Informer().HasSynced)
+	secretsInformer := ctx.KubeSharedInformerFactory.Core().V1().Secrets()
+	bctrl.AddHandled(secretsInformer.Informer(), &controllerpkg.BlockingEventHandler{WorkFunc: ctrl.secretDeleted})
 	ctrl.secretLister = secretsInformer.Lister()
+
+	ctrl.BaseController = bctrl
 	ctrl.issuerFactory = issuer.NewIssuerFactory(ctx)
-	ctrl.ctx = logf.NewContext(ctx.RootContext, nil, ControllerName)
 
 	return ctrl
 }
 
 // TODO: replace with generic handleObjet function (like Navigator)
 func (c *Controller) secretDeleted(obj interface{}) {
-	log := logf.FromContext(c.ctx)
+	log := logf.FromContext(c.BaseController.Ctx)
 
 	var secret *corev1.Secret
 	var ok bool
@@ -97,70 +80,8 @@ func (c *Controller) secretDeleted(obj interface{}) {
 			log.Error(err, "error computing key for resource")
 			continue
 		}
-		c.queue.AddRateLimited(key)
+		c.BaseController.Queue.AddRateLimited(key)
 	}
-}
-
-func (c *Controller) Run(workers int, stopCh <-chan struct{}) error {
-	ctx, cancel := context.WithCancel(c.ctx)
-	defer cancel()
-	log := logf.FromContext(ctx)
-
-	log.Info("starting control loop")
-	// wait for all the informer caches we depend on are synced
-	if !cache.WaitForCacheSync(stopCh, c.watchedInformers...) {
-		// TODO: replace with Errorf call to glog
-		return fmt.Errorf("error waiting for informer caches to sync")
-	}
-
-	var wg sync.WaitGroup
-	for i := 0; i < workers; i++ {
-		wg.Add(1)
-		// TODO (@munnerz): make time.Second duration configurable
-		go wait.Until(func() {
-			defer wg.Done()
-			c.worker(ctx)
-		}, time.Second, stopCh)
-	}
-	<-stopCh
-	log.Info("shutting down queue as workqueue signaled shutdown")
-	c.queue.ShutDown()
-	log.V(logf.DebugLevel).Info("waiting for workers to exit...")
-	wg.Wait()
-	log.V(logf.DebugLevel).Info("workers exited")
-	return nil
-}
-
-func (c *Controller) worker(ctx context.Context) {
-	log := logf.FromContext(c.ctx)
-
-	log.V(logf.DebugLevel).Info("starting worker")
-	for {
-		obj, shutdown := c.queue.Get()
-		if shutdown {
-			break
-		}
-
-		var key string
-		// use an inlined function so we can use defer
-		func() {
-			defer c.queue.Done(obj)
-			var ok bool
-			if key, ok = obj.(string); !ok {
-				return
-			}
-			log := log.WithValues("key", key)
-			log.Info("syncing item")
-			if err := c.syncHandler(ctx, key); err != nil {
-				log.Error(err, "re-queuing item  due to error processing")
-				c.queue.AddRateLimited(obj)
-				return
-			}
-			log.Info("finished processing work item")
-			c.queue.Forget(obj)
-		}()
-	}
-	log.V(logf.DebugLevel).Info("exiting worker loop")
 }
 
 func (c *Controller) processNextWorkItem(ctx context.Context, key string) error {
@@ -193,6 +114,6 @@ const (
 
 func init() {
 	controllerpkg.Register(ControllerName, func(ctx *controllerpkg.Context) (controllerpkg.Interface, error) {
-		return New(ctx).Run, nil
+		return New(ctx).BaseController.Run, nil
 	})
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -649,7 +649,6 @@ k8s.io/client-go/discovery/fake
 k8s.io/client-go/testing
 k8s.io/client-go/tools/cache
 k8s.io/client-go/util/workqueue
-k8s.io/client-go/informers/extensions/v1beta1
 k8s.io/client-go/listers/extensions/v1beta1
 k8s.io/client-go/kubernetes/fake
 k8s.io/client-go/tools/clientcmd
@@ -779,6 +778,7 @@ k8s.io/client-go/informers/coordination/v1
 k8s.io/client-go/informers/coordination/v1beta1
 k8s.io/client-go/informers/core/v1
 k8s.io/client-go/informers/events/v1beta1
+k8s.io/client-go/informers/extensions/v1beta1
 k8s.io/client-go/informers/networking/v1
 k8s.io/client-go/informers/networking/v1beta1
 k8s.io/client-go/informers/node/v1alpha1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds a `BaseController` struct as a collection of common fields in the Controllers, along with the common functions `Run()` and `worker()`.
The Controllers have been modified to use this struct.

**Which issue this PR fixes**: fixes #1003 

**Special notes for your reviewer**:
I'm not sure how well these changes align with Go best practices, particularly with regards to accessing the fields of the `BaseController` from the Controller - I am very open to any reviews of this PR.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
