### PR TITLE
Fix incorrect `issuewild` handling in matchCAA

### DIFF
--- a/pkg/issuer/acme/dns/util/BUILD.bazel
+++ b/pkg/issuer/acme/dns/util/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
     srcs = ["wait_test.go"],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    deps = ["//vendor/github.com/miekg/dns:go_default_library"],
 )
 
 filegroup(

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -33,6 +33,9 @@ var (
 
 const defaultResolvConf = "/etc/resolv.conf"
 
+const issueTag = "issue"
+const issuewildTag = "issuewild"
+
 var defaultNameservers = []string{
 	"8.8.8.8:53",
 	"8.8.4.4:53",
@@ -247,19 +250,23 @@ func ValidateCAA(domain string, issuerID []string, iswildcard bool, nameservers 
 }
 
 func matchCAA(caas []*dns.CAA, issuerIDs map[string]bool, iswildcard bool) bool {
-	expectedTag := "issue"
-	if iswildcard {
-		expectedTag = "issuewild"
-	}
+	matches := false
 	for _, caa := range caas {
-		if caa.Tag != expectedTag {
-			continue
+		// if we require a wildcard certificate, we must prioritize any issuewild
+		// tags - only if it matches (regardless of any other entries) can we
+		// issue a wildcard certificate
+		if iswildcard && caa.Tag == issuewildTag {
+			return issuerIDs[caa.Value]
 		}
-		if issuerIDs[caa.Value] {
-			return true
+
+		// issue tags allow any certificate, we perform a check which will only
+		// be returned if we do not need a wildcard certificate, or if we need
+		// a wildcard certificate and no issuewild entries are present
+		if caa.Tag == issueTag {
+			matches = matches || issuerIDs[caa.Value]
 		}
 	}
-	return false
+	return matches
 }
 
 // lookupNameservers returns the authoritative nameservers for the given fqdn.

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -227,6 +227,7 @@ func ValidateCAA(domain string, issuerID []string, iswildcard bool, nameservers 
 			}
 			caas = append(caas, caa)
 		}
+		// once we've found any CAA records, we use these CAAs
 		if len(caas) != 0 {
 			break
 		}

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -178,6 +178,7 @@ func TestResolveConfServers(t *testing.T) {
 	}
 }
 
+// TODO: find a website which uses issuewild?
 func TestValidateCAA(t *testing.T) {
 	// google installs a CAA record at google.com
 	// ask for the www.google.com record to test that
@@ -190,6 +191,13 @@ func TestValidateCAA(t *testing.T) {
 	err = ValidateCAA("www.google.com", []string{"daniel.homebrew.ca"}, false, RecursiveNameservers)
 	if err == nil {
 		t.Fatalf("expected err, got success")
+	}
+	// if the CAA record allows non-wildcards then it has an `issue` tag,
+	// and it is known that it has no issuewild tags, then wildcard certificates
+	// will also be allowed
+	err = ValidateCAA("www.google.com", []string{"pki.goog"}, true, RecursiveNameservers)
+	if err != nil {
+		t.Fatalf("unexpected error: %s", err)
 	}
 	// ask for a domain you know does not have CAA records.
 	// it should succeed


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes incorrect handling of the `issuewild` tag in `matchCAA`, so that `issuewild` entries will take priority on any wildcard certificate verifications, but `issue` entries can also permit these in the absence of entries of the former.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1587  

**Special notes for your reviewer**:
I have added a test to verify that wildcard certificates are possible with `www.google.com`'s CAA record, but this could be quite fragile since it is dependent on Google not adding an `issuewild` entry in the future.

I would like to add a test for verifying that `issuewild` does take priority, but I wasn't able to find any websites which had this in their CAA record.  

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix incorrect handling of `issuewild` tag when verifying CAA
```
