### PR TITLE
Removing use of kubectl --show-all in docs

### DIFF
--- a/docs/getting-started/troubleshooting.rst
+++ b/docs/getting-started/troubleshooting.rst
@@ -98,8 +98,7 @@ the state of the pods that have been deployed:
 
 .. code-block:: shell
 
-   # Get all pods, including Completed and Errored pods
-   kubectl get pods --show-all --namespace cert-manager
+   kubectl get pods --namespace cert-manager
 
    NAME                                            READY   STATUS      RESTARTS   AGE
    cert-manager-7cbdc48784-rpgnt                   1/1     Running     0          3m


### PR DESCRIPTION
**What this PR does / why we need it**:
_--show-all_ has been deprecated in kubernetes v1.15, docs are stale.

**Which issue this PR fixes**:
fixes #1814

**Special notes for your reviewer**:
As there is no alternative for _--show-all_ I went with a less-is-more approach and deleted both the flag and the comment.

**Release note**:
None needed, this only updated the docs. No code changes.
