### PR TITLE
Add support to Network Policy into Acme Solver

### DIFF
--- a/pkg/issuer/acme/http/BUILD.bazel
+++ b/pkg/issuer/acme/http/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "http.go",
         "ingress.go",
+        "networkpolicy.go",
         "pod.go",
         "service.go",
     ],
@@ -18,6 +19,7 @@ go_library(
         "//pkg/util:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
@@ -26,6 +28,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/listers/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/client-go/listers/networking/v1:go_default_library",
     ],
 )
 
@@ -34,6 +37,7 @@ go_test(
     srcs = [
         "http_test.go",
         "ingress_test.go",
+        "networkpolicy_test.go",
         "pod_test.go",
         "service_test.go",
         "util_test.go",
@@ -45,6 +49,7 @@ go_test(
         "//test/util/generate:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/extensions/v1beta1:go_default_library",
+        "//vendor/k8s.io/api/networking/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",

--- a/pkg/issuer/acme/http/networkpolicy.go
+++ b/pkg/issuer/acme/http/networkpolicy.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+)
+
+func (s *Solver) ensureNetworkPolicy(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (*networkingv1.NetworkPolicy, error) {
+	log := logf.FromContext(ctx).WithName("ensureNetworkPolicy")
+
+	log.V(logf.DebugLevel).Info("checking for existing HTTP01 solver network policies for challenge")
+	existingNetworkPolicies, err := s.getNetworkPoliciesForChallenge(ctx, ch)
+	if err != nil {
+		return nil, err
+	}
+	if len(existingNetworkPolicies) == 1 {
+		logf.WithRelatedResource(log, existingNetworkPolicies[0]).Info("found one existing HTTP01 solver Network Policy for challenge resource")
+		return existingNetworkPolicies[0], nil
+	}
+	if len(existingNetworkPolicies) > 1 {
+		log.Info("multiple challenge solver network policies found for challenge. cleaning up all existing services.")
+		err := s.cleanupNetworkPolicy(ctx, ch)
+		if err != nil {
+			return nil, err
+		}
+		return nil, fmt.Errorf("multiple existing challenge solver network policies found and cleaned up. retrying challenge sync")
+	}
+
+	log.Info("creating HTTP01 challenge solver network policy")
+	return s.createNetworkPolicy(issuer, ch)
+}
+
+// getNetworkPoliciesForChallenge returns a list of network policies that were created to solve
+// http challenges for the given domain
+func (s *Solver) getNetworkPoliciesForChallenge(ctx context.Context, ch *v1alpha1.Challenge) ([]*networkingv1.NetworkPolicy, error) {
+	log := logf.FromContext(ctx)
+
+	podLabels := podLabels(ch)
+	selector := labels.NewSelector()
+	for key, val := range podLabels {
+		req, err := labels.NewRequirement(key, selection.Equals, []string{val})
+		if err != nil {
+			return nil, err
+		}
+		selector = selector.Add(*req)
+	}
+
+	networkPolicyList, err := s.networkPolicyLister.NetworkPolicies(ch.Namespace).List(selector)
+	if err != nil {
+		return nil, err
+	}
+
+	var relevantNetworkPolicies []*networkingv1.NetworkPolicy
+	for _, networkpolicy := range networkPolicyList {
+		if !metav1.IsControlledBy(networkpolicy, ch) {
+			logf.WithRelatedResource(log, networkpolicy).Info("found existing solver network policy for this challenge resource, however " +
+				"it does not have an appropriate OwnerReference referencing this challenge. Skipping it altogether.")
+			continue
+		}
+		relevantNetworkPolicies = append(relevantNetworkPolicies, networkpolicy)
+	}
+
+	return relevantNetworkPolicies, nil
+}
+
+// createNetworkPolicy will create the network policy required to solve this challenge
+// in the target API server.
+func (s *Solver) createNetworkPolicy(issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) (*networkingv1.NetworkPolicy, error) {
+	np := buildNetworkPolicy(issuer, ch)
+	return s.Client.NetworkingV1().NetworkPolicies(ch.Namespace).Create(np)
+}
+
+// buildNetworkPolicy builds a Network Policy object to allow any object to communicate with
+// cm-acme-http-solver
+func buildNetworkPolicy(issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) *networkingv1.NetworkPolicy {
+	podLabels := podLabels(ch)
+
+	var protocol corev1.Protocol
+	protocol = "TCP"
+
+	port := intstr.FromInt(acmeSolverListenPort)
+
+	networkpolicy := &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName:    "cm-acme-http-solver-",
+			Namespace:       ch.Namespace,
+			Labels:          podLabels,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: podLabels,
+			},
+			PolicyTypes: []networkingv1.PolicyType{"Ingress"},
+			Ingress: []networkingv1.NetworkPolicyIngressRule{
+				{
+					Ports: []networkingv1.NetworkPolicyPort{
+						{
+							Port:     &port,
+							Protocol: &protocol,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	return networkpolicy
+}
+
+// cleanupNetworkPolicy will remove the network policies added to allow ingress controller
+// to reach the cm-acme-http-solver
+func (s *Solver) cleanupNetworkPolicy(ctx context.Context, ch *v1alpha1.Challenge) error {
+	log := logf.FromContext(ctx, "cleanupNetworkPolicy")
+
+	networkpolicies, err := s.getNetworkPoliciesForChallenge(ctx, ch)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	for _, networkpolicy := range networkpolicies {
+		log := logf.WithRelatedResource(log, networkpolicy).V(logf.DebugLevel)
+		log.Info("deleting network policy resource")
+		log.Info("Namespace: %v", networkpolicy.Namespace)
+		err := s.Client.NetworkingV1().NetworkPolicies(networkpolicy.Namespace).Delete(networkpolicy.Name, nil)
+
+		if err != nil {
+			log.Info("failed to delete network policy resource", "error", err)
+			errs = append(errs, err)
+			continue
+		}
+		log.Info("successfully deleted network policy resource")
+	}
+	return utilerrors.NewAggregate(errs)
+}

--- a/pkg/issuer/acme/http/networkpolicy_test.go
+++ b/pkg/issuer/acme/http/networkpolicy_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	coretesting "k8s.io/client-go/testing"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+func TestEnsureNetworkPolicy(t *testing.T) {
+	const createdNetworkPolicyKey = "createdNetworkPolicy"
+	tests := map[string]solverFixture{
+		"should return an existing networkpolicy if one already exists": {
+			Challenge: &v1alpha1.Challenge{
+				Spec: v1alpha1.ChallengeSpec{
+					DNSName: "example.com",
+					Config: &v1alpha1.SolverConfig{
+						HTTP01: &v1alpha1.HTTP01SolverConfig{},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				np, err := s.Solver.createNetworkPolicy(s.Issuer, s.Challenge)
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+				s.testResources[createdNetworkPolicyKey] = np
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				createdNetworkPolicy := s.testResources[createdNetworkPolicyKey].(*networkingv1.NetworkPolicy)
+				resp := args[0].(*networkingv1.NetworkPolicy)
+				if resp == nil {
+					t.Errorf("unexpected network policy = nil")
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(resp, createdNetworkPolicy) {
+					t.Errorf("Expected %v to equal %v", resp, createdNetworkPolicy)
+				}
+			},
+		},
+		"should create a new network policy if one does not exist": {
+			Challenge: &v1alpha1.Challenge{
+				Spec: v1alpha1.ChallengeSpec{
+					DNSName: "example.com",
+					Config: &v1alpha1.SolverConfig{
+						HTTP01: &v1alpha1.HTTP01SolverConfig{},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				expectedNetworkPolicy := buildNetworkPolicy(s.Issuer, s.Challenge)
+
+				// create a reactor that fails the test if a network policy is created
+				s.Builder.FakeKubeClient().PrependReactor("create", "networkpolicy", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					networkpolicy := action.(coretesting.CreateAction).GetObject().(*networkingv1.NetworkPolicy)
+					// clear network policy name as we don't know it yet in the expectedNetworkPolicy
+					networkpolicy.Name = ""
+					if !reflect.DeepEqual(networkpolicy, expectedNetworkPolicy) {
+						t.Errorf("Expected %v to equal %v", networkpolicy, expectedNetworkPolicy)
+					}
+					return false, ret, nil
+				})
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				resp := args[0].(*networkingv1.NetworkPolicy)
+				err := args[1]
+				if resp == nil && err == nil {
+					t.Errorf("unexpected networkpolicy = nil")
+					t.Fail()
+					return
+				}
+				networkpolicies, err := s.Solver.networkPolicyLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("unexpected error listing network policies: %v", err)
+					t.Fail()
+					return
+				}
+				if len(networkpolicies) != 1 {
+					t.Errorf("unexpected %d network policies in lister: %+v", len(networkpolicies), networkpolicies)
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(networkpolicies[0], resp) {
+					t.Errorf("Expected %v to equal %v", networkpolicies[0], resp)
+				}
+			},
+		},
+		"should clean up if multiple network policies exist": {
+			Challenge: &v1alpha1.Challenge{
+				Spec: v1alpha1.ChallengeSpec{
+					DNSName: "example.com",
+					Config: &v1alpha1.SolverConfig{
+						HTTP01: &v1alpha1.HTTP01SolverConfig{},
+					},
+				},
+			},
+			Err: true,
+			PreFn: func(t *testing.T, s *solverFixture) {
+				_, err := s.Solver.createNetworkPolicy(s.Issuer, s.Challenge)
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+				_, err = s.Solver.createNetworkPolicy(s.Issuer, s.Challenge)
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				networkpolicies, err := s.Solver.networkPolicyLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("error listing network policies: %v", err)
+					t.Fail()
+					return
+				}
+				if len(networkpolicies) != 0 {
+					t.Errorf("expected network policies to have been cleaned up, but there were %d policies left", len(networkpolicies))
+				}
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.Setup(t)
+			resp, err := test.Solver.ensureNetworkPolicy(context.TODO(), test.Issuer, test.Challenge)
+			if err != nil && !test.Err {
+				t.Errorf("Expected function to not error, but got: %v", err)
+			}
+			if err == nil && test.Err {
+				t.Errorf("Expected function to get an error, but got: %v", err)
+			}
+			test.Finish(t, resp, err)
+		})
+	}
+}
+
+func TestGetNetworkPoliciesForChallenge(t *testing.T) {
+	const createdNetworkPolicyKey = "createdNetworkPolicy"
+	tests := map[string]solverFixture{
+		"should return one network policy that matches": {
+			Challenge: &v1alpha1.Challenge{
+				Spec: v1alpha1.ChallengeSpec{
+					DNSName: "example.com",
+					Config: &v1alpha1.SolverConfig{
+						HTTP01: &v1alpha1.HTTP01SolverConfig{},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				ing, err := s.Solver.createNetworkPolicy(s.Issuer, s.Challenge)
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+
+				s.testResources[createdNetworkPolicyKey] = ing
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				createdNetworkPolicy := s.testResources[createdNetworkPolicyKey].(*networkingv1.NetworkPolicy)
+				resp := args[0].([]*networkingv1.NetworkPolicy)
+				if len(resp) != 1 {
+					t.Errorf("expected one network policy to be returned, but got %d", len(resp))
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(resp[0], createdNetworkPolicy) {
+					t.Errorf("Expected %v to equal %v", resp[0], createdNetworkPolicy)
+				}
+			},
+		},
+		"should not return a network policy for the same certificate but different domain": {
+			Challenge: &v1alpha1.Challenge{
+				Spec: v1alpha1.ChallengeSpec{
+					DNSName: "example.com",
+					Config: &v1alpha1.SolverConfig{
+						HTTP01: &v1alpha1.HTTP01SolverConfig{},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				differentChallenge := s.Challenge.DeepCopy()
+				differentChallenge.Spec.DNSName = "invaliddomain"
+				_, err := s.Solver.createNetworkPolicy(s.Issuer, differentChallenge)
+				if err != nil {
+					t.Errorf("error preparing test: %v", err)
+				}
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				resp := args[0].([]*networkingv1.NetworkPolicy)
+				if len(resp) != 0 {
+					t.Errorf("expected zero network policies to be returned, but got %d", len(resp))
+					t.Fail()
+					return
+				}
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			test.Setup(t)
+			resp, err := test.Solver.getNetworkPoliciesForChallenge(context.TODO(), test.Challenge)
+			if err != nil && !test.Err {
+				t.Errorf("Expected function to not error, but got: %v", err)
+			}
+			if err == nil && test.Err {
+				t.Errorf("Expected function to get an error, but got: %v", err)
+			}
+			test.Finish(t, resp, err)
+		})
+	}
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -447,6 +447,7 @@ k8s.io/api/core/v1
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1beta1
 k8s.io/api/extensions/v1beta1
+k8s.io/api/networking/v1
 k8s.io/api/authorization/v1
 k8s.io/api/rbac/v1
 k8s.io/api/apps/v1
@@ -463,7 +464,6 @@ k8s.io/api/certificates/v1beta1
 k8s.io/api/coordination/v1
 k8s.io/api/coordination/v1beta1
 k8s.io/api/events/v1beta1
-k8s.io/api/networking/v1
 k8s.io/api/networking/v1beta1
 k8s.io/api/node/v1alpha1
 k8s.io/api/node/v1beta1
@@ -651,6 +651,7 @@ k8s.io/client-go/tools/cache
 k8s.io/client-go/util/workqueue
 k8s.io/client-go/listers/extensions/v1beta1
 k8s.io/client-go/kubernetes/fake
+k8s.io/client-go/listers/networking/v1
 k8s.io/client-go/tools/clientcmd
 k8s.io/client-go/tools/clientcmd/api
 k8s.io/client-go/plugin/pkg/client/auth/azure
@@ -816,7 +817,6 @@ k8s.io/client-go/listers/certificates/v1beta1
 k8s.io/client-go/listers/coordination/v1
 k8s.io/client-go/listers/coordination/v1beta1
 k8s.io/client-go/listers/events/v1beta1
-k8s.io/client-go/listers/networking/v1
 k8s.io/client-go/listers/networking/v1beta1
 k8s.io/client-go/listers/node/v1alpha1
 k8s.io/client-go/listers/node/v1beta1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR adds support for Network Policy into Acme Solver.

Basically it creates a Network Policy object, together with Service, POD and Ingress to allow the communication between Ingress and the Solver in some more restrictive environments

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: None

**Special notes for your reviewer**:  I'm submitting the PR for a first review (while I write some tests, make some improvements, etc).

There were some tests made to see if Network Policy would impact into the behaviour of the rest of the cluster/namespace.

If there's a Network Policy in the Namespace denying everything, the NP created by the cert-manager will allow only the ingress into the cm-acme-http-solver.

If there's no Network Policy in the Namespace, to avoid generating downtime/restrictive Network Policies that might impact in other deploys in the same Namespace the Network Policy is strict with the podSelector.

This needs some more testing (will do this by this week).



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Adds support for creating a Network Policy object into the cluster, when using ACME Solver
```
