### PR TITLE
Fix issues with updating ACME account email

### DIFF
--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -198,51 +198,31 @@ func (a *Acme) Setup(ctx context.Context) error {
 
 	// if we got an account successfully, we must check if the registered
 	// email is the same as in the issuer spec
-
-	// if no email was specified, then registeredEmail will remain empty
-	registeredEmail := ""
-	if len(account.Contact) > 0 {
-		registeredEmail = strings.Replace(account.Contact[0], "mailto:", "", 1)
-	}
-
-	// if they are different, we update the account
 	specEmail := a.issuer.GetSpec().ACME.Email
-	if registeredEmail != specEmail {
-		log.Info("updating ACME account email address", "email", specEmail)
-		emailurl := []string(nil)
-		if a.issuer.GetSpec().ACME.Email != "" {
-			emailurl = []string{fmt.Sprintf("mailto:%s", strings.ToLower(specEmail))}
-		}
-		account.Contact = emailurl
+	account, registeredEmail, err := ensureEmailUpToDate(ctx, cl, account, specEmail)
+	if err != nil {
+		s := messageAccountUpdateFailed + err.Error()
+		log.Error(err, "failed to update ACME account")
+		a.Recorder.Event(a.issuer, v1.EventTypeWarning, errorAccountUpdateFailed, s)
+		apiutil.SetIssuerCondition(a.issuer, v1alpha1.IssuerConditionReady, v1alpha1.ConditionFalse, errorAccountUpdateFailed, s)
 
-		account, err = cl.UpdateAccount(ctx, account)
-		if err != nil {
-			s := messageAccountUpdateFailed + err.Error()
-			log.Error(err, "failed to update ACME account")
-			a.Recorder.Event(a.issuer, v1.EventTypeWarning, errorAccountUpdateFailed, s)
-			apiutil.SetIssuerCondition(a.issuer, v1alpha1.IssuerConditionReady, v1alpha1.ConditionFalse, errorAccountUpdateFailed, s)
-
-			acmeErr, ok := err.(*acmeapi.Error)
-			// If this is not an ACME error, we will simply return it and retry later
-			if !ok {
-				return err
-			}
-
-			// If the status code is 400 (BadRequest), we will *not* retry this registration
-			// as it implies that something about the request (i.e. email address or private key)
-			// is invalid.
-			if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
-				log.Error(acmeErr, "skipping updating account email as a "+
-					"BadRequest response was returned from the ACME server")
-				return nil
-			}
-
-			// Otherwise if we receive anything other than a 400, we will retry.
+		acmeErr, ok := err.(*acmeapi.Error)
+		// If this is not an ACME error, we will simply return it and retry later
+		if !ok {
 			return err
 		}
 
-		// update the registeredEmail var so it is updated properly in the status below
-		registeredEmail = specEmail
+		// If the status code is 400 (BadRequest), we will *not* retry this registration
+		// as it implies that something about the request (i.e. email address or private key)
+		// is invalid.
+		if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
+			log.Error(acmeErr, "skipping updating account email as a "+
+				"BadRequest response was returned from the ACME server")
+			return nil
+		}
+
+		// Otherwise if we receive anything other than a 400, we will retry.
+		return err
 	}
 
 	log.Info("verified existing registration with ACME server")
@@ -251,6 +231,37 @@ func (a *Acme) Setup(ctx context.Context) error {
 	a.issuer.GetStatus().ACMEStatus().LastRegisteredEmail = registeredEmail
 
 	return nil
+}
+
+func ensureEmailUpToDate(ctx context.Context, cl client.Interface, acc *acmeapi.Account, specEmail string) (*acmeapi.Account, string, error) {
+	log := logf.FromContext(ctx)
+
+	// if no email was specified, then registeredEmail will remain empty
+	registeredEmail := ""
+	if len(acc.Contact) > 0 {
+		registeredEmail = strings.Replace(acc.Contact[0], "mailto:", "", 1)
+	}
+
+	// if they are different, we update the account
+	if registeredEmail != specEmail {
+		log.Info("updating ACME account email address", "email", specEmail)
+		emailurl := []string(nil)
+		if specEmail != "" {
+			emailurl = []string{fmt.Sprintf("mailto:%s", strings.ToLower(specEmail))}
+		}
+		acc.Contact = emailurl
+
+		var err error
+		acc, err = cl.UpdateAccount(ctx, acc)
+		if err != nil {
+			return nil, "", err
+		}
+
+		// update the registeredEmail var so it is updated properly in the status below
+		registeredEmail = specEmail
+	}
+
+	return acc, registeredEmail, nil
 }
 
 // registerAccount will register a new ACME account with the server. If an

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -208,7 +208,7 @@ func (a *Acme) Setup(ctx context.Context) error {
 	// if they are different, we update the account
 	specEmail := a.issuer.GetSpec().ACME.Email
 	if registeredEmail != specEmail {
-		log.Info("Updating ACME account with email %s", specEmail)
+		log.Info("updating ACME account email address", "email", specEmail)
 		emailurl := []string(nil)
 		if a.issuer.GetSpec().ACME.Email != "" {
 			emailurl = []string{fmt.Sprintf("mailto:%s", strings.ToLower(specEmail))}
@@ -241,6 +241,8 @@ func (a *Acme) Setup(ctx context.Context) error {
 			return err
 		}
 
+		// update the registeredEmail var so it is updated properly in the status below
+		registeredEmail = specEmail
 	}
 
 	log.Info("verified existing registration with ACME server")


### PR DESCRIPTION
**What this PR does / why we need it**:

The first commit in this PR fixes an issue where the new email address would not be persisted to the Kubernetes API on the Issuer resources `status` field after the email has been updated. It also fixes a logging error.

The second commit refactors the logic for updating the email address into its own function, which should make it easier for us to unit tests this in future 😄

**Release note**:
```release-note
NONE
```
