### PR TITLE
Add validation for CommonName and DNSNames length

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -79,7 +79,9 @@ spec:
               description: CommonName is a common name to be used on the Certificate.
                 If no CommonName is given, then the first entry in DNSNames is used
                 as the CommonName. The CommonName should have a length shorter than
-                64 bytes to avoid generating invalid CSRs.
+                64 bytes to avoid generating invalid CSRs; in order to have longer
+                domain names, set the CommonName (or first DNSNames entry) to have
+                less than 64 bytes, and then add the longer domain name to DNSNames.
               type: string
             dnsNames:
               description: DNSNames is a list of subject alt names to be used on the

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -78,16 +78,16 @@ spec:
             commonName:
               description: CommonName is a common name to be used on the Certificate.
                 If no CommonName is given, then the first entry in DNSNames is used
-                as the CommonName. The CommonName should have a length shorter than
-                64 bytes to avoid generating invalid CSRs; in order to have longer
+                as the CommonName. The CommonName should have a length of 64 characters
+                or fewer to avoid generating invalid CSRs; in order to have longer
                 domain names, set the CommonName (or first DNSNames entry) to have
-                less than 64 bytes, and then add the longer domain name to DNSNames.
+                64 characters or fewer, and then add the longer domain name to DNSNames.
               type: string
             dnsNames:
               description: DNSNames is a list of subject alt names to be used on the
                 Certificate. If no CommonName is given, then the first entry in DNSNames
-                is used as the CommonName - any requirements for the CommonName would
-                then also apply to this first entry.
+                is used as the CommonName and must have a length of 64 characters
+                or fewer.
               items:
                 type: string
               type: array

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -76,11 +76,16 @@ spec:
               - config
               type: object
             commonName:
-              description: CommonName is a common name to be used on the Certificate
+              description: CommonName is a common name to be used on the Certificate.
+                If no CommonName is given, then the first entry in DNSNames is used
+                as the CommonName. The CommonName should have a length shorter than
+                64 bytes to avoid generating invalid CSRs.
               type: string
             dnsNames:
               description: DNSNames is a list of subject alt names to be used on the
-                Certificate
+                Certificate. If no CommonName is given, then the first entry in DNSNames
+                is used as the CommonName - any requirements for the CommonName would
+                then also apply to this first entry.
               items:
                 type: string
               type: array

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -85,11 +85,11 @@ Appears In:
 </tr>
 <tr>
 <td><code>commonName</code><br /> <em>string</em></td>
-<td>CommonName is a common name to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName. The CommonName should have a length shorter than 64 bytes to avoid generating invalid CSRs; in order to have longer domain names, set the CommonName (or first DNSNames entry) to have less than 64 bytes, and then add the longer domain name to DNSNames.</td>
+<td>CommonName is a common name to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName. The CommonName should have a length of 64 characters or fewer to avoid generating invalid CSRs; in order to have longer domain names, set the CommonName (or first DNSNames entry) to have 64 characters or fewer, and then add the longer domain name to DNSNames.</td>
 </tr>
 <tr>
 <td><code>dnsNames</code><br /> <em>string array</em></td>
-<td>DNSNames is a list of subject alt names to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName - any requirements for the CommonName would then also apply to this first entry.</td>
+<td>DNSNames is a list of subject alt names to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName and must have a length of 64 characters or fewer.</td>
 </tr>
 <tr>
 <td><code>duration</code><br /> *<a href="#duration-v1">Duration</a>*</td>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -85,11 +85,11 @@ Appears In:
 </tr>
 <tr>
 <td><code>commonName</code><br /> <em>string</em></td>
-<td>CommonName is a common name to be used on the Certificate</td>
+<td>CommonName is a common name to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName. The CommonName should have a length shorter than 64 bytes to avoid generating invalid CSRs.</td>
 </tr>
 <tr>
 <td><code>dnsNames</code><br /> <em>string array</em></td>
-<td>DNSNames is a list of subject alt names to be used on the Certificate</td>
+<td>DNSNames is a list of subject alt names to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName - any requirements for the CommonName would then also apply to this first entry.</td>
 </tr>
 <tr>
 <td><code>duration</code><br /> *<a href="#duration-v1">Duration</a>*</td>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -85,7 +85,7 @@ Appears In:
 </tr>
 <tr>
 <td><code>commonName</code><br /> <em>string</em></td>
