### PR TITLE
Add nginx ingress annotations to prevent domain conflicts on http01 s…

### DIFF
--- a/docs/tutorials/acme/quick-start/example/ingress-tls.yaml
+++ b/docs/tutorials/acme/quick-start/example/ingress-tls.yaml
@@ -5,6 +5,7 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"    
     certmanager.k8s.io/issuer: "letsencrypt-staging"
+    nginx.org/mergeable-ingress-type: "master"
 
 spec:
   tls:

--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -128,6 +128,7 @@ func buildIngressResource(issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge,
 	// TODO: add additional annotations to help workaround problematic ingress controller behaviours
 	ingAnnotations := make(map[string]string)
 	ingAnnotations["nginx.ingress.kubernetes.io/whitelist-source-range"] = "0.0.0.0/0,::/0"
+	ingAnnotations["nginx.org/mergeable-ingress-type"] = "minion"
 
 	if ingClass != nil {
 		ingAnnotations[util.IngressKey] = *ingClass


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:


Fix `wrong status code '404', expected '200'` when using http01 issuer with nginx-ingress by adding `nginx.org/mergeable-ingress-type: "master"` and `nginx.org/mergeable-ingress-type: "minion"` annotations to avoid host conflicts on http01 issuer.

cert-manager creates an ingress with same host as the clients ingress, which is ignored by nginx.

This config:
```
---
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: api
  namespace: production
  annotations:
    kubernetes.io/ingress.class: "nginx"
    certmanager.k8s.io/issuer: "letsencrypt-prod"
    certmanager.k8s.io/acme-challenge-type: http01
spec:
  tls:
  - hosts:
    - my.domain
    secretName: api-tls
  rules:
  - host: my.domain
    http:
      paths:
      - path: /
        backend:
          serviceName: api
          servicePort: 3000
```
Leads to this errors on nginx logs:

`conflicting server name "my.domain" on 0.0.0.0:80, ignored`

`"GET /.well-known/acme-challenge/AK94LF_RCdMq_yriPKU7IlAdxPclVzNmIAxpIfEkX-c HTTP/1.1" 404 209 "http://my.domain/.well-known/acme-challenge/AK94LF_RCdMq_yriPKU7IlAdxPclVzNmIAxpIfEkX-c" "Go-http-client/1.1" "-"`

Nginx ingress docs:
https://github.com/nginxinc/kubernetes-ingress/tree/master/examples/mergeable-ingress-types

**Which issue this PR fixes** 
https://github.com/jetstack/cert-manager/issues/656
