### PR TITLE
Add support for specifying ACME HTTP01 ingress name as an annotation on Certificates

### DIFF
--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -791,7 +791,7 @@ Appears In:
 </tr>
 <tr>
 <td><code>class</code><br /> <em>string</em></td>
-<td>The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of &#39;class&#39; or &#39;name&#39; may be specified.</td>
+<td>The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of &#39;class&#39;, &#39;name&#39; or &#39;allowManuallySpecifiedIngress&#39; may be specified.</td>
 </tr>
 <tr>
 <td><code>name</code><br /> <em>string</em></td>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -786,6 +786,10 @@ Appears In:
 </tr>
 </thead>
 <tbody><tr>
+<td><code>allowManuallySpecifiedIngress</code><br /> <em>boolean</em></td>
+<td>Allow certificates using this issuer to specify the ingress to be edited as an annotation on their configuration. This gives certificate developers the ability to define the solver, without needing access to editing the issuer.</td>
+</tr>
+<tr>
 <td><code>class</code><br /> <em>string</em></td>
 <td>The ingress class to use when creating Ingress resources to solve ACME challenges that use this challenge solver. Only one of &#39;class&#39; or &#39;name&#39; may be specified.</td>
 </tr>

--- a/docs/tasks/issuers/setup-acme/http01/index.rst
+++ b/docs/tasks/issuers/setup-acme/http01/index.rst
@@ -51,6 +51,35 @@ This mode should be avoided when using ingress controllers that expose a single
 IP for all ingress resources, as it can create compatibility problems with
 certain ingress-controller specific annotations.
 
+allowManuallySpecifiedIngress
+-----------------------------
+
+Access to editing an existing issuer resource may be inconvenient to developers
+who want to create a new Certificate for newly created domains. In these
+instances, a solver can be added to the issuer to permit the manual
+specification of the ingress to be edited in order to solve HTTP01 challenges.
+
+The developer can then add an annotation to their certificate like so:
+
+.. code-block:: yaml
+   :linenos:
+   :emphasize-lines: 6
+   
+   apiVersion: certmanager.k8s.io/v1alpha1
+   kind: Certificate
+   metadata:
+     name: example-com
+     annotations:
+       http01.acme.certmanager.k8s.io/ingress-to-edit: "ingress-to-edit-to-solve-challenges"
+   spec:
+     secretName: example-com-tls
+     dnsNames:
+     - example.com
+     - www.example.com
+     issuerRef:
+       name: letsencrypt-staging
+       kind: Issuer
+
 servicePort
 -----------
 

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -269,7 +269,8 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 
 	// The ingress class to use when creating Ingress resources to solve ACME
 	// challenges that use this challenge solver.
-	// Only one of 'class' or 'name' may be specified.
+	// Only one of 'class', 'name' or 'allowManuallySpecifiedIngress' may be
+	// specified.
 	// +optional
 	Class *string `json:"class,omitempty"`
 
@@ -281,19 +282,19 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	Name string `json:"name,omitempty"`
 
-	// Optional pod template used to configure the ACME challenge solver pods
-	// used for HTTP01 challenges. Only labels and annotations may be set and
-	// will be merged ontop of the defaults. PodTemplate labels and annotation
-	// fields will override fields with matching keys.
-	// +optional
-	PodTemplate *ACMEChallengeSolverHTTP01IngressPodTemplate `json:"podTemplate,omitempty"`
-
 	// Allow certificates using this issuer to specify the ingress to be edited
 	// as an annotation on their configuration.
 	// This gives certificate developers the ability to define the solver, without
 	// needing access to editing the issuer.
 	// +optional
 	AllowManuallySpecifiedIngress bool `json:"allowManuallySpecifiedIngress,omitempty"`
+
+	// Optional pod template used to configure the ACME challenge solver pods
+	// used for HTTP01 challenges. Only labels and annotations may be set and
+	// will be merged ontop of the defaults. PodTemplate labels and annotation
+	// fields will override fields with matching keys.
+	// +optional
+	PodTemplate *ACMEChallengeSolverHTTP01IngressPodTemplate `json:"podTemplate,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressPodTemplate struct {

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -287,6 +287,13 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// fields will override fields with matching keys.
 	// +optional
 	PodTemplate *ACMEChallengeSolverHTTP01IngressPodTemplate `json:"podTemplate,omitempty"`
+
+	// Allow certificates using this issuer to specify the ingress to be edited
+	// as an annotation on their configuration.
+	// This gives certificate developers the ability to define the solver, without
+	// needing access to editing the issuer.
+	// +optional
+	AllowManuallySpecifiedIngress bool `json:"allowManuallySpecifiedIngress,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressPodTemplate struct {

--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -138,6 +138,25 @@ func ValidateACMEIssuerChallengeSolverHTTP01Config(http01 *v1alpha1.ACMEChalleng
 func ValidateACMEIssuerChallengeSolverHTTP01IngressConfig(ingress *v1alpha1.ACMEChallengeSolverHTTP01Ingress, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 
+	numIngressSpecifiers := 0
+
+	if ingress.Class != nil {
+		numIngressSpecifiers++
+	}
+
+	if ingress.Name != "" {
+		if numIngressSpecifiers > 0 {
+			el = append(el, field.Forbidden(fldPath.Child("name"), "may not specify more than one of class, name, or allowManuallySpecifiedIngress"))
+		}
+		numIngressSpecifiers++
+	}
+
+	if ingress.AllowManuallySpecifiedIngress {
+		if numIngressSpecifiers > 0 {
+			el = append(el, field.Forbidden(fldPath.Child("allowManuallySpecifiedIngress"), "may not specify more than one of class, name, or allowManuallySpecifiedIngress"))
+		}
+	}
+
 	if ingress.PodTemplate != nil {
 		el = append(el, ValidateACMEIssuerChallengeSolverHTTP01IngressPodTemplateConfig(ingress.PodTemplate, fldPath.Child("podTemplate"))...)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds support for an annotation on Certificates `http01.acme.certmanager.k8s.io/ingress-to-edit` to manually specify the ingress to edit, to overcome the need to have access to adding a specific solver entry in the Issuer.
A new field `AllowManuallySpecifiedIngress` is available for Issuer solvers to enable this annotation to be used - if the annotation is set but the this option is not enabled, then the solver selection procedure will continue as if the annotation was not set.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1666 

**Special notes for your reviewer**:
The tests only ensure the solver is correctly set after creation, I am assuming that anything after this point is reliant on the correctness of the `sync()` function in general, and another PR should handle adding tests for the new solver.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds support for Certificate annotation `http01.acme.certmanager.k8s.io/ingress-to-edit` to manually specify the Ingress to edit, when the option is enabled under `AllowManuallySpecifiedIngress` in one of the Issuer's solvers.
```
