### PR TITLE
Enable 'status' subresource on CRDs

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -1799,8 +1799,6 @@ spec:
           type: object
       required:
       - metadata
-      - spec
-      - status
       type: object
   versions:
   - name: v1alpha1
@@ -7332,8 +7330,6 @@ spec:
           type: object
       required:
       - metadata
-      - spec
-      - status
       type: object
   versions:
   - name: v1alpha1

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -33,7 +33,8 @@ spec:
     - cr
     - crs
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: CertificateRequest is a type to represent a Certificate Signing
@@ -185,7 +186,8 @@ spec:
     - cert
     - certs
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Certificate is a type to represent a Certificate from ACME
@@ -441,7 +443,8 @@ spec:
     kind: Challenge
     plural: challenges
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Challenge is a type to represent a Challenge request with an ACME
@@ -1823,6 +1826,8 @@ spec:
     kind: ClusterIssuer
     plural: clusterissuers
   scope: Cluster
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -3766,6 +3771,8 @@ spec:
     kind: Issuer
     plural: issuers
   scope: Namespaced
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       properties:
@@ -5728,7 +5735,8 @@ spec:
     kind: Order
     plural: orders
   scope: Namespaced
-  subresources: {}
+  subresources:
+    status: {}
   validation:
     openAPIV3Schema:
       description: Order is a type to represent an Order with an ACME server

--- a/docs/getting-started/install/kubernetes.rst
+++ b/docs/getting-started/install/kubernetes.rst
@@ -14,6 +14,10 @@ resources which represent certificate authorities.
 More information on configuring different Issuer types can be found in the
 :doc:`respective setup guides </tasks/issuers/index>`.
 
+.. note::
+   From cert-manager v0.10.0 onwards, the minimum supported version of
+   Kubernetes is v1.10.0. Users still running Kubernetes 1.9 or below should
+   upgrade to a supported version before installing cert-manager.
 
 Installing with regular manifests
 =================================

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -28,6 +28,7 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 // +kubebuilder:printcolumn:name="Issuer",type="string",JSONPath=".spec.issuerRef.name",description="",priority=1
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=certificates,shortName=cert;certs
 type Certificate struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
