### PR TITLE
Respect --namespace flag in rfc2136 provider

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -187,8 +187,8 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 	eventBroadcaster.StartRecordingToSink(&corev1.EventSinkImpl{Interface: cl.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, v1.EventSource{Component: controllerAgentName})
 
-	sharedInformerFactory := informers.NewFilteredSharedInformerFactory(intcl, time.Second*30, opts.Namespace, nil)
-	kubeSharedInformerFactory := kubeinformers.NewFilteredSharedInformerFactory(cl, time.Second*30, opts.Namespace, nil)
+	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(intcl, time.Second*30, informers.WithNamespace(opts.Namespace))
+	kubeSharedInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(cl, time.Second*30, kubeinformers.WithNamespace(opts.Namespace))
 	return &controller.Context{
 		RootContext:               ctx,
 		StopCh:                    stopCh,

--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -48,7 +48,6 @@ go_test(
         "//pkg/acme/client:go_default_library",
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/controller/test:go_default_library",
-        "//pkg/issuer/acme/dns:go_default_library",
         "//test/unit/gen:go_default_library",
         "//third_party/crypto/acme:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -27,7 +27,6 @@ import (
 	acmecl "github.com/jetstack/cert-manager/pkg/acme/client"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
-	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns"
 	"github.com/jetstack/cert-manager/test/unit/gen"
 	acmeapi "github.com/jetstack/cert-manager/third_party/crypto/acme"
 )
@@ -324,10 +323,6 @@ func TestSyncHappyPath(t *testing.T) {
 			if test.Builder == nil {
 				test.Builder = &testpkg.Builder{}
 			}
-			// Don't initialise webhook based DNS solvers during tests as we do
-			// not have a valid RESTConfig that can be used in the Initialize
-			// functions.
-			dns.WebhookSolvers = nil
 			test.Setup(t)
 			chalCopy := test.Challenge.DeepCopy()
 			err := test.Controller.Sync(test.Ctx, chalCopy)


### PR DESCRIPTION
**What this PR does / why we need it**:

When we moved the rfc2136 solver to implement the webhook interface internally, we forgot to handle setting a namespace filter on the constructed informer factory.

This PR passes the option through to the solver so it can be properly filtered, thus resolving RBAC issues 😄 

**Which issue this PR fixes**: fixes #1838 

**Release note**:
```release-note
Fix issue causing challenge controller to attempt to list Secrets across all namespaces even when --namespace is specified
```
