### PR TITLE
WIP: Certificate Request Mutating Webhook

### DIFF
--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/webhook",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/apis/certmanager/mutation/webhooks:go_default_library",
         "//pkg/apis/certmanager/validation/webhooks:go_default_library",
         "//vendor/github.com/openshift/generic-admission-server/pkg/cmd:go_default_library",
         "//vendor/k8s.io/klog:go_default_library",

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -24,12 +24,15 @@ import (
 	"github.com/openshift/generic-admission-server/pkg/cmd"
 	"k8s.io/klog"
 
-	"github.com/jetstack/cert-manager/pkg/apis/certmanager/validation/webhooks"
+	mutationwebhooks "github.com/jetstack/cert-manager/pkg/apis/certmanager/mutation/webhooks"
+	validationwebhooks "github.com/jetstack/cert-manager/pkg/apis/certmanager/validation/webhooks"
 )
 
-var certHook cmd.ValidatingAdmissionHook = &webhooks.CertificateAdmissionHook{}
-var issuerHook cmd.ValidatingAdmissionHook = &webhooks.IssuerAdmissionHook{}
-var clusterIssuerHook cmd.ValidatingAdmissionHook = &webhooks.ClusterIssuerAdmissionHook{}
+var certValidatingHook cmd.ValidatingAdmissionHook = &validationwebhooks.CertificateAdmissionHook{}
+var issuerValidatingHook cmd.ValidatingAdmissionHook = &validationwebhooks.IssuerAdmissionHook{}
+var clusterIssuerValidatingHook cmd.ValidatingAdmissionHook = &validationwebhooks.ClusterIssuerAdmissionHook{}
+
+var certRequestMutatingHook cmd.MutatingAdmissionHook = &mutationwebhooks.CertificateRequestMutatingHook{}
 
 func main() {
 	// Avoid "logging before flag.Parse" errors from glog
@@ -46,9 +49,10 @@ func main() {
 	}
 
 	cmd.RunAdmissionServer(
-		certHook,
-		issuerHook,
-		clusterIssuerHook,
+		certValidatingHook,
+		issuerValidatingHook,
+		clusterIssuerValidatingHook,
+		certRequestMutatingHook,
 	)
 }
 

--- a/pkg/apis/certmanager/BUILD.bazel
+++ b/pkg/apis/certmanager/BUILD.bazel
@@ -19,6 +19,7 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//pkg/apis/certmanager/install:all-srcs",
+        "//pkg/apis/certmanager/mutation/webhooks:all-srcs",
         "//pkg/apis/certmanager/v1alpha1:all-srcs",
         "//pkg/apis/certmanager/validation:all-srcs",
     ],

--- a/pkg/apis/certmanager/mutation/webhooks/BUILD.bazel
+++ b/pkg/apis/certmanager/mutation/webhooks/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["certificaterequest.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/apis/certmanager/mutation/webhooks",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager:go_default_library",
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//vendor/k8s.io/api/admission/v1beta1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/client-go/rest:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/apis/certmanager/mutation/webhooks/certificaterequest.go
+++ b/pkg/apis/certmanager/mutation/webhooks/certificaterequest.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package webhooks
+
+import (
+	"encoding/json"
+	"net/http"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	restclient "k8s.io/client-go/rest"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+type CertificateRequestMutatingHook struct {
+}
+
+func (c *CertificateRequestMutatingHook) Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error {
+	return nil
+}
+
+func (c *CertificateRequestMutatingHook) MutatingResource() (plural schema.GroupVersionResource, singular string) {
+	gv := v1alpha1.SchemeGroupVersion
+	gv.Group = "admission." + gv.Group
+	// override version to be the version of the admissionresponse resource
+	gv.Version = "v1beta1"
+	return gv.WithResource("certificaterequests"), "certificaterequest"
+}
+
+type patchOperation struct {
+	Op    string      `json:"op"`
+	Path  string      `json:"path"`
+	Value interface{} `json:"value,omitempty"`
+}
+
+func (c *CertificateRequestMutatingHook) Admit(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
+	status := &admissionv1beta1.AdmissionResponse{}
+
+	obj := &v1alpha1.CertificateRequest{}
+	err := json.Unmarshal(admissionSpec.Object.Raw, obj)
+	if err != nil {
+		status.Allowed = false
+		status.Result = &metav1.Status{
+			Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+			Message: err.Error(),
+		}
+		return status
+	}
+
+	if obj.Spec.IssuerRef.Group == "" {
+		patch := patchOperation{
+			Op:    "add",
+			Path:  "/spec/issuerref/group",
+			Value: certmanager.GroupName,
+		}
+
+		patchBytes, err := json.Marshal(patch)
+		if err != nil {
+			status.Allowed = false
+			status.Result = &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			}
+			return status
+		}
+
+		status.Patch = patchBytes
+		status.PatchType = func() *admissionv1beta1.PatchType {
+			pt := admissionv1beta1.PatchTypeJSONPatch
+			return &pt
+		}()
+
+	}
+
+	status.Allowed = true
+
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a mutating webhook to the CertificateRequest resource. Currently only defaults an empty group reference to `certmanager.k8s.io`

```release-note
NONE
```

/hold
rebased on #1860 
/assign
