### PR TITLE
Add handling of updates to ACME email field in Issuers

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -609,6 +609,11 @@ spec:
           properties:
             acme:
               properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
                 uri:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA
@@ -888,6 +893,11 @@ spec:
           properties:
             acme:
               properties:
+                lastRegisteredEmail:
+                  description: LastRegisteredEmail is the email associated with the
+                    latest registered ACME account, in order to track changes made
+                    to registered account associated with the  Issuer
+                  type: string
                 uri:
                   description: URI is the unique account identifier, which can also
                     be used to retrieve account details from the CA

--- a/pkg/acme/client/fake.go
+++ b/pkg/acme/client/fake.go
@@ -42,6 +42,7 @@ type FakeACME struct {
 	FakeHTTP01ChallengeResponse func(token string) (string, error)
 	FakeDNS01ChallengeRecord    func(token string) (string, error)
 	FakeDiscover                func(ctx context.Context) (acme.Directory, error)
+	FakeUpdateAccount           func(ctx context.Context, a *acme.Account) (*acme.Account, error)
 }
 
 func (f *FakeACME) CreateOrder(ctx context.Context, order *acme.Order) (*acme.Order, error) {
@@ -142,4 +143,11 @@ func (f *FakeACME) Discover(ctx context.Context) (acme.Directory, error) {
 	// We only use Discover to find CAAIdentities, so returning an
 	// empty directory here will be fine
 	return acme.Directory{}, nil
+}
+
+func (f *FakeACME) UpdateAccount(ctx context.Context, a *acme.Account) (*acme.Account, error) {
+	if f.FakeUpdateAccount != nil {
+		return f.FakeUpdateAccount(ctx, a)
+	}
+	return nil, fmt.Errorf("UpdateAccount not implemented")
 }

--- a/pkg/acme/client/interfaces.go
+++ b/pkg/acme/client/interfaces.go
@@ -37,6 +37,7 @@ type Interface interface {
 	HTTP01ChallengeResponse(token string) (string, error)
 	DNS01ChallengeRecord(token string) (string, error)
 	Discover(ctx context.Context) (acme.Directory, error)
+	UpdateAccount(ctx context.Context, a *acme.Account) (*acme.Account, error)
 }
 
 var _ Interface = &acme.Client{}

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -103,3 +103,8 @@ func (l *Logger) Discover(ctx context.Context) (acme.Directory, error) {
 	klog.Infof("Calling Discover")
 	return l.baseCl.Discover(ctx)
 }
+
+func (l *Logger) UpdateAccount(ctx context.Context, a *acme.Account) (*acme.Account, error) {
+	klog.Infof("Calling UpdateAccount")
+	return l.baseCl.UpdateAccount(ctx, a)
+}

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -538,6 +538,12 @@ type ACMEIssuerStatus struct {
 	// account details from the CA
 	// +optional
 	URI string `json:"uri,omitempty"`
+
+	// LastRegisteredEmail is the email associated with the latest registered
+	// ACME account, in order to track changes made to registered account
+	// associated with the  Issuer
+	// +optional
+	LastRegisteredEmail string `json:"lastRegisteredEmail,omitempty"`
 }
 
 // IssuerCondition contains condition information for an Issuer.

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -40,12 +40,14 @@ import (
 const (
 	errorAccountRegistrationFailed = "ErrRegisterACMEAccount"
 	errorAccountVerificationFailed = "ErrVerifyACMEAccount"
+	errorAccountUpdateFailed       = "ErrUpdateACMEAccount"
 
 	successAccountRegistered = "ACMEAccountRegistered"
 	successAccountVerified   = "ACMEAccountVerified"
 
 	messageAccountRegistrationFailed = "Failed to register ACME account: "
 	messageAccountVerificationFailed = "Failed to verify ACME account: "
+	messageAccountUpdateFailed       = "Failed to update ACME account:"
 	messageAccountRegistered         = "The ACME account was registered with the ACME server"
 	messageAccountVerified           = "The ACME account was verified with the ACME server"
 )
@@ -169,27 +171,6 @@ func (a *Acme) Setup(ctx context.Context) error {
 	// registerAccount will also verify the account exists if it already
 	// exists.
 	account, err := a.registerAccount(ctx, cl)
-
-	// if we got an account successfully, we must check if the registered
-	// email is the same as in the issuer spec
-	registeredEmail := ""
-	if err == nil {
-		if len(account.Contact) > 0 {
-			registeredEmail = strings.Replace(account.Contact[0], "mailto:", "", 1)
-		}
-
-		// if they are different, we update the account
-		if registeredEmail != a.issuer.GetSpec().ACME.Email {
-			emailurl := []string(nil)
-			if a.issuer.GetSpec().ACME.Email != "" {
-				emailurl = []string{fmt.Sprintf("mailto:%s", strings.ToLower(a.issuer.GetSpec().ACME.Email))}
-			}
-			account.Contact = emailurl
-			account, err = cl.UpdateAccount(ctx, account)
-		}
-	}
-
-	// handle errs from both registerAccount and UpdateAccount
 	if err != nil {
 		s := messageAccountVerificationFailed + err.Error()
 		log.Error(err, "failed to verify ACME account")
@@ -213,6 +194,53 @@ func (a *Acme) Setup(ctx context.Context) error {
 
 		// Otherwise if we receive anything other than a 400, we will retry.
 		return err
+	}
+
+	// if we got an account successfully, we must check if the registered
+	// email is the same as in the issuer spec
+
+	// if no email was specified, then registeredEmail will remain empty
+	registeredEmail := ""
+	if len(account.Contact) > 0 {
+		registeredEmail = strings.Replace(account.Contact[0], "mailto:", "", 1)
+	}
+
+	// if they are different, we update the account
+	specEmail := a.issuer.GetSpec().ACME.Email
+	if registeredEmail != specEmail {
+		log.Info("Updating ACME account with email %s", specEmail)
+		emailurl := []string(nil)
+		if a.issuer.GetSpec().ACME.Email != "" {
+			emailurl = []string{fmt.Sprintf("mailto:%s", strings.ToLower(specEmail))}
+		}
+		account.Contact = emailurl
+
+		account, err = cl.UpdateAccount(ctx, account)
+		if err != nil {
+			s := messageAccountUpdateFailed + err.Error()
+			log.Error(err, "failed to update ACME account")
+			a.Recorder.Event(a.issuer, v1.EventTypeWarning, errorAccountUpdateFailed, s)
+			apiutil.SetIssuerCondition(a.issuer, v1alpha1.IssuerConditionReady, v1alpha1.ConditionFalse, errorAccountUpdateFailed, s)
+
+			acmeErr, ok := err.(*acmeapi.Error)
+			// If this is not an ACME error, we will simply return it and retry later
+			if !ok {
+				return err
+			}
+
+			// If the status code is 400 (BadRequest), we will *not* retry this registration
+			// as it implies that something about the request (i.e. email address or private key)
+			// is invalid.
+			if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
+				log.Error(acmeErr, "skipping updating account email as a "+
+					"BadRequest response was returned from the ACME server")
+				return nil
+			}
+
+			// Otherwise if we receive anything other than a 400, we will retry.
+			return err
+		}
+
 	}
 
 	log.Info("verified existing registration with ACME server")


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When the `email` in the `spec.acme` field of an Issuer changes, compares this with the newly added field `lastRegisteredEmail` in `status.acme`.
If they are different then the registering process is begun, otherwise nothing.
On success the field is updated to the spec value, otherwise on failure or no difference it is kept the same.
As the `status` has changed then `updateIssuerStatus` will be called, and changes should be made to the actual Issuer.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1667 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds the handling of updates to the `spec.acme.email` field in Issuers
```
