### PR TITLE
cert-manager-webhook secret exists in cert-manager ns

### DIFF
--- a/docs/getting-started/troubleshooting.rst
+++ b/docs/getting-started/troubleshooting.rst
@@ -115,5 +115,5 @@ again.
 .. note::
    Check if the Secret exists by running::
 
-     kubectl get secret cert-manager-webhook-webhook-tls
+     kubectl --namespace cert-manager get secret cert-manager-webhook-webhook-tls
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The secret should exist in the `cert-manager` namespace, otherwise we would be checking `default` namespace.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:
- N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cert-manager-webhook secret exists in cert-manager ns
```
