### PR TITLE
Fire an Event when no acme solver matches an identifier being validated

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -402,6 +402,7 @@ func (c *controller) createOrder(ctx context.Context, cl acmecl.Interface, issue
 		} else {
 			cs, err = challengeSpecForAuthorization(ctx, cl, issuer, o, authz)
 			if err != nil {
+				c.recorder.Eventf(o, corev1.EventTypeWarning, "NoMatchingSolver", "Failed to create challenge for domain %q: %v", authz.Identifier.Value, err)
 				return fmt.Errorf("error constructing Challenge resource for authorization: %v", err)
 			}
 		}
@@ -574,7 +575,7 @@ func challengeSpecForAuthorization(ctx context.Context, cl acmecl.Interface, iss
 	}
 
 	if selectedSolver == nil || selectedChallenge == nil {
-		return nil, fmt.Errorf("failed to find matching challenge solver for challenge")
+		return nil, fmt.Errorf("no configured challenge solvers can be used for this challenge")
 	}
 
 	key, err := keyForChallenge(cl, selectedChallenge)


### PR DESCRIPTION
**What this PR does / why we need it**:

This should make it obvious to users why their Order is not progressing if no solver type can be chosen.

This has exposed some issues with the way we handle this case too, which I'll open a separate issue to track improving.

**Which issue this PR fixes**: fixes #1718

**Release note**:
```release-note
Fire informational Event if an ACME solver cannot be chosen for a domain on an Order
```
