### PR TITLE
Adds sign interfaces for Issuers

### DIFF
--- a/pkg/issuer/acme/BUILD.bazel
+++ b/pkg/issuer/acme/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "acme.go",
         "issue.go",
         "setup.go",
+        "sign.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/acme",
     visibility = ["//visibility:public"],

--- a/pkg/issuer/acme/sign.go
+++ b/pkg/issuer/acme/sign.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acme
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+)
+
+func (a *Acme) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer.IssueResponse, error) {
+	return nil, errors.New("sign not implemented by ACME issuer")
+}

--- a/pkg/issuer/ca/BUILD.bazel
+++ b/pkg/issuer/ca/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "ca.go",
         "issue.go",
         "setup.go",
+        "sign.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/ca",
     visibility = ["//visibility:public"],

--- a/pkg/issuer/ca/sign.go
+++ b/pkg/issuer/ca/sign.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+)
+
+func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer.IssueResponse, error) {
+	return nil, errors.New("sign not implemented by CA issuer")
+}

--- a/pkg/issuer/fake/fake.go
+++ b/pkg/issuer/fake/fake.go
@@ -26,6 +26,7 @@ import (
 type Issuer struct {
 	FakeSetup func(context.Context) error
 	FakeIssue func(context.Context, *cmapi.Certificate) (*issuer.IssueResponse, error)
+	FakeSign  func(context.Context, *cmapi.CertificateRequest) (*issuer.IssueResponse, error)
 }
 
 var _ issuer.Interface = &Issuer{}
@@ -41,4 +42,10 @@ func (i *Issuer) Setup(ctx context.Context) error {
 // resource given
 func (i *Issuer) Issue(ctx context.Context, crt *cmapi.Certificate) (*issuer.IssueResponse, error) {
 	return i.FakeIssue(ctx, crt)
+}
+
+// Sign attempts to issue a certificate as described by the CertificateRequest
+// resource given
+func (i *Issuer) Sign(ctx context.Context, cr *cmapi.CertificateRequest) (*issuer.IssueResponse, error) {
+	return i.FakeSign(ctx, cr)
 }

--- a/pkg/issuer/issuer.go
+++ b/pkg/issuer/issuer.go
@@ -31,6 +31,10 @@ type Interface interface {
 	// Issue attempts to issue a certificate as described by the certificate
 	// resource given
 	Issue(context.Context, *v1alpha1.Certificate) (*IssueResponse, error)
+
+	// Sign attempts to issue a certificate as described by the CertificateRequest
+	// resource given
+	Sign(context.Context, *v1alpha1.CertificateRequest) (*IssueResponse, error)
 }
 
 type IssueResponse struct {

--- a/pkg/issuer/selfsigned/BUILD.bazel
+++ b/pkg/issuer/selfsigned/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "issue.go",
         "selfsigned.go",
         "setup.go",
+        "sign.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/selfsigned",
     visibility = ["//visibility:public"],

--- a/pkg/issuer/selfsigned/sign.go
+++ b/pkg/issuer/selfsigned/sign.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfsigned
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+)
+
+func (c *SelfSigned) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer.IssueResponse, error) {
+	return nil, errors.New("sign not implemented by SelfSigned issuer")
+}

--- a/pkg/issuer/vault/BUILD.bazel
+++ b/pkg/issuer/vault/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "issue.go",
         "setup.go",
+        "sign.go",
         "vault.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/vault",

--- a/pkg/issuer/vault/sign.go
+++ b/pkg/issuer/vault/sign.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+)
+
+func (v *Vault) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer.IssueResponse, error) {
+	return nil, errors.New("sign not implemented by vault issuer")
+}

--- a/pkg/issuer/venafi/BUILD.bazel
+++ b/pkg/issuer/venafi/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "issue.go",
         "setup.go",
+        "sign.go",
         "venafi.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/venafi",

--- a/pkg/issuer/venafi/sign.go
+++ b/pkg/issuer/venafi/sign.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package venafi
+
+import (
+	"context"
+	"errors"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+)
+
+func (v *Venafi) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer.IssueResponse, error) {
+	return nil, errors.New("sign not implemented by Venafi issuer")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds sign interface to interfaces `	Sign(context.Context, *v1alpha1.CertificateRequest) (*IssueResponse, error)`

This is a requirement for moving over to using CertificateRequests to issue certificates using x509 certificate requests instead of exposing keys.

**Special notes for your reviewer**:
Rebased on top of #1789 

```release-note
Adds Sign interface to Issuers
```


