### PR TITLE
Remove use of klog from more places

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -121,7 +121,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 	c.acmeHelper = acme.NewHelper(c.secretLister, ctx.ClusterResourceNamespace)
-	c.scheduler = scheduler.New(c.challengeLister, ctx.SchedulerOptions.MaxConcurrentChallenges)
+	c.scheduler = scheduler.New(logf.NewContext(ctx.RootContext, c.log), c.challengeLister, ctx.SchedulerOptions.MaxConcurrentChallenges)
 	c.recorder = ctx.Recorder
 	c.cmClient = ctx.CMClient
 	c.httpSolver = http.NewSolver(ctx)

--- a/pkg/controller/acmechallenges/scheduler/BUILD.bazel
+++ b/pkg/controller/acmechallenges/scheduler/BUILD.bazel
@@ -9,8 +9,9 @@ go_library(
         "//pkg/acme:go_default_library",
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/client/listers/certmanager/v1alpha1:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"testing"
@@ -307,7 +308,7 @@ func TestScheduleN(t *testing.T) {
 				challengesInformer.Informer().GetIndexer().Add(ch)
 			}
 
-			s := New(challengesInformer.Lister(), maxConcurrentChallenges)
+			s := New(context.Background(), challengesInformer.Lister(), maxConcurrentChallenges)
 
 			if test.expected == nil {
 				test.expected = []*cmapi.Challenge{}

--- a/pkg/controller/acmeorders/BUILD.bazel
+++ b/pkg/controller/acmeorders/BUILD.bazel
@@ -33,7 +33,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
         "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -75,14 +75,14 @@ type controller struct {
 	// a certificate currently requires renewal.
 	// This is a field on the controller struct to avoid having to maintain a reference
 	// to the controller context, and to make it easier to fake out this call during tests.
-	certificateNeedsRenew func(cert *x509.Certificate, crt *v1alpha1.Certificate) bool
+	certificateNeedsRenew func(ctx context.Context, cert *x509.Certificate, crt *v1alpha1.Certificate) bool
 
 	// calculateDurationUntilRenew returns the amount of time before the controller should
 	// begin attempting to renew the certificate, given the provided existing certificate
 	// and certificate spec.
 	// This is a field on the controller struct to avoid having to maintain a reference
 	// to the controller context, and to make it easier to fake out this call during tests.
-	calculateDurationUntilRenew func(cert *x509.Certificate, crt *v1alpha1.Certificate) time.Duration
+	calculateDurationUntilRenew func(ctx context.Context, cert *x509.Certificate, crt *v1alpha1.Certificate) time.Duration
 
 	// if addOwnerReferences is enabled then the controller will add owner references
 	// to the secret resources it creates

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -186,7 +186,7 @@ func (c *controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 	}
 
 	// check if the certificate needs renewal
-	needsRenew := c.certificateNeedsRenew(cert, crt)
+	needsRenew := c.certificateNeedsRenew(ctx, cert, crt)
 	if needsRenew {
 		dbg.Info("invoking issue function due to certificate needing renewal")
 		return c.issue(ctx, i, crtCopy)
@@ -312,7 +312,7 @@ func (c *controller) scheduleRenewal(ctx context.Context, crt *v1alpha1.Certific
 		return
 	}
 
-	renewIn := c.calculateDurationUntilRenew(cert, crt)
+	renewIn := c.calculateDurationUntilRenew(ctx, cert, crt)
 	c.scheduledWorkQueue.Add(key, renewIn)
 
 	log.WithValues("duration_until_renewal", renewIn.String()).Info("certificate scheduled for renewal")

--- a/pkg/controller/helper_test.go
+++ b/pkg/controller/helper_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package controller
 
 import (
+	"context"
 	"crypto/x509"
 	"testing"
 	"time"
@@ -107,7 +108,7 @@ func TestCalculateDurationUntilRenew(t *testing.T) {
 			},
 		}
 		x509Cert := &x509.Certificate{NotBefore: v.notBefore, NotAfter: v.notAfter}
-		duration := c.CalculateDurationUntilRenew(x509Cert, cert)
+		duration := c.CalculateDurationUntilRenew(context.Background(), x509Cert, cert)
 		if duration != v.expectedExpiry {
 			t.Errorf("test # %d - %s: got %v, expected %v", k, v.desc, duration, v.expectedExpiry)
 		}

--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -31,7 +31,6 @@ go_library(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/issuer/acme/dns/BUILD.bazel
+++ b/pkg/issuer/acme/dns/BUILD.bazel
@@ -20,10 +20,10 @@ go_library(
         "//pkg/issuer/acme/dns/route53:go_default_library",
         "//pkg/issuer/acme/dns/util:go_default_library",
         "//pkg/issuer/acme/dns/webhook:go_default_library",
+        "//pkg/logs:go_default_library",
         "//vendor/github.com/pkg/errors:go_default_library",
         "//vendor/k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
-        "//vendor/k8s.io/klog:go_default_library",
     ],
 )
 

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package dns
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
@@ -191,7 +192,7 @@ func TestSolverFor(t *testing.T) {
 			test.Setup(t)
 			defer test.Finish(t)
 			s := test.Solver
-			dnsSolver, _, err := s.solverForChallenge(test.Issuer, test.Challenge)
+			dnsSolver, _, err := s.solverForChallenge(context.Background(), test.Issuer, test.Challenge)
 			if err != nil && !test.expectErr {
 				t.Errorf("expected solverFor to not error, but got: %s", err.Error())
 				return
@@ -241,7 +242,7 @@ func TestSolveForDigitalOcean(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -294,7 +295,7 @@ func TestRoute53TrimCreds(t *testing.T) {
 	defer f.Finish(t)
 
 	s := f.Solver
-	_, _, err := s.solverForChallenge(f.Issuer, f.Challenge)
+	_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
 	if err != nil {
 		t.Fatalf("expected solverFor to not error, but got: %s", err)
 	}
@@ -388,7 +389,7 @@ func TestRoute53AmbientCreds(t *testing.T) {
 		f.Setup(t)
 		defer f.Finish(t)
 		s := f.Solver
-		_, _, err := s.solverForChallenge(f.Issuer, f.Challenge)
+		_, _, err := s.solverForChallenge(context.Background(), f.Issuer, f.Challenge)
 		if !reflect.DeepEqual(tt.out.expectedErr, err) {
 			t.Fatalf("expected error %v, got error %v", tt.out.expectedErr, err)
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

This continues work to remove references to klog from our codebase. There are now no direct references in the whole of `pkg/controller` 😄 🎉

**Release note**:
```release-note
NONE
```
