### PR TITLE
Add solvers field in kube-lego migration guide

### DIFF
--- a/docs/tutorials/acme/migrating-from-kube-lego.rst
+++ b/docs/tutorials/acme/migrating-from-kube-lego.rst
@@ -161,7 +161,10 @@ Create a file named ``cluster-issuer.yaml``:
        privateKeySecretRef:
          name: letsencrypt-private-key
        # Enable the HTTP-01 challenge provider
-       http01: {}
+       solvers:
+       - http01:
+           ingress:
+             class: nginx
 
 We then submit this file to our Kubernetes cluster:
 
@@ -172,35 +175,14 @@ We then submit this file to our Kubernetes cluster:
 You should be able to verify the ACME account has been verified successfully:
 
 .. code-block:: shell
-   :emphasize-lines: 26-31
 
    $ kubectl describe clusterissuer letsencrypt-staging
-   Name:         letsencrypt-staging
-   Namespace:
-   Labels:       <none>
-   Annotations:  <none>
-   API Version:  certmanager.k8s.io/v1alpha1
-   Kind:         ClusterIssuer
-   Metadata:
-     Cluster Name:
-     Creation Timestamp:  2017-11-30T22:33:40Z
-     Generation:          0
-     Resource Version:    4450170
-     Self Link:           /apis/certmanager.k8s.io/v1alpha1/letsencrypt-staging
-     UID:                 83d04e6b-d61e-11e7-ac26-42010a840044
-   Spec:
-     Acme:
-       Email:  user@example.com
-       Http 01:
-       Private Key Secret Ref:
-         Key:
-         Name:  letsencrypt-private-key
-       Server:  https://acme-staging-v02.api.letsencrypt.org/directory
+   ...
    Status:
      Acme:
-       Uri:  https://acme-staging-v02.api.letsencrypt.org/acme/acct/11217539
+       Uri:  https://acme-staging-v02.api.letsencrypt.org/acme/acct/7571319
      Conditions:
-       Last Transition Time:  2018-04-12T17:32:30Z
+       Last Transition Time:  2019-01-30T14:52:03Z
        Message:               The ACME account was registered with the ACME server
        Reason:                ACMEAccountRegistered
        Status:                True


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds the `solvers` field in the kube-lego migration guide doc.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1611 

**Special notes for your reviewer**:
Just copies code blocks from https://docs.cert-manager.io/en/latest/tasks/issuers/setup-acme/index.html

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
