### PR TITLE
Add truncation of certificate name when forming order name

### DIFF
--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -398,7 +398,9 @@ func buildOrder(crt *v1alpha1.Certificate, csr []byte) (*v1alpha1.Order, error) 
 		return nil, err
 	}
 
-	// truncate certificate name so final name will be <= 63 characters
+	// truncate certificate name so final name will be <= 63 characters.
+	// hash (uint32) will be at most 10 digits long, and we account for
+	// the hyphen.
 	return &v1alpha1.Order{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf("%.52s-%d", crt.Name, hash),

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -398,9 +398,10 @@ func buildOrder(crt *v1alpha1.Certificate, csr []byte) (*v1alpha1.Order, error) 
 		return nil, err
 	}
 
+	// truncate certificate name so final name will be <= 63 characters
 	return &v1alpha1.Order{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:            fmt.Sprintf("%s-%d", crt.Name, hash),
+			Name:            fmt.Sprintf("%.52s-%d", crt.Name, hash),
 			Namespace:       crt.Namespace,
 			Labels:          orderLabels(crt),
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)},


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Truncates Certificate name when forming Order name to 52 characters, to allow space for hash - fixing issue with name being longer than 63 characters.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1552 


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix bug with auto-generated Order names being longer than 63 characters
```
