### PR TITLE
include self-signed root CA in chain

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -336,10 +336,6 @@ func EncodeX509(cert *x509.Certificate) ([]byte, error) {
 func EncodeX509Chain(certs []*x509.Certificate) ([]byte, error) {
 	caPem := bytes.NewBuffer([]byte{})
 	for _, cert := range certs {
-		if bytes.Equal(cert.RawIssuer, cert.RawSubject) {
-			// Don't include self-signed certificate
-			continue
-		}
 		err := pem.Encode(caPem, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Signed-off-by: Aron Parsons <aron@knackworks.com>

**What this PR does / why we need it**:

Currently, cert-manager explicitly excludes self-signed CA certificates from the secrets it generates, even when the operator opts to include their self-signed CA certificate in the issuer secret.  It is critical to include the full CA chain so that mutual TLS authentication and verifying the whole chain work with the in-cluster secrets, versus having to include the root CA in every pod that needs it (which differs per container image and is a huge PITA to maintain).

The choice to exclude these certificates was made as part of https://github.com/jetstack/cert-manager/pull/1077.

All the details below, including current behavior and the behavior when this PR is applied.  Hopefully not too much detail, and I have commentary in between the command output to create the full story.

ClusterIssuer:
```
$ k -n certs describe clusterissuer
Name:         ca-issuer
Namespace:    
Labels:       app=certs
              chart=certs-2019.0.6
              heritage=Tiller
              release=certs
Annotations:  flux.weave.works/antecedent: certs:helmrelease/certs
API Version:  certmanager.k8s.io/v1alpha1
Kind:         ClusterIssuer
Metadata:
  Creation Timestamp:  2019-08-02T03:49:04Z
  Generation:          2
  Resource Version:    56512
  Self Link:           /apis/certmanager.k8s.io/v1alpha1/clusterissuers/ca-issuer
  UID:                 78e42b26-b4d8-11e9-b8f0-566fac170003
Spec:
  Ca:
    Secret Name:  ca-key-pair
Status:
  Conditions:
    Last Transition Time:  2019-08-02T03:49:06Z
    Message:               Signing CA verified
    Reason:                KeyPairVerified
    Status:                True
    Type:                  Ready
Events:
  Type    Reason           Age                From          Message
  ----    ------           ----               ----          -------
  Normal  KeyPairVerified  65s (x3 over 70s)  cert-manager  Signing CA verified
```

Root Certificate:
```
$ k -n certs get secret ca-keyca\.crt}' | base64 -dta.t
-----BEGIN CERTIFICATE-----
MIIFWDCCA0CgAwIBAgIUOIcIPkkuCKUN/vgeQadDicdQI98wDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI5MDcy
NzE2NDUwMFowRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEbMBkGA1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMIICIjANBgkqhkiG9w0BAQEF
AAOCAg8AMIICCgKCAgEAzSNyYrMCb5r5RYsomUE5ylqHZpD8edLFwMMqMHCg9OEv
S0Qs3zvIuI1BcAIS4X29ZWR/yXnrlf0yLzRrOos7xSk+DuQLGBvOWkPb8Vtm54qi
NWxSxDBhE7MRkwbxz6SZMTC2uGHg2qhijHONsFxoOun2m0dAbM/TV4OXlrn+/ME/
U5VkN4bWpMMO+Gt9wqZ8DKfJlmMDgk4tJPP20Q8VhdIC5cNDOL6tg4s5yr1N31Gr
OJvX5Wm7zSi27BALaeeT4XIo7DiNLn68y23Gz8Z7FZyUtCfB04tGH5L3B+2eGhi+
fHmSFyzdWvykn3iHZPmUIqnj2TaTG5u/audhWpniKNmGWKUodaSPrv4h9+ziSvDe
b/m89FRALFICouiDWr8FwsYx8++ph43tGlU8YcLk2UphGizjG7n1L8D8P8eu939N
Hmwl1AUOhzjZzwz/p7jg0PlM3bcUrVtRNcKbih0PxX+AzuKNrJn3NuJK8IaFHFA2
lcEu+f6Al/Urb5RQEngTJTdm35XXJwyoPzP9Zd5tKm+znIKbZCIB8u3Mg5xGcDOj
GJq4E3OCKJgTkFzgDJT4mr0ynHJdYkN4q0VOYl5MTKmEil0VS6e25yMW5iuMI9DZ
uBxgYymI3rC4Di9i9yPty5TWMJ3airtDx9HA4ZPKC4wwVzbgRKbp9of6sLXu358C
AwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0O
BBYEFGOVswbzmN5tT8HkQp/Ba38BrIqPMA0GCSqGSIb3DQEBDQUAA4ICAQBLaY80
Zmmd0cfP1Fw/IDkRTh/2hl7KA3AWw7EeKa+cynI/mXOQsjmWODhUFacj9yTLimC0
mt4afCwhSvI6LqeR94LAAvGB1o8pvkZYvMt4MZdLhPW2TCBAuvcnr08JDznNBkp3
JAXvQc0CVzKvQuCmOjibuhxiVhjywXtv0SRY4sUo+6jU7rtbFxeCeGVVZkwTGQlh
j//sA6gTT7qO4uMRUnAjqDeKlyAQN8408PVIdfYUni78ApHNhiIYElKX9fw3F8Ok
VSD4QARmxd1lIMf91CTCCxdqYx63NrBvuHH3WFnKdoGinl5VwAS4NWCx0ikyNaEU
c1lQFAGf+AJFu7WPUqQdAa4SyplKmZfn6dF/qymbPX7H/C9hY7vnwGM30mkHe5rp
JJNUFwLOV5oH+K2rg4V5WZBiYfiW3ILXA678hFGbfO/4n//c+20ssg4SD8MjZSMI
GRqBrlmTUrtAng+cK7TARTO+bWa/IcQg4LXRnDK7S0N8poE2MxBWvaGboleM7eDW
TuOENhK0Ri0/ngphOs/cNEsCiARhtW6ImJa5Un9Aq7uiusel6B1+8lPxTl9+BFqz
R7Aw680c2FgPiTJVTikTvqk8XEsSPFIi/B2uHXprb1y975MBfYp9HVC7h8IaaN3x
F5YWgysI6xZWCS9JfVwqqZ6U+ATvoBchJ0F+NA==
-----END CERTIFICATE-----

$ k -n certs get secret ca-key-pair -ojsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -text | grep -e Issuer: -e Subject: -e CA:TRUE
        Issuer: C=US, O=stack-bootstrap, CN=stack-bootstrap CA
        Subject: C=US, O=stack-bootstrap, CN=stack-bootstrap CA
                CA:TRUE
```

Intermediate Certificate:
```
$ k -n certs get secret ca-keytls\.crt}' | base64 -data.c
-----BEGIN CERTIFICATE-----
MIIFxjCCA66gAwIBAgIULooy6Qv0Gb5z9s+oO/nd1X+KRTgwDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI0MDcy
ODE2NDUwMFowUTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEoMCYGA1UEAxMfc3RhY2stYm9vdHN0cmFwIEludGVybWVkaWF0ZSBDQTCCAiIw
DQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANg3y0DNuK/l1nAxg0bZs36oFf7k
UoePwAupqy6tpYFy6qJvaJrZZv6FKJweFWIjhdabIxbIoadYYo12yExtywOJzXx+
Nr6zEAI9pqKtO+s1XbnTeM1h6A9uL7KSquHS48v5cKVR0JYtkSJ/NXGlW1f5n/Ew
T1xU4BDPBtdxKd2ZG8gsqPKKQ6LDWhJkhKchfcz+Hs0K117lO4NnZzsrUOlJyTBS
Izp61SfjMsdiQjkEqBUIJ9M2XcS/FXS/T8Eue5D8NKG7CyNCAvF+te+rOjYglfyQ
lmKePoLmWGZNjJfmy6UgPn/0+XsnN06+TbSTwAEAyXXOg9OaDThDSPWt27MBq+fT
KvPh00BEIOWjsbFSTNfwdmCJ9Qm6j4CBn+ODQi7S89cSQwJltMQk5IcmedLmjUjf
YF5FMupN9h6RAo3pkFczgaFDqdVKnr9h0ffG5fNvuoVN8KKOWqSxalvsS6UKDqoI
Uzx/AI8uRHTCQAT+tw9KvSTU+xYFzfMEsbxX7xclk6UArGjDLdzzFPcQMu1jZmND
ei+JXUCqXaU+sraVC5SPUDSg9xbYqF7blnjXt7wwcd6/hp6QoKoOfi7ThLrZsbYq
qnUkzdNYmfx9e4fXNTwO+HwdZbRwDlzStK1Wd0+UI2366xf4nSJzd+uwgJtAaB0O
Do5rkaugJNAViEu7AgMBAAGjgaIwgZ8wDgYDVR0PAQH/BAQDAgGGMBIGA1UdEwEB
/wQIMAYBAf8CAQAwHQYDVR0OBBYEFM+c5ZTruGloPirCpqKTNOQDf21NMB8GA1Ud
IwQYMBaAFGOVswbzmN5tT8HkQp/Ba38BrIqPMDkGA1UdHwQyMDAwLqAsoCqGKGh0
dHBzOi8vc3RhY2stYm9vdHN0cmFwL2FwaS92MS9jZnNzbC9jcmwwDQYJKoZIhvcN
AQENBQADggIBALl2UYfbC5cCsgTOOHa9+ZZ9TrjKc3dEIW1dRrj2L5aE/g3OXNe+
8037C2Gcfg5FCxzEr+KpwMgixxD4+XIdKYEuDkSaVGfBr2DIBnKADic/+4CqQGgP
nYwIAjGcz2QeZQvbeX77W+pZDMGb4SBzwc+Ji+kICfRPjlHEHDS8iP5TBnr/uQe/
S1/DQvQdmS9w8j7v0XJA7kH7ROCI9RANLtf7/mi7g4tThyELdYMjzsiGUjInA1Uv
ykTCuAxRHUqtXDe3v8O03n1hzAEcQms7LxtJCiKtzPLjppdWfvIwxDj1wtf8AOzB
lhM3YYJE1Ms5cMnQAvvI0OYvAiNoHi3qU8r9fsXyLmr4PVVvAfUIaC0L02PRoCFX
fjzcAAO/JPk+kBoQRL1ZaCgfmyLU+3QafEjgHLgvE9PLO9jKLMJGH8MxlKoEZhmg
PPx5JR2gUFDUrDJU058kEYurOzBzfw83HpiGyrStR/hCJCr8eBz/E/v43pIbzWp1
QkfZK3UCiLk8Q7D3Uw45N4t0NcJvl8zUH+5Q4vBgsdJFvqc0H+bXnmrsHmc9lW0z
LftUwk4S5A+LP2u97UP0crqiNQKiFRoOSz4tFEEb4CI7tnmgtss4w1Y7Lfhu7RxR
X+kUW/zT3ctX67FZ+3cdoGK/rWgbdhJTsjPCkGYWge/K1BjWnWP4W9L7
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
MIIFWDCCA0CgAwIBAgIUOIcIPkkuCKUN/vgeQadDicdQI98wDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI5MDcy
NzE2NDUwMFowRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEbMBkGA1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMIICIjANBgkqhkiG9w0BAQEF
AAOCAg8AMIICCgKCAgEAzSNyYrMCb5r5RYsomUE5ylqHZpD8edLFwMMqMHCg9OEv
S0Qs3zvIuI1BcAIS4X29ZWR/yXnrlf0yLzRrOos7xSk+DuQLGBvOWkPb8Vtm54qi
NWxSxDBhE7MRkwbxz6SZMTC2uGHg2qhijHONsFxoOun2m0dAbM/TV4OXlrn+/ME/
U5VkN4bWpMMO+Gt9wqZ8DKfJlmMDgk4tJPP20Q8VhdIC5cNDOL6tg4s5yr1N31Gr
OJvX5Wm7zSi27BALaeeT4XIo7DiNLn68y23Gz8Z7FZyUtCfB04tGH5L3B+2eGhi+
fHmSFyzdWvykn3iHZPmUIqnj2TaTG5u/audhWpniKNmGWKUodaSPrv4h9+ziSvDe
b/m89FRALFICouiDWr8FwsYx8++ph43tGlU8YcLk2UphGizjG7n1L8D8P8eu939N
Hmwl1AUOhzjZzwz/p7jg0PlM3bcUrVtRNcKbih0PxX+AzuKNrJn3NuJK8IaFHFA2
lcEu+f6Al/Urb5RQEngTJTdm35XXJwyoPzP9Zd5tKm+znIKbZCIB8u3Mg5xGcDOj
GJq4E3OCKJgTkFzgDJT4mr0ynHJdYkN4q0VOYl5MTKmEil0VS6e25yMW5iuMI9DZ
uBxgYymI3rC4Di9i9yPty5TWMJ3airtDx9HA4ZPKC4wwVzbgRKbp9of6sLXu358C
AwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0O
BBYEFGOVswbzmN5tT8HkQp/Ba38BrIqPMA0GCSqGSIb3DQEBDQUAA4ICAQBLaY80
Zmmd0cfP1Fw/IDkRTh/2hl7KA3AWw7EeKa+cynI/mXOQsjmWODhUFacj9yTLimC0
mt4afCwhSvI6LqeR94LAAvGB1o8pvkZYvMt4MZdLhPW2TCBAuvcnr08JDznNBkp3
JAXvQc0CVzKvQuCmOjibuhxiVhjywXtv0SRY4sUo+6jU7rtbFxeCeGVVZkwTGQlh
j//sA6gTT7qO4uMRUnAjqDeKlyAQN8408PVIdfYUni78ApHNhiIYElKX9fw3F8Ok
VSD4QARmxd1lIMf91CTCCxdqYx63NrBvuHH3WFnKdoGinl5VwAS4NWCx0ikyNaEU
c1lQFAGf+AJFu7WPUqQdAa4SyplKmZfn6dF/qymbPX7H/C9hY7vnwGM30mkHe5rp
JJNUFwLOV5oH+K2rg4V5WZBiYfiW3ILXA678hFGbfO/4n//c+20ssg4SD8MjZSMI
GRqBrlmTUrtAng+cK7TARTO+bWa/IcQg4LXRnDK7S0N8poE2MxBWvaGboleM7eDW
TuOENhK0Ri0/ngphOs/cNEsCiARhtW6ImJa5Un9Aq7uiusel6B1+8lPxTl9+BFqz
R7Aw680c2FgPiTJVTikTvqk8XEsSPFIi/B2uHXprb1y975MBfYp9HVC7h8IaaN3x
F5YWgysI6xZWCS9JfVwqqZ6U+ATvoBchJ0F+NA==
-----END CERTIFICATE-----

$ k -n certs get secret ca-key-pair -ojsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text | grep -e Issuer: -e Subject: -e CA:TRUE
        Issuer: C=US, O=stack-bootstrap, CN=stack-bootstrap CA
        Subject: C=US, O=stack-bootstrap, CN=stack-bootstrap Intermediate CA
                CA:TRUE, pathlen:0
```

I have the root CA appended to `tls.crt` as per https://github.com/jetstack/cert-manager/issues/1067 indicates that it should be included in the secrets created by the issuer.

Requesting a certificate issues it, but the full chain is not included in `tls.crt`, just the intermediate CA.  This prevents verifying the full chain by only referencing the secret values.

Certificate Request:
```
apiVersion: certmanager.k8s.io/v1alpha1
kind: Certificate
metadata:
  name: ztest
spec:
  secretName: ztest
  duration: 24h
  renewBefore: 12h
  dnsNames:
  - foo.example.com
  issuerRef:
    name: ca-issuer
    kind: ClusterIssuer
```

Details of `ca.crt` in the created secret:
```
$ k -n certs get secret ztest -ojsonpath='{.data.ca\.crt}' | base64 -d
-----BEGIN CERTIFICATE-----
MIIFxjCCA66gAwIBAgIULooy6Qv0Gb5z9s+oO/nd1X+KRTgwDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI0MDcy
ODE2NDUwMFowUTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEoMCYGA1UEAxMfc3RhY2stYm9vdHN0cmFwIEludGVybWVkaWF0ZSBDQTCCAiIw
DQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANg3y0DNuK/l1nAxg0bZs36oFf7k
UoePwAupqy6tpYFy6qJvaJrZZv6FKJweFWIjhdabIxbIoadYYo12yExtywOJzXx+
Nr6zEAI9pqKtO+s1XbnTeM1h6A9uL7KSquHS48v5cKVR0JYtkSJ/NXGlW1f5n/Ew
T1xU4BDPBtdxKd2ZG8gsqPKKQ6LDWhJkhKchfcz+Hs0K117lO4NnZzsrUOlJyTBS
Izp61SfjMsdiQjkEqBUIJ9M2XcS/FXS/T8Eue5D8NKG7CyNCAvF+te+rOjYglfyQ
lmKePoLmWGZNjJfmy6UgPn/0+XsnN06+TbSTwAEAyXXOg9OaDThDSPWt27MBq+fT
KvPh00BEIOWjsbFSTNfwdmCJ9Qm6j4CBn+ODQi7S89cSQwJltMQk5IcmedLmjUjf
YF5FMupN9h6RAo3pkFczgaFDqdVKnr9h0ffG5fNvuoVN8KKOWqSxalvsS6UKDqoI
Uzx/AI8uRHTCQAT+tw9KvSTU+xYFzfMEsbxX7xclk6UArGjDLdzzFPcQMu1jZmND
ei+JXUCqXaU+sraVC5SPUDSg9xbYqF7blnjXt7wwcd6/hp6QoKoOfi7ThLrZsbYq
qnUkzdNYmfx9e4fXNTwO+HwdZbRwDlzStK1Wd0+UI2366xf4nSJzd+uwgJtAaB0O
Do5rkaugJNAViEu7AgMBAAGjgaIwgZ8wDgYDVR0PAQH/BAQDAgGGMBIGA1UdEwEB
/wQIMAYBAf8CAQAwHQYDVR0OBBYEFM+c5ZTruGloPirCpqKTNOQDf21NMB8GA1Ud
IwQYMBaAFGOVswbzmN5tT8HkQp/Ba38BrIqPMDkGA1UdHwQyMDAwLqAsoCqGKGh0
dHBzOi8vc3RhY2stYm9vdHN0cmFwL2FwaS92MS9jZnNzbC9jcmwwDQYJKoZIhvcN
AQENBQADggIBALl2UYfbC5cCsgTOOHa9+ZZ9TrjKc3dEIW1dRrj2L5aE/g3OXNe+
8037C2Gcfg5FCxzEr+KpwMgixxD4+XIdKYEuDkSaVGfBr2DIBnKADic/+4CqQGgP
nYwIAjGcz2QeZQvbeX77W+pZDMGb4SBzwc+Ji+kICfRPjlHEHDS8iP5TBnr/uQe/
S1/DQvQdmS9w8j7v0XJA7kH7ROCI9RANLtf7/mi7g4tThyELdYMjzsiGUjInA1Uv
ykTCuAxRHUqtXDe3v8O03n1hzAEcQms7LxtJCiKtzPLjppdWfvIwxDj1wtf8AOzB
lhM3YYJE1Ms5cMnQAvvI0OYvAiNoHi3qU8r9fsXyLmr4PVVvAfUIaC0L02PRoCFX
fjzcAAO/JPk+kBoQRL1ZaCgfmyLU+3QafEjgHLgvE9PLO9jKLMJGH8MxlKoEZhmg
PPx5JR2gUFDUrDJU058kEYurOzBzfw83HpiGyrStR/hCJCr8eBz/E/v43pIbzWp1
QkfZK3UCiLk8Q7D3Uw45N4t0NcJvl8zUH+5Q4vBgsdJFvqc0H+bXnmrsHmc9lW0z
LftUwk4S5A+LP2u97UP0crqiNQKiFRoOSz4tFEEb4CI7tnmgtss4w1Y7Lfhu7RxR
X+kUW/zT3ctX67FZ+3cdoGK/rWgbdhJTsjPCkGYWge/K1BjWnWP4W9L7
-----END CERTIFICATE-----

k -n certs get secret ztest -ojsonpath='{.data.ca\.crt}' | base64 -d | openssl x509 -text | grep -e Issuer: -e Subject: -e CA:TRUE
        Issuer: C=US, O=stack-bootstrap, CN=stack-bootstrap CA
        Subject: C=US, O=stack-bootstrap, CN=stack-bootstrap Intermediate CA
                CA:TRUE, pathlen:0
```

Details of `tls.crt` in the created secret:
```
$ k -n certs get secret ztest -ojsonpath='{.data.tls\.crt}' | base64 -d
-----BEGIN CERTIFICATE-----
MIIEaTCCAlGgAwIBAgIQFh0ah86olry9hjS7wLLXjzANBgkqhkiG9w0BAQsFADBR
MQswCQYDVQQGEwJVUzEYMBYGA1UEChMPc3RhY2stYm9vdHN0cmFwMSgwJgYDVQQD
Ex9zdGFjay1ib290c3RyYXAgSW50ZXJtZWRpYXRlIENBMB4XDTE5MDgwMjAzNTM0
M1oXDTE5MDgwMzAzNTM0M1owMTEVMBMGA1UEChMMY2VydC1tYW5hZ2VyMRgwFgYD
VQQDEw9mb28uZXhhbXBsZS5jb20wggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEK
AoIBAQDgc+MPvTtKt1yMgqXge7o7XnuL5g85sPcC1jhCI3JfpttDyiFnoi4/ci5Z
sZtexm+0DE0JZqAlxFP7BRQdDJVfciz/o0vZhkZ+p6RqtSzVQMyhFjUWZet5mM4i
kQvFf+Gx1bU6hyrfV6RP3BLA962Q3iw5ytUSSAa6c3gGc/IpW/Ic2BRWm1Tc9CtF
SHXBfMdjh0UNmRudNRAg+GRv6zPmTkbH51z1ujqMeUAGAUO9qvx+dDEUjhLZW43g
6NVZTjkZkvT49EHXp6G2FHRYXj4qJmYSxyagso4AcS/UA+0iJbu+qxS2nnZl39h8
vRtBNg6Kiq8/d+vzVOAeSu91goENAgMBAAGjXTBbMA4GA1UdDwEB/wQEAwIFoDAM
BgNVHRMBAf8EAjAAMB8GA1UdIwQYMBaAFM+c5ZTruGloPirCpqKTNOQDf21NMBoG
A1UdEQQTMBGCD2Zvby5leGFtcGxlLmNvbTANBgkqhkiG9w0BAQsFAAOCAgEAClPX
k+EzcN+70YsH2ZgNd0dpk4QfidsnBwoPh16V0EjCPtwKvd9kr46UpCIJWNCxrCyP
5CJlSvbRmIED/N0ZPf5+sE9+lOY8xn2EneYXGWbpa3eFflJL9y9q8plLeL68o3i7
k2svRvTuPPWcM3hzzl0QMrgH2svzT76p4UHICZFFPy0Rn+Rpy7b+0TMacoaqrLYx
jFr7c5x/x5DgLcUOXxK4cE/i58iEiR4E7rq9DZvfoyJ4VhGDnPaI51Ov1kALAKgn
igx/wY4uA73/Whl/DI4IazPHyZ2GBM/66G4V59i1O+/+Wc3H5dIoMrQHRJzqxa5F
tRzyilGDX82C5O0FTVspsHyPB5nfJpOu+QBZWPOcG3AcCcZ/dxU+c3RXmSFgLNwI
Xvbdutljmh0s1VJyCE3jBXBxTuAGKlyZWQN9JHJL1x0mDhpW+YIBiUFlDeEHN37/
EUyhb8qKmgjsnMzRe/Mlj8UbRr68deVyeM6H+YGtp6bWr3meUnv5MWOABkwMlvYQ
d8rc1lKElKkPVbqxMQ7G6e3dmmSTTWiKAFawDOzhEgA1Se8GgZHbmj7vnd0e8kIt
QP3bNO9Kjpysqn6z4ke+A+3rpkMdWAxp28Tx7NNGAcdGmhXXat8VbIsieUW6gb5T
8hcmk2q7oZCsdniVsaF5CSqemkk/nGPqf/VYM84=
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
MIIFxjCCA66gAwIBAgIULooy6Qv0Gb5z9s+oO/nd1X+KRTgwDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI0MDcy
ODE2NDUwMFowUTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEoMCYGA1UEAxMfc3RhY2stYm9vdHN0cmFwIEludGVybWVkaWF0ZSBDQTCCAiIw
DQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANg3y0DNuK/l1nAxg0bZs36oFf7k
UoePwAupqy6tpYFy6qJvaJrZZv6FKJweFWIjhdabIxbIoadYYo12yExtywOJzXx+
Nr6zEAI9pqKtO+s1XbnTeM1h6A9uL7KSquHS48v5cKVR0JYtkSJ/NXGlW1f5n/Ew
T1xU4BDPBtdxKd2ZG8gsqPKKQ6LDWhJkhKchfcz+Hs0K117lO4NnZzsrUOlJyTBS
Izp61SfjMsdiQjkEqBUIJ9M2XcS/FXS/T8Eue5D8NKG7CyNCAvF+te+rOjYglfyQ
lmKePoLmWGZNjJfmy6UgPn/0+XsnN06+TbSTwAEAyXXOg9OaDThDSPWt27MBq+fT
KvPh00BEIOWjsbFSTNfwdmCJ9Qm6j4CBn+ODQi7S89cSQwJltMQk5IcmedLmjUjf
YF5FMupN9h6RAo3pkFczgaFDqdVKnr9h0ffG5fNvuoVN8KKOWqSxalvsS6UKDqoI
Uzx/AI8uRHTCQAT+tw9KvSTU+xYFzfMEsbxX7xclk6UArGjDLdzzFPcQMu1jZmND
ei+JXUCqXaU+sraVC5SPUDSg9xbYqF7blnjXt7wwcd6/hp6QoKoOfi7ThLrZsbYq
qnUkzdNYmfx9e4fXNTwO+HwdZbRwDlzStK1Wd0+UI2366xf4nSJzd+uwgJtAaB0O
Do5rkaugJNAViEu7AgMBAAGjgaIwgZ8wDgYDVR0PAQH/BAQDAgGGMBIGA1UdEwEB
/wQIMAYBAf8CAQAwHQYDVR0OBBYEFM+c5ZTruGloPirCpqKTNOQDf21NMB8GA1Ud
IwQYMBaAFGOVswbzmN5tT8HkQp/Ba38BrIqPMDkGA1UdHwQyMDAwLqAsoCqGKGh0
dHBzOi8vc3RhY2stYm9vdHN0cmFwL2FwaS92MS9jZnNzbC9jcmwwDQYJKoZIhvcN
AQENBQADggIBALl2UYfbC5cCsgTOOHa9+ZZ9TrjKc3dEIW1dRrj2L5aE/g3OXNe+
8037C2Gcfg5FCxzEr+KpwMgixxD4+XIdKYEuDkSaVGfBr2DIBnKADic/+4CqQGgP
nYwIAjGcz2QeZQvbeX77W+pZDMGb4SBzwc+Ji+kICfRPjlHEHDS8iP5TBnr/uQe/
S1/DQvQdmS9w8j7v0XJA7kH7ROCI9RANLtf7/mi7g4tThyELdYMjzsiGUjInA1Uv
ykTCuAxRHUqtXDe3v8O03n1hzAEcQms7LxtJCiKtzPLjppdWfvIwxDj1wtf8AOzB
lhM3YYJE1Ms5cMnQAvvI0OYvAiNoHi3qU8r9fsXyLmr4PVVvAfUIaC0L02PRoCFX
fjzcAAO/JPk+kBoQRL1ZaCgfmyLU+3QafEjgHLgvE9PLO9jKLMJGH8MxlKoEZhmg
PPx5JR2gUFDUrDJU058kEYurOzBzfw83HpiGyrStR/hCJCr8eBz/E/v43pIbzWp1
QkfZK3UCiLk8Q7D3Uw45N4t0NcJvl8zUH+5Q4vBgsdJFvqc0H+bXnmrsHmc9lW0z
LftUwk4S5A+LP2u97UP0crqiNQKiFRoOSz4tFEEb4CI7tnmgtss4w1Y7Lfhu7RxR
X+kUW/zT3ctX67FZ+3cdoGK/rWgbdhJTsjPCkGYWge/K1BjWnWP4W9L7
-----END CERTIFICATE-----
```

You can see that the root CA is not included in the generated secret because of this conditional: https://github.com/jetstack/cert-manager/blob/master/pkg/util/pki/csr.go#L339

I do not believe that the choice to exclude the self-signed root certificate is valid.  In the case of a self-signed CA chain, not including the root CA makes including the intermediate pointless, as the whole chain can not be verified.

Below is the output of removing that check for self-signed CAs, and shows that the full chain is included in `tls.crt`, as desired.  I believe this is a safe change to make, because I have explicitly included my root CA in `tls.crt` of the issuer so that it does get included; if someone did not want that, they would opt not to put their full CA chain to the secret.

Patched version of cert-manager and full CA chain included, as desired:
```
$ k -n certs get secret ztest -ojsonpath='{.data.tls\.crt}' | base64 -d
-----BEGIN CERTIFICATE-----
MIIEajCCAlKgAwIBAgIRALmzxuAKbi4Lptgiy853j8AwDQYJKoZIhvcNAQELBQAw
UTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEoMCYGA1UE
AxMfc3RhY2stYm9vdHN0cmFwIEludGVybWVkaWF0ZSBDQTAeFw0xOTA4MDIwNDA1
MTFaFw0xOTA4MDMwNDA1MTFaMDExFTATBgNVBAoTDGNlcnQtbWFuYWdlcjEYMBYG
A1UEAxMPZm9vLmV4YW1wbGUuY29tMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIB
CgKCAQEA2+03pYc70XJD/0vnEJQq4BEE6a38cNLL3SvdSsPMU+KW3vYzYvl4zS2Z
JRJ7Ar6YF17Tj4vzKeOCjEdLwdRsqsLoCumAXnce7uGLpKUvk43jd8qWNPdEEQ4W
jaXey6QLbRpCgyqFaQNg69YgoJHkaYdcpH+FKw08KIh71MtBPfJ6EyqHACiCkXb2
8SHpZG7XizyRKDfy95uKYBlVGV1QfW4eMMOZAyEn4xr0KVoA7QbWqzac/oTu/Ctz
Lv/WMWogR8FBpD6h2s9lqrDUGeFLwtfzFESrvHmn6HNvnUU90FlvZi2zu3TvLSDM
ge7tqfzupsOmRvIdEdHnN4g1PGsfSQIDAQABo10wWzAOBgNVHQ8BAf8EBAMCBaAw
DAYDVR0TAQH/BAIwADAfBgNVHSMEGDAWgBTPnOWU67hpaD4qwqaikzTkA39tTTAa
BgNVHREEEzARgg9mb28uZXhhbXBsZS5jb20wDQYJKoZIhvcNAQELBQADggIBAFr3
7nPne6aN67i+Agn2RvTK18CG0QlGgfCabwmE0gU9RBi1KOP0Blzudj9FX9hWIf8m
j6++R3/aPz8uaGAgtslqlWGnH1uyzSSpAr/He+M2AS3fRXG7cBFBgXOTUqtgd2Me
ppcJ0lpEbCyV3WXqU0rXASHpat4D2944yDM7e94X9ikVuPodT5WvmkcLt3maYC9B
VkKlG6plzUzrYbTjePZMVYLh+o0hcyJG7mmdYhIJJ6zmReXAFnEf6Xnw/A1nOBFD
zhU61U+he9OI1YNsoR7ihZrN2Tay6nE7J3/JUGHYcx2w19aKE7XXo2Y5AewaEmIw
FUOR9bnss1TskRHi6YVPKNFWR2RUxQi/hRzTVw3QzFwSMFjvAQWo28sdp7VgygxA
kpN8WxZ9a0wJx/ACQXZiaR0rudUqY3V207H/Afsn1urzYHwAtYgtekKmBO9ak7+O
zwpivitDSZANscS4/VtE7nA9X78zSyUmvm5vV0hixEcO4NEkZezEJgdGeAyr+95P
YXNZkRZ9BaT6/ZnCLkX4EqJuuqVWEKJgcXQNXzr8+pzSWNL9P15QOlbeKv218Dhs
00jkObrpk5lTQvbL746AzgoXHiMl6Y7ot1Y5Em9jhOR4467MbzFSBuhJGAP8AcT3
yU3dxG8mwQrzd9MxhvtPMFDHxIfL2duMJvva16yO
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
MIIFxjCCA66gAwIBAgIULooy6Qv0Gb5z9s+oO/nd1X+KRTgwDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI0MDcy
ODE2NDUwMFowUTELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEoMCYGA1UEAxMfc3RhY2stYm9vdHN0cmFwIEludGVybWVkaWF0ZSBDQTCCAiIw
DQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBANg3y0DNuK/l1nAxg0bZs36oFf7k
UoePwAupqy6tpYFy6qJvaJrZZv6FKJweFWIjhdabIxbIoadYYo12yExtywOJzXx+
Nr6zEAI9pqKtO+s1XbnTeM1h6A9uL7KSquHS48v5cKVR0JYtkSJ/NXGlW1f5n/Ew
T1xU4BDPBtdxKd2ZG8gsqPKKQ6LDWhJkhKchfcz+Hs0K117lO4NnZzsrUOlJyTBS
Izp61SfjMsdiQjkEqBUIJ9M2XcS/FXS/T8Eue5D8NKG7CyNCAvF+te+rOjYglfyQ
lmKePoLmWGZNjJfmy6UgPn/0+XsnN06+TbSTwAEAyXXOg9OaDThDSPWt27MBq+fT
KvPh00BEIOWjsbFSTNfwdmCJ9Qm6j4CBn+ODQi7S89cSQwJltMQk5IcmedLmjUjf
YF5FMupN9h6RAo3pkFczgaFDqdVKnr9h0ffG5fNvuoVN8KKOWqSxalvsS6UKDqoI
Uzx/AI8uRHTCQAT+tw9KvSTU+xYFzfMEsbxX7xclk6UArGjDLdzzFPcQMu1jZmND
ei+JXUCqXaU+sraVC5SPUDSg9xbYqF7blnjXt7wwcd6/hp6QoKoOfi7ThLrZsbYq
qnUkzdNYmfx9e4fXNTwO+HwdZbRwDlzStK1Wd0+UI2366xf4nSJzd+uwgJtAaB0O
Do5rkaugJNAViEu7AgMBAAGjgaIwgZ8wDgYDVR0PAQH/BAQDAgGGMBIGA1UdEwEB
/wQIMAYBAf8CAQAwHQYDVR0OBBYEFM+c5ZTruGloPirCpqKTNOQDf21NMB8GA1Ud
IwQYMBaAFGOVswbzmN5tT8HkQp/Ba38BrIqPMDkGA1UdHwQyMDAwLqAsoCqGKGh0
dHBzOi8vc3RhY2stYm9vdHN0cmFwL2FwaS92MS9jZnNzbC9jcmwwDQYJKoZIhvcN
AQENBQADggIBALl2UYfbC5cCsgTOOHa9+ZZ9TrjKc3dEIW1dRrj2L5aE/g3OXNe+
8037C2Gcfg5FCxzEr+KpwMgixxD4+XIdKYEuDkSaVGfBr2DIBnKADic/+4CqQGgP
nYwIAjGcz2QeZQvbeX77W+pZDMGb4SBzwc+Ji+kICfRPjlHEHDS8iP5TBnr/uQe/
S1/DQvQdmS9w8j7v0XJA7kH7ROCI9RANLtf7/mi7g4tThyELdYMjzsiGUjInA1Uv
ykTCuAxRHUqtXDe3v8O03n1hzAEcQms7LxtJCiKtzPLjppdWfvIwxDj1wtf8AOzB
lhM3YYJE1Ms5cMnQAvvI0OYvAiNoHi3qU8r9fsXyLmr4PVVvAfUIaC0L02PRoCFX
fjzcAAO/JPk+kBoQRL1ZaCgfmyLU+3QafEjgHLgvE9PLO9jKLMJGH8MxlKoEZhmg
PPx5JR2gUFDUrDJU058kEYurOzBzfw83HpiGyrStR/hCJCr8eBz/E/v43pIbzWp1
QkfZK3UCiLk8Q7D3Uw45N4t0NcJvl8zUH+5Q4vBgsdJFvqc0H+bXnmrsHmc9lW0z
LftUwk4S5A+LP2u97UP0crqiNQKiFRoOSz4tFEEb4CI7tnmgtss4w1Y7Lfhu7RxR
X+kUW/zT3ctX67FZ+3cdoGK/rWgbdhJTsjPCkGYWge/K1BjWnWP4W9L7
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
MIIFWDCCA0CgAwIBAgIUOIcIPkkuCKUN/vgeQadDicdQI98wDQYJKoZIhvcNAQEN
BQAwRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJhcDEbMBkG
A1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMB4XDTE5MDczMDE2NDUwMFoXDTI5MDcy
NzE2NDUwMFowRDELMAkGA1UEBhMCVVMxGDAWBgNVBAoTD3N0YWNrLWJvb3RzdHJh
cDEbMBkGA1UEAxMSc3RhY2stYm9vdHN0cmFwIENBMIICIjANBgkqhkiG9w0BAQEF
AAOCAg8AMIICCgKCAgEAzSNyYrMCb5r5RYsomUE5ylqHZpD8edLFwMMqMHCg9OEv
S0Qs3zvIuI1BcAIS4X29ZWR/yXnrlf0yLzRrOos7xSk+DuQLGBvOWkPb8Vtm54qi
NWxSxDBhE7MRkwbxz6SZMTC2uGHg2qhijHONsFxoOun2m0dAbM/TV4OXlrn+/ME/
U5VkN4bWpMMO+Gt9wqZ8DKfJlmMDgk4tJPP20Q8VhdIC5cNDOL6tg4s5yr1N31Gr
OJvX5Wm7zSi27BALaeeT4XIo7DiNLn68y23Gz8Z7FZyUtCfB04tGH5L3B+2eGhi+
fHmSFyzdWvykn3iHZPmUIqnj2TaTG5u/audhWpniKNmGWKUodaSPrv4h9+ziSvDe
b/m89FRALFICouiDWr8FwsYx8++ph43tGlU8YcLk2UphGizjG7n1L8D8P8eu939N
Hmwl1AUOhzjZzwz/p7jg0PlM3bcUrVtRNcKbih0PxX+AzuKNrJn3NuJK8IaFHFA2
lcEu+f6Al/Urb5RQEngTJTdm35XXJwyoPzP9Zd5tKm+znIKbZCIB8u3Mg5xGcDOj
GJq4E3OCKJgTkFzgDJT4mr0ynHJdYkN4q0VOYl5MTKmEil0VS6e25yMW5iuMI9DZ
uBxgYymI3rC4Di9i9yPty5TWMJ3airtDx9HA4ZPKC4wwVzbgRKbp9of6sLXu358C
AwEAAaNCMEAwDgYDVR0PAQH/BAQDAgEGMA8GA1UdEwEB/wQFMAMBAf8wHQYDVR0O
BBYEFGOVswbzmN5tT8HkQp/Ba38BrIqPMA0GCSqGSIb3DQEBDQUAA4ICAQBLaY80
Zmmd0cfP1Fw/IDkRTh/2hl7KA3AWw7EeKa+cynI/mXOQsjmWODhUFacj9yTLimC0
mt4afCwhSvI6LqeR94LAAvGB1o8pvkZYvMt4MZdLhPW2TCBAuvcnr08JDznNBkp3
JAXvQc0CVzKvQuCmOjibuhxiVhjywXtv0SRY4sUo+6jU7rtbFxeCeGVVZkwTGQlh
j//sA6gTT7qO4uMRUnAjqDeKlyAQN8408PVIdfYUni78ApHNhiIYElKX9fw3F8Ok
VSD4QARmxd1lIMf91CTCCxdqYx63NrBvuHH3WFnKdoGinl5VwAS4NWCx0ikyNaEU
c1lQFAGf+AJFu7WPUqQdAa4SyplKmZfn6dF/qymbPX7H/C9hY7vnwGM30mkHe5rp
JJNUFwLOV5oH+K2rg4V5WZBiYfiW3ILXA678hFGbfO/4n//c+20ssg4SD8MjZSMI
GRqBrlmTUrtAng+cK7TARTO+bWa/IcQg4LXRnDK7S0N8poE2MxBWvaGboleM7eDW
TuOENhK0Ri0/ngphOs/cNEsCiARhtW6ImJa5Un9Aq7uiusel6B1+8lPxTl9+BFqz
R7Aw680c2FgPiTJVTikTvqk8XEsSPFIi/B2uHXprb1y975MBfYp9HVC7h8IaaN3x
F5YWgysI6xZWCS9JfVwqqZ6U+ATvoBchJ0F+NA==
-----END CERTIFICATE-----
```