### PR TITLE
Use proxy from env in self check request

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -198,6 +198,7 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 	// TODO(dmo): figure out if we need to add a more specific timeout for
 	// individual checks
 	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
 		// we're only doing 1 request, make the code around this
 		// simpler by disabling keepalives
 		DisableKeepAlives: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: allows to use proxy environment variables in self-check request

**Which issue this PR fixes**:

**Special notes for your reviewer**: [default transport uses proxy environment variables](https://golang.org/pkg/net/http/#RoundTripper), but since [0.6](https://github.com/jetstack/cert-manager/blob/v0.6.0/pkg/issuer/acme/http/http.go#L159) custom transport is used and it is impossible to send self-check request through proxy. This is needed to get certificates for internal services (see https://github.com/jetstack/cert-manager/pull/942#issuecomment-433112965)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Use proxy environment variables in self-check request
```
