### PR TITLE
Fix indentation on ACME setup examples

### DIFF
--- a/docs/tasks/issuers/setup-acme/index.rst
+++ b/docs/tasks/issuers/setup-acme/index.rst
@@ -112,10 +112,10 @@ along with a DNS01 solver that can be used for wildcard certificates:
        - http01:
            ingress:
              class: nginx
-       - dns01:
-           selector:
-             matchLabels:
-               use-cloudflare-solver: "true"
+       - selector:
+           matchLabels:
+             use-cloudflare-solver: "true"
+         dns01:
            cloudflare:
              email: user@example.com
              apiKeySecretRef:
@@ -151,10 +151,10 @@ For example:
        - http01:
            ingress:
              class: nginx
-       - dns01:
-           selector:
-             dnsNames:
-             - '*.example.com'
+       - selector:
+           dnsNames:
+           - '*.example.com'
+         dns01:
            cloudflare:
              email: user@example.com
              apiKeySecretRef:


### PR DESCRIPTION
The `selector` field needs to be on the same level as the solver type (either `dns01` or `http01`).

**What this PR does / why we need it**:

Fixes invalid example config in the docs.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix indentation on ACME setup examples
```