### PR TITLE
Adds Sign function to CA issuer

### DIFF
--- a/pkg/issuer/ca/BUILD.bazel
+++ b/pkg/issuer/ca/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "issue_test.go",
+        "sign_test.go",
         "util_test.go",
     ],
     embed = [":go_default_library"],

--- a/pkg/issuer/ca/issue.go
+++ b/pkg/issuer/ca/issue.go
@@ -18,8 +18,6 @@ package ca
 
 import (
 	"context"
-	"crypto"
-	"crypto/x509"
 
 	corev1 "k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -94,7 +92,7 @@ func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) (*issuer.Issu
 
 	template.PublicKey = signeePublicKey
 
-	resp, err := c.signTemplate(caCerts, caKey, template)
+	resp, err := pki.SignCSRTemplate(caCerts, caKey, template)
 	if err != nil {
 		log.Error(err, "error signing certificate")
 		c.Recorder.Eventf(crt, corev1.EventTypeWarning, "ErrorSigning", "Error signing certificate: %v", err)
@@ -112,32 +110,4 @@ func (c *CA) Issue(ctx context.Context, crt *v1alpha1.Certificate) (*issuer.Issu
 	log.Info("certificate issued")
 
 	return resp, nil
-}
-
-func (c *CA) signTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template *x509.Certificate) (*issuer.IssueResponse, error) {
-	caCert := caCerts[0]
-
-	certPem, _, err := pki.SignCertificate(template, caCert, template.PublicKey, caKey)
-	if err != nil {
-		return nil, err
-
-	}
-
-	chainPem, err := pki.EncodeX509Chain(caCerts)
-	if err != nil {
-		return nil, err
-	}
-
-	certPem = append(certPem, chainPem...)
-
-	// encode the CA certificate to be bundled in the output
-	caPem, err := pki.EncodeX509(caCerts[0])
-	if err != nil {
-		return nil, err
-	}
-
-	return &issuer.IssueResponse{
-		Certificate: certPem,
-		CA:          caPem,
-	}, nil
 }

--- a/pkg/issuer/ca/issue_test.go
+++ b/pkg/issuer/ca/issue_test.go
@@ -95,6 +95,11 @@ func noPrivateKeyFieldsSetCheck(expectedCA []byte) func(t *testing.T, s *caFixtu
 	return func(t *testing.T, s *caFixture, args ...interface{}) {
 		resp := args[1].(*issuer.IssueResponse)
 
+		if resp == nil {
+			t.Errorf("no response given, got=%s", resp)
+			return
+		}
+
 		if len(resp.PrivateKey) > 0 {
 			t.Errorf("expected no new private key to be generated but got: %s",
 				resp.PrivateKey)

--- a/pkg/issuer/ca/issue_test.go
+++ b/pkg/issuer/ca/issue_test.go
@@ -86,6 +86,28 @@ func allFieldsSetCheck(expectedCA []byte) func(t *testing.T, s *caFixture, args 
 		if resp.PrivateKey == nil {
 			t.Errorf("expected new private key to be generated")
 		}
+
+		certificatesFieldsSetCheck(expectedCA)(t, s, args...)
+	}
+}
+
+func noPrivateKeyFieldsSetCheck(expectedCA []byte) func(t *testing.T, s *caFixture, args ...interface{}) {
+	return func(t *testing.T, s *caFixture, args ...interface{}) {
+		resp := args[1].(*issuer.IssueResponse)
+
+		if len(resp.PrivateKey) > 0 {
+			t.Errorf("expected no new private key to be generated but got: %s",
+				resp.PrivateKey)
+		}
+
+		certificatesFieldsSetCheck(expectedCA)(t, s, args...)
+	}
+}
+
+func certificatesFieldsSetCheck(expectedCA []byte) func(t *testing.T, s *caFixture, args ...interface{}) {
+	return func(t *testing.T, s *caFixture, args ...interface{}) {
+		resp := args[1].(*issuer.IssueResponse)
+
 		if resp.Certificate == nil {
 			t.Errorf("expected new certificate to be issued")
 		}

--- a/pkg/issuer/ca/sign.go
+++ b/pkg/issuer/ca/sign.go
@@ -36,6 +36,10 @@ func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer
 	if err != nil {
 		log := logf.WithRelatedResourceName(log, c.issuer.GetSpec().CA.SecretName, c.resourceNamespace, "Secret")
 		log.Info("error getting signing CA for Issuer")
+
+		// We're fine to return errors here and later since upon a retry the issuer
+		// will be marked as 'not ready' - therefore this codepath wont be reached
+		// again
 		return nil, err
 	}
 

--- a/pkg/issuer/ca/sign.go
+++ b/pkg/issuer/ca/sign.go
@@ -46,7 +46,7 @@ func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest) (*issuer
 		return nil, err
 	}
 
-	resp, err := c.signTemplate(caCerts, caKey, template)
+	resp, err := pki.SignCSRTemplate(caCerts, caKey, template)
 	if err != nil {
 		log.Error(err, "error signing certificate")
 		c.Recorder.Eventf(cr, corev1.EventTypeWarning, "ErrorSigning", "Error signing certificate: %v", err)

--- a/pkg/issuer/ca/sign_test.go
+++ b/pkg/issuer/ca/sign_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+func generateCSR(t *testing.T, secretKey crypto.Signer) ([]byte, error) {
+	asn1Subj, _ := asn1.Marshal(pkix.Name{
+		CommonName: "test",
+	}.ToRDNSequence())
+	template := x509.CertificateRequest{
+		RawSubject:         asn1Subj,
+		SignatureAlgorithm: x509.SHA256WithRSA,
+	}
+
+	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, secretKey)
+	if err != nil {
+		return nil, err
+	}
+
+	csr := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
+
+	return csr, nil
+}
+
+func generateSelfSignedCertFromCR(t *testing.T, cr *v1alpha1.CertificateRequest, key crypto.Signer,
+	duration time.Duration) (derBytes, pemBytes []byte) {
+	template, err := pki.GenerateTemplateFromCertificateRequest(cr)
+	if err != nil {
+		t.Errorf("error generating template: %v", err)
+	}
+
+	derBytes, err = x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	if err != nil {
+		t.Errorf("error signing cert: %v", err)
+		t.FailNow()
+	}
+
+	pemByteBuffer := bytes.NewBuffer([]byte{})
+	err = pem.Encode(pemByteBuffer, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
+	if err != nil {
+		t.Errorf("failed to encode cert: %v", err)
+		t.FailNow()
+	}
+
+	return derBytes, pemByteBuffer.Bytes()
+}
+
+func TestSign(t *testing.T) {
+	// Build root RSA CA
+	rsaPK := generateRSAPrivateKey(t)
+	rsaPKBytes := pki.EncodePKCS1PrivateKey(rsaPK)
+
+	caCSR, err := generateCSR(t, rsaPK)
+	if err != nil {
+		t.Errorf("failed to generate CA CSR: %s", err)
+		t.FailNow()
+	}
+
+	rootRSACR := gen.CertificateRequest("test-root-ca",
+		gen.SetCertificateRequestCSR(caCSR),
+		gen.SetCertificateRequestIsCA(true),
+		gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour * 24 * 60}),
+	)
+
+	// generate a self signed root ca valid for 60d
+	_, rsaPEMCert := generateSelfSignedCertFromCR(t, rootRSACR, rsaPK, time.Hour*24*60)
+	rootRSACASecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "root-ca-secret",
+			Namespace: gen.DefaultTestNamespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: rsaPKBytes,
+			corev1.TLSCertKey:       rsaPEMCert,
+		},
+	}
+
+	tests := map[string]caFixture{
+		"sign a CertificateRequest": {
+			Issuer: gen.Issuer("ca-issuer",
+				gen.SetIssuerCA(v1alpha1.CAIssuer{SecretName: "root-ca-secret"}),
+			),
+			CertificateRequest: gen.CertificateRequest("test-cr",
+				gen.SetCertificateRequestIsCA(true),
+				gen.SetCertificateRequestCSR(caCSR),
+			),
+			Builder: &testpkg.Builder{
+				KubeObjects:        []runtime.Object{rootRSACASecret},
+				CertManagerObjects: []runtime.Object{},
+			},
+			// we are not expecting key on response
+			CheckFn: noPrivateKeyFieldsSetCheck(rsaPEMCert),
+			Err:     false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if test.Builder == nil {
+				test.Builder = &testpkg.Builder{}
+			}
+			test.Setup(t)
+			crCopy := test.CertificateRequest.DeepCopy()
+			resp, err := test.CA.Sign(test.Ctx, crCopy)
+			if err != nil && !test.Err {
+				t.Errorf("Expected function to not error, but got: %v", err)
+			}
+			if err == nil && test.Err {
+				t.Errorf("Expected function to get an error, but got: %v", err)
+			}
+			test.Finish(t, crCopy, resp, err)
+		})
+	}
+}