@@ -35,6 +35,7 @@ const (
 // +kubebuilder:printcolumn:name="Issuer",type="string",JSONPath=".spec.issuerRef.name",description="",priority=1
 // +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.conditions[?(@.type==\"Ready\")].message",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=certificaterequests,shortName=cr;crs
 type CertificateRequest struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -32,6 +32,7 @@ import (
 // +kubebuilder:printcolumn:name="Domain",type="string",JSONPath=".spec.dnsName"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.reason",description="",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=challenges
 type Challenge struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -38,8 +38,8 @@ type Challenge struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   ChallengeSpec   `json:"spec"`
-	Status ChallengeStatus `json:"status"`
+	Spec   ChallengeSpec   `json:"spec,omitempty"`
+	Status ChallengeStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -24,9 +24,10 @@ import (
 
 // +genclient
 // +genclient:nonNamespaced
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=clusterissuers,scope=Cluster
 type ClusterIssuer struct {
 	metav1.TypeMeta   `json:",inline"`
@@ -47,9 +48,10 @@ type ClusterIssuerList struct {
 }
 
 // +genclient
-// +k8s:openapi-gen=true
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
+// +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=issuers
 type Issuer struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -32,6 +32,7 @@ import (
 // +kubebuilder:printcolumn:name="Issuer",type="string",JSONPath=".spec.issuerRef.name",description="",priority=1
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=".status.reason",description="",priority=1
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC."
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:path=orders
 type Order struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -38,8 +38,8 @@ type Order struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   OrderSpec   `json:"spec"`
-	Status OrderStatus `json:"status"`
+	Spec   OrderSpec   `json:"spec,omitempty"`
+	Status OrderStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -163,7 +163,7 @@ func (c *controller) runScheduler(ctx context.Context) {
 		ch = ch.DeepCopy()
 		ch.Status.Processing = true
 
-		_, err := c.cmClient.CertmanagerV1alpha1().Challenges(ch.Namespace).Update(ch)
+		_, err := c.cmClient.CertmanagerV1alpha1().Challenges(ch.Namespace).UpdateStatus(ch)
 		if err != nil {
 			log.Error(err, "error scheduling challenge for processing")
 			return

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -69,7 +69,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmapi.Challenge) (err error) 
 		if reflect.DeepEqual(oldChal.Status, ch.Status) && len(oldChal.Finalizers) == len(ch.Finalizers) {
 			return
 		}
-		_, updateErr := c.cmClient.CertmanagerV1alpha1().Challenges(ch.Namespace).Update(ch)
+		_, updateErr := c.cmClient.CertmanagerV1alpha1().Challenges(ch.Namespace).UpdateStatus(ch)
 		if err != nil {
 			err = utilerrors.NewAggregate([]error{err, updateErr})
 		}

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -89,7 +89,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengeURL("testurl"),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), gen.DefaultTestNamespace,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), "status", gen.DefaultTestNamespace,
 						gen.ChallengeFrom(baseChallenge,
 							gen.SetChallengeProcessing(true),
 							gen.SetChallengeURL("testurl"),
@@ -126,7 +126,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengeType("http-01"),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), gen.DefaultTestNamespace,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), "status", gen.DefaultTestNamespace,
 						gen.ChallengeFrom(baseChallenge,
 							gen.SetChallengeProcessing(true),
 							gen.SetChallengeURL("testurl"),
@@ -168,7 +168,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengePresented(true),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), gen.DefaultTestNamespace,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), "status", gen.DefaultTestNamespace,
 						gen.ChallengeFrom(baseChallenge,
 							gen.SetChallengeProcessing(true),
 							gen.SetChallengeURL("testurl"),
@@ -220,7 +220,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengePresented(true),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), gen.DefaultTestNamespace,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), "status", gen.DefaultTestNamespace,
 						gen.ChallengeFrom(baseChallenge,
 							gen.SetChallengeProcessing(true),
 							gen.SetChallengeURL("testurl"),
@@ -275,7 +275,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengePresented(true),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), gen.DefaultTestNamespace,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), "status", gen.DefaultTestNamespace,
 						gen.ChallengeFrom(baseChallenge,
 							gen.SetChallengeProcessing(false),
 							gen.SetChallengeURL("testurl"),
@@ -308,7 +308,7 @@ func TestSyncHappyPath(t *testing.T) {
 					gen.SetChallengePresented(true),
 				), testIssuerHTTP01Enabled},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), gen.DefaultTestNamespace,
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("challenges"), "status", gen.DefaultTestNamespace,
 						gen.ChallengeFrom(baseChallenge,
 							gen.SetChallengeProcessing(false),
 							gen.SetChallengeURL("testurl"),

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -74,7 +74,7 @@ func (c *controller) Sync(ctx context.Context, o *cmapi.Order) (err error) {
 			return
 		}
 		log.Info("updating Order resource status")
-		_, updateErr := c.cmClient.CertmanagerV1alpha1().Orders(o.Namespace).Update(o)
+		_, updateErr := c.cmClient.CertmanagerV1alpha1().Orders(o.Namespace).UpdateStatus(o)
 		if err != nil {
 			log.Error(err, "failed to update status")
 			err = utilerrors.NewAggregate([]error{err, updateErr})

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -153,7 +153,7 @@ dGVzdA==
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{testIssuerHTTP01Enabled, testOrder},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), testOrderPending.Namespace, testOrderPending)),
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), "status", testOrderPending.Namespace, testOrderPending)),
 				},
 			},
 			acmeClient: &acmecl.FakeACME{
@@ -196,7 +196,7 @@ dGVzdA==
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{testIssuerHTTP01Enabled, testOrderPending, testAuthorizationChallengeValid},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), testOrderReady.Namespace, testOrderReady)),
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), "status", testOrderReady.Namespace, testOrderReady)),
 				},
 			},
 			acmeClient: &acmecl.FakeACME{
@@ -210,7 +210,7 @@ dGVzdA==
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{testIssuerHTTP01Enabled, testOrderReady, testAuthorizationChallengeValid},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), testOrderValid.Namespace, testOrderValid)),
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), "status", testOrderValid.Namespace, testOrderValid)),
 				},
 				ExpectedEvents: []string{
 					"Normal OrderValid Order completed successfully",
@@ -231,7 +231,7 @@ dGVzdA==
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{testIssuerHTTP01Enabled, testOrderPending, testAuthorizationChallengeInvalid},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), testOrderInvalid.Namespace, testOrderInvalid)),
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(v1alpha1.SchemeGroupVersion.WithResource("orders"), "status", testOrderInvalid.Namespace, testOrderInvalid)),
 				},
 			},
 			acmeClient: &acmecl.FakeACME{

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -187,8 +187,5 @@ func (c *Controller) updateCertificateRequestStatus(ctx context.Context, old, ne
 	}
 
 	log.V(logf.DebugLevel).Info("updating resource due to change in status", "diff", pretty.Diff(string(oldBytes), string(newBytes)))
-	// TODO: replace Update call with UpdateStatus. This requires a custom API
-	// server with the /status subresource enabled and/or subresource support
-	// for CRDs (https://github.com/kubernetes/kubernetes/issues/38113)
-	return c.cmClient.CertmanagerV1alpha1().CertificateRequests(new.Namespace).Update(new)
+	return c.cmClient.CertmanagerV1alpha1().CertificateRequests(new.Namespace).UpdateStatus(new)
 }

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -256,8 +256,9 @@ func TestSync(t *testing.T) {
 					gen.CertificateRequest("test"),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCRIssuePendingCondition,
 					)),
