### PR TITLE
Fixed manifest file link for openshift

### DIFF
--- a/docs/getting-started/install/openshift.rst
+++ b/docs/getting-started/install/openshift.rst
@@ -69,7 +69,7 @@ are included in a single YAML manifest file:
 .. code-block:: shell
 
    # Install the CustomResourceDefinitions and cert-manager itself
-   oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.8.0-beta.0/cert-manager-openshift.yaml
+   oc apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.8.0/cert-manager-openshift.yaml
 
 .. note::
    The ``--validate=false`` flag is added to the ``oc apply`` command above


### PR DESCRIPTION
The beta link was still in the docs. Fixed that.