### PR TITLE
Add container-level SecurityContext configurable parameters in charts

### DIFF
--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -93,13 +93,12 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `serviceAccount.create` | If `true`, create a new service account | `true` |
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `resources` | CPU/memory resource requests/limits | |
-| `securityContext.enabled` | Enable pod-level security context | `false` |
+| `securityContext.enabled` | Enable security context | `false` |
 | `securityContext.fsGroup` | Group ID for the container | `1001` |
 | `securityContext.runAsUser` | User ID for the container | `1001` |
-| `containerSecurityContext.enabled` | Enable container-level security context | `false` |
-| `containerSecurityContext.allowPrivilegeEscalation` | If `true`, enable processes to gain more privilege than their parent processes | `false` |
-| `containerSecurityContext.readOnlyRootFilesystem` | If `true`, set the container to be a read-only root filesystem | `true` |
-| `containerSecurityContext.privileged` | If `true`, run the container in privileged mode  | `false` |
+| `securityContext.allowPrivilegeEscalation` | If `true`, enable processes to gain more privilege than their parent processes | `false` |
+| `securityContext.readOnlyRootFilesystem` | If `true`, set the container to be a read-only root filesystem | `true` |
+| `securityContext.privileged` | If `true`, run the container in privileged mode  | `false` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -93,13 +93,13 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `serviceAccount.create` | If `true`, create a new service account | `true` |
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `resources` | CPU/memory resource requests/limits | |
-| `podSecurityContext.enabled` | Enable pod-level security context | `false` |
-| `podSecurityContext.fsGroup` | Group ID for the container | `1001` |
-| `podSecurityContext.runAsUser` | User ID for the container | `1001` |
-| `securityContext.enabled` | Enable container-level security context | `false` |
-| `securityContext.allowPrivilegeEscalation` | If `true`, enable processes to gain more privilege than their parent processes | `false` |
-| `securityContext.readOnlyRootFilesystem` | If `true`, set the container to be a read-only root filesystem | `true` |
-| `securityContext.privileged` | If `true`, run the container in privileged mode  | `false` |
+| `securityContext.enabled` | Enable pod-level security context | `false` |
+| `securityContext.fsGroup` | Group ID for the container | `1001` |
+| `securityContext.runAsUser` | User ID for the container | `1001` |
+| `containerSecurityContext.enabled` | Enable container-level security context | `false` |
+| `containerSecurityContext.allowPrivilegeEscalation` | If `true`, enable processes to gain more privilege than their parent processes | `false` |
+| `containerSecurityContext.readOnlyRootFilesystem` | If `true`, set the container to be a read-only root filesystem | `true` |
+| `containerSecurityContext.privileged` | If `true`, run the container in privileged mode  | `false` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -93,9 +93,13 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `serviceAccount.create` | If `true`, create a new service account | `true` |
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `resources` | CPU/memory resource requests/limits | |
-| `securityContext.enabled` | Enable security context | `false` |
-| `securityContext.fsGroup` | Group ID for the container | `1001` |
-| `securityContext.runAsUser` | User ID for the container | `1001` |
+| `podSecurityContext.enabled` | Enable pod-level security context | `false` |
+| `podSecurityContext.fsGroup` | Group ID for the container | `1001` |
+| `podSecurityContext.runAsUser` | User ID for the container | `1001` |
+| `securityContext.enabled` | Enable container-level security context | `false` |
+| `securityContext.allowPrivilegeEscalation` | If `true`, enable processes to gain more privilege than their parent processes | `false` |
+| `securityContext.readOnlyRootFilesystem` | If `true`, set the container to be a read-only root filesystem | `true` |
+| `securityContext.privileged` | If `true`, run the container in privileged mode  | `false` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -40,10 +40,10 @@ spec:
       {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.podSecurityContext.enabled }}
+      {{- if .Values.securityContext.enabled }}
       securityContext:
-        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
-        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+        runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -80,11 +80,11 @@ spec:
           - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
           {{- end }}
           {{- end }}
-          {{- if .Values.securityContext.enabled }}
+          {{- if .Values.containerSecurityContext.enabled }}
           securityContext:
-            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
-            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
-            privileged: {{ .Values.securityContext.privileged }}
+            allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
+            privileged: {{ .Values.containerSecurityContext.privileged }}
           {{- end }}
           ports:
           - containerPort: 9402

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -40,10 +40,10 @@ spec:
       {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName | quote }}
       {{- end }}
-      {{- if .Values.securityContext.enabled }}
+      {{- if .Values.podSecurityContext.enabled }}
       securityContext:
-        fsGroup: {{ .Values.securityContext.fsGroup }}
-        runAsUser: {{ .Values.securityContext.runAsUser }}
+        fsGroup: {{ .Values.podSecurityContext.fsGroup }}
+        runAsUser: {{ .Values.podSecurityContext.runAsUser }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -79,6 +79,12 @@ spec:
           {{- if .defaultACMEDNS01ChallengeProvider }}
           - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
           {{- end }}
+          {{- end }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            privileged: {{ .Values.securityContext.privileged }}
           {{- end }}
           ports:
           - containerPort: 9402

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -80,11 +80,11 @@ spec:
           - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
           {{- end }}
           {{- end }}
-          {{- if .Values.containerSecurityContext.enabled }}
+          {{- if .Values.securityContext.enabled }}
           securityContext:
-            allowPrivilegeEscalation: {{ .Values.containerSecurityContext.allowPrivilegeEscalation }}
-            readOnlyRootFilesystem: {{ .Values.containerSecurityContext.readOnlyRootFilesystem }}
-            privileged: {{ .Values.containerSecurityContext.privileged }}
+            allowPrivilegeEscalation: {{ .Values.securityContext.allowPrivilegeEscalation }}
+            readOnlyRootFilesystem: {{ .Values.securityContext.readOnlyRootFilesystem }}
+            privileged: {{ .Values.securityContext.privileged }}
           {{- end }}
           ports:
           - containerPort: 9402

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -65,14 +65,14 @@ resources: {}
 
 # Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-podSecurityContext:
+securityContext:
   enabled: false
   fsGroup: 1001
   runAsUser: 1001
 
 # (Container) Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-securityContext:
+containerSecurityContext:
   enabled: false
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -65,15 +65,11 @@ resources: {}
 
 # Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
 securityContext:
   enabled: false
   fsGroup: 1001
   runAsUser: 1001
-
-# (Container) Security Context
-# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
-containerSecurityContext:
-  enabled: false
   allowPrivilegeEscalation: false
   readOnlyRootFilesystem: true
   privileged: false

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -65,10 +65,18 @@ resources: {}
 
 # Pod Security Context
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
-securityContext:
+podSecurityContext:
   enabled: false
   fsGroup: 1001
   runAsUser: 1001
+
+# (Container) Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+securityContext:
+  enabled: false
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  privileged: false
 
 podAnnotations: {}
 


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds configurable parameters for container-level SecurityContext in the helm charts, under the current SecurityContext values.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1701 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add container-level SecurityContext configurable parameters
```