-<td>CommonName is a common name to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName. The CommonName should have a length shorter than 64 bytes to avoid generating invalid CSRs.</td>
+<td>CommonName is a common name to be used on the Certificate. If no CommonName is given, then the first entry in DNSNames is used as the CommonName. The CommonName should have a length shorter than 64 bytes to avoid generating invalid CSRs; in order to have longer domain names, set the CommonName (or first DNSNames entry) to have less than 64 bytes, and then add the longer domain name to DNSNames.</td>
 </tr>
 <tr>
 <td><code>dnsNames</code><br /> <em>string array</em></td>

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -66,10 +66,10 @@ type CertificateSpec struct {
 	// CommonName is a common name to be used on the Certificate.
 	// If no CommonName is given, then the first entry in DNSNames is used as
 	// the CommonName.
-	// The CommonName should have a length shorter than 64 bytes to avoid
+	// The CommonName should have a length of 64 characters or fewer to avoid
 	// generating invalid CSRs; in order to have longer domain names, set the
-	// CommonName (or first DNSNames entry) to have less than 64 bytes, and
-	// then add the longer domain name to DNSNames.
+	// CommonName (or first DNSNames entry) to have 64 characters or fewer,
+	// and then add the longer domain name to DNSNames.
 	// +optional
 	CommonName string `json:"commonName,omitempty"`
 
@@ -87,8 +87,7 @@ type CertificateSpec struct {
 
 	// DNSNames is a list of subject alt names to be used on the Certificate.
 	// If no CommonName is given, then the first entry in DNSNames is used as
-	// the CommonName - any requirements for the CommonName would then also
-	// apply to this first entry.
+	// the CommonName and must have a length of 64 characters or fewer.
 	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -63,7 +63,11 @@ const (
 
 // CertificateSpec defines the desired state of Certificate
 type CertificateSpec struct {
-	// CommonName is a common name to be used on the Certificate
+	// CommonName is a common name to be used on the Certificate.
+	// If no CommonName is given, then the first entry in DNSNames is used as
+	// the CommonName.
+	// The CommonName should have a length shorter than 64 bytes to avoid
+	// generating invalid CSRs.
 	// +optional
 	CommonName string `json:"commonName,omitempty"`
 
@@ -79,7 +83,10 @@ type CertificateSpec struct {
 	// +optional
 	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
 
-	// DNSNames is a list of subject alt names to be used on the Certificate
+	// DNSNames is a list of subject alt names to be used on the Certificate.
+	// If no CommonName is given, then the first entry in DNSNames is used as
+	// the CommonName - any requirements for the CommonName would then also
+	// apply to this first entry.
 	// +optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -67,7 +67,9 @@ type CertificateSpec struct {
 	// If no CommonName is given, then the first entry in DNSNames is used as
 	// the CommonName.
 	// The CommonName should have a length shorter than 64 bytes to avoid
-	// generating invalid CSRs.
+	// generating invalid CSRs; in order to have longer domain names, set the
+	// CommonName (or first DNSNames entry) to have less than 64 bytes, and
+	// then add the longer domain name to DNSNames.
 	// +optional
 	CommonName string `json:"commonName,omitempty"`
 

--- a/pkg/apis/certmanager/validation/certificate.go
+++ b/pkg/apis/certmanager/validation/certificate.go
@@ -50,14 +50,14 @@ func ValidateCertificateSpec(crt *v1alpha1.CertificateSpec, fldPath *field.Path)
 	if len(crt.CommonName) == 0 && len(crt.DNSNames) == 0 {
 		el = append(el, field.Required(fldPath.Child("dnsNames"), "at least one dnsName is required if commonName is not set"))
 	}
-	// if a common name has been specified, ensure it is no longer than 63 chars
-	if len(crt.CommonName) > 63 {
-		el = append(el, field.TooLong(fldPath.Child("commonName"), crt.CommonName, 63))
+	// if a common name has been specified, ensure it is no longer than 64 chars
+	if len(crt.CommonName) > 64 {
+		el = append(el, field.TooLong(fldPath.Child("commonName"), crt.CommonName, 64))
 	}
-	// if the common name has *not* been specified, ensure the first dnsName is no longer than 63 chars
+	// if the common name has *not* been specified, ensure the first dnsName is no longer than 64 chars
 	// as it will be used as the commonName
-	if crt.CommonName == "" && len(crt.DNSNames) > 0 && len(crt.DNSNames[0]) > 63 {
-		el = append(el, field.TooLong(fldPath.Child("dnsNames").Index(0), crt.DNSNames[0], 63))
+	if crt.CommonName == "" && len(crt.DNSNames) > 0 && len(crt.DNSNames[0]) > 64 {
+		el = append(el, field.TooLong(fldPath.Child("dnsNames").Index(0), crt.DNSNames[0], 64))
 	}
 
 	if len(crt.IPAddresses) > 0 {

--- a/pkg/apis/certmanager/validation/certificate.go
+++ b/pkg/apis/certmanager/validation/certificate.go
@@ -49,14 +49,14 @@ func ValidateCertificateSpec(crt *v1alpha1.CertificateSpec, fldPath *field.Path)
 	}
 	if len(crt.CommonName) == 0 && len(crt.DNSNames) == 0 {
 		el = append(el, field.Required(fldPath.Child("dnsNames"), "at least one dnsName is required if commonName is not set"))
-	} else if crt.CommonName != "" {
-		// if we have a commonName, check it is below 64 bytes long
-		if len(crt.CommonName) > 63 {
-			el = append(el, field.TooLong(fldPath.Child("commonName"), crt.CommonName, 63))
-		}
-	} else if len(crt.DNSNames[0]) > 63 {
-		// if we do not have a commonName, check that the first dnsName (used
-		// as the commonName) is below 64 bytes long
+	}
+	// if a common name has been specified, ensure it is no longer than 63 chars
+	if len(crt.CommonName) > 63 {
+		el = append(el, field.TooLong(fldPath.Child("commonName"), crt.CommonName, 63))
+	}
+	// if the common name has *not* been specified, ensure the first dnsName is no longer than 63 chars
+	// as it will be used as the commonName
+	if crt.CommonName == "" && len(crt.DNSNames) > 0 && len(crt.DNSNames[0]) > 63 {
 		el = append(el, field.TooLong(fldPath.Child("dnsNames").Index(0), crt.DNSNames[0], 63))
 	}
 

--- a/pkg/apis/certmanager/validation/certificate_test.go
+++ b/pkg/apis/certmanager/validation/certificate_test.go
@@ -395,53 +395,63 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("ipAddresses").Index(0), "blah", "invalid IP address"),
 			},
 		},
-		"invalid certificate with commonName longer than 63 bytes": {
+		"valid certificate with commonName exactly 64 bytes": {
 			cfg: &v1alpha1.Certificate{
 				Spec: v1alpha1.CertificateSpec{
-					CommonName: "this-is-a-certificate-common-name-which-is-longer-than-sixty-three-bytes",
+					CommonName: "this-is-a-big-long-string-which-is-exactly-sixty-four-characters",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+				},
+			},
+			errs: []*field.Error{},
+		},
+		"invalid certificate with commonName longer than 64 bytes": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "this-is-a-big-long-string-which-has-exactly-sixty-five-characters",
 					SecretName: "abc",
 					IssuerRef:  validIssuerRef,
 				},
 			},
 			errs: []*field.Error{
-				field.TooLong(fldPath.Child("commonName"), "this-is-a-certificate-common-name-which-is-longer-than-sixty-three-bytes", 63),
+				field.TooLong(fldPath.Child("commonName"), "this-is-a-big-long-string-which-has-exactly-sixty-five-characters", 64),
 			},
 		},
-		"invalid certificate with no commonName and first dnsName longer than 63 bytes": {
+		"invalid certificate with no commonName and first dnsName longer than 64 bytes": {
 			cfg: &v1alpha1.Certificate{
 				Spec: v1alpha1.CertificateSpec{
 					SecretName: "abc",
 					IssuerRef:  validIssuerRef,
 					DNSNames: []string{
-						"this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes",
+						"this-is-a-big-long-string-which-has-exactly-sixty-five-characters",
 						"dnsName",
 					},
 				},
 			},
 			errs: []*field.Error{
-				field.TooLong(fldPath.Child("dnsNames").Index(0), "this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes", 63),
+				field.TooLong(fldPath.Child("dnsNames").Index(0), "this-is-a-big-long-string-which-has-exactly-sixty-five-characters", 64),
 			},
 		},
-		"valid certificate with no commonName and second dnsName longer than 63 bytes": {
+		"valid certificate with no commonName and second dnsName longer than 64 bytes": {
 			cfg: &v1alpha1.Certificate{
 				Spec: v1alpha1.CertificateSpec{
 					SecretName: "abc",
 					IssuerRef:  validIssuerRef,
 					DNSNames: []string{
 						"dnsName",
-						"this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes",
+						"this-is-a-big-long-string-which-has-exactly-sixty-five-characters",
 					},
 				},
 			},
 		},
-		"valid certificate with commonName and first dnsName longer than 63 bytes": {
+		"valid certificate with commonName and first dnsName longer than 64 bytes": {
 			cfg: &v1alpha1.Certificate{
 				Spec: v1alpha1.CertificateSpec{
 					CommonName: "testcn",
 					SecretName: "abc",
 					IssuerRef:  validIssuerRef,
 					DNSNames: []string{
-						"this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes",
+						"this-is-a-big-long-string-which-has-exactly-sixty-five-characters",
 						"dnsName",
 					},
 				},

--- a/pkg/apis/certmanager/validation/certificate_test.go
+++ b/pkg/apis/certmanager/validation/certificate_test.go
@@ -395,6 +395,58 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("ipAddresses").Index(0), "blah", "invalid IP address"),
 			},
 		},
+		"invalid certificate with commonName longer than 63 bytes": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "this-is-a-certificate-common-name-which-is-longer-than-sixty-three-bytes",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+				},
+			},
+			errs: []*field.Error{
+				field.TooLong(fldPath.Child("commonName"), "this-is-a-certificate-common-name-which-is-longer-than-sixty-three-bytes", 63),
+			},
+		},
+		"invalid certificate with no commonName and first dnsName longer than 63 bytes": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					DNSNames: []string{
+						"this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes",
+						"dnsName",
+					},
+				},
+			},
+			errs: []*field.Error{
+				field.TooLong(fldPath.Child("dnsNames").Index(0), "this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes", 63),
+			},
+		},
+		"valid certificate with no commonName and second dnsName longer than 63 bytes": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					DNSNames: []string{
+						"dnsName",
+						"this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes",
+					},
+				},
+			},
+		},
+		"valid certificate with commonName and first dnsName longer than 63 bytes": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					DNSNames: []string{
+						"this-is-a-certificate-dns-name-which-is-longer-than-sixty-three-bytes",
+						"dnsName",
+					},
+				},
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -136,7 +136,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01) (Old format)", 
 		// the maximum length of a single segment of the domain being requested
 		const maxLengthOfDomainSegment = 63
 		By("Creating a Certificate")