@@ -283,8 +284,9 @@ func TestSync(t *testing.T) {
 						gen.SetIssuerSelfSigned(cmapi.SelfSignedIssuer{}),
 					)},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCRReadyCondition,
 					)),
@@ -312,8 +314,9 @@ func TestSync(t *testing.T) {
 					),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCRReadyConditionWithGroupRef,
 					)),
@@ -379,8 +382,9 @@ func TestSync(t *testing.T) {
 					),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCRGarbageCondition,
 					)),
@@ -397,8 +401,9 @@ func TestSync(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{gen.CertificateRequest("test")},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCRIssuerNotFoundPendingCondition,
 					)),
@@ -424,8 +429,9 @@ func TestSync(t *testing.T) {
 					),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCRIssuerNotFoundPendingCondition,
 					)),
@@ -471,8 +477,9 @@ func TestSync(t *testing.T) {
 					),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleFailedValidationCR,
 					)),

--- a/pkg/controller/certificates/certificate_request_test.go
+++ b/pkg/controller/certificates/certificate_request_test.go
@@ -1486,8 +1486,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1518,8 +1519,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1552,8 +1554,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1587,8 +1590,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificateRequest,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1626,8 +1630,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1667,8 +1672,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificateRequest,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1707,8 +1713,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1748,8 +1755,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificateRequest,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1789,8 +1797,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificateRequestReady,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1833,8 +1842,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1877,8 +1887,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificateRequest,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1916,8 +1927,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -1956,8 +1968,9 @@ func TestUpdateStatus(t *testing.T) {
 					exampleBundle1.certificateRequest,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleBundle1.certificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -594,8 +594,5 @@ func updateCertificateStatus(ctx context.Context, m *metrics.Metrics, cmClient c
 		return nil, nil
 	}
 	log.V(logf.DebugLevel).Info("updating resource due to change in status", "diff", pretty.Diff(string(oldBytes), string(newBytes)))
-	// TODO: replace Update call with UpdateStatus. This requires a custom API
-	// server with the /status subresource enabled and/or subresource support
-	// for CRDs (https://github.com/kubernetes/kubernetes/issues/38113)
-	return cmClient.CertmanagerV1alpha1().Certificates(new.Namespace).Update(new)
+	return cmClient.CertmanagerV1alpha1().Certificates(new.Namespace).UpdateStatus(new)
 }

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -182,8 +182,9 @@ func TestSync(t *testing.T) {
 					exampleCert,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertNotFoundCondition,
 					)),
