### PR TITLE
Add omitempty to spec and status fields

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -1796,8 +1796,6 @@ spec:
           type: object
       required:
       - metadata
-      - spec
-      - status
       type: object
   versions:
   - name: v1alpha1
@@ -7324,8 +7322,6 @@ spec:
           type: object
       required:
       - metadata
-      - spec
-      - status
       type: object
   versions:
   - name: v1alpha1

--- a/pkg/apis/certmanager/v1alpha1/types_challenge.go
+++ b/pkg/apis/certmanager/v1alpha1/types_challenge.go
@@ -37,8 +37,8 @@ type Challenge struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   ChallengeSpec   `json:"spec"`
-	Status ChallengeStatus `json:"status"`
+	Spec   ChallengeSpec   `json:"spec,omitempty"`
+	Status ChallengeStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/certmanager/v1alpha1/types_order.go
+++ b/pkg/apis/certmanager/v1alpha1/types_order.go
@@ -37,8 +37,8 @@ type Order struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
-	Spec   OrderSpec   `json:"spec"`
-	Status OrderStatus `json:"status"`
+	Spec   OrderSpec   `json:"spec,omitempty"`
+	Status OrderStatus `json:"status,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
**What this PR does / why we need it**:

Pulled out of #1922 so it can be cherry-picked back to v0.9.

**Release note**:
```release-note
Mark 'spec' and 'status' as non-required fields in CRDs
```
