### PR TITLE
Add documentation on taking care when setting `renewBefore` to be close to `duration`

### DIFF
--- a/docs/tasks/issuing-certificates/index.rst
+++ b/docs/tasks/issuing-certificates/index.rst
@@ -68,6 +68,16 @@ The Certificate will be issued using the issuer named ``ca-issuer`` in the
    :doc:`webhook </getting-started/webhook>` component can prevent cert-manager
    from functioning correctly (`#1269`_).
 
+.. note::
+   Take care when setting the ``renewBefore`` field to be very close to the
+   ``duration`` as this can lead to a renewal loop, where the Certificate is
+   always in the renewal period. Some Issuers set the ``notBefore`` field on
+   their issued X.509 certificate before the issue time to fix clock-skew
+   issues, leading to the working duration of a certificate to be less than
+   the full duration of the certificate. For example, Let's Encrypt sets it
+   to be one hour before issue time, so the actual *working duration* of the
+   certificate is 89 days, 23 hours (the *full duration* remains 90 days). 
+
 A full list of the fields supported on the Certificate resource can be found in
 the `API reference documentation`_.
 

--- a/pkg/controller/helper_test.go
+++ b/pkg/controller/helper_test.go
@@ -89,6 +89,15 @@ func TestCalculateDurationUntilRenew(t *testing.T) {
 			renewBefore:    &metav1.Duration{time.Hour * 24 * 40},
 			expectedExpiry: time.Hour * 24 * 35 * 2 / 3,
 		},
+		{
+			// the notBefore of an LE certificate is one hour before issuance
+			desc:           "expiry of let's encrypt certificate",
+			notBefore:      now().Add(-time.Hour),
+			notAfter:       now().Add(-time.Hour).Add(time.Hour * 24 * 90),
+			duration:       nil,
+			renewBefore:    &metav1.Duration{time.Hour*2159 + time.Minute*50},
+			expectedExpiry: -time.Minute * 50,
+		},
 	}
 	for k, v := range tests {
 		cert := &v1alpha1.Certificate{


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Some issuers set the `notBefore` field of their issued X.509 certificates to be before the time of issuance to handle clock-skew issues, for example Let's Encrypt sets it to be one hour before.
In the case of LE, this means that the working duration is actually `89d23h`, while the full duration (`notAfter - notBefore`) remains `90d`.
This can cause issues if the `renewBefore` field of Certificate resources is set to be very close to the full duration, e.g. `89d23h50m`, since it will **always** be in the renewal period and so the controllers will **always** try to renew it.

I have added a test to demonstrate what happens in this case, and added documentation describing what is happening and to take care when setting `renewBefore`.
I think this is more appropriate than adding a validation check to prohibit users from setting `renewBefore` to be too close to the `duration`, since this could be overly restrictive in cases where the clock-skew handling of issuers is not as conservative as LE's (e.g. Vault only sets it to be `30s` before).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1506 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
