### PR TITLE
Do not validate issuerRef's Kind field if group is not recognised

### DIFF
--- a/pkg/apis/certmanager/validation/certificate.go
+++ b/pkg/apis/certmanager/validation/certificate.go
@@ -123,13 +123,14 @@ func validateIssuerRef(issuerRef v1alpha1.ObjectReference, fldPath *field.Path) 
 	if issuerRef.Name == "" {
 		el = append(el, field.Required(issuerRefPath.Child("name"), "must be specified"))
 	}
-	switch issuerRef.Kind {
-	case "":
-	case "Issuer", "ClusterIssuer":
-	default:
-		el = append(el, field.Invalid(issuerRefPath.Child("kind"), issuerRef.Kind, "must be one of Issuer or ClusterIssuer"))
+	if issuerRef.Group == "" || issuerRef.Group == v1alpha1.SchemeGroupVersion.Group {
+		switch issuerRef.Kind {
+		case "":
+		case "Issuer", "ClusterIssuer":
+		default:
+			el = append(el, field.Invalid(issuerRefPath.Child("kind"), issuerRef.Kind, "must be one of Issuer or ClusterIssuer"))
+		}
 	}
-
 	return el
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This is needed in order to allow issuerRef's that specify `kind` fields other than Issuer/ClusterIssuer to be accepted by the validation webhook.

With this patch, we only validate the kind field if the group name field is empty.

This may need to be backported to v0.9 to support the on-going out-of-tree issuer efforts.

**Release note**:
```release-note
Don't validate issuerRef.kind field if issuerRef.group is set in order to support out-of-tree Issuer types
```
