### PR TITLE
Keep temporary CA inside the secrets resource

### DIFF
--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -69,7 +69,7 @@ type controller struct {
 	log logr.Logger
 
 	// localTemporarySigner signs a certificate that is stored temporarily
-	localTemporarySigner func(crt *v1alpha1.Certificate, pk []byte) ([]byte, error)
+	localTemporarySigner func(crt *v1alpha1.Certificate, pk []byte) ([]byte, []byte, error)
 
 	// certificateNeedsRenew is a function that can be used to determine whether
 	// a certificate currently requires renewal.


### PR DESCRIPTION
**What this PR does / why we need it**:

It sets the `ca.crt` certificate entry instead of `null` value, like:

```yaml
kubectl get secrets my-tls -o yaml
apiVersion: v1
data:
  ca.crt: null
  tls.crt: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUMz
....
```

In case when ACME handshake takes much time, or unavailable because of connectivity or other issues, there should be a way to tell local services to at least use temp CA. Besides `ca.crt: null` breaks the kubectl validation, when you update the secret object via the `kubectl edit secret my-tls`.

This is a tiny improvement and should not harm. Let me know if you have any questions.

/cc @Diaphteiros 