@@ -206,8 +207,9 @@ func TestSync(t *testing.T) {
 					testIssuerReady,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertNotFoundCondition,
 					)),
@@ -272,8 +274,9 @@ func TestSync(t *testing.T) {
 					exampleCert,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertNotFoundCondition,
 					)),
@@ -324,8 +327,9 @@ func TestSync(t *testing.T) {
 					exampleCert,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertNotFoundCondition,
 					)),
@@ -390,8 +394,9 @@ func TestSync(t *testing.T) {
 					exampleCert,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertNotFoundCondition,
 					)),
@@ -465,8 +470,9 @@ func TestSync(t *testing.T) {
 					gen.Certificate("test"),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleCert,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -551,8 +557,9 @@ func TestSync(t *testing.T) {
 					gen.Certificate("test"),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleCert,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -634,8 +641,9 @@ func TestSync(t *testing.T) {
 							},
 						},
 					)),
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertTemporaryCondition,
 					)),
@@ -680,8 +688,9 @@ func TestSync(t *testing.T) {
 					exampleCert,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleCert,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -746,8 +755,9 @@ func TestSync(t *testing.T) {
 					),
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(exampleCert,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
@@ -782,8 +792,9 @@ func TestSync(t *testing.T) {
 				},
 				ExpectedActions: []testpkg.Action{
 					// specifically tests that a secret is created - behaves as usual
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						exampleCertNotFoundCondition,
 					)),
@@ -966,8 +977,9 @@ func TestDisableOldConfigFeatureFlagDisabled(t *testing.T) {
 					newFormatCertificate,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificates"),
+						"status",
 						gen.DefaultTestNamespace,
 						gen.CertificateFrom(newFormatCertificate,
 							gen.SetCertificateStatusCondition(cmapi.CertificateCondition{

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -88,8 +88,5 @@ func (c *controller) updateIssuerStatus(old, new *v1alpha1.ClusterIssuer) (*v1al
 	if reflect.DeepEqual(old.Status, new.Status) {
 		return nil, nil
 	}
-	// TODO: replace Update call with UpdateStatus. This requires a custom API
-	// server with the /status subresource enabled and/or subresource support
-	// for CRDs (https://github.com/kubernetes/kubernetes/issues/38113)
-	return c.cmClient.CertmanagerV1alpha1().ClusterIssuers().Update(new)
+	return c.cmClient.CertmanagerV1alpha1().ClusterIssuers().UpdateStatus(new)
 }

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -88,8 +88,5 @@ func (c *controller) updateIssuerStatus(old, new *v1alpha1.Issuer) (*v1alpha1.Is
 	if reflect.DeepEqual(old.Status, new.Status) {
 		return nil, nil
 	}
-	// TODO: replace Update call with UpdateStatus. This requires a custom API
-	// server with the /status subresource enabled and/or subresource support
-	// for CRDs (https://github.com/kubernetes/kubernetes/issues/38113)
-	return c.cmClient.CertmanagerV1alpha1().Issuers(new.Namespace).Update(new)
+	return c.cmClient.CertmanagerV1alpha1().Issuers(new.Namespace).UpdateStatus(new)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This patches enables the 'status' subresource on our CRDs and switches the controllers over to use `UpdateStatus` instead of `Update`.

This has been supported in Kubernetes since v1.8 or v1.9, and enabled by default (i.e. on GKE etc) since 1.10.

Given that Kubernetes 1.11 is now the oldest supported version (as of 1.15 being recently released), we are now 6mths clear of EOL for k8s 1.9. I think it's now probably safe to switch this and break compatibility with Kubernetes 1.9 (making our minimum supported version 1.10).

**Release note**:
```release-note
Enable 'status' subresource on cert-manager CRDs (this change bumps the minimum supported Kubernetes version to 1.10)
```
