### PR TITLE
CR KEP: Updates the beta strategy for Certificates controller

### DIFF
--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -11,7 +11,7 @@ approvers:
   - "@munnerz"
 editor: "@joshvanl"
 creation-date: 2019-07-08
-last-updated: 2019-07-08
+last-updated: 2019-07-09
 status: implementable
 ---
 
@@ -230,19 +230,21 @@ human user.
 
 ##### Alpha
 
-- Creation of `CertificateRequest` resource
-- A CA issuer `CertificateRequest` controller
-- Exposing the single controller via a feature gated flag
+- Creation of `CertificateRequest` resource.
+- A CA issuer `CertificateRequest` controller.
+- Exposing the single controller via a feature gated flag.
 
 ##### Alpha -> Beta Graduation
 
-- All issuers have a `CertificateRequest` controller
-- All controllers are enabled by default
+- All issuers have a `CertificateRequest` controller.
+- All controllers are enabled by default.
+- The `Certificate` controller optionally makes use of the `CertificateRequest`
+  resource to resolve certificates when a feature flag is enabled.
 
 ##### Beta -> GA Graduation
 
-- The `CertificateRequest` API resource should be considered stable
-- The `Certificate` resource make use of the `CertificateRequest` resource to
+- The `CertificateRequest` API resource should be considered stable.
+- The `Certificate` controller makes use of the `CertificateRequest` resource to
   resolve certificates.
 
 ##### Removing a deprecated flag


### PR DESCRIPTION
Adds the option earlier in graduation to get the Certificates controller using `CertificateRequets`.
Try things sooner and catch more bugs.

```release-note
NONE
```

/assign @munnerz 
