### PR TITLE
Include Group name in IssuerRef for CertificateRequest controller ownership distinction

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -112,6 +112,8 @@ spec:
                 with the provided name will be used. The 'name' field in this stanza
                 is required at all times.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -279,9 +281,12 @@ spec:
                 the 'kind' field is not set, or set to 'Issuer', an Issuer resource
                 with the given name in the same namespace as the CertificateRequest
                 will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
-                with the provided name will be used.  The 'name' field in this stanza
-                is required at all times.
+                with the provided name will be used. The 'name' field in this stanza
+                is required at all times. The group field refers to the API group
+                of the issuer which defaults to 'certmanager.k8s.io' if empty.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -414,6 +419,8 @@ spec:
                 Issuer, an error will be returned and the Challenge will be marked
                 as failed.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -1243,6 +1250,8 @@ spec:
                 Issuer, an error will be returned and the Order will be marked as
                 failed.
               properties:
+                group:
+                  type: string
                 kind:
                   type: string
                 name:
@@ -1290,6 +1299,8 @@ spec:
                       is not an 'ACME' Issuer, an error will be returned and the Challenge
                       will be marked as failed.
                     properties:
+                      group:
+                        type: string
                       kind:
                         type: string
                       name:

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -2172,7 +2172,7 @@ Appears In:
 <td><code>ObjectReference</code></td>
 </tr>
 </tbody></table>
-<p>ObjectReference is a reference to an object with a given name and kind.</p>
+<p>ObjectReference is a reference to an object with a given name, kind and group.</p>
 <aside class="notice">
 Appears In:
 
@@ -2190,6 +2190,10 @@ Appears In:
 </tr>
 </thead>
 <tbody><tr>
+<td><code>group</code><br /> <em>string</em></td>
+<td></td>
+</tr>
+<tr>
 <td><code>kind</code><br /> <em>string</em></td>
 <td></td>
 </tr>

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -51,11 +51,13 @@ type LocalObjectReference struct {
 	Name string `json:"name"`
 }
 
-// ObjectReference is a reference to an object with a given name and kind.
+// ObjectReference is a reference to an object with a given name, kind and group.
 type ObjectReference struct {
 	Name string `json:"name"`
 	// +optional
 	Kind string `json:"kind,omitempty"`
+	// +optional
+	Group string `json:"group,omitempty"`
 }
 
 const (

--- a/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
@@ -58,8 +58,9 @@ type CertificateRequestSpec struct {
 	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
 	// the given name in the same namespace as the CertificateRequest will be
 	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
-	// the provided name will be used.  The 'name' field in this stanza is
-	// required at all times.
+	// the provided name will be used. The 'name' field in this stanza is
+	// required at all times. The group field refers to the API group of the
+	// issuer which defaults to 'certmanager.k8s.io' if empty.
 	IssuerRef ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest

--- a/pkg/controller/certificaterequests/BUILD.bazel
+++ b/pkg/controller/certificaterequests/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager:go_default_library",
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/apis/certmanager/validation:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -27,6 +27,7 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/validation"
 	"github.com/jetstack/cert-manager/pkg/issuer"
@@ -49,6 +50,11 @@ func (c *Controller) Sync(ctx context.Context, cr *v1alpha1.CertificateRequest) 
 
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
+
+	if !(cr.Spec.IssuerRef.Group == "" || cr.Spec.IssuerRef.Group == certmanager.GroupName) {
+		dbg.Info("certificate request issuerRef group does not match certmanager group so skipping processing")
+		return nil
+	}
 
 	if apiutil.CertificateRequestHasCondition(cr, v1alpha1.CertificateRequestCondition{
 		Type:   v1alpha1.CertificateRequestConditionReady,

--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager:go_default_library",
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//pkg/apis/certmanager/validation:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -37,6 +37,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/validation"
 	"github.com/jetstack/cert-manager/pkg/feature"
@@ -78,6 +79,12 @@ func (c *controller) Sync(ctx context.Context, crt *v1alpha1.Certificate) (err e
 
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
+
+	// TODO: if not 'certmanager.k8s.io, then use CertificateRequest stratagy if feature gate set
+	if !(crt.Spec.IssuerRef.Group == "" || crt.Spec.IssuerRef.Group == certmanager.GroupName) {
+		dbg.Info("certificate issuerRef group does not match certmanager group so skipping processing")
+		return nil
+	}
 
 	crtCopy := crt.DeepCopy()
 	defer func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a string `Group` to object reference. This is used by the CertificateRequest controllers to distinguish ownership of CertificateRequest resources. This therefore allows external controllers to have the same kind issuer reference but will be namespaces by the group.

The certmanager.k8s.io CertificateRequest controllers will watch for groups `""` and `"certmanager.k8s.io"`.

TODO:
Add a mutating webhook to inject the `certmanager.k8s.io` group name into issuer references when the field is empty.

Rebased on #1836 
/hold
/assign

```release-note
Adds `group` to `issuerRef` in `CertificateRequest` resources to distinguish resource ownership of incoming CertificateRequests so enabling full external issuer support. 
```
