### PR TITLE
Fix enum type validation schema in API

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -121,6 +121,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -311,6 +315,9 @@ spec:
                 either "rsa" or "ecdsa" If KeyAlgorithm is specified and KeySize is
                 not provided, key size of 256 will be used for "ecdsa" key algorithm
                 and key size of 2048 will be used for "rsa" key algorithm.
+              enum:
+              - rsa
+              - ecdsa
               type: string
             keyEncoding:
               description: KeyEncoding is the private key cryptography standards (PKCS)
@@ -318,6 +325,9 @@ spec:
                 allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8,
                 respectively. If KeyEncoding is not specified, then PKCS#1 will be
                 used by default.
+              enum:
+              - pkcs1
+              - pkcs8
               type: string
             keySize:
               description: KeySize is the key bit size of the corresponding private
@@ -366,6 +376,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -616,6 +630,11 @@ spec:
                           - name
                           type: object
                         environment:
+                          enum:
+                          - AzurePublicCloud
+                          - AzureChinaCloud
+                          - AzureGermanCloud
+                          - AzureUSGovernmentCloud
                           type: string
                         hostedZoneName:
                           type: string
@@ -681,6 +700,9 @@ spec:
                     cnameStrategy:
                       description: CNAMEStrategy configures how the DNS01 provider
                         should handle CNAME records when found in DNS zones.
+                      enum:
+                      - None
+                      - Follow
                       type: string
                     digitalocean:
                       description: ACMEIssuerDNS01ProviderDigitalOcean is a structure
@@ -1762,6 +1784,14 @@ spec:
             state:
               description: State contains the current 'state' of the challenge. If
                 not set, the state of the challenge is unknown.
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
           type: object
       required:
@@ -1929,6 +1959,11 @@ spec:
                                 - name
                                 type: object
                               environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
                                 type: string
                               hostedZoneName:
                                 type: string
@@ -1998,6 +2033,9 @@ spec:
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
                             type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
@@ -2278,6 +2316,11 @@ spec:
                                 - name
                                 type: object
                               environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
                                 type: string
                               hostedZoneName:
                                 type: string
@@ -2347,6 +2390,9 @@ spec:
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
                             type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
@@ -3681,6 +3727,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -3852,6 +3902,11 @@ spec:
                                 - name
                                 type: object
                               environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
                                 type: string
                               hostedZoneName:
                                 type: string
@@ -3921,6 +3976,9 @@ spec:
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
                             type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
@@ -4201,6 +4259,11 @@ spec:
                                 - name
                                 type: object
                               environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
                                 type: string
                               hostedZoneName:
                                 type: string
@@ -4270,6 +4333,9 @@ spec:
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
                             type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
@@ -5604,6 +5670,10 @@ spec:
                   status:
                     description: Status of the condition, one of ('True', 'False',
                       'Unknown').
+                    enum:
+                    - "True"
+                    - "False"
+                    - Unknown
                     type: string
                   type:
                     description: Type of the condition, currently ('Ready').
@@ -5971,6 +6041,11 @@ spec:
                                 - name
                                 type: object
                               environment:
+                                enum:
+                                - AzurePublicCloud
+                                - AzureChinaCloud
+                                - AzureGermanCloud
+                                - AzureUSGovernmentCloud
                                 type: string
                               hostedZoneName:
                                 type: string
@@ -6040,6 +6115,9 @@ spec:
                           cnameStrategy:
                             description: CNAMEStrategy configures how the DNS01 provider
                               should handle CNAME records when found in DNS zones.
+                            enum:
+                            - None
+                            - Follow
                             type: string
                           digitalocean:
                             description: ACMEIssuerDNS01ProviderDigitalOcean is a
@@ -7228,6 +7306,14 @@ spec:
             state:
               description: State contains the current state of this Order resource.
                 States 'success' and 'expired' are 'final'
