### PR TITLE
Bump vcert to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 // indirect
 	github.com/SAP/go-hdb v0.14.1 // indirect
 	github.com/SermoDigital/jose v0.9.1 // indirect
-	github.com/Venafi/vcert v0.0.0-20181029235941-5068538d4d65
+	github.com/Venafi/vcert v0.0.0-20190530133915-e207710a0ab9
 	github.com/appscode/jsonpatch v0.0.0-20190108182946-7c0e3b262f30 // indirect
 	github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da // indirect
 	github.com/armon/go-radix v1.0.0 // indirect
@@ -87,7 +87,6 @@ require (
 	github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sethgrid/pester v0.0.0-20190127155807-68a33a018ad0 // indirect
-	github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a // indirect
 	github.com/spf13/cobra v0.0.0-20170905172051-b78744579491
 	github.com/spf13/pflag v1.0.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -32,8 +32,8 @@ github.com/SermoDigital/jose v0.9.1 h1:atYaHPD3lPICcbK1owly3aPm0iaJGSGPi0WD4vLzn
 github.com/SermoDigital/jose v0.9.1/go.mod h1:ARgCUhI1MHQH+ONky/PAtmVHQrP5JlGY0F3poXOp/fA=
 github.com/Shopify/sarama v1.19.0/go.mod h1:FVkBWblsNy7DGZRfXLU0O9RCGt5g3g3yEuWXgklEdEo=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
-github.com/Venafi/vcert v0.0.0-20181029235941-5068538d4d65 h1:An1XpraQx4IkI2i0kcXFS+VjTSK/lRb1ZioZRmTdDMA=
-github.com/Venafi/vcert v0.0.0-20181029235941-5068538d4d65/go.mod h1:3dpfrCI+31cDZosD+1UX8GFziVFORaegByXtzT1dwNo=
+github.com/Venafi/vcert v0.0.0-20190530133915-e207710a0ab9 h1:dt3QeZOpoi4ee72KwblGKmX2v6WbVS37yjCeZq6SV9w=
+github.com/Venafi/vcert v0.0.0-20190530133915-e207710a0ab9/go.mod h1:3sXw16DKVded/kLVDma2veqEUQC7O37h98ims7cIvN4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
@@ -226,6 +226,7 @@ github.com/hashicorp/vault v0.9.6 h1:AalVi4vunOMSXX7eD8j8WKxkWr2AmG6yvz9o3ITSaMc
 github.com/hashicorp/vault v0.9.6/go.mod h1:KfSyffbKxoVyspOdlaGVjIuwLobi07qD1bAbosPMpP0=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb h1:b5rjCoWHc7eqmAS4/qyk21ZsHyb6Mxv/jykxvNTkU4M=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/howeyc/gopass v0.0.0-20170109162249-bf9dde6d0d2c/go.mod h1:lADxMC39cJJqL93Duh1xhAs4I2Zs8mKS89XWXFGp9cs=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
@@ -392,6 +393,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181025213731-e84da0312774/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190325154230-a5d413f7728c/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20190424203555-c05e17bb3b2d/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734 h1:p/H982KKEjUnLJkM3tt/LemDnOc1GiZL5FCVlORJ5zo=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -436,6 +438,7 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190312061237-fead79001313/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20190425045458-9f0b1ff7b46a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82 h1:vsphBvatvfbhlb4PO1BYSr9dzugGxJ/SQHoNufZJq1w=
 golang.org/x/sys v0.0.0-20190502175342-a43fa875dd82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -491,6 +494,7 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/inf.v0 v0.9.0/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
+gopkg.in/ini.v1 v1.38.2/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/ini.v1 v1.42.0 h1:7N3gPTt50s8GuLortA00n8AqRTk75qOP98+mTPpgzRk=
 gopkg.in/ini.v1 v1.42.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/mgo.v2 v2.0.0-20180705113604-9856a29383ce h1:xcEWjVhvbDy+nHP67nPDDpbYrY+ILlfndk4bRioVHaU=
@@ -543,3 +547,4 @@ sigs.k8s.io/testing_frameworks v0.1.1 h1:cP2l8fkA3O9vekpy5Ks8mmA0NW/F7yBdXf8brkW
 sigs.k8s.io/testing_frameworks v0.1.1/go.mod h1:VVBKrHmJ6Ekkfz284YKhQePcdycOzNH9qL6ht1zEr/U=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=

--- a/pkg/issuer/venafi/BUILD.bazel
+++ b/pkg/issuer/venafi/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/issuer:go_default_library",
+        "//pkg/logs:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//vendor/github.com/Venafi/vcert:go_default_library",
         "//vendor/github.com/Venafi/vcert/pkg/certificate:go_default_library",

--- a/pkg/issuer/venafi/connector_test.go
+++ b/pkg/issuer/venafi/connector_test.go
@@ -26,9 +26,9 @@ type fakeConnector struct {
 	*fake.Connector
 
 	PingFunc                  func() error
-	ReadZoneConfigurationFunc func(string) (*endpoint.ZoneConfiguration, error)
+	ReadZoneConfigurationFunc func() (*endpoint.ZoneConfiguration, error)
 	RetrieveCertificateFunc   func(*certificate.Request) (*certificate.PEMCollection, error)
-	RequestCertificateFunc    func(*certificate.Request, string) (string, error)
+	RequestCertificateFunc    func(*certificate.Request) (string, error)
 	RenewCertificateFunc      func(*certificate.RenewalRequest) (string, error)
 }
 
@@ -46,11 +46,11 @@ func (f *fakeConnector) Ping() (err error) {
 	return f.Connector.Ping()
 }
 
-func (f *fakeConnector) ReadZoneConfiguration(zone string) (config *endpoint.ZoneConfiguration, err error) {
+func (f *fakeConnector) ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error) {
 	if f.ReadZoneConfigurationFunc != nil {
-		return f.ReadZoneConfigurationFunc(zone)
+		return f.ReadZoneConfigurationFunc()
 	}
-	return f.Connector.ReadZoneConfiguration(zone)
+	return f.Connector.ReadZoneConfiguration()
 }
 
 func (f *fakeConnector) RetrieveCertificate(req *certificate.Request) (certificates *certificate.PEMCollection, err error) {
@@ -60,11 +60,11 @@ func (f *fakeConnector) RetrieveCertificate(req *certificate.Request) (certifica
 	return f.Connector.RetrieveCertificate(req)
 }
 
-func (f *fakeConnector) RequestCertificate(req *certificate.Request, zone string) (requestID string, err error) {
+func (f *fakeConnector) RequestCertificate(req *certificate.Request) (requestID string, err error) {
 	if f.RequestCertificateFunc != nil {
-		return f.RequestCertificateFunc(req, zone)
+		return f.RequestCertificateFunc(req)
 	}
-	return f.Connector.RequestCertificate(req, zone)
+	return f.Connector.RequestCertificate(req)
 }
 
 func (f *fakeConnector) RenewCertificate(req *certificate.RenewalRequest) (requestID string, err error) {

--- a/pkg/issuer/venafi/issue.go
+++ b/pkg/issuer/venafi/issue.go
@@ -94,8 +94,7 @@ func (v *Venafi) Issue(ctx context.Context, crt *v1alpha1.Certificate) (*issuer.
 	// Retrieve a copy of the Venafi zone.
 	// This contains default values and policy control info that we can apply
 	// and check against locally.
-	zoneName := v.issuer.GetSpec().Venafi.Zone
-	zoneCfg, err := v.client.ReadZoneConfiguration(zoneName)
+	zoneCfg, err := v.client.ReadZoneConfiguration()
 	if err != nil {
 		v.Recorder.Eventf(crt, corev1.EventTypeWarning, "ReadZone", "Failed to read Venafi zone configuration: %v", err)
 		return nil, err
@@ -140,7 +139,7 @@ func (v *Venafi) Issue(ctx context.Context, crt *v1alpha1.Certificate) (*issuer.
 
 	v.Recorder.Eventf(crt, corev1.EventTypeNormal, "Requesting", "Requesting certificate from Venafi server...")
 	// Actually send a request to the Venafi server for a certificate.
-	requestID, err := v.client.RequestCertificate(vreq, zoneName)
+	requestID, err := v.client.RequestCertificate(vreq)
 	if err != nil {
 		v.Recorder.Eventf(crt, corev1.EventTypeWarning, "Request", "Failed to request a certificate from Venafi: %v", err)
 		return nil, err

--- a/pkg/issuer/venafi/issue_test.go
+++ b/pkg/issuer/venafi/issue_test.go
@@ -35,6 +35,11 @@ func checkCertificateIssued(t *testing.T, s *fixture, args ...interface{}) {
 	returnedCert := args[0].(*cmapi.Certificate)
 	resp := args[1].(*issuer.IssueResponse)
 
+	if resp == nil {
+		t.Errorf("expected IssueResponse to be non-nil")
+		t.FailNow()
+		return
+	}
 	if err, ok := args[2].(error); ok && err != nil {
 		t.Errorf("expected no error to be returned, but got: %v", err)
 		return
@@ -87,10 +92,9 @@ func TestIssue(t *testing.T) {
 				gen.SetCertificateDNSNames("example.com"),
 			),
 			Client: fakeConnector{
-				ReadZoneConfigurationFunc: func(zone string) (*endpoint.ZoneConfiguration, error) {
+				ReadZoneConfigurationFunc: func() (*endpoint.ZoneConfiguration, error) {
 					return &endpoint.ZoneConfiguration{
-						Organization:       "testing-org",
-						OrganizationLocked: true,
+						Organization: "testing-org",
 					}, nil
 				},
 			}.Default(),
@@ -112,10 +116,9 @@ func TestIssue(t *testing.T) {
 				gen.SetCertificateDNSNames("example.com"),
 			),
 			Client: fakeConnector{
-				ReadZoneConfigurationFunc: func(zone string) (*endpoint.ZoneConfiguration, error) {
+				ReadZoneConfigurationFunc: func() (*endpoint.ZoneConfiguration, error) {
 					return &endpoint.ZoneConfiguration{
-						Organization:       "testing-org",
-						OrganizationLocked: false,
+						Organization: "testing-org",
 					}, nil
 				},
 			}.Default(),

--- a/pkg/issuer/venafi/venafi.go
+++ b/pkg/issuer/venafi/venafi.go
@@ -56,8 +56,8 @@ type Venafi struct {
 // out its functionality during tests easier.
 type connector interface {
 	Ping() (err error)
-	ReadZoneConfiguration(zone string) (config *endpoint.ZoneConfiguration, err error)
-	RequestCertificate(req *certificate.Request, zone string) (requestID string, err error)
+	ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error)
+	RequestCertificate(req *certificate.Request) (requestID string, err error)
 	RetrieveCertificate(req *certificate.Request) (certificates *certificate.PEMCollection, err error)
 	RenewCertificate(req *certificate.RenewalRequest) (requestID string, err error)
 }

--- a/vendor/github.com/Venafi/vcert/config.go
+++ b/vendor/github.com/Venafi/vcert/config.go
@@ -26,51 +26,57 @@ import (
 	"path/filepath"
 )
 
+// Config is a basic structure for high level initiating connector to Trust Platform (TPP)/Venafi Cloud
 type Config struct {
-	ConnectorType   endpoint.ConnectorType
-	BaseUrl         string
-	Zone            string
-	Credentials     *endpoint.Authentication
+	// ConnectorType specify what do you want to use. May be "Cloud", "TPP" or "Fake" for development.
+	ConnectorType endpoint.ConnectorType
+	// BaseUrl should be specified for Venafi Platform. Optional for Cloud implementations that do not use https://venafi.cloud/.
+	BaseUrl string
+	// Zone is name of a policy zone in Venafi Platform or Cloud. For TPP, if necessary, escape backslash symbols.   For example,  "test\\zone" or `test\zone`.
+	Zone string
+	// Credentials should contain either User and Password for TPP connections or an APIKey for Cloud.
+	Credentials *endpoint.Authentication
+	// ConnectionTrust  may contain a trusted CA or certificate of server if you use self-signed certificate.
 	ConnectionTrust string // *x509.CertPool
 	LogVerbose      bool
-	ConfigFile      string
-	ConfigSection   string
 }
 
-func (cfg *Config) LoadFromFile() error {
-	if cfg.ConfigSection == "" {
-		cfg.ConfigSection = ini.DEFAULT_SECTION
-	}
-	log.Printf("Loading configuration from %s section %s", cfg.ConfigFile, cfg.ConfigSection)
+// LoadFromFile is deprecated. In the future will be rewrited.
+func LoadConfigFromFile(path, section string) (cfg Config, err error) {
 
-	fname, err := expand(cfg.ConfigFile)
+	if section == "" {
+		section = ini.DEFAULT_SECTION
+	}
+	log.Printf("Loading configuration from %s section %s", path, section)
+
+	fname, err := expand(path)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %s", err)
+		return cfg, fmt.Errorf("failed to load config: %s", err)
 	}
 
 	iniFile, err := ini.Load(fname)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %s", err)
+		return cfg, fmt.Errorf("failed to load config: %s", err)
 	}
 
 	err = validateFile(iniFile)
 	if err != nil {
-		return fmt.Errorf("failed to load config: %s", err)
+		return cfg, fmt.Errorf("failed to load config: %s", err)
 	}
 
 	ok := func() bool {
-		for _, section := range iniFile.Sections() {
-			if section.Name() == cfg.ConfigSection {
+		for _, s := range iniFile.Sections() {
+			if s.Name() == section {
 				return true
 			}
 		}
 		return false
 	}()
 	if !ok {
-		return fmt.Errorf("section %s has not been found in %s", cfg.ConfigSection, cfg.ConfigFile)
+		return cfg, fmt.Errorf("section %s has not been found in %s", section, path)
 	}
 
-	var m Dict = iniFile.Section(cfg.ConfigSection).KeysHash()
+	var m dict = iniFile.Section(section).KeysHash()
 
 	var connectorType endpoint.ConnectorType
 	var baseUrl string
@@ -98,17 +104,17 @@ func (cfg *Config) LoadFromFile() error {
 	} else if m.has("test_mode") && m["test_mode"] == "true" {
 		connectorType = endpoint.ConnectorTypeFake
 	} else {
-		return fmt.Errorf("failed to load config: connector type cannot be defined")
+		return cfg, fmt.Errorf("failed to load config: connector type cannot be defined")
 	}
 
 	if m.has("trust_bundle") {
 		fname, err := expand(m["trust_bundle"])
 		if err != nil {
-			return fmt.Errorf("failed to load trust-bundle: %s", err)
+			return cfg, fmt.Errorf("failed to load trust-bundle: %s", err)
 		}
 		data, err := ioutil.ReadFile(fname)
 		if err != nil {
-			return fmt.Errorf("failed to load trust-bundle: %s", err)
+			return cfg, fmt.Errorf("failed to load trust-bundle: %s", err)
 		}
 		cfg.ConnectionTrust = string(data)
 	}
@@ -117,7 +123,7 @@ func (cfg *Config) LoadFromFile() error {
 	cfg.Credentials = auth
 	cfg.BaseUrl = baseUrl
 
-	return nil
+	return
 }
 
 func expand(path string) (string, error) {
@@ -131,18 +137,18 @@ func expand(path string) (string, error) {
 	return filepath.Join(usr.HomeDir, path[1:]), nil
 }
 
-type Dict map[string]string
+type dict map[string]string
 
-func (d Dict) has(key string) bool {
+func (d dict) has(key string) bool {
 	if _, ok := d[key]; ok {
 		return true
 	}
 	return false
 }
 
-type Set map[string]bool
+type set map[string]bool
 
-func (d Set) has(key string) bool {
+func (d set) has(key string) bool {
 	if _, ok := d[key]; ok {
 		return true
 	}
@@ -150,14 +156,14 @@ func (d Set) has(key string) bool {
 }
 
 func validateSection(s *ini.Section) error {
-	var TPPValidKeys Set = map[string]bool{
+	var TPPValidKeys set = map[string]bool{
 		"tpp_url":      true,
 		"tpp_user":     true,
 		"tpp_password": true,
 		"tpp_zone":     true,
 		"trust_bundle": true,
 	}
-	var CloudValidKeys Set = map[string]bool{
+	var CloudValidKeys set = map[string]bool{
 		"trust_bundle": true,
 		"cloud_url":    true,
 		"cloud_apikey": true,
@@ -165,11 +171,11 @@ func validateSection(s *ini.Section) error {
 	}
 
 	log.Printf("Validating configuration section %s", s.Name())
-	var m Dict = s.KeysHash()
+	var m dict = s.KeysHash()
 
 	if m.has("tpp_url") {
 		// looks like TPP config section
-		for k, _ := range m {
+		for k := range m {
 			if !TPPValidKeys.has(k) {
 				return fmt.Errorf("illegal key '%s' in TPP section %s", k, s.Name())
 			}
@@ -182,7 +188,7 @@ func validateSection(s *ini.Section) error {
 		}
 	} else if m.has("cloud_apikey") {
 		// looks like Cloud config section
-		for k, _ := range m {
+		for k := range m {
 			if !CloudValidKeys.has(k) {
 				return fmt.Errorf("illegal key '%s' in Cloud section %s", k, s.Name())
 			}

--- a/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/certificatePolicies.go
+++ b/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/certificatePolicies.go
@@ -16,14 +16,19 @@
 
 package cloud
 
-import "time"
+import (
+	"github.com/Venafi/vcert/pkg/endpoint"
+	"regexp"
+	"strings"
+	"time"
+)
 
 type certificatePolicy struct {
 	CertificatePolicyType certificatePolicyType `json:"certificatePolicyType,omitempty"`
 	ID                    string                `json:"id,omitempty"`
 	CompanyID             string                `json:"companyId,omitempty"`
 	Name                  string                `json:"name,omitempty"`
-	SystemGenerated       bool                  `json:"systemGeneratedate,omitempty"`
+	SystemGenerated       bool                  `json:"systemGenerated,omitempty"`
 	CreationDateString    string                `json:"creationDate,omitempty"`
 	CreationDate          time.Time             `json:"-"`
 	CertificateProviderID string                `json:"certificateProviderId,omitempty"`
@@ -32,7 +37,7 @@ type certificatePolicy struct {
 	SubjectOURegexes      []string              `json:"subjectOURegexes,omitempty"`
 	SubjectSTRegexes      []string              `json:"subjectSTRegexes,omitempty"`
 	SubjectLRegexes       []string              `json:"subjectLRegexes,omitempty"`
-	SubjectCRegexes       []string              `json:"subjectCRegexes,omitempty"`
+	SubjectCRegexes       []string              `json:"subjectCValues,omitempty"`
 	SANRegexes            []string              `json:"sanRegexes,omitempty"`
 	KeyTypes              []allowedKeyType      `json:"keyTypes,omitempty"`
 	KeyReuse              bool                  `json:"keyReuse,omitempty"`
@@ -47,20 +52,87 @@ type certificatePolicyType string
 
 const (
 	certificatePolicyTypeIdentity certificatePolicyType = "CERTIFICATE_IDENTITY"
-	certificatePolicyTypeUse                            = "CERTIFICATE_USE"
+	certificatePolicyTypeUse      certificatePolicyType = "CERTIFICATE_USE"
 )
 
 type keyType string
 
-const (
-	keyTypeRSA        keyType = "RSA"
-	keyTypeDSA                = "DSA"
-	keyTypeEC                 = "EC"
-	keyTypeGost3410           = "GOST3410"
-	keyTypeECGost3410         = "ECGOST3410"
-	keyTypeReserved3          = "RESERVED3"
-	keyTypeUnknown            = "UNKNOWN"
-)
+func (cp certificatePolicy) toPolicy() (p endpoint.Policy) {
+	addStartEnd := func(s string) string {
+		if !strings.HasPrefix(s, "^") {
+			s = "^" + s
+		}
+		if !strings.HasSuffix(s, "$") {
+			s = s + "$"
+		}
+		return s
+	}
+	addStartEndToArray := func(ss []string) []string {
+		a := make([]string, len(ss))
+		for i, s := range ss {
+			a[i] = addStartEnd(s)
+		}
+		return a
+	}
+	p.SubjectCNRegexes = addStartEndToArray(cp.SubjectCNRegexes)
+	p.SubjectOURegexes = addStartEndToArray(cp.SubjectOURegexes)
+	p.SubjectCRegexes = addStartEndToArray(cp.SubjectCRegexes)
+	p.SubjectSTRegexes = addStartEndToArray(cp.SubjectSTRegexes)
+	p.SubjectLRegexes = addStartEndToArray(cp.SubjectLRegexes)
+	p.SubjectORegexes = addStartEndToArray(cp.SubjectORegexes)
+	p.DnsSanRegExs = addStartEndToArray(cp.SANRegexes)
+	p.AllowKeyReuse = cp.KeyReuse
+	allowWildCards := false
+	for _, s := range p.SubjectCNRegexes {
+		if strings.HasPrefix(s, "^.*") {
+			allowWildCards = true
+		}
+	}
+	if !allowWildCards {
+		for _, s := range p.DnsSanRegExs {
+			if strings.HasPrefix(s, "^.*") {
+				allowWildCards = true
+			}
+		}
+	}
+	p.AllowWildcards = allowWildCards
+	for _, kt := range cp.KeyTypes {
+		keyConfiguration := endpoint.AllowedKeyConfiguration{}
+		if err := keyConfiguration.KeyType.Set(string(kt.KeyType)); err != nil {
+			panic(err)
+		}
+		keyConfiguration.KeySizes = kt.KeyLengths[:]
+		p.AllowedKeyConfigurations = append(p.AllowedKeyConfigurations, keyConfiguration)
+	}
+	return
+}
+
+func isNotRegexp(s string) bool {
+	matched, err := regexp.MatchString(`[a-zA-Z0-9 ]+`, s)
+	if !matched || err != nil {
+		return false
+	}
+	return true
+}
+func (cp certificatePolicy) toZoneConfig(zc *endpoint.ZoneConfiguration) {
+	if len(cp.SubjectCRegexes) > 0 && isNotRegexp(cp.SubjectCRegexes[0]) {
+		zc.Country = cp.SubjectCRegexes[0]
+	}
+	if len(cp.SubjectORegexes) > 0 && isNotRegexp(cp.SubjectORegexes[0]) {
+		zc.Organization = cp.SubjectORegexes[0]
+	}
+	if len(cp.SubjectSTRegexes) > 0 && isNotRegexp(cp.SubjectSTRegexes[0]) {
+		zc.Province = cp.SubjectSTRegexes[0]
+	}
+	if len(cp.SubjectLRegexes) > 0 && isNotRegexp(cp.SubjectLRegexes[0]) {
+		zc.Locality = cp.SubjectLRegexes[0]
+	}
+	for _, ou := range cp.SubjectOURegexes {
+		if isNotRegexp(ou) {
+			zc.OrganizationalUnit = append(zc.OrganizationalUnit, ou)
+		}
+	}
+}
 
 /*
 "signatureAlgorithm":{"type":"string","enum":["MD2_WITH_RSA_ENCRYPTION","MD5_WITH_RSA_ENCRYPTION","SHA1_WITH_RSA_ENCRYPTION","SHA1_WITH_RSA_ENCRYPTION2","SHA256_WITH_RSA_ENCRYPTION","SHA384_WITH_RSA_ENCRYPTION","SHA512_WITH_RSA_ENCRYPTION","ID_DSA_WITH_SHA1","dsaWithSHA1","EC_DSA_WITH_SHA1","EC_DSA_WITH_SHA224","EC_DSA_WITH_SHA256","EC_DSA_WITH_SHA384","EC_DSA_WITH_SHA512","UNKNOWN","SHA1_WITH_RSAandMGF1","GOST_R3411_94_WITH_GOST_R3410_2001","GOST_R3411_94_WITH_GOST_R3410_94"]},

--- a/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/company.go
+++ b/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/company.go
@@ -17,8 +17,6 @@
 package cloud
 
 import (
-	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
 	"github.com/Venafi/vcert/pkg/endpoint"
 	"time"
 )
@@ -41,7 +39,7 @@ type zone struct {
 	CertificatePolicyIDs             certificatePolicyID `json:"certificatePolicyIds,omitempty"`
 	DefaultCertificateIdentityPolicy string              `json:"defaultCertificateIdentityPolicyId,omitempty"`
 	DefaultCertificateUsePolicy      string              `json:"defaultCertificateUsePolicyId,omitempty"`
-	SystemGenerated                  bool                `json:"systemGeneratedate,omitempty"`
+	SystemGenerated                  bool                `json:"systemGenerated,omitempty"`
 	CreationDateString               string              `json:"creationDate,omitempty"`
 	CreationDate                     time.Time           `json:"-"`
 }
@@ -51,24 +49,14 @@ type certificatePolicyID struct {
 	CertificateUse      []string `json:"CERTIFICATE_USE,omitempty"`
 }
 
-func (z *zone) GetZoneConfiguration(ud *userDetails, policy *certificatePolicy) *endpoint.ZoneConfiguration {
-	zoneConfig := endpoint.ZoneConfiguration{}
-
-	if policy != nil {
-		if policy.KeyTypes != nil {
-			certKeyType := certificate.KeyTypeRSA
-			for _, kt := range policy.KeyTypes {
-				certKeyType.Set(fmt.Sprintf("%s", kt.KeyType))
-				keyConfiguration := endpoint.AllowedKeyConfiguration{}
-				keyConfiguration.KeyType = certKeyType
-				for _, size := range kt.KeyLengths {
-					keyConfiguration.KeySizes = append(keyConfiguration.KeySizes, size)
-				}
-				zoneConfig.AllowedKeyConfigurations = append(zoneConfig.AllowedKeyConfigurations, keyConfiguration)
-			}
-		}
+func (z *zone) getZoneConfiguration(ud *userDetails, policy *certificatePolicy) (zoneConfig *endpoint.ZoneConfiguration) {
+	zoneConfig = endpoint.NewZoneConfiguration()
+	if policy == nil {
+		return
 	}
-	return &zoneConfig
+	zoneConfig.Policy = policy.toPolicy()
+	policy.toZoneConfig(zoneConfig)
+	return
 }
 
 const (

--- a/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/connector.go
+++ b/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/connector.go
@@ -17,17 +17,18 @@
 package cloud
 
 import (
-	"bytes"
 	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
-	"github.com/Venafi/vcert/pkg/certificate"
-	"github.com/Venafi/vcert/pkg/endpoint"
-	"io/ioutil"
-	"log"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
+
+	"github.com/Venafi/vcert/pkg/certificate"
+	"github.com/Venafi/vcert/pkg/endpoint"
 )
 
 const apiURL = "api.venafi.cloud/v1/"
@@ -35,26 +36,29 @@ const apiURL = "api.venafi.cloud/v1/"
 type urlResource string
 
 const (
-	urlResourceUserAccounts           urlResource = "useraccounts"
-	urlResourcePing                               = "ping"
-	urlResourceZones                              = "zones"
-	urlResourceZoneByTag                          = urlResourceZones + "/tag/%s"
-	urlResourceCertificatePolicies                = "certificatepolicies"
-	urlResourcePoliciesByID                       = urlResourceCertificatePolicies + "%s"
-	urlResourcePoliciesForZoneByID                = urlResourceCertificatePolicies + "?zoneId=%s"
-	urlResourceCertificateRequests                = "certificaterequests"
-	urlResourceCertificateStatus                  = urlResourceCertificateRequests + "/%s"
-	urlResourceCertificateRetrieve                = urlResourceCertificateRequests + "/%s/certificate"
-	urlResourceCertificateSearch                  = "certificatesearch"
-	urlResourceManagedCertificates                = "managedcertificates"
-	urlResourceManagedCertificateById             = urlResourceManagedCertificates + "/%s"
+	urlResourceUserAccounts              urlResource = "useraccounts"
+	urlResourcePing                                  = "ping"
+	urlResourceZones                                 = "zones"
+	urlResourceZoneByTag                             = urlResourceZones + "/tag/%s"
+	urlResourceCertificatePolicies                   = "certificatepolicies"
+	urlResourcePoliciesByID                          = urlResourceCertificatePolicies + "/%s"
+	urlResourcePoliciesForZoneByID                   = urlResourceCertificatePolicies + "?zoneId=%s"
+	urlResourceCertificateRequests                   = "certificaterequests"
+	urlResourceCertificateStatus                     = urlResourceCertificateRequests + "/%s"
+	urlResourceCertificateRetrieveViaCSR             = urlResourceCertificateRequests + "/%s/certificate"
+	urlResourceCertificateRetrieve                   = "certificates/%s"
+	urlResourceCertificateRetrievePem                = urlResourceCertificateRetrieve + "/encoded"
+	urlResourceCertificateSearch                     = "certificatesearch"
+	urlResourceManagedCertificates                   = "managedcertificates"
+	urlResourceManagedCertificateByID                = urlResourceManagedCertificates + "/%s"
+	urlResourceDiscovery                             = "discovery"
 )
 
 type condorChainOption string
 
 const (
 	condorChainOptionRootFirst condorChainOption = "ROOT_FIRST"
-	condorChainOptionRootLast                    = "EE_FIRST"
+	condorChainOptionRootLast  condorChainOption = "EE_FIRST"
 )
 
 // Connector contains the base data needed to communicate with the Venafi Cloud servers
@@ -68,10 +72,37 @@ type Connector struct {
 }
 
 // NewConnector creates a new Venafi Cloud Connector object used to communicate with Venafi Cloud
-func NewConnector(verbose bool, trust *x509.CertPool) *Connector {
-	c := Connector{verbose: verbose, trust: trust}
-	c.SetBaseURL(apiURL)
-	return &c
+func NewConnector(url string, zone string, verbose bool, trust *x509.CertPool) (*Connector, error) {
+	c := Connector{verbose: verbose, trust: trust, zone: zone}
+	var err error
+	c.baseURL, err = normalizeURL(url)
+	if err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+//normalizeURL allows overriding the default URL used to communicate with Venafi Cloud
+func normalizeURL(url string) (normalizedURL string, err error) {
+	if url == "" {
+		url = apiURL
+		//return "", fmt.Errorf("base URL cannot be empty")
+	}
+	modified := strings.ToLower(url)
+	reg := regexp.MustCompile("^http(|s)://")
+	if reg.FindStringIndex(modified) == nil {
+		modified = "https://" + modified
+	} else {
+		modified = reg.ReplaceAllString(modified, "https://")
+	}
+	reg = regexp.MustCompile("/v1(|/)$")
+	if reg.FindStringIndex(modified) == nil {
+		modified += "v1/"
+	} else {
+		modified = reg.ReplaceAllString(modified, "/v1/")
+	}
+	normalizedURL = modified
+	return normalizedURL, nil
 }
 
 func (c *Connector) SetZone(z string) {
@@ -82,108 +113,59 @@ func (c *Connector) GetType() endpoint.ConnectorType {
 	return endpoint.ConnectorTypeCloud
 }
 
-//Ping attempts to connect to the Venafi Cloud API and returns an errror if it cannot
+// Ping attempts to connect to the Venafi Cloud API and returns an errror if it cannot
 func (c *Connector) Ping() (err error) {
-	url := c.getURL(urlResourcePing)
 
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != http.StatusOK {
-		err = fmt.Errorf("Unexpected status code on Venafi Cloud ping. Status: %d %s", resp.StatusCode, resp.Status)
-	}
-	return err
+	return nil
 }
 
-//Authenticate authenticates the user with Venafi Cloud using the provided API Key
+// Authenticate authenticates the user with Venafi Cloud using the provided API Key
 func (c *Connector) Authenticate(auth *endpoint.Authentication) (err error) {
 	if auth == nil {
 		return fmt.Errorf("failed to authenticate: missing credentials")
 	}
 	c.apiKey = auth.APIKey
 	url := c.getURL(urlResourceUserAccounts)
-	b := []byte{}
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("GET", url, reader)
+	statusCode, status, body, err := c.request("GET", url, nil, true)
 	if err != nil {
 		return err
 	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	resp, err := http.DefaultClient.Do(request)
+	ud, err := parseUserDetailsResult(http.StatusOK, statusCode, status, body)
 	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	ud, err := parseUserDetailsResult(http.StatusOK, resp.StatusCode, resp.Status, body)
-	if err != nil {
-		if c.verbose {
-			log.Printf("JSON sent for %s\n%s", url, b)
-		}
-
-		return err
+		return
 	}
 	c.user = ud
-	return nil
+	return
 }
 
-//Register registers a new user with Venafi Cloud
-func (c *Connector) Register(email string) (err error) {
-	b, err := json.Marshal(userAccount{Username: email, UserAccountType: "API"})
-
-	url := c.getURL(urlResourceUserAccounts)
-
-	reader := bytes.NewReader(b)
-	resp, err := http.Post(url, "application/json", reader)
+func (c *Connector) ReadPolicyConfiguration() (policy *endpoint.Policy, err error) {
+	config, err := c.ReadZoneConfiguration()
 	if err != nil {
-		return err
+		return nil, err
 	}
-	defer resp.Body.Close()
-
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return err
-	}
-
-	//the user has already been registered and there is nothing to parse
-	if resp.StatusCode == http.StatusAccepted {
-		return nil
-	}
-	ud, err := parseUserDetailsResult(http.StatusCreated, resp.StatusCode, resp.Status, body)
-	if err != nil {
-		if c.verbose {
-			log.Printf("JSON sent for %s\n%s", url, b)
-		}
-
-		return err
-	}
-	c.user = ud
-	return nil
+	policy = &config.Policy
+	return
 }
 
-//ReadZoneConfiguration reads the Zone information needed for generating and requesting a certificate from Venafi Cloud
-func (c *Connector) ReadZoneConfiguration(zone string) (config *endpoint.ZoneConfiguration, err error) {
-	z, err := c.getZoneByTag(zone)
+// ReadZoneConfiguration reads the Zone information needed for generating and requesting a certificate from Venafi Cloud
+func (c *Connector) ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error) {
+	if c.zone == "" {
+		return nil, fmt.Errorf("empty zone name")
+	}
+	z, err := c.getZoneByTag(c.zone)
 	if err != nil {
 		return nil, err
 	}
 	p, err := c.getPoliciesByID([]string{z.DefaultCertificateIdentityPolicy, z.DefaultCertificateUsePolicy})
-	config = z.GetZoneConfiguration(c.user, p)
+	if err != nil {
+		return
+	}
+	config = z.getZoneConfiguration(c.user, p)
 	return config, nil
 }
 
-//RequestCertificate submits the CSR to the Venafi Cloud API for processing
-func (c *Connector) RequestCertificate(req *certificate.Request, zone string) (requestID string, err error) {
-
-	if zone == "" {
-		zone = c.zone
-	}
-
+// RequestCertificate submits the CSR to the Venafi Cloud API for processing
+func (c *Connector) RequestCertificate(req *certificate.Request) (requestID string, err error) {
 	if req.CsrOrigin == certificate.ServiceGeneratedCSR {
 		return "", fmt.Errorf("service generated CSR is not supported by Saas service")
 	}
@@ -192,34 +174,18 @@ func (c *Connector) RequestCertificate(req *certificate.Request, zone string) (r
 	if c.user == nil || c.user.Company == nil {
 		return "", fmt.Errorf("Must be autheticated to request a certificate")
 	}
-	z, err := c.getZoneByTag(zone)
-	if err != nil {
-		return "", err
-	}
-	b, _ := json.Marshal(certificateRequest{ZoneID: z.ID, CSR: string(req.CSR)})
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("POST", url, reader)
-	if err != nil {
-		return "", err
-	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	request.Header.Add("content-type", "application/json")
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	z, err := c.getZoneByTag(c.zone)
 	if err != nil {
 		return "", err
 	}
 
-	cr, err := parseCertificateRequestResult(resp.StatusCode, resp.Status, body)
-	if err != nil {
-		if c.verbose {
-			log.Printf("JSON sent for %s\n%s", url, b)
-		}
+	statusCode, status, body, err := c.request("POST", url, certificateRequest{ZoneID: z.ID, CSR: string(req.GetCSR())})
 
+	if err != nil {
+		return "", err
+	}
+	cr, err := parseCertificateRequestResult(statusCode, status, body)
+	if err != nil {
 		return "", err
 	}
 	requestID = cr.CertificateRequests[0].ID
@@ -227,61 +193,41 @@ func (c *Connector) RequestCertificate(req *certificate.Request, zone string) (r
 	return requestID, nil
 }
 
-func (c *Connector) getCertificateStatus(requestID string) (*certificateStatus, error) {
-	var err error
+func (c *Connector) getCertificateStatus(requestID string) (certStatus *certificateStatus, err error) {
 	url := c.getURL(urlResourceCertificateStatus)
-	if c.user == nil || c.user.Company == nil {
-		err = fmt.Errorf("Must be autheticated to retieve certificate")
-		return nil, err
-	}
 	url = fmt.Sprintf(url, requestID)
-
-	b := []byte{}
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("GET", url, reader)
+	statusCode, _, body, err := c.request("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	request.Header.Add("Accept", "application/json")
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-
-	switch resp.StatusCode {
-	case http.StatusOK:
-		var data = &certificateStatus{}
-		err = json.Unmarshal(body, data)
+	if statusCode == http.StatusOK {
+		certStatus = &certificateStatus{}
+		err = json.Unmarshal(body, certStatus)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse certificate request status response: %s", err)
 		}
-		return data, nil
-	default:
-		if body != nil {
-			respErrors, err := parseResponseErrors(body)
-			if err == nil {
-				respError := fmt.Sprintf("Unexpected status code on Venafi Cloud certificate search. Status: %d\n", resp.StatusCode)
-				for _, e := range respErrors {
-					respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
-				}
-				return nil, fmt.Errorf(respError)
-			}
-		}
-		return nil, fmt.Errorf("Unexpected status code on Venafi Cloud certificate search. Status: %d", resp.StatusCode)
+		return
 	}
+	respErrors, err := parseResponseErrors(body)
+	if err == nil {
+		respError := fmt.Sprintf("Unexpected status code on Venafi Cloud certificate search. Status: %d\n", statusCode)
+		for _, e := range respErrors {
+			respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
+		}
+		return nil, fmt.Errorf(respError)
+	}
+
+	return nil, fmt.Errorf("Unexpected status code on Venafi Cloud certificate search. Status: %d", statusCode)
+
 }
 
-//RetrieveCertificate retrieves the certificate for the specified ID
+// RetrieveCertificate retrieves the certificate for the specified ID
 func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates *certificate.PEMCollection, err error) {
 
 	if req.FetchPrivateKey {
 		return nil, fmt.Errorf("Failed to retrieve private key from Venafi Cloud service: not supported")
 	}
-
-	if req.PickupID == "" && req.Thumbprint != "" {
+	if req.PickupID == "" && req.CertID == "" && req.Thumbprint != "" {
 		// search cert by Thumbprint and fill pickupID
 		var certificateRequestId string
 		searchResult, err := c.searchCertificatesByFingerprint(req.Thumbprint)
@@ -299,7 +245,12 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 			if certificateRequestId != "" && certificateRequestId != c.CertificateRequestId {
 				isOnlyOneCertificateRequestId = false
 			}
-			certificateRequestId = c.CertificateRequestId
+			if c.CertificateRequestId != "" {
+				certificateRequestId = c.CertificateRequestId
+			}
+			if c.Id != "" {
+				req.CertID = c.Id
+			}
 		}
 		if !isOnlyOneCertificateRequestId {
 			return nil, fmt.Errorf("More than one CertificateRequestId was found with the same Fingerprint: %s", reqIds)
@@ -309,66 +260,78 @@ func (c *Connector) RetrieveCertificate(req *certificate.Request) (certificates 
 	}
 
 	startTime := time.Now()
-	for {
-		status, err := c.getCertificateStatus(req.PickupID)
-		if err != nil {
-			return nil, fmt.Errorf("unable to retrieve: %s", err)
+	//Wait for certificate to be issued by checking it's PickupID
+	//If certID is filled then certificate should be already issued.
+	if req.CertID == "" {
+		for {
+			if req.PickupID == "" {
+				break
+			}
+			status, err := c.getCertificateStatus(req.PickupID)
+			if err != nil {
+				return nil, fmt.Errorf("unable to retrieve: %s", err)
+			}
+			if status.Status == "ISSUED" {
+				break // to fetch the cert itself
+			} else if status.Status == "FAILED" {
+				return nil, fmt.Errorf("Failed to retrieve certificate. Status: %v", status)
+			}
+			// status.Status == "REQUESTED" || status.Status == "PENDING"
+			if req.Timeout == 0 {
+				return nil, endpoint.ErrCertificatePending{CertificateID: req.PickupID, Status: status.Status}
+			}
+			if time.Now().After(startTime.Add(req.Timeout)) {
+				return nil, endpoint.ErrRetrieveCertificateTimeout{CertificateID: req.PickupID}
+			}
+			// fmt.Printf("pending... %s\n", status.Status)
+			time.Sleep(2 * time.Second)
 		}
-		if status.Status == "ISSUED" {
-			break // to fetch the cert itself
-		} else if status.Status == "FAILED" {
-			return nil, fmt.Errorf("Failed to retrieve certificate. Status: %v", status)
-		}
-		// status.Status == "REQUESTED" || status.Status == "PENDING"
-		if req.Timeout == 0 {
-			return nil, endpoint.ErrCertificatePending{CertificateID: req.PickupID, Status: status.Status}
-		}
-		if time.Now().After(startTime.Add(req.Timeout)) {
-			return nil, endpoint.ErrRetrieveCertificateTimeout{CertificateID: req.PickupID}
-		}
-		// fmt.Printf("pending... %s\n", status.Status)
-		time.Sleep(2 * time.Second)
 	}
 
-	url := c.getURL(urlResourceCertificateRetrieve)
 	if c.user == nil || c.user.Company == nil {
 		return nil, fmt.Errorf("Must be autheticated to retieve certificate")
 	}
-	url = fmt.Sprintf(url, req.PickupID)
-	url += "?chainOrder=%s&format=PEM"
-	switch req.ChainOption {
-	case certificate.ChainOptionRootFirst:
-		url = fmt.Sprintf(url, condorChainOptionRootFirst)
-	default:
-		url = fmt.Sprintf(url, condorChainOptionRootLast)
-	}
-	b := []byte{}
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("GET", url, reader)
-	if err != nil {
-		return nil, err
-	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	request.Header.Add("Accept", "text/plain")
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if resp.StatusCode == http.StatusOK {
-		return newPEMCollectionFromResponse(body, req.ChainOption)
-	} else if resp.StatusCode == http.StatusConflict { // Http Status Code 409 means the certificate has not been signed by the ca yet.
-		return nil, endpoint.ErrCertificatePending{CertificateID: req.PickupID}
-	} else {
-		if c.verbose {
-			log.Printf("JSON sent for %s\n%s", url, b)
+
+	switch {
+	case req.CertID != "":
+		url := c.getURL(urlResourceCertificateRetrievePem)
+		url = fmt.Sprintf(url, req.CertID)
+		statusCode, status, body, err := c.request("GET", url, nil)
+		if err != nil {
+			return nil, err
 		}
-		return nil, fmt.Errorf("Failed to retrieve certificate. StatusCode: %d -- Status: %s -- Server Data: %s", resp.StatusCode, resp.Status, body)
+		if statusCode != http.StatusOK {
+			return nil, fmt.Errorf("Failed to retrieve certificate. StatusCode: %d -- Status: %s -- Server Data: %s", statusCode, status, body)
+		}
+		return newPEMCollectionFromResponse(body, certificate.ChainOptionIgnore)
+	case req.PickupID != "":
+		url := c.getURL(urlResourceCertificateRetrieveViaCSR)
+		url = fmt.Sprintf(url, req.PickupID)
+		url += "?chainOrder=%s&format=PEM"
+		switch req.ChainOption {
+		case certificate.ChainOptionRootFirst:
+			url = fmt.Sprintf(url, condorChainOptionRootFirst)
+		default:
+			url = fmt.Sprintf(url, condorChainOptionRootLast)
+		}
+		statusCode, status, body, err := c.request("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+		if statusCode == http.StatusOK {
+			certificates, err = newPEMCollectionFromResponse(body, req.ChainOption)
+			if err != nil {
+				return nil, err
+			}
+			err = req.CheckCertificate(certificates.Certificate)
+			return certificates, err
+		} else if statusCode == http.StatusConflict { // Http Status Code 409 means the certificate has not been signed by the ca yet.
+			return nil, endpoint.ErrCertificatePending{CertificateID: req.PickupID}
+		} else {
+			return nil, fmt.Errorf("Failed to retrieve certificate. StatusCode: %d -- Status: %s -- Server Data: %s", statusCode, status, body) //todo:remove body from err
+		}
 	}
+	return nil, fmt.Errorf("Couldn't retrieve certificate because both PickupID and CertId are empty")
 }
 
 // RevokeCertificate attempts to revoke the certificate
@@ -423,7 +386,7 @@ func (c *Connector) RenewCertificate(renewReq *certificate.RenewalRequest) (requ
 		return "", fmt.Errorf("failed to submit renewal request for certificate: ManagedCertificateId is empty, certificate status is %s", previousRequest.Status)
 	}
 
-	if managedCertificateId == "" {
+	if zoneId == "" {
 		return "", fmt.Errorf("failed to submit renewal request for certificate: ZoneId is empty, certificate status is %s", previousRequest.Status)
 	}
 
@@ -451,40 +414,20 @@ func (c *Connector) RenewCertificate(renewReq *certificate.RenewalRequest) (requ
 		return "", fmt.Errorf("Must be autheticated to request a certificate")
 	}
 
-	req := certificateRequest{
-		ZoneID: zoneId,
-		ExistingManagedCertificateId: managedCertificateId,
-	}
-	if renewReq.CertificateRequest != nil && 0 < len(renewReq.CertificateRequest.CSR) {
-		req.CSR = string(renewReq.CertificateRequest.CSR)
+	req := certificateRequest{ZoneID: zoneId, ExistingManagedCertificateId: managedCertificateId}
+	if renewReq.CertificateRequest != nil && len(renewReq.CertificateRequest.GetCSR()) != 0 {
+		req.CSR = string(renewReq.CertificateRequest.GetCSR())
 		req.ReuseCSR = false
 	} else {
 		req.ReuseCSR = true
 	}
-	b, _ := json.Marshal(req)
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("POST", url, reader)
+	statusCode, status, body, err := c.request("POST", url, req)
 	if err != nil {
-		return "", err
-	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	request.Header.Add("content-type", "application/json")
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return "", err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return "", err
+		return
 	}
 
-	cr, err := parseCertificateRequestResult(resp.StatusCode, resp.Status, body)
+	cr, err := parseCertificateRequestResult(statusCode, status, body)
 	if err != nil {
-		if c.verbose {
-			log.Printf("JSON sent for %s\n%s", url, b)
-		}
-
 		return "", fmt.Errorf("Failed to renew certificate: %s", err)
 	}
 	return cr.CertificateRequests[0].ID, nil
@@ -496,28 +439,12 @@ func (c *Connector) getZoneByTag(tag string) (*zone, error) {
 		return nil, fmt.Errorf("Must be autheticated to read the zone configuration")
 	}
 	url = fmt.Sprintf(url, tag)
-	b := []byte{}
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("GET", url, reader)
+	statusCode, status, body, err := c.request("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	resp, err := http.DefaultClient.Do(request)
+	z, err := parseZoneConfigurationResult(statusCode, status, body)
 	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	z, err := parseZoneConfigurationResult(resp.StatusCode, resp.Status, body)
-	if err != nil {
-		if c.verbose {
-			log.Printf("JSON sent for %s\n%s", url, b)
-		}
-
 		return nil, err
 	}
 	return z, nil
@@ -525,34 +452,18 @@ func (c *Connector) getZoneByTag(tag string) (*zone, error) {
 
 func (c *Connector) getPoliciesByID(ids []string) (*certificatePolicy, error) {
 	policy := new(certificatePolicy)
-	url := c.getURL(urlResourcePoliciesByID)
 	if c.user == nil {
 		return nil, fmt.Errorf("Must be autheticated to read the zone configuration")
 	}
 	for _, id := range ids {
+		url := c.getURL(urlResourcePoliciesByID)
 		url = fmt.Sprintf(url, id)
-		b := []byte{}
-		reader := bytes.NewReader(b)
-		request, err := http.NewRequest("GET", url, reader)
+		statusCode, status, body, err := c.request("GET", url, nil)
 		if err != nil {
 			return nil, err
 		}
-		request.Header.Add("tppl-api-key", c.apiKey)
-		resp, err := http.DefaultClient.Do(request)
+		p, err := parseCertificatePolicyResult(statusCode, status, body)
 		if err != nil {
-			return nil, err
-		}
-		defer resp.Body.Close()
-		body, err := ioutil.ReadAll(resp.Body)
-		if err != nil {
-			return nil, err
-		}
-		p, err := parseCertificatePolicyResult(resp.StatusCode, resp.Status, body)
-		if err != nil {
-			if c.verbose {
-				log.Printf("JSON sent for %s\n%s", url, b)
-			}
-
 			return nil, err
 		}
 		switch p.CertificatePolicyType {
@@ -564,11 +475,9 @@ func (c *Connector) getPoliciesByID(ids []string) (*certificatePolicy, error) {
 			policy.SubjectLRegexes = p.SubjectLRegexes
 			policy.SubjectCRegexes = p.SubjectCRegexes
 			policy.SANRegexes = p.SANRegexes
-			break
 		case certificatePolicyTypeUse:
 			policy.KeyTypes = p.KeyTypes
 			policy.KeyReuse = p.KeyReuse
-			break
 		}
 	}
 	return policy, nil
@@ -579,36 +488,11 @@ func (c *Connector) searchCertificates(req *SearchRequest) (*CertificateSearchRe
 	var err error
 
 	url := c.getURL(urlResourceCertificateSearch)
-	if c.user == nil || c.user.Company == nil {
-		err = fmt.Errorf("Must be autheticated")
-		return nil, err
-	}
-
-	b, _ := json.Marshal(req)
-	reader := bytes.NewReader(b)
-	request, err := http.NewRequest("POST", url, reader)
+	statusCode, _, body, err := c.request("POST", url, req)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	request.Header.Add("content-type", "application/json")
-	request.Header.Add("accept", "application/json")
-
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if c.verbose {
-		fmt.Printf("REQ: %s\n", b)
-		fmt.Printf("RES: %s\n", body)
-	}
-
-	searchResult, err := ParseCertificateSearchResponse(resp.StatusCode, body)
+	searchResult, err := ParseCertificateSearchResponse(statusCode, body)
 	if err != nil {
 		return nil, err
 	}
@@ -653,35 +537,14 @@ type managedCertificate struct {
 
 func (c *Connector) getManagedCertificate(managedCertId string) (*managedCertificate, error) {
 	var err error
-	url := c.getURL(urlResourceManagedCertificateById)
+	url := c.getURL(urlResourceManagedCertificateByID)
 	url = fmt.Sprintf(url, managedCertId)
-	if c.user == nil || c.user.Company == nil {
-		err = fmt.Errorf("Must be autheticated")
-		return nil, err
-	}
-
-	request, err := http.NewRequest("GET", url, nil)
+	statusCode, _, body, err := c.request("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Add("tppl-api-key", c.apiKey)
-	request.Header.Add("accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if c.verbose {
-		fmt.Printf("REQ: %s\n", url)
-		fmt.Printf("RES: %s\n", body)
-	}
-
-	switch resp.StatusCode {
+	switch statusCode {
 	case http.StatusOK:
 		var res = &managedCertificate{}
 		err = json.Unmarshal(body, res)
@@ -693,18 +556,75 @@ func (c *Connector) getManagedCertificate(managedCertId string) (*managedCertifi
 		if body != nil {
 			respErrors, err := parseResponseErrors(body)
 			if err == nil {
-				respError := fmt.Sprintf("Unexpected status code on Venafi Cloud certificate search. Status: %d\n", resp.StatusCode)
+				respError := fmt.Sprintf("Unexpected status code on Venafi Cloud certificate search. Status: %d\n", statusCode)
 				for _, e := range respErrors {
 					respError += fmt.Sprintf("Error Code: %d Error: %s\n", e.Code, e.Message)
 				}
 				return nil, fmt.Errorf(respError)
 			}
 		}
-		return nil, fmt.Errorf("Unexpected status code on Venafi Cloud certificate search. Status: %d", resp.StatusCode)
+		return nil, fmt.Errorf("Unexpected status code on Venafi Cloud certificate search. Status: %d", statusCode)
 	}
 
 }
 
 func (c *Connector) ImportCertificate(req *certificate.ImportRequest) (*certificate.ImportResponse, error) {
-	return nil, fmt.Errorf("import is not supported")
+	pBlock, _ := pem.Decode([]byte(req.CertificateData))
+	if pBlock == nil {
+		return nil, fmt.Errorf("can`t parse certificate")
+	}
+	zone := req.PolicyDN
+	if zone == "" {
+		zone = c.zone
+	}
+	base64.StdEncoding.EncodeToString(pBlock.Bytes)
+	fingerprint := certThumprint(pBlock.Bytes)
+	e := importRequestEndpoint{
+		OCSP: 1,
+		Certificates: []importRequestEndpointCert{
+			{
+				Certificate: base64.StdEncoding.EncodeToString(pBlock.Bytes),
+				Fingerprint: fingerprint,
+			},
+		},
+		Protocols: []importRequestEndpointProtocol{
+			{
+				Certificates: []string{fingerprint},
+			},
+		},
+	}
+	request := importRequest{
+		ZoneName:  zone,
+		Endpoints: []importRequestEndpoint{e},
+	}
+
+	url := c.getURL(urlResourceDiscovery)
+	statusCode, status, body, err := c.request("POST", url, request)
+	if err != nil {
+		return nil, err
+	}
+	var r struct {
+		CreatedCertificates int
+		CreatedInstances    int
+		UpdatedCertificates int
+		UpdatedInstances    int
+	}
+	err = json.Unmarshal(body, &r)
+	if statusCode != http.StatusCreated {
+		return nil, fmt.Errorf("bad server status responce %d %s", statusCode, status)
+	} else if err != nil {
+		return nil, fmt.Errorf("can`t unmarshal json response %s", err)
+	} else if !(r.CreatedCertificates == 1 || r.UpdatedCertificates == 1) {
+		return nil, fmt.Errorf("certificate was not imported on unknown reason")
+	}
+	foundCert, err := c.searchCertificatesByFingerprint(fingerprint)
+	if err != nil {
+		return nil, err
+	}
+	if len(foundCert.Certificates) != 1 {
+		return nil, fmt.Errorf("certificate has been imported but could not be found on platform after that")
+	}
+	cert := foundCert.Certificates[0]
+	resp := &certificate.ImportResponse{CertificateDN: cert.SubjectCN[0], CertId: cert.Id}
+	return resp, nil
 }

--- a/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/search.go
+++ b/vendor/github.com/Venafi/vcert/pkg/venafi/cloud/search.go
@@ -50,13 +50,13 @@ type Paging struct {
 
 const (
 	EQ    Operator = "EQ"
-	FIND           = "FIND"
-	GT             = "GT"
-	GTE            = "GTE"
-	IN             = "IN"
-	LT             = "LT"
-	LTE            = "LTE"
-	MATCH          = "MATCH"
+	FIND  Operator = "FIND"
+	GT    Operator = "GT"
+	GTE   Operator = "GTE"
+	IN    Operator = "IN"
+	LT    Operator = "LT"
+	LTE   Operator = "LTE"
+	MATCH Operator = "MATCH"
 )
 
 type CertificateSearchResponse struct {
@@ -69,7 +69,7 @@ type Certificate struct {
 	ManagedCertificateId string   `json:"managedCertificateId"`
 	CertificateRequestId string   `json:"certificateRequestId"`
 	SubjectCN            []string `json:"subjectCN"`
-	/*...and many more fields... */
+	/* ... and many more fields ... */
 }
 
 func ParseCertificateSearchResponse(httpStatusCode int, body []byte) (searchResult *CertificateSearchResponse, err error) {

--- a/vendor/github.com/Venafi/vcert/pkg/venafi/tpp/search.go
+++ b/vendor/github.com/Venafi/vcert/pkg/venafi/tpp/search.go
@@ -19,7 +19,6 @@ package tpp
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"strings"
 )
@@ -53,33 +52,12 @@ func (c *Connector) searchCertificates(req *SearchRequest) (*CertificateSearchRe
 
 	var err error
 
-	url, _ := c.getURL(urlResourceCertificateSearch)
-
-	url = fmt.Sprintf("%s?%s", url, strings.Join(*req, "&"))
-
-	request, err := http.NewRequest("GET", url, nil)
+	url := fmt.Sprintf("%s?%s", urlResourceCertificateSearch, strings.Join(*req, "&"))
+	statusCode, _, body, err := c.request("GET", urlResource(url), nil)
 	if err != nil {
 		return nil, err
 	}
-	request.Header.Add("x-venafi-api-key", c.apiKey)
-	request.Header.Add("cache-control", "no-cache")
-	request.Header.Add("accept", "application/json")
-
-	resp, err := http.DefaultClient.Do(request)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-	if c.verbose {
-		fmt.Printf("REQ: %s\n", url)
-		fmt.Printf("RES: %s\n", body)
-	}
-
-	searchResult, err := ParseCertificateSearchResponse(resp.StatusCode, body)
+	searchResult, err := ParseCertificateSearchResponse(statusCode, body)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/Venafi/vcert/vcert.go
+++ b/vendor/github.com/Venafi/vcert/vcert.go
@@ -13,19 +13,21 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
+/*
+VCert is a Go library, SDK, and command line utility designed to simplify key generation and enrollment of machine identities (also known as SSL/TLS certificates and keys) that comply with enterprise security policy by using the Venafi Platform or Venafi Cloud.
+*/
 package vcert
 
 import (
 	"fmt"
 )
 
-//ProjectName contains the friendly name of the vcert utiltity
-const ProjectName string = "Venafi Certificate Utility"
+//projectName contains the friendly name of the vcert utiltity
+const projectName string = "Venafi Certificate Utility"
 
 var (
-	versionString         string
 	versionBuildTimeStamp string
+	versionString         string
 )
 
 //GetFormattedVersionString gets a friendly printable string to represent the version
@@ -33,13 +35,8 @@ func GetFormattedVersionString() string {
 	if versionBuildTimeStamp != "" {
 		versionBuildTimeStamp = fmt.Sprintf("\tBuild Timestamp: %s\n", versionBuildTimeStamp)
 	}
-	return fmt.Sprintf("%s\n\tVersion: %s\n%s", ProjectName, GetVersionString(), versionBuildTimeStamp)
-}
-
-//GetVersionString gets a simple version string
-func GetVersionString() string {
 	if versionString == "" {
-		versionString = "3.18.3.1"
+		versionString = "Unknown"
 	}
-	return versionString
+	return fmt.Sprintf("%s\n\tVersion: %s\n%s", projectName, versionString, versionBuildTimeStamp)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -24,7 +24,7 @@ github.com/NYTimes/gziphandler
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
-# github.com/Venafi/vcert v0.0.0-20181029235941-5068538d4d65
+# github.com/Venafi/vcert v0.0.0-20190530133915-e207710a0ab9
 github.com/Venafi/vcert
 github.com/Venafi/vcert/pkg/certificate
 github.com/Venafi/vcert/pkg/endpoint


### PR DESCRIPTION
**What this PR does / why we need it**:

This resolves issues when talking to the latest iteration of the Venafi Cloud API, which appears to have removed the `ping/` endpoint (causing previous versions of this library to fail).

**Release note**:
```release-note
Bump Venafi vcert dependency to latest version
```

/cc @alljames @mattbates 