-		_, err := certClient.Create(util.NewCertManagerACMECertificateOldFormat(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, nil, nil, acmeIngressClass, fmt.Sprintf("%s.%s", cmutil.RandStringRunes(maxLengthOfDomainSegment), acmeIngressDomain)))
+		_, err := certClient.Create(util.NewCertManagerACMECertificateOldFormat(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, nil, nil, acmeIngressClass, acmeIngressDomain, fmt.Sprintf("%s.%s", cmutil.RandStringRunes(maxLengthOfDomainSegment), acmeIngressDomain)))
 		Expect(err).NotTo(HaveOccurred())
 		err = h.WaitCertificateIssuedValid(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/issuers/acme/certificate/http01_new.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01_new.go
@@ -190,7 +190,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 			Namespace:  f.Namespace.Name,
 			SecretName: certificateSecretName,
 			IssuerName: issuerName,
-			DNSNames:   []string{fmt.Sprintf("%s.%s", cmutil.RandStringRunes(maxLengthOfDomainSegment), acmeIngressDomain)},
+			DNSNames:   []string{acmeIngressDomain, fmt.Sprintf("%s.%s", cmutil.RandStringRunes(maxLengthOfDomainSegment), acmeIngressDomain)},
 		})
 		_, err := certClient.Create(cert)
 		Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds checks to the validation webhook to ensure that CommonName length is below 64 bytes, or that the first entry in DNSNames (if CommonName is empty) is below 64 bytes.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1812 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Limit length for CommonName to 63 bytes
```
