### PR TITLE
docs(azure): Fix DNS challenge instructions

### DIFF
--- a/docs/tasks/issuers/setup-acme/dns01/azuredns.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/azuredns.rst
@@ -12,11 +12,11 @@ To create the service principal:
   :linenos:
 
   AZURE_CERT_MANAGER_SP_NAME=SOME_SERVICE_PRINCIPAL_NAME
-  AZURE_CERT_MANAGER_SP_PASSWORD=SOME_PASSWORD
   AZURE_CERT_MANAGER_DNS_RESOURCE_GROUP=SOME_RESOURCE_GROUP
   AZURE_CERT_MANAGER_DNS_NAME=SOME_DNS_ZONE
 
-  AZURE_CERT_MANAGER_SP_APP_ID=$(az ad sp create-for-rbac --name $AZURE_CERT_MANAGER_SP_NAME --password $AZURE_CERT_MANAGER_SP_PASSWORD --query "appId" --output tsv)
+  # Password is automatically generated. Query with "password" to get it
+  AZURE_CERT_MANAGER_SP_APP_ID=$(az ad sp create-for-rbac --name $AZURE_CERT_MANAGER_SP_NAME --query "appId" --output tsv)
 
   # Lower the Permissions of the SP
   az role assignment delete --assignee $AZURE_CERT_MANAGER_SP_APP_ID --role Contributor


### PR DESCRIPTION
**What this PR does / why we need it**:
There is no longer `--password` option.
https://docs.microsoft.com/en-us/cli/azure/ad/sp?view=azure-cli-latest#az-ad-sp-create-for-rbac

Just let the CLI creates the password for us.

**Which issue this PR fixes** 
N/A

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix DNS challenge instructions for Azure.
```
