### PR TITLE
Add support for secrets to CA injector

### DIFF
--- a/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
@@ -14,7 +14,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch"]
+    verbs: ["get", "list", "watch", "update"]
   - apiGroups: [""]
     resources: ["configmaps", "events"]
     verbs: ["*"]

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -145,7 +145,7 @@ func (r *genericInjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	target := r.injector.NewTarget()
 	if err := r.Client.Get(ctx, req.NamespacedName, target.AsObject()); err != nil {
 		log.Error(err, "unable to fetch target object to inject into")
-		return ctrl.Result{}, err
+		return ctrl.Result{}, dropNotFound(err)
 	}
 
 	// ensure that it wants injection

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -56,7 +56,13 @@ var (
 		listType:     &apireg.APIServiceList{},
 	}
 
-	injectorSetups  = []injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup}
+	SecretSetup = injectorSetup{
+		resourceName: "secret",
+		injector:     secretInjector{},
+		listType:     &corev1.SecretList{},
+	}
+
+	injectorSetups  = []injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup, SecretSetup}
 	ControllerNames []string
 )
 


### PR DESCRIPTION
This allows for injection of CA data to k8s secrets.

Signed-off-by: Ingo Gottwald <in.gottwald@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Having a self-signed CA as cluster issuer leaves all consumers of that CA with the problem that the `ca.crt` is in a secret in the `cert-manager` namespace that you cannot mount from other namespaces in order to trust the CA. Also sharing the whole secret is unpractical since it includes the key that should not be shared.

This PR lets you submit an empty secret in your namespace with the cainjector annotation to let it take care of injecting only the `ca.crt` part into the secret.

Example:

```
$ cat <<EOF | kubectl apply --validate=false -f -
apiVersion: v1
type: kubernetes.io/tls
kind: Secret
metadata:
  annotations:
    certmanager.k8s.io/inject-ca-from: cert-manager/self-signed-ca-cert
  name: secret-to-get-injection
  namespace: default
data:
  ca.crt: null
  tls.crt: null
  tls.key: null
EOF
```
As soon as the cainjector controller picks it up, the `ca.crt` will be filed with the CA data.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: refs #494 (slightly related)

**Special notes for your reviewer**:
Changing this line was necessary and looks like a drive-by bugfix to me: https://github.com/gottwald/cert-manager/blob/4b84562d1b4fbcfc4ec46a14f0c3f813830fe30f/pkg/controller/cainjector/controller.go#L148
Without `dropNotFound` when you delete the target, the controller will find itself in an endless retry loop of reconciling the CA into a target that does not exist. Returning the "not-found-error" will re-trigger retries again and again.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
