### PR TITLE
Encode CSR on Order into PEM format and properly handle decoding

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -212,9 +212,25 @@ func (c *controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 	// if the current state is 'ready', we need to generate a CSR and finalize
 	// the order
 	case cmapi.Ready:
+
+		// Due to a bug in the initial release of this controller, we previously
+		// only supported DER encoded CSRs and not PEM encoded as they are intended
+		// to be as part of our API.
+		// To work around this, we first attempt to decode the CSR into DER bytes
+		// by running pem.Decode. If the PEM block is empty, we assume that the CSR
+		// is DER encoded and continue to call FinalizeOrder.
+		var derBytes []byte
+		block, _ := pem.Decode(o.Spec.CSR)
+		if block == nil {
+			log.Info("failed to parse CSR as PEM data, attempting to treat CSR as DER encoded for compatibility reasons")
+			derBytes = o.Spec.CSR
+		} else {
+			derBytes = block.Bytes
+		}
+
 		// TODO: we could retrieve a copy of the certificate resource here and
 		// stored it on the Order resource to prevent extra calls to the API
-		certSlice, err := cl.FinalizeOrder(ctx, o.Status.FinalizeURL, o.Spec.CSR)
+		certSlice, err := cl.FinalizeOrder(ctx, o.Status.FinalizeURL, derBytes)
 
 		// always update the order status after calling Finalize - this allows
 		// us to record the current orders status on this order resource

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -19,8 +19,8 @@ package acme
 import (
 	"context"
 	"crypto"
-	"crypto/x509"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"hash/fnv"
 	"time"
@@ -312,13 +312,18 @@ func (a *Acme) createNewOrder(ctx context.Context, crt *v1alpha1.Certificate, te
 		return err
 	}
 
-	csrBytes, err := pki.EncodeCSR(csr, key)
+	csrDER, err := pki.EncodeCSR(csr, key)
 	if err != nil {
 		return err
 	}
 
+	// encode the DER CSR bytes into PEM format
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrDER,
+	})
+
 	// set the CSR field on the order to be created
-	template.Spec.CSR = csrBytes
+	template.Spec.CSR = csrPEM
 
 	o, err := a.CMClient.CertmanagerV1alpha1().Orders(template.Namespace).Create(template)
 	if err != nil {
@@ -360,7 +365,7 @@ func existingOrderIsValidForKey(o *v1alpha1.Order, key crypto.Signer) (bool, err
 		// Handles a weird case where an Order exists *without* a CSR set
 		return false, nil
 	}
-	existingCSR, err := x509.ParseCertificateRequest(csrBytes)
+	existingCSR, err := pki.DecodeX509CertificateRequestBytes(csrBytes)
 	if err != nil {
 		// Absorb invalid CSR data as 'not valid'
 		return false, nil

--- a/pkg/issuer/acme/issue_test.go
+++ b/pkg/issuer/acme/issue_test.go
@@ -119,10 +119,14 @@ func TestIssueHappyPath(t *testing.T) {
 			CommonName: "test.com",
 		},
 	}
-	testCertCSR, err := pki.EncodeCSR(testCertCSRTemplate, pk)
+	testCertCSRDER, err := pki.EncodeCSR(testCertCSRTemplate, pk)
 	if err != nil {
 		t.Errorf("error generating csr1: %v", err)
 	}
+	// encode the DER CSR bytes into PEM format
+	testCertCSR := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: testCertCSRDER,
+	})
 
 	// build actual test fixtures
 	testCert := &v1alpha1.Certificate{
@@ -327,14 +331,22 @@ func TestIssueRetryCases(t *testing.T) {
 			CommonName: "test.com",
 		},
 	}
-	testCSR1, err := pki.EncodeCSR(testCertCSRTemplate, pk1)
+	testCSR1DER, err := pki.EncodeCSR(testCertCSRTemplate, pk1)
 	if err != nil {
 		t.Errorf("error generating csr1: %v", err)
 	}
-	testCSR2, err := pki.EncodeCSR(testCertCSRTemplate, pk2)
+	// encode the DER CSR bytes into PEM format
+	testCSR1 := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: testCSR1DER,
+	})
+	testCSR2DER, err := pki.EncodeCSR(testCertCSRTemplate, pk2)
 	if err != nil {
 		t.Errorf("error generating csr2: %v", err)
 	}
+	// encode the DER CSR bytes into PEM format
+	testCSR2 := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: testCSR2DER,
+	})
 
 	testCert := &v1alpha1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{Name: "testcrt", Namespace: "default"},


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously the Order resource's CSR field was set to a DER encoded CSR instead of the expected format, PEM.

This PR does two things:

1) changes the ACME Issuer to create Orders with PEM encoded CSRs
2) changes the `acmeorders` controller to be able to handle both PEM and DER encoded CSRs, to prevent users upgrading from a release without this patch having broken in-flight orders.

In future, we should also extend our validation to validate that the CSR is PEM encoded. We will need to wait until after all users have moved off problematic versions before we can do so however, as otherwise we'd block updates to existing Order resources containing DER encoded CSRs.

Due to the way we check if the Order is up to date for a Certificate already, existing Order resources will be re-created as the CSR data will no longer decode properly in the `existingOrderIsValidForKey` function. This should be fairly harmless as Let's Encrypt supports deduplicating orders nowadays anyway, so the same Order will simply be resumed.

**Release note**:
```release-note
Properly encode the CSR field on Order resources as PEM data instead of DER
```

/cc @JoshVanL 