### PR TITLE
Add Prometheus metrics for Certificate ready status

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -585,6 +585,8 @@ func generateLocallySignedTemporaryCertificate(crt *v1alpha1.Certificate, pk []b
 }
 
 func (c *controller) updateCertificateStatus(ctx context.Context, old, new *v1alpha1.Certificate) (*v1alpha1.Certificate, error) {
+	defer c.metrics.UpdateCertificateStatus(new)
+
 	log := logf.FromContext(ctx, "updateStatus")
 	oldBytes, _ := json.Marshal(old.Status)
 	newBytes, _ := json.Marshal(new.Status)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -71,7 +71,7 @@ var CertificateReadyStatus = prometheus.NewGaugeVec(
 	prometheus.GaugeOpts{
 		Namespace: namespace,
 		Name:      "certificate_ready_status",
-		Help:      "The ready status of the Certificate.",
+		Help:      "The ready status of the certificate.",
 	},
 	[]string{"name", "namespace", "condition"},
 )
@@ -257,7 +257,6 @@ func (m *Metrics) UpdateCertificateStatus(crt *v1alpha1.Certificate) {
 }
 
 func updateCertificateReadyStatus(crt *v1alpha1.Certificate, current v1alpha1.ConditionStatus) {
-
 	key, err := cache.DeletionHandlingMetaNamespaceKeyFunc(crt)
 	if err != nil {
 		return


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds metrics to track the ready status of certificates.
Built over/modified from @seleznev's patch.

Also refactors the clean up to use a cleanUpFunctions slice.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1679 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Prometheus metrics for tracking Certificate readiness
```