--- a/pkg/issuer/ca/util_test.go
+++ b/pkg/issuer/ca/util_test.go
@@ -33,8 +33,9 @@ type caFixture struct {
 	CA *CA
 	*test.Builder
 
-	Issuer      v1alpha1.GenericIssuer
-	Certificate *v1alpha1.Certificate
+	Issuer             v1alpha1.GenericIssuer
+	Certificate        *v1alpha1.Certificate
+	CertificateRequest *v1alpha1.CertificateRequest
 
 	PreFn   func(*testing.T, *caFixture)
 	CheckFn func(*testing.T, *caFixture, ...interface{})

--- a/pkg/util/pki/BUILD.bazel
+++ b/pkg/util/pki/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/issuer:go_default_library",
         "//pkg/util/errors:go_default_library",
     ],
 )

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -23,6 +23,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"math/big"
 	"net"
@@ -271,7 +272,14 @@ func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, p
 	return pemBytes.Bytes(), cert, err
 }
 
+// SignCSRTemplate signs a certificate template usually based upon a CSR. This
+// function expects all fields to be present in the certificate template,
+// including it's public key.
 func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template *x509.Certificate) (*issuer.IssueResponse, error) {
+	if len(caCerts) == 0 {
+		return nil, errors.New("no CA certificates given to sign CSR template")
+	}
+
 	caCert := caCerts[0]
 
 	certPem, _, err := SignCertificate(template, caCert, template.PublicKey, caKey)

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -230,7 +230,7 @@ func GenerateTemplateFromCertificateRequest(cr *v1alpha1.CertificateRequest) (*x
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    csr.PublicKeyAlgorithm,
 		PublicKey:             csr.PublicKey,
-		IsCA:                  false,
+		IsCA:                  cr.Spec.IsCA,
 		Subject:               csr.Subject,
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(certDuration),

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -194,6 +194,55 @@ func GenerateTemplate(crt *v1alpha1.Certificate) (*x509.Certificate, error) {
 	}, nil
 }
 
+// GenerateTemplate will create a x509.Certificate for the given
+// CertificateRequest resource
+func GenerateTemplateFromCertificateRequest(cr *v1alpha1.CertificateRequest) (*x509.Certificate, error) {
+	block, _ := pem.Decode(cr.Spec.CSRPEM)
+	if block == nil {
+		return nil, fmt.Errorf("failed to decode csr from certificate request resource %s/%s",
+			cr.Namespace, cr.Name)
+	}
+
+	csr, err := x509.ParseCertificateRequest(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := csr.CheckSignature(); err != nil {
+		return nil, err
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate serial number: %s", err.Error())
+	}
+
+	certDuration := v1alpha1.DefaultCertificateDuration
+	if cr.Spec.Duration != nil {
+		certDuration = cr.Spec.Duration.Duration
+	}
+
+	keyUsages := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+
+	return &x509.Certificate{
+		Version:               csr.Version,
+		BasicConstraintsValid: true,
+		SerialNumber:          serialNumber,
+		PublicKeyAlgorithm:    csr.PublicKeyAlgorithm,
+		PublicKey:             csr.PublicKey,
+		IsCA:                  false,
+		Subject:               csr.Subject,
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(certDuration),
+		// see http://golang.org/pkg/crypto/x509/#KeyUsage
+		KeyUsage:    keyUsages,
+		DNSNames:    csr.DNSNames,
+		IPAddresses: csr.IPAddresses,
+		URIs:        csr.URIs,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}, nil
+}
+
 // SignCertificate returns a signed x509.Certificate object for the given
 // *v1alpha1.Certificate crt.
 // publicKey is the public key of the signee, and signerKey is the private

--- a/test/unit/gen/BUILD.bazel
+++ b/test/unit/gen/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "certificate.go",
+        "certificaterequest.go",
         "challenge.go",
         "doc.go",
         "issuer.go",

--- a/test/unit/gen/certificaterequest.go
+++ b/test/unit/gen/certificaterequest.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+type CertificateRequestModifier func(*v1alpha1.CertificateRequest)
+
+func CertificateRequest(name string, mods ...CertificateRequestModifier) *v1alpha1.CertificateRequest {
+	c := &v1alpha1.CertificateRequest{
+		ObjectMeta: ObjectMeta(name),
+	}
+	for _, mod := range mods {
+		mod(c)
+	}
+	return c
+}
+
+func CertificateRequestFrom(cr *v1alpha1.CertificateRequest, mods ...CertificateRequestModifier) *v1alpha1.CertificateRequest {
+	cr = cr.DeepCopy()
+	for _, mod := range mods {
+		mod(cr)
+	}
+	return cr
+}
+
+// SetIssuer sets the CertificateRequest.spec.issuerRef field
+func SetCertificateRequestIssuer(o v1alpha1.ObjectReference) CertificateRequestModifier {
+	return func(c *v1alpha1.CertificateRequest) {
+		c.Spec.IssuerRef = o
+	}
+}
+
+func SetCertificateRequestCSR(csr []byte) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Spec.CSRPEM = csr
+	}
+}
+
+func SetCertificateRequestIsCA(isCA bool) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Spec.IsCA = isCA
+	}
+}
+
+func SetCertificateRequestDuration(duration *metav1.Duration) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Spec.Duration = duration
+	}
+}
+
+func SetCertificateRequestCA(ca []byte) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Status.CA = ca
+	}
+}
+
+func SetCertificateRequestCertificate(cert []byte) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Status.Certificate = cert
+	}
+}
+
+func SetCertificateRequestStatusCondition(c v1alpha1.CertificateRequestCondition) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		if len(cr.Status.Conditions) == 0 {
+			cr.Status.Conditions = []v1alpha1.CertificateRequestCondition{c}
+			return
+		}
+		for i, existingC := range cr.Status.Conditions {
+			if existingC.Type == c.Type {
+				cr.Status.Conditions[i] = c
+				return
+			}
+		}
+		cr.Status.Conditions = append(cr.Status.Conditions, c)
+	}
+}
+
+func SetCertificateRequestNamespace(namespace string) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.ObjectMeta.Namespace = namespace
+	}
+}


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

**What this PR does / why we need it**:
Adds `sign` functionality to the CA issuer.
Enables signing of CSRs using custom CA without generation or exposing of keys.

```release-note
Adds CSR signing to CA issuer
```
