### PR TITLE
Change bazel build to only build for current --platform

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,31 +1,19 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_bundle")
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
-load("//hack:def.bzl", "multiarch_bundle")
 
 # export WORKSPACE so workspace_binary rules can be used outside the root
 exports_files(["WORKSPACE"])
 
 # gazelle:proto disable_global
 
-# this target creates targets:
-# 'images' (all arch and os)
-# 'images.linux-amd64'
-# 'images.linux-arm64'
-# 'images.linux-arm'
-multiarch_bundle(
+container_bundle(
     name = "images",
-    arch = [
-        "amd64",
-        "arm64",
-        "arm",
-    ],
     images = {
-        "{STABLE_DOCKER_REPO}/cert-manager-controller-{arch}:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
-        "{STABLE_DOCKER_REPO}/cert-manager-acmesolver-{arch}:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
-        "{STABLE_DOCKER_REPO}/cert-manager-webhook-{arch}:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
-        "{STABLE_DOCKER_REPO}/cert-manager-cainjector-{arch}:{STABLE_DOCKER_TAG}": "//cmd/cainjector:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-controller:{STABLE_DOCKER_TAG}": "//cmd/controller:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//cmd/acmesolver:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-webhook:{STABLE_DOCKER_TAG}": "//cmd/webhook:image",
+        "{STABLE_DOCKER_REPO}/cert-manager-cainjector:{STABLE_DOCKER_TAG}": "//cmd/cainjector:image",
     },
-    os = ["linux"],
 )
 
 docker_push(

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,7 @@ images:
 	bazel run //hack/release -- \
 		--repo-root "$$(pwd)" \
 		--images \
+		--images.export=true \
 		--images.goarch="amd64" \
 		--app-version="$(APP_VERSION)" \
 		--docker-repo="$(DOCKER_REPO)"

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -3,8 +3,8 @@ load("//hack:def.bzl", "image")
 
 image(
     name = "image",
-    component = "acmesolver",
     binary = ":acmesolver",
+    component = "acmesolver",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -4,6 +4,7 @@ load("//hack:def.bzl", "image")
 image(
     name = "image",
     component = "acmesolver",
+    binary = ":acmesolver",
     visibility = ["//visibility:public"],
 )
 
@@ -21,6 +22,7 @@ go_library(
 go_binary(
     name = "acmesolver",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "multiarch_image")
+load("//hack:def.bzl", "image")
 
-# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
-multiarch_image(
+image(
     name = "image",
     component = "acmesolver",
     visibility = ["//visibility:public"],

--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "multiarch_image")
+load("//hack:def.bzl", "image")
 
-# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
-multiarch_image(
+image(
     name = "image",
     component = "cainjector",
     visibility = ["//visibility:public"],

--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -4,6 +4,7 @@ load("//hack:def.bzl", "image")
 image(
     name = "image",
     component = "cainjector",
+    binary = ":cainjector",
     visibility = ["//visibility:public"],
 )
 
@@ -31,6 +32,7 @@ go_library(
 go_binary(
     name = "cainjector",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -3,8 +3,8 @@ load("//hack:def.bzl", "image")
 
 image(
     name = "image",
-    component = "cainjector",
     binary = ":cainjector",
+    component = "cainjector",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -4,6 +4,7 @@ load("//hack:def.bzl", "image")
 image(
     name = "image",
     component = "controller",
+    binary = ":controller",
     visibility = ["//visibility:public"],
 )
 
@@ -42,6 +43,7 @@ go_library(
 go_binary(
     name = "controller",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "multiarch_image")
+load("//hack:def.bzl", "image")
 
-# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
-multiarch_image(
+image(
     name = "image",
     component = "controller",
     visibility = ["//visibility:public"],

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -3,8 +3,8 @@ load("//hack:def.bzl", "image")
 
 image(
     name = "image",
-    component = "controller",
     binary = ":controller",
+    component = "controller",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -4,6 +4,7 @@ load("//hack:def.bzl", "image")
 image(
     name = "image",
     component = "webhook",
+    binary = ":webhook",
     visibility = ["//visibility:public"],
 )
 
@@ -22,6 +23,7 @@ go_library(
 go_binary(
     name = "webhook",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -3,8 +3,8 @@ load("//hack:def.bzl", "image")
 
 image(
     name = "image",
-    component = "webhook",
     binary = ":webhook",
+    component = "webhook",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -1,8 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack:def.bzl", "multiarch_image")
+load("//hack:def.bzl", "image")
 
-# Expands to target names such as 'image.linux-amd64', 'image.linux-arm64'
-multiarch_image(
+image(
     name = "image",
     component = "webhook",
     visibility = ["//visibility:public"],

--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -19,6 +19,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 def image(
     name,
     component,
+    binary,
     user = "1000",
     stamp = True,
     **kwargs):
@@ -26,7 +27,7 @@ def image(
     go_image(
         name = "%s.app" % name,
         base = "@static_base//image",
-        embed = [":go_default_library"],
+        binary = binary,
         tags = ["manual"],
         pure = "on",
     )
@@ -43,5 +44,6 @@ def image(
         name = name + ".export",
         images = {
             component + ":{STABLE_APP_GIT_COMMIT}": ":" + name,
-        }
+        },
+        tags = ["manual"],
     )

--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -16,98 +16,32 @@ load("@io_bazel_rules_docker//container:image.bzl", "container_image")
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
-## stamped_image is a macro for creating :app and :image targets
-def stamped_image(
-    name, # use "image"
-    base = None,
-    user = "1000",
-    stamp = True,  # stamp by default, but allow overrides
-    **kwargs):
-  go_image(
-      name = "%s.app" % name,
-      base = base,
-      embed = [":go_default_library"],
-      goarch = "amd64",
-      goos = "linux",
-      pure = "on",
-  )
-
-  container_image(
-      name = name,
-      base = ":%s.app" % name,
-      user = user,
-      stamp = stamp,
-      **kwargs)
-
-def multiarch_image(
+def image(
     name,
     component,
-    goarch = ["amd64", "arm64", "arm"],
-    goos = ["linux"],
     user = "1000",
     stamp = True,
     **kwargs):
 
-  for arch in goarch:
-    for os in goos:
-      go_image(
-          name = "%s.app_%s-%s" % (name, os, arch),
-          base = "@static_base//image",
-          embed = [":go_default_library"],
-          goarch = arch,
-          goos = os,
-          pure = "on",
-      )
+    go_image(
+        name = "%s.app" % name,
+        base = "@static_base//image",
+        embed = [":go_default_library"],
+        tags = ["manual"],
+        pure = "on",
+    )
 
-      container_image(
-          name = "%s.%s-%s" % (name, os, arch),
-          base = "%s.app_%s-%s" % (name, os, arch),
-          user = user,
-          stamp = stamp,
-          **kwargs)
-
-      suffix = ""
-      if arch != "amd64":
-        suffix = "-%s" % arch
-
-      container_bundle(
-          name = "%s.%s-%s.export" % (name, os, arch),
-          images = {
-              ("{STABLE_DOCKER_REPO}/cert-manager-%s%s:{STABLE_APP_VERSION}" % (component, suffix)): ":%s.%s-%s" % (name, os, arch),
-              ("{STABLE_DOCKER_REPO}/cert-manager-%s%s:{STABLE_APP_GIT_COMMIT}" % (component, suffix)): ":%s.%s-%s" % (name, os, arch),
-          },
-      )
-
-  container_image(
-      name = name,
-      base = "%s.%s-%s" % (name, goos[0], goarch[0]),
-      **kwargs)
-
-def multiarch_bundle(
-    name,
-    images,
-    os = ["linux"],
-    arch = ["amd64", "arm64", "arm"],
-    **kwargs):
-
-    all_images = {}
-    for a in arch:
-      for o in os:
-        oa_images = {}
-        for (k, v) in images.items():
-          image_name = k.replace("{arch}", a)
-          image_name = image_name.replace("{os}", o)
-
-          oa_images[image_name] = "%s.%s-%s" % (v, o, a)
-
-        container_bundle(
-            name = "%s.%s-%s" % (name, o, a),
-            images = oa_images,
-            **kwargs)
-
-        all_images.update(oa_images)
+    container_image(
+        name = name,
+        base = "%s.app" % name,
+        user = user,
+        stamp = stamp,
+        tags = ["manual"],
+        **kwargs)
 
     container_bundle(
-        name = name,
-        images = all_images,
-        **kwargs)
+        name = name + ".export",
+        images = {
+            component + ":{STABLE_APP_GIT_COMMIT}": ":" + name,
+        }
+    )

--- a/hack/def.bzl
+++ b/hack/def.bzl
@@ -28,7 +28,6 @@ def image(
         name = "%s.app" % name,
         base = "@static_base//image",
         binary = binary,
-        tags = ["manual"],
         pure = "on",
     )
 
@@ -37,7 +36,6 @@ def image(
         base = "%s.app" % name,
         user = user,
         stamp = stamp,
-        tags = ["manual"],
         **kwargs)
 
     container_bundle(
@@ -45,5 +43,4 @@ def image(
         images = {
             component + ":{STABLE_APP_GIT_COMMIT}": ":" + name,
         },
-        tags = ["manual"],
     )

--- a/hack/release/pkg/bazel/flags.go
+++ b/hack/release/pkg/bazel/flags.go
@@ -68,7 +68,7 @@ func (g *Bazel) Cmd(ctx context.Context, args ...string) *exec.Cmd {
 		fmt.Sprintf("APP_VERSION=%s", flags.Default.AppVersion),
 		fmt.Sprintf("APP_GIT_COMMIT=%s", flags.Default.GitCommitRef),
 	)
-	log.Info("set command environment variables", "env", cmd.Env)
+	log.V(logf.LogLevelTrace).Info("set command environment variables", "env", cmd.Env)
 	cmd.Dir = flags.Default.RepoRoot
 	return cmd
 }

--- a/test/e2e/charts/pebble/BUILD.bazel
+++ b/test/e2e/charts/pebble/BUILD.bazel
@@ -1,11 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_image(
     name = "image",
     base = "@static_base//image",
+    binary = ":app",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "app",
     embed = ["@org_letsencrypt_pebble//cmd/pebble:go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
     pure = "on",
     visibility = ["//visibility:public"],
 )

--- a/test/e2e/charts/pebble/BUILD.bazel
+++ b/test/e2e/charts/pebble/BUILD.bazel
@@ -1,5 +1,7 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+
+# gazelle:ignore
 
 go_image(
     name = "image",
@@ -12,7 +14,6 @@ go_binary(
     name = "app",
     embed = ["@org_letsencrypt_pebble//cmd/pebble:go_default_library"],
     pure = "on",
-    visibility = ["//visibility:public"],
 )
 
 filegroup(

--- a/test/e2e/framework/addon/samplewebhook/sample/BUILD.bazel
+++ b/test/e2e/framework/addon/samplewebhook/sample/BUILD.bazel
@@ -4,10 +4,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 go_image(
     name = "image",
     base = "@static_base//image",
-    embed = [":go_default_library"],
-    goarch = "amd64",
-    goos = "linux",
-    pure = "on",
+    binary = ":sample",
     visibility = ["//visibility:public"],
 )
 
@@ -27,6 +24,7 @@ go_library(
 go_binary(
     name = "sample",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes how we perform a crossbuild for multiple platforms to only ever make use of the `--platform` flag, and never to explicitly set goos or goarch on go_image rules.

Also modifies the release tool to handle this change.

Due to complexities in the way bazel exposes the current architecture being built for, this means we can no longer suffix image names with their architecture when building them. Instead, i've moved this logic into the `//hack/release` tool, which now handles automatically tagging built docker images with appropriate tags.

**Special notes for your reviewer**:

To build for different architectures, you can run:

```
# Build for arm64
bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_arm64 //cmd/acmesolver:image.export

# Build for amd64
bazel run --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //cmd/acmesolver:image.export
```

**Release note**:
```release-note
NONE
```

/cc @JoshVanL 