### PR TITLE
Fix ECDSA certificate issuance with ACME issuer

### DIFF
--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -294,12 +294,12 @@ func (a *Acme) getCertificatePrivateKey(ctx context.Context, crt *v1alpha1.Certi
 	log.V(4).Info("Generating new private key")
 
 	// generate a new private key.
-	rsaKey, err := pki.GenerateRSAPrivateKey(2048)
+	privateKey, err := pki.GeneratePrivateKeyForCertificate(crt)
 	if err != nil {
 		return nil, false, err
 	}
 
-	return rsaKey, true, nil
+	return privateKey, true, nil
 }
 
 func (a *Acme) createNewOrder(ctx context.Context, crt *v1alpha1.Certificate, template *v1alpha1.Order, key crypto.Signer) error {

--- a/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//test/e2e/framework/matcher:go_default_library",
         "//test/e2e/suite/issuers/acme/dnsproviders:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "//test/util/generate:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/test/e2e/suite/issuers/acme/certificate/http01_new.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01_new.go
@@ -171,6 +171,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 			gen.SetCertificateDNSNames(acmeIngressDomain),
 			gen.SetCertificateKeyAlgorithm(v1alpha1.ECDSAKeyAlgorithm),
 		)
+		cert.Namespace = f.Namespace.Name
 		_, err := certClient.Create(cert)
 		Expect(err).NotTo(HaveOccurred())
 		By("Verifying the Certificate is valid and of type ECDSA")


### PR DESCRIPTION
**What this PR does / why we need it**:

We previously always generated a 2048 bit RSA private key in the ACME issuer even if an ECDSA key was requested. This also meant we'd have an RSA private key with an ECDSA certificate in issued certificates.

**Which issue this PR fixes**: fixes #1741

**Release note**:
```release-note
Fix bug causing ECDSA certificates to be issued using 2048-bit RSA private keys
```

/milestone v0.8