### PR TITLE
hack/release: add --stamp=true when running 'bazel run'

### DIFF
--- a/hack/release/pkg/bazel/flags.go
+++ b/hack/release/pkg/bazel/flags.go
@@ -119,7 +119,7 @@ func (g *Bazel) Run(ctx context.Context, target string, args ...string) *exec.Cm
 // Bazel's --platforms variable will be set automatically.
 func (g *Bazel) RunPlatform(ctx context.Context, os, arch, target string, args ...string) *exec.Cmd {
 	platform := fmt.Sprintf("--platforms=@io_bazel_rules_go//go/toolchain:%s_%s", os, arch)
-	return g.Cmd(ctx, append([]string{"run", platform, target}, args...)...)
+	return g.Cmd(ctx, append([]string{"run", platform, "--stamp=true", target}, args...)...)
 }
 
 // RunE will run the given targets on the current host OS.

--- a/hack/release/pkg/log/log.go
+++ b/hack/release/pkg/log/log.go
@@ -50,7 +50,6 @@ func InitLogs(fs *pflag.FlagSet) {
 	fs.MarkHidden("log_file")
 	fs.MarkHidden("logtostderr")
 	fs.MarkHidden("alsologtostderr")
-	fs.MarkHidden("v")
 	fs.MarkHidden("skip_headers")
 	fs.MarkHidden("stderrthreshold")
 	fs.MarkHidden("vmodule")


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes issue where the app-version and git commit info wasn't properly set when building release targets.

Before:
```
$ docker run "quay.io/jetstack/cert-manager-controller:v0.9.0-alpha.0"
I0708 14:02:38.361114       1 start.go:76] cert-manager "level"=0 "msg"="starting controller"  "git-commit"="{STABLE_APP_GIT_COMMIT}" "version"="{STABLE_APP_VERSION}"
```

After:
```
$ docker run "quay.io/jetstack/cert-manager-controller:v0.9.0-alpha.0"
I0708 14:42:16.619575       1 start.go:76] cert-manager "level"=0 "msg"="starting controller"  "git-commit"="458c7193d" "version"="v0.9.0-alpha.0"
```

/assign @JoshVanL 

**Release note**:
```release-note
NONE
```
