### PR TITLE
Truncate presentedKey in error to avoid creating a lot of events with big reason values

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -229,7 +229,7 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 
 	if string(presentedKey) != key {
 		log.V(logf.DebugLevel).Info("key returned by server did not match expected", "actual", presentedKey, "expected", key)
-		return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey, key)
+		return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey[:len(key)], key)
 	}
 
 	log.V(logf.DebugLevel).Info("reachability test succeeded")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

We've found a case where cert-manager is populating`Challenge.status.reason` with large values of HTML/JS/CSS, that is, the full response body from the failed challenge request in a cluster that is not configured properly to respond to challenges. This can very quickly fill up etcd and cause memory usage to explode.

This PR truncates the `presentedKey` (the challenge response) for the composed error message that eventually makes it's way to the `Challenge.status.reason`. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

The limit for truncation was chosen somewhat arbitrarily as the length of the key it's comparing to. Do you have an opinion on what this limit should be?

Opening with the basic idea for the proposal / discussion, will refine and add tests after that.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
