### PR TITLE
Quick-Start example clarity suggestions

### DIFF
--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -475,6 +475,19 @@ operation. These two resources are:
     certificates. An Issuer is specific to a single namespace in Kubernetes,
     and a ClusterIssuer is meant to be a cluster-wide definition for the same
     purpose.
+    
+    Note that if you're using this document as a guide to configure cert-manager
+    for your own Issuer, you must either create the Issuers in the same namespace
+    as your Ingress resouces, adding '-n my-namespace' to your 'kubectl create'
+    commands, or use a ClusterIssuer. ClusterIssuer resouces apply across all
+    Ingress resources in your cluster and don't have this namespace-matching
+    requirement.
+    
+    More information on the difference between Issuers and ClusterIssuers, how
+    to create ClusterIssuers, and when you might choose to use each can be found
+    at:
+    
+    https://docs.cert-manager.io/en/latest/tasks/issuers/index.html#difference-between-issuers-and-clusterissuers
 
 :doc:`Certificate </reference/certificates>`
 
@@ -500,15 +513,6 @@ that is working switch to a production issuer.
 Create this definition locally and update the email address to your own. This
 email required by Let's Encrypt and used to notify you of certificate
 expirations and updates.
-
-.. note::
-
-    If you're using this document as a guide to configure cert-manager for your
-    own ingress, it's important to note that you must install the issuers in the
-    same namespace as your ingress. This example installs the ingress in the 
-    `default` namespace, so it doesn't need to be specified. If your ingress is in
-    another namespace add `-n my-namespace` to the `kubectl create` commands below.
-
 
 - staging issuer: `staging-issuer.yaml`_
 

--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -354,17 +354,24 @@ install cert-manager. This example installed cert-manager into the
     # chart in the next step for `release-0.8` of cert-manager:
     $ kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/deploy/manifests/00-crds.yaml
 
-    ## IMPORTANT: if the cert-manager namespace **already exists**, you MUST ensure
-    ## it has an additional label on it in order for the deployment to succeed
-    $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true"
+    # Create the namespace for cert-manager
+    $ kubectl create namespace cert-manager
+
+    # Label the cert-manager namespace to disable resource validation
+    $ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
 
     ## Add the Jetstack Helm repository
     $ helm repo add jetstack https://charts.jetstack.io
+    
     ## Updating the repo just incase it already existed
     $ helm repo update
 
     ## Install the cert-manager helm chart
-    $ helm install --name cert-manager --namespace cert-manager jetstack/cert-manager
+    $ helm install \
+      --name cert-manager \
+      --namespace cert-manager \
+      --version v0.8.0 \
+      jetstack/cert-manager
    
     NAME:   cert-manager
     LAST DEPLOYED: Wed Jan  9 13:36:13 2019
@@ -493,6 +500,15 @@ that is working switch to a production issuer.
 Create this definition locally and update the email address to your own. This
 email required by Let's Encrypt and used to notify you of certificate
 expirations and updates.
+
+.. note::
+
+    If you're using this document as a guide to configure cert-manager for your
+    own ingress, it's important to note that you must install the issuers in the
+    same namespace as your ingress. This example installs the ingress in the 
+    `default` namespace, so it doesn't need to be specified. If your ingress is in
+    another namespace add `-n my-namespace` to the `kubectl create` commands below.
+
 
 - staging issuer: `staging-issuer.yaml`_
 

--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -477,15 +477,14 @@ operation. These two resources are:
     purpose.
     
     Note that if you're using this document as a guide to configure cert-manager
-    for your own Issuer, you must either create the Issuers in the same namespace
-    as your Ingress resouces, adding '-n my-namespace' to your 'kubectl create'
-    commands, or use a ClusterIssuer. ClusterIssuer resouces apply across all
-    Ingress resources in your cluster and don't have this namespace-matching
-    requirement.
+    for your own Issuer, you must create the Issuers in the same namespace
+    as your Ingress resouces by adding '-n my-namespace' to your 'kubectl create'
+    commands. Your other option is to replace your Issuers with ClusterIssuers.
+    ClusterIssuer resources apply across all Ingress resources in your cluster
+    and don't have this namespace-matching requirement.
     
-    More information on the difference between Issuers and ClusterIssuers, how
-    to create ClusterIssuers, and when you might choose to use each can be found
-    at:
+    More information on the differences between Issuers and ClusterIssuers and
+    when you might choose to use each can be found at:
     
     https://docs.cert-manager.io/en/latest/tasks/issuers/index.html#difference-between-issuers-and-clusterissuers
 

--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -362,7 +362,7 @@ install cert-manager. This example installed cert-manager into the
 
     ## Add the Jetstack Helm repository
     $ helm repo add jetstack https://charts.jetstack.io
-    
+
     ## Updating the repo just incase it already existed
     $ helm repo update
 
@@ -372,7 +372,7 @@ install cert-manager. This example installed cert-manager into the
       --namespace cert-manager \
       --version v0.8.0 \
       jetstack/cert-manager
-   
+
     NAME:   cert-manager
     LAST DEPLOYED: Wed Jan  9 13:36:13 2019
     NAMESPACE: cert-manager
@@ -535,7 +535,7 @@ will need to update this example and add in your own email address.
 .. literalinclude:: example/production-issuer.yaml
    :language: yaml
    :emphasize-lines: 10
-   
+
 .. _`production-issuer.yaml`: https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/docs/tutorials/acme/quick-start/example/production-issuer.yaml
 
 .. code-block:: shell
@@ -733,7 +733,7 @@ can update the annotations in the ingress to specify the production issuer:
 
 .. literalinclude:: example/ingress-tls-final.yaml
    :language: yaml
-   
+
 .. _`ingress-tls-final.yaml`: https://raw.githubusercontent.com/jetstack/cert-manager/release-0.8/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml
 
 .. code-block:: shell


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

I ran into a couple of problems using this document as a guide to
deploying cert-manager in my own cluster. This is the most comprehensive
document on getting the latest cert-manager up and running, so I
think using it this way will be common. These suggestions are
intended to improve the clarify of the doc in a way that I think
would have helped me get running more quickly.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

N/A

**Special notes for your reviewer**:

Summary of changes:

1. Previous version referenced the `cert-manager` namespace already
existing, but don't instruct you to create it at any point. Changed
these instructions to simply match [the "Getting Started" instructions](https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html#installing-with-helm)
in creating and labelling the namespace.

2. Getting started also includes a version arg in the actual `helm`
call, so I've changed this to match as well.

3. Added a note that the namespace of the issuers must match the
name of the ingress.

I wasn't 100% sure that number 3 was a strong requirement, but my
cert-manager silently didn't create any certs unless I was sure to
match the ingress and issuer namespaces. If this is the case, another
option for this doc that might demonstrate the need to match even
more clearly would be to change this entire example so that both
the ingress and the issuer are in a custom namespace. I think
creating ingresses in custom namespaces is a common use case.

Apologies if I've misunderstood any requirements as I've only been
learning to use cert-manager recently. I tried to follow existing
conventions within this doc.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
