### PR TITLE
Adds the CertificateRequest annotations section to JEP

### DIFF
--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -211,16 +211,19 @@ In order for `CertificateRequest` controllers to resolve requests, extra
 information may be needed that is not present in the API Spec. To pass on this
 information, a set of one or more annotations should be defined, with reliable
 value pairs. These annotations should be considered optional. Any
-`CertificiateRequest` controller that rely on these to function should fallback
-gracefully or be marked as failed in the event a required annotation is missing.
-The currently defined annotations are:
+`CertificiateRequest` controller that relies on these to function should
+fallback gracefully or be marked as failed in the event a required annotation is
+missing. The currently defined annotations are:
 
 - `certmanager.k8s.io/private-key-secret-name`: The name of the secret, in the
   same namespace as the `CertificateRequest`, that stores the private key which
   was used to sign the x509 certificate signing request. This is required by the
- `SelfSigning` issuer to sign its own certificate. Currently the `Certificate`
-  controller adds this annotation to all `CertificateRequest` resources it
-  creates with the defined `SecretName` in the Spec of the `Certificate`.
+  `SelfSigning` issuer to sign its own certificate. If this annotation is missing
+  or empty, the `SelfSign` `CertificateRequest` controller will mark the resource
+  as failed and no further processing will take place on it. Currently the
+  `Certificate` controller adds this annotation to all `CertificateRequest`
+  resources it creates with the defined `SecretName` in the Spec of the
+  `Certificate`.
 
 ### Test Plan
 

--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -11,7 +11,7 @@ approvers:
   - "@munnerz"
 editor: "@joshvanl"
 creation-date: 2019-07-08
-last-updated: 2019-07-09
+last-updated: 2019-08-01
 status: implementable
 ---
 
@@ -205,6 +205,17 @@ ownership of the default pool of issuers in the cert-manager project.
 
 Until the mutating webhook is fully implemented, we will handle defaulting
 internally in the controller.
+
+### CertificateRequest Annotations
+In order for `CertificateRequest` controllers to resolve requests, extra
+information may be needed that is not present in the API Spec. To pass on this
+information, a set of one or more annotations should be defined, with reliable
+value pairs. These are;
+
+- `certmanager.k8s.io/private-key-secret-name`: The name of the secret, in the
+  same namespace as the `CertificateRequest`, that stores the private key which
+  was used to sign the x509 certificate signing request. This is required by the
+ `SelfSigning` issuer to sign its own certificate.
 
 ### Test Plan
 

--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -210,12 +210,17 @@ internally in the controller.
 In order for `CertificateRequest` controllers to resolve requests, extra
 information may be needed that is not present in the API Spec. To pass on this
 information, a set of one or more annotations should be defined, with reliable
-value pairs. These are;
+value pairs. These annotations should be considered optional. Any
+`CertificiateRequest` controller that rely on these to function should fallback
+gracefully or be marked as failed in the event a required annotation is missing.
+The currently defined annotations are:
 
 - `certmanager.k8s.io/private-key-secret-name`: The name of the secret, in the
   same namespace as the `CertificateRequest`, that stores the private key which
   was used to sign the x509 certificate signing request. This is required by the
- `SelfSigning` issuer to sign its own certificate.
+ `SelfSigning` issuer to sign its own certificate. Currently the `Certificate`
+  controller adds this annotation to all `CertificateRequest` resources it
+  creates with the defined `SecretName` in the Spec of the `Certificate`.
 
 ### Test Plan
 


### PR DESCRIPTION
Signed-off-by: JoshVanL <vleeuwenjoshua@gmail.com>

Adds the annotations section to the `CerticiateRequest` enhancement proposal.

Also includes the private key annotation that is required by the self signing issuer.

```release-note
NONE
```

/assign @munnerz 
