### PR TITLE
Use find + sort to ensure we list CRD files consistently across multiple dev environments

### DIFF
--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -34,7 +34,7 @@ out="deploy/manifests/00-crds.yaml"
 rm "$out" > /dev/null 2>&1 || true
 mkdir -p "$(dirname $out)"
 touch "$out"
-for file in ${output}/*; do
+for file in $(find "${output}" -type f | sort); do
     cat "$file" >> "$out"
     echo "---" >> "$out"
 done


### PR DESCRIPTION
**What this PR does / why we need it**:
When adding new resources we found inconsistencies in how bash expanded and for looped over `dir/*`.
This should keep things consistent and passing CI. 

```release-note
NONE
```

/assign @munnerz 
