### PR TITLE
Fix bug where solver with no selector causes nil pointer

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -452,10 +452,14 @@ func challengeSpecForAuthorization(ctx context.Context, cl acmecl.Interface, iss
 			continue
 		}
 
-		if cfg.Selector == nil && selectedSolver == nil {
-			dbg.Info("selecting solver due to nil selector and no previously selected solver")
-			selectedSolver = cfg.DeepCopy()
-			selectedChallenge = acmech
+		if cfg.Selector == nil {
+			if selectedSolver == nil {
+				dbg.Info("selecting solver due to nil selector and no previously selected solver")
+				selectedSolver = cfg.DeepCopy()
+				selectedChallenge = acmech
+			} else {
+				dbg.Info("not selecting solver as previously selected solver has a just as or more specific selector")
+			}
 			continue
 		}
 

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -453,13 +453,13 @@ func challengeSpecForAuthorization(ctx context.Context, cl acmecl.Interface, iss
 		}
 
 		if cfg.Selector == nil {
-			if selectedSolver == nil {
-				dbg.Info("selecting solver due to nil selector and no previously selected solver")
-				selectedSolver = cfg.DeepCopy()
-				selectedChallenge = acmech
-			} else {
+			if selectedSolver != nil {
 				dbg.Info("not selecting solver as previously selected solver has a just as or more specific selector")
+				continue
 			}
+			dbg.Info("selecting solver due to match all selector and no previously selected solver")
+			selectedSolver = cfg.DeepCopy()
+			selectedChallenge = acmech
 			continue
 		}
 

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -1412,6 +1412,39 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				},
 			},
 		},
+		"uses correct solver when selector explicitly names dnsName (reversed)": {
+			acmeClient: basicACMEClient,
+			issuer: &v1alpha1.Issuer{
+				Spec: v1alpha1.IssuerSpec{
+					IssuerConfig: v1alpha1.IssuerConfig{
+						ACME: &v1alpha1.ACMEIssuer{
+							Solvers: []v1alpha1.ACMEChallengeSolver{
+								exampleComDNSNameSelectorSolver,
+								emptySelectorSolverHTTP01,
+							},
+						},
+					},
+				},
+			},
+			order: &v1alpha1.Order{
+				Spec: v1alpha1.OrderSpec{
+					DNSNames: []string{"example.com"},
+				},
+			},
+			authz: &acmeapi.Authorization{
+				Identifier: acmeapi.AuthzID{
+					Value: "example.com",
+				},
+				Challenges: []*acmeapi.Challenge{acmeChallengeHTTP01},
+			},
+			expectedChallengeSpec: &v1alpha1.ChallengeSpec{
+				Type:    "http-01",
+				DNSName: "example.com",
+				Token:   acmeChallengeHTTP01.Token,
+				Key:     "http01",
+				Solver:  &exampleComDNSNameSelectorSolver,
+			},
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Michael Tsang <michael.tsang@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Previously when the `selectedSolver` has been set, and the current solver has no selector, a nil pointer panic would occur as it would try to retrieve data from the selector - we now just skip if the `selectedSolver` has already been set since it must be just as or more specific than the current.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