+              enum:
+              - valid
+              - ready
+              - pending
+              - processing
+              - invalid
+              - expired
+              - errored
               type: string
             url:
               description: URL of the Order. This will initially be empty when the

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -26,6 +26,7 @@ const (
 )
 
 // ConditionStatus represents a condition's status.
+// +kubebuilder:validation:Enum=True;False;Unknown
 type ConditionStatus string
 
 // These are valid condition statuses. "ConditionTrue" means a resource is in

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -47,6 +47,7 @@ type CertificateList struct {
 	Items []Certificate `json:"items"`
 }
 
+// +kubebuilder:validation:Enum=rsa;ecdsa
 type KeyAlgorithm string
 
 const (
@@ -54,6 +55,7 @@ const (
 	ECDSAKeyAlgorithm KeyAlgorithm = "ecdsa"
 )
 
+// +kubebuilder:validation:Enum=pkcs1;pkcs8
 type KeyEncoding string
 
 const (
@@ -130,7 +132,6 @@ type CertificateSpec struct {
 	// If KeyAlgorithm is specified and KeySize is not provided,
 	// key size of 256 will be used for "ecdsa" key algorithm and
 	// key size of 2048 will be used for "rsa" key algorithm.
-	// +kubebuilder:validation:Enum=rsa;ecdsa
 	// +optional
 	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
 
@@ -166,7 +167,6 @@ type CertificateCondition struct {
 	Type CertificateConditionType `json:"type"`
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
-	// +kubebuilder:validation:Enum=True;False;Unknown
 	Status ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
@@ -102,7 +102,6 @@ type CertificateRequestCondition struct {
 	Type CertificateRequestConditionType `json:"type"`
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
-	// +kubebuilder:validation:Enum=True;False;Unknown
 	Status ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -127,7 +127,6 @@ type ChallengeStatus struct {
 
 	// State contains the current 'state' of the challenge.
 	// If not set, the state of the challenge is unknown.
-	// +kubebuilder:validation:Enum=valid;ready;pending;processing;invalid;expired;errored
 	// +optional
 	State State `json:"state,omitempty"`
 }

--- a/pkg/apis/certmanager/v1alpha1/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha1/types_issuer.go
@@ -338,7 +338,6 @@ type ACMEChallengeSolverDNS01 struct {
 	// CNAMEStrategy configures how the DNS01 provider should handle CNAME
 	// records when found in DNS zones.
 	// +optional
-	// +kubebuilder:validation:Enum=None;Follow
 	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy,omitempty"`
 
 	// +optional
@@ -396,7 +395,6 @@ type ACMEIssuerDNS01Provider struct {
 	// CNAMEStrategy configures how the DNS01 provider should handle CNAME
 	// records when found in DNS zones.
 	// +optional
-	// +kubebuilder:validation:Enum=None;Follow
 	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy,omitempty"`
 
 	// +optional
@@ -432,6 +430,7 @@ type ACMEIssuerDNS01Provider struct {
 // CNAMEStrategy configures how the DNS01 provider should handle CNAME records
 // when found in DNS zones.
 // By default, the None strategy will be applied (i.e. do not follow CNAMEs).
+// +kubebuilder:validation:Enum=None;Follow
 type CNAMEStrategy string
 
 const (
@@ -505,10 +504,19 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	// +optional
 	HostedZoneName string `json:"hostedZoneName,omitempty"`
 
-	// +kubebuilder:validation:Enum=,AzurePublicCloud,AzureChinaCloud,AzureGermanCloud,AzureUSGovernmentCloud
 	// +optional
-	Environment string `json:"environment,omitempty"`
+	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 }
+
+// +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
+type AzureDNSEnvironment string
+
+const (
+	AzurePublicCloud       AzureDNSEnvironment = "AzurePublicCloud"
+	AzureChinaCloud        AzureDNSEnvironment = "AzureChinaCloud"
+	AzureGermanCloud       AzureDNSEnvironment = "AzureGermanCloud"
+	AzureUSGovernmentCloud AzureDNSEnvironment = "AzureUSGovernmentCloud"
+)
 
 // ACMEIssuerDNS01ProviderAcmeDNS is a structure containing the
 // configuration for ACME-DNS servers
@@ -597,7 +605,6 @@ type IssuerCondition struct {
 	Type IssuerConditionType `json:"type"`
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
-	// +kubebuilder:validation:Enum=True;False;Unknown
 	Status ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -117,7 +117,6 @@ type OrderStatus struct {
 
 	// State contains the current state of this Order resource.
 	// States 'success' and 'expired' are 'final'
-	// +kubebuilder:validation:Enum=valid;ready;pending;processing;invalid;expired;errored
 	// +optional
 	State State `json:"state,omitempty"`
 
@@ -143,6 +142,7 @@ type OrderStatus struct {
 // Full details of these values can be found here: https://tools.ietf.org/html/draft-ietf-acme-acme-15#section-7.1.6
 // Clients utilising this type must also gracefully handle unknown
 // values, as the contents of this enumeration may be added to over time.
+// +kubebuilder:validation:Enum=valid;ready;pending;processing;invalid;expired;errored
 type State string
 
 const (

--- a/pkg/apis/certmanager/validation/issuer.go
+++ b/pkg/apis/certmanager/validation/issuer.go
@@ -276,10 +276,10 @@ func ValidateACMEIssuerDNS01Config(iss *v1alpha1.ACMEIssuerDNS01Config, fldPath 
 					el = append(el, field.Required(fldPath.Child("azuredns", "resourceGroupName"), ""))
 				}
 				switch p.AzureDNS.Environment {
-				case "", "AzurePublicCloud", "AzureChinaCloud", "AzureGermanCloud", "AzureUSGovernmentCloud":
+				case "", v1alpha1.AzurePublicCloud, v1alpha1.AzureChinaCloud, v1alpha1.AzureGermanCloud, v1alpha1.AzureUSGovernmentCloud:
 				default:
 					el = append(el, field.Invalid(fldPath.Child("azuredns", "environment"), p.AzureDNS.Environment,
-						"must be either empty or one of AzurePublicCloud, AzureChinaCloud, AzureGermanCloud or AzureUSGovernmentCloud"))
+						fmt.Sprintf("must be either empty or one of %s, %s, %s or %s", v1alpha1.AzurePublicCloud, v1alpha1.AzureChinaCloud, v1alpha1.AzureGermanCloud, v1alpha1.AzureUSGovernmentCloud)))
 				}
 			}
 		}

--- a/pkg/apis/certmanager/validation/issuer_test.go
+++ b/pkg/apis/certmanager/validation/issuer_test.go
@@ -590,7 +590,7 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(providersPath.Index(0).Child("azuredns", "subscriptionID"), ""),
 				field.Required(providersPath.Index(0).Child("azuredns", "tenantID"), ""),
 				field.Required(providersPath.Index(0).Child("azuredns", "resourceGroupName"), ""),
-				field.Invalid(providersPath.Index(0).Child("azuredns", "environment"), "an env",
+				field.Invalid(providersPath.Index(0).Child("azuredns", "environment"), v1alpha1.AzureDNSEnvironment("an env"),
 					"must be either empty or one of AzurePublicCloud, AzureChinaCloud, AzureGermanCloud or AzureUSGovernmentCloud"),
 			},
 		},

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -345,7 +345,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, issuer v1alpha1.Generic
 		}
 
 		impl, err = s.dnsProviderConstructors.azureDNS(
-			providerConfig.AzureDNS.Environment,
+			string(providerConfig.AzureDNS.Environment),
 			providerConfig.AzureDNS.ClientID,
 			string(clientSecretBytes),
 			providerConfig.AzureDNS.SubscriptionID,


### PR DESCRIPTION
**What this PR does / why we need it**:

controller-tools requires the enum validation definitions to be set on the types themselves, and not fields of that type.

This PR adjusts our CRD schema validation to include these enum types.

**Release note**:
```release-note
NONE
```

/assign @JoshVanL 