### PR TITLE
Fix panic in HTTP01 solver if ingress field is not specified

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -84,8 +84,9 @@ func http01LogCtx(ctx context.Context) context.Context {
 
 func httpDomainCfgForChallenge(issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (*v1alpha1.ACMEChallengeSolverHTTP01Ingress, error) {
 	if ch.Spec.Solver != nil {
-		if ch.Spec.Solver.HTTP01 == nil {
-			return nil, fmt.Errorf("challenge's 'solver' field is specified but not HTTP01 ingress config provided")
+		if ch.Spec.Solver.HTTP01 == nil || ch.Spec.Solver.HTTP01.Ingress == nil {
+			return nil, fmt.Errorf("challenge's 'solver' field is specified but no HTTP01 ingress config provided. " +
+				"Ensure solvers[].http01.ingress is specified on your issuer resource")
 		}
 		return ch.Spec.Solver.HTTP01.Ingress, nil
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

If a user has not specified anything under the `issuer.spec.acme.solvers[].http01.ingress` field, but *has* set `issuer.spec.acme.solvers[].http01` to some non-nil value, we would panic when calling `buildService` in the HTTP01 challenge solver as a `http01` structure would be returned with a nil `ingress` field.

**Which issue this PR fixes**: fixes #1739

**Release note**:
```release-note
Fix a panic when a misconfigured Issuer is used for HTTP01 challenge solving
```

/milestone v0.8