### PR TITLE
Add very basic Certificates based conformance suite

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -452,9 +452,11 @@ func (c *controller) updateSecret(ctx context.Context, crt *v1alpha1.Certificate
 		secret.Annotations[v1alpha1.CommonNameAnnotationKey] = x509Cert.Subject.CommonName
 		secret.Annotations[v1alpha1.AltNamesAnnotationKey] = strings.Join(x509Cert.DNSNames, ",")
 		secret.Annotations[v1alpha1.IPSANAnnotationKey] = strings.Join(pki.IPAddressesToString(x509Cert.IPAddresses), ",")
+		secret.Annotations[v1alpha1.CertificateNameKey] = crt.Name
 	}
 
 	// Always set the certificate name label on the target secret
+	// TODO: remove this behaviour - there is a max length limit of 64 chars on label values which causes issues here
 	secret.Labels[v1alpha1.CertificateNameKey] = crt.Name
 
 	// set the actual values in the secret

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -222,6 +222,7 @@ func TestSync(t *testing.T) {
 									cmapi.CertificateNameKey: "test",
 								},
 								Annotations: map[string]string{
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -290,6 +291,7 @@ func TestSync(t *testing.T) {
 								},
 								Annotations: map[string]string{
 									"testannotation":                 "true",
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -340,6 +342,7 @@ func TestSync(t *testing.T) {
 									cmapi.CertificateNameKey: "test",
 								},
 								Annotations: map[string]string{
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -408,6 +411,7 @@ func TestSync(t *testing.T) {
 								},
 								Annotations: map[string]string{
 									"testannotation":                 "true",
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -492,6 +496,7 @@ func TestSync(t *testing.T) {
 								},
 								Annotations: map[string]string{
 									"testannotation":                 "true",
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -620,6 +625,7 @@ func TestSync(t *testing.T) {
 								},
 								Annotations: map[string]string{
 									"testannotation":                 "true",
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -707,6 +713,7 @@ func TestSync(t *testing.T) {
 								},
 								Annotations: map[string]string{
 									"testannotation":                 "true",
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",
@@ -798,6 +805,7 @@ func TestSync(t *testing.T) {
 									cmapi.CertificateNameKey: "test",
 								},
 								Annotations: map[string]string{
+									cmapi.CertificateNameKey:         "test",
 									"certmanager.k8s.io/alt-names":   "example.com",
 									"certmanager.k8s.io/common-name": "example.com",
 									"certmanager.k8s.io/ip-sans":     "",

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -163,7 +163,7 @@ func (h *Helper) ValidateIssuedCertificate(certificate *v1alpha1.Certificate, ro
 		return nil, fmt.Errorf("Expected certificate expiry date to be %v, but got %v", certificate.Status.NotAfter, cert.NotAfter)
 	}
 
-	label, ok := secret.Labels[v1alpha1.CertificateNameKey]
+	label, ok := secret.Annotations[v1alpha1.CertificateNameKey]
 	if !ok {
 		return nil, fmt.Errorf("Expected secret to have certificate-name label, but had none")
 	}

--- a/test/e2e/suite/conformance/BUILD.bazel
+++ b/test/e2e/suite/conformance/BUILD.bazel
@@ -6,7 +6,12 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance",
     tags = ["manual"],
     visibility = ["//visibility:public"],
-    deps = ["//test/e2e/suite/conformance/rbac:go_default_library"],
+    deps = [
+        "//test/e2e/suite/conformance/certificates/acme:go_default_library",
+        "//test/e2e/suite/conformance/certificates/ca:go_default_library",
+        "//test/e2e/suite/conformance/certificates/selfsigned:go_default_library",
+        "//test/e2e/suite/conformance/rbac:go_default_library",
+    ],
 )
 
 filegroup(
@@ -20,6 +25,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//test/e2e/suite/conformance/certificates:all-srcs",
         "//test/e2e/suite/conformance/rbac:all-srcs",
     ],
     tags = ["automanaged"],

--- a/test/e2e/suite/conformance/certificates/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/BUILD.bazel
@@ -1,0 +1,38 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "featureset.go",
+        "suite.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/util:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//test/e2e/suite/conformance/certificates/acme:all-srcs",
+        "//test/e2e/suite/conformance/certificates/ca:all-srcs",
+        "//test/e2e/suite/conformance/certificates/selfsigned:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/suite/conformance/certificates/acme/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/acme/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["acme.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/acme",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/addon/pebble:go_default_library",
+        "//test/e2e/framework/addon/tiller:go_default_library",
+        "//test/e2e/suite/conformance/certificates:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -38,9 +38,18 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 
 	provisioner := &acmeIssuerProvisioner{setGroupName: false}
 	(&certificates.Suite{
-		Name:                "ACME",
+		Name:                "ACME HTTP01",
 		CreateIssuerFunc:    provisioner.create,
 		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
+
+	// crProvisioner sets the issuerRef.group field on Certificates it creates
+	crProvisioner := &acmeIssuerProvisioner{setGroupName: true}
+	(&certificates.Suite{
+		Name:                "ACME HTTP01 (CertificateRequest)",
+		CreateIssuerFunc:    crProvisioner.create,
+		DeleteIssuerFunc:    crProvisioner.delete,
 		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
 })

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfsigned
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/pebble"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
+	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
+)
+
+var _ = framework.ConformanceDescribe("Certificates", func() {
+	// unsupportedFeatures is a list of features that are not supported by the ACME
+	// issuer type using HTTP01
+	var unsupportedFeatures = certificates.NewFeatureSet(
+		certificates.IPAddressFeature,
+		certificates.Wildcards,
+	)
+
+	provisioner := &acmeIssuerProvisioner{setGroupName: false}
+	(&certificates.Suite{
+		Name:                "ACME",
+		CreateIssuerFunc:    provisioner.create,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
+})
+
+type acmeIssuerProvisioner struct {
+	tiller *tiller.Tiller
+	pebble *pebble.Pebble
+	// if setGroupName is true, the 'group name' field on the IssuerRef will be
+	// set the 'certmanager.k8s.io'.
+	// Setting the group name will cause the new 'certificate requests' based
+	// implementation to be used, however this is not implemented for ACME yet
+	// See: https://github.com/jetstack/cert-manager/pull/1943
+	setGroupName bool
+}
+
+func (a *acmeIssuerProvisioner) delete(f *framework.Framework, ref cmapi.ObjectReference) {
+	Expect(a.pebble.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision pebble")
+	Expect(a.tiller.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision tiller")
+}
+
+// create will deploy the required components to run an ACME issuer based test.
+// This includes:
+// - tiller
+// - pebble
+// - a properly configured Issuer resource
+func (a *acmeIssuerProvisioner) create(f *framework.Framework) cmapi.ObjectReference {
+	a.tiller = &tiller.Tiller{
+		Name:               "tiller-deploy",
+		ClusterPermissions: false,
+		Namespace:          f.Namespace.Name,
+	}
+	Expect(a.tiller.Setup(f.Config)).NotTo(HaveOccurred(), "failed to setup tiller")
+	Expect(a.tiller.Provision()).NotTo(HaveOccurred(), "failed to provision tiller")
+
+	a.pebble = &pebble.Pebble{
+		Tiller:    a.tiller,
+		Name:      "cm-e2e-create-acme-issuer",
+		Namespace: f.Namespace.Name,
+	}
+	Expect(a.pebble.Setup(f.Config)).NotTo(HaveOccurred(), "failed to setup pebble")
+	Expect(a.pebble.Provision()).NotTo(HaveOccurred(), "failed to provision pebble")
+
+	By("Creating an ACME issuer")
+	issuer := &cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "acme-issuer",
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				ACME: &cmapi.ACMEIssuer{
+					Server:        a.pebble.Details().Host,
+					SkipTLSVerify: true,
+					PrivateKey: cmapi.SecretKeySelector{
+						LocalObjectReference: cmapi.LocalObjectReference{
+							Name: "acme-private-key",
+						},
+					},
+					Solvers: []cmapi.ACMEChallengeSolver{
+						{
+							HTTP01: &cmapi.ACMEChallengeSolverHTTP01{
+								// Not setting the Class or Name field will cause cert-manager to create
+								// new ingress resources that do not specify a class to solve challenges,
+								// which means all Ingress controllers should act on the ingresses.
+								Ingress: &cmapi.ACMEChallengeSolverHTTP01Ingress{},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Create(issuer)
+	Expect(err).NotTo(HaveOccurred(), "failed to create acme issuer")
+
+	return cmapi.ObjectReference{
+		Group: emptyOrString(a.setGroupName, cmapi.SchemeGroupVersion.Group),
+		Kind:  cmapi.IssuerKind,
+		Name:  issuer.Name,
+	}
+}
+
+// emptyOrString will return the given string 's' if 'set' is true,
+// otherwise it will return the empty string.
+func emptyOrString(set bool, s string) string {
+	if set {
+		return s
+	}
+	return ""
+}

--- a/test/e2e/suite/conformance/certificates/ca/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/ca/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["ca.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/ca",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//test/e2e/suite/conformance/certificates:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/suite/conformance/certificates/ca/ca.go
+++ b/test/e2e/suite/conformance/certificates/ca/ca.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfsigned
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
+)
+
+var _ = framework.ConformanceDescribe("Certificates", func() {
+	(&certificates.Suite{
+		Name:             "CA",
+		CreateIssuerFunc: createCAIssuer,
+	}).Define()
+})
+
+func createCAIssuer(f *framework.Framework) cmapi.ObjectReference {
+	By("Creating a SelfSigned issuer")
+	rootCertSecret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(newSigningKeypairSecret("root-cert"))
+	Expect(err).NotTo(HaveOccurred(), "failed to create root signing keypair secret")
+
+	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "ca",
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				CA: &cmapi.CAIssuer{
+					SecretName: rootCertSecret.Name,
+				},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to create ca issuer")
+
+	return cmapi.ObjectReference{
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
+		Name:  issuer.Name,
+	}
+}
+
+const rootCert = `-----BEGIN CERTIFICATE-----
+MIID4DCCAsigAwIBAgIJAJzTROInmDkQMA0GCSqGSIb3DQEBCwUAMFMxCzAJBgNV
+BAYTAlVLMQswCQYDVQQIEwJOQTEVMBMGA1UEChMMY2VydC1tYW5hZ2VyMSAwHgYD
+VQQDExdjZXJ0LW1hbmFnZXIgdGVzdGluZyBDQTAeFw0xNzA5MTAxODMzNDNaFw0y
+NzA5MDgxODMzNDNaMFMxCzAJBgNVBAYTAlVLMQswCQYDVQQIEwJOQTEVMBMGA1UE
+ChMMY2VydC1tYW5hZ2VyMSAwHgYDVQQDExdjZXJ0LW1hbmFnZXIgdGVzdGluZyBD
+QTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBAM+Q2AO4hARav0qwjk7I
+4mEh5R201HS8s7HpaLOXBNvvh7qJ9yJz6jLqYg6EvP0K/bK56Cp2oe2igd7GOxpV
+3YPOc3CG0CCqHMprEcvxj2xBKX00Rtcn4oVLhDPhAb0BV/R7NFLeWxzh+ggvPI1X
+m1qLaWYqYZEJ5bBsYXD3tPdS4GGINRz8Zvih46f0Z2wVkCGoTpsbX8HO74sa2Day
+UjzAsWGlO5bZGiMSHjDEnf9yek2TcjEyVoohoOLaQg/ng21T5RWzeZKTl1cznwuG
+Vr9tZfHFqxQ5qeaId+1ICtxNvkEjbTnZl6Wy9Cthn0dxwOeS5TqMJ7SFNXy1gp4j
+f/MCAwEAAaOBtjCBszAdBgNVHQ4EFgQUBtrjvWfbkLA0iX6sKVRhKUo864kwgYMG
+A1UdIwR8MHqAFAba471n25CwNIl+rClUYSlKPOuJoVekVTBTMQswCQYDVQQGEwJV
+SzELMAkGA1UECBMCTkExFTATBgNVBAoTDGNlcnQtbWFuYWdlcjEgMB4GA1UEAxMX
+Y2VydC1tYW5hZ2VyIHRlc3RpbmcgQ0GCCQCc00TiJ5g5EDAMBgNVHRMEBTADAQH/
+MA0GCSqGSIb3DQEBCwUAA4IBAQCR+jXhup5tCKwhAf8xgvp589BczQOjmotuZGEL
+Dcint2y263ChEdsoLhyJfvFCAZfTSm+UT95Hl+ZKVuoVEcAS7udaFUFpC/gIYVOi
+H4/uvJps4SpVCB7+T/orcTjZ2ewT23mQAQg+B+iwX9VCof+fadkYOg1XD9/eaj6E
+9McXID3iuCXg02RmEOwVMrTggHPwHrOGAilSaZc58cJZHmMYlT5rGrJcWS/AyXnH
+VOodKC004yjh7w9aSbCCbAL0tDEnhm4Jrb8cxt7pDWbdEVUeuk9LZRQtluYBnmJU
+kQ7ALfUfUh/RUpCV4uI6sEI3NDX2YqQbOtsBD/hNaL1F85FA
+-----END CERTIFICATE-----`
+
+const rootKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpAIBAAKCAQEAz5DYA7iEBFq/SrCOTsjiYSHlHbTUdLyzselos5cE2++Huon3
+InPqMupiDoS8/Qr9srnoKnah7aKB3sY7GlXdg85zcIbQIKocymsRy/GPbEEpfTRG
+1yfihUuEM+EBvQFX9Hs0Ut5bHOH6CC88jVebWotpZiphkQnlsGxhcPe091LgYYg1
+HPxm+KHjp/RnbBWQIahOmxtfwc7vixrYNrJSPMCxYaU7ltkaIxIeMMSd/3J6TZNy
+MTJWiiGg4tpCD+eDbVPlFbN5kpOXVzOfC4ZWv21l8cWrFDmp5oh37UgK3E2+QSNt
+OdmXpbL0K2GfR3HA55LlOowntIU1fLWCniN/8wIDAQABAoIBAQCYvGvIKSG0FpbG
+vi6pmLbEZO20s1jW4fiUxT2PUWR49sR4pocdahB/EOvA5TowNcNDnftSK+Ox+q/4
+HwRkt6R+Fg/qULmcH7F53dnFqeYw8a42/J3YOvg7v7rzdfISg4eWVobFJ+wBz+Nt
+3FyBYWLm+MlBLZSH5rGG5em59/zJNHWIhH+oQPfCxAkYEvd8tXOTUzjhqvEfjaJy
+FZghnT9xto4MwDdNCPbtzdNjTMhiv0AHkcZGGtRJfkehXX2qhXOQ2UzzO9XrMZnv
+5KgYf+bXKJsyS3SPl6TTl7vg2gKBciRvsdFhMy5I5GyIADrEDJnNNmXQRtiaFLfd
+k/aqfPT5AoGBAPquMouZUbVS/Qh+qbls7G4zAuznfCiqdctcKmUGPRP4sTTjWdUp
+fjI+UTt1e8hncmr4RY7Oa9kUV/kDwzS5spUZZ+u0PczS3XKxOwNOleoH00dfc9vt
+cxctHdPdDTndRi8Z4k3m931jIX7jB/Pyx8qeNYB3pj0k3ThktwMbAVLnAoGBANP4
+beI5zpbvtAdExJcuxx2mRDGF0lIdKC0bvQaeqM3Lwqnmc0Fz1dbP7KXDa+SdJWPd
+res+NHPZoEPeEJuDTSngXOLNECZe4Ja9frn1TeY858vMJBwIkyc8zu+sgXxjQUM+
+TWUlTUhtXyybkRnxAEny4OT2TTgmXITJaKOmV1UVAoGAHaXSlo4YitB42rNYUXTf
+dZ0U4H30Qj7+1YFeBjq5qI4GL1IgQsS4hyq1osmfTTFm593bJCunt7HfQbU/NhIs
+W9P4ZXkYwgvCYxkw+JAnzNkGFO/mHQG1Ve1hFLiVIt3XuiRejoYdiTfbM02YmDKD
+jKQvgbUk9SBSBaRrvLNJ8csCgYAYnrZEnGo+ZcEHRxl+ZdSCwRkSl3SCTRiphJtD
+9ZGttYj6quWgKJAhzyyxZC1X9FivbMQSmrsE6bYPq+9J4MpJnuGrBh5mFocHeyMI
+/lD5+QEDTsay6twMpqdydxrjE7Q01zuuD9MWIn33dGo6FR/vduJgNatqZipA0hPx
+ThS+sQKBgQDh0+cVo1mfYiCkp3IQPB8QYiJ/g2/UBk6pH8ZZDZ+A5td6NveiWO1y
+wTEUWkX2qyz9SLxWDGOhdKqxNrLCUSYSOV/5/JQEtBm6K50ArFtrY40JP/T/5KvM
+tSK2ayFX1wQ3PuEmewAogy/20tWo80cr556AXA62Utl2PzLK30Db8w==
+-----END RSA PRIVATE KEY-----`
+
+func newSigningKeypairSecret(name string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		StringData: map[string]string{
+			corev1.TLSCertKey:       rootCert,
+			corev1.TLSPrivateKeyKey: rootKey,
+		},
+	}
+}

--- a/test/e2e/suite/conformance/certificates/featureset.go
+++ b/test/e2e/suite/conformance/certificates/featureset.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import "strings"
+
+// NewFeatureSet constructs a new feature set with the given features.
+func NewFeatureSet(feats ...Feature) FeatureSet {
+	fs := make(FeatureSet)
+	for _, f := range feats {
+		fs.Add(f)
+	}
+	return fs
+}
+
+// FeatureSet represents a set of features.
+// This type does not indicate whether or not features are enabled, rather it
+// just defines a grouping of features (i.e. a 'set').
+type FeatureSet map[Feature]struct{}
+
+// Add adds a feature to the set
+func (fs FeatureSet) Add(f Feature) {
+	fs[f] = struct{}{}
+}
+
+// Delete removes a feature from the set
+func (fs FeatureSet) Delete(f Feature) {
+	_, ok := fs[f]
+	if ok {
+		delete(fs, f)
+	}
+}
+
+// Contains returns true if the FeatureSet contains the given feature
+func (fs FeatureSet) Contains(f Feature) bool {
+	_, ok := fs[f]
+	return ok
+}
+
+// String returns this FeatureSet as a comma separated string
+func (fs FeatureSet) String() string {
+	featsSlice := make([]string, len(fs))
+
+	i := 0
+	for f := range fs {
+		featsSlice[i] = string(f)
+		i++
+	}
+
+	return strings.Join(featsSlice, ", ")
+}
+
+type Feature string
+
+// String returns the Feature name as a string
+func (f Feature) String() string {
+	return string(f)
+}
+
+const (
+	// IPAddressFeature denotes tests that set the IPAddresses field.
+	// Some issuer's are never going to allow issuing certificates with IP SANs
+	// set as they are considered bad-practice.
+	IPAddressFeature Feature = "IPAddresses"
+
+	// DurationFeature denotes tests that set the 'duration' field to some
+	// custom value.
+	// Some issuers enforce a particular certificate duration, meaning they
+	// will never pass tests that validate the duration is as expected.
+	DurationFeature Feature = "Duration"
+
+	// Wildcards denotes tests that request certificates for wildcard domains.
+	// Some issuer's disable wildcard certificate issuance, so this feature
+	// allows runs of the suite to exclude those tests that utilise wildcards.
+	Wildcards Feature = "Wildcards"
+)

--- a/test/e2e/suite/conformance/certificates/selfsigned/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/selfsigned/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["selfsigned.go"],
+    importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/selfsigned",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//test/e2e/framework:go_default_library",
+        "//test/e2e/suite/conformance/certificates:go_default_library",
+        "//vendor/github.com/onsi/ginkgo:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
+++ b/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selfsigned
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
+)
+
+var _ = framework.ConformanceDescribe("Certificates", func() {
+	(&certificates.Suite{
+		Name:             "SelfSigned",
+		CreateIssuerFunc: createSelfSignedIssuer,
+	}).Define()
+})
+
+func createSelfSignedIssuer(f *framework.Framework) cmapi.ObjectReference {
+	By("Creating a SelfSigned issuer")
+	_, err := f.CertManagerClientSet.CertmanagerV1alpha1().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "selfsigned",
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				SelfSigned: &cmapi.SelfSignedIssuer{},
+			},
+		},
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
+
+	return cmapi.ObjectReference{
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
+		Name:  "selfsigned",
+	}
+}

--- a/test/e2e/suite/conformance/certificates/suite.go
+++ b/test/e2e/suite/conformance/certificates/suite.go
@@ -91,9 +91,14 @@ func (s *Suite) complete(f *framework.Framework) {
 func (s *Suite) Define() {
 	Describe("with issuer type "+s.Name, func() {
 		f := framework.NewDefaultFramework("certificates")
-		if !s.completed {
-			s.complete(f)
-		}
+
+		// wrap this in a BeforeEach else flags will not have been parsed at
+		// the time that the `complete` function is called.
+		BeforeEach(func() {
+			if !s.completed {
+				s.complete(f)
+			}
+		})
 
 		By("Running test suite with the following unsupported features: " + s.UnsupportedFeatures.String())
 		ctx := context.Background()

--- a/test/e2e/suite/conformance/certificates/suite.go
+++ b/test/e2e/suite/conformance/certificates/suite.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+)
+
+// Suite defines a reusable conformance test suite that can be used against any
+// Issuer implementation.
+type Suite struct {
+	// Name is the name of the issuer being tested, e.g. SelfSigned, CA, ACME
+	// This field must be provided.
+	Name string
+
+	// CreateIssuerFunc is a function that provisions a new issuer resource and
+	// returns an ObjectReference to that Issuer that will be used as the
+	// IssuerRef on Certificate resources that this suite creates.
+	// This field must be provided.
+	CreateIssuerFunc func(*framework.Framework) cmapi.ObjectReference
+
+	// DeleteIssuerFunc is a function that is run after the test has completed
+	// in order to clean up resources created for a test (e.g. the resources
+	// created in CreateIssuerFunc).
+	// This function will be run regardless whether the test passes or fails.
+	// If not specified, this function will be skipped.
+	DeleteIssuerFunc func(*framework.Framework, cmapi.ObjectReference)
+
+	// DomainSuffix is a suffix used on all domain requests.
+	// This is useful when the issuer being tested requires special
+	// configuration for a set of domains in order for certificates to be
+	// issued, such as the ACME issuer.
+	// If not set, this will be defaulted to the configured 'domain' for the
+	// nginx-ingress addon.
+	DomainSuffix string
+
+	// UnsupportedFeatures is a list of features that are not supported by this
+	// invocation of the test suite.
+	// This is useful if a particular issuers explicitly does not support
+	// certain features due to restrictions in their implementation.
+	UnsupportedFeatures FeatureSet
+
+	// completed is used internally to track whether Complete() has been called
+	completed bool
+}
+
+// complete will validate configuration and set default values.
+func (s *Suite) complete(f *framework.Framework) {
+	// TODO: work out how to fail an entire 'Describe' block so we can validate these are correctly set
+	//Expect(s.Name).NotTo(Equal(""), "Name must be set")
+	//Expect(s.CreateIssuerFunc).NotTo(BeNil(), "CreateIssuerFunc must be set")
+
+	if s.DomainSuffix == "" {
+		s.DomainSuffix = f.Config.Addons.Nginx.Global.Domain
+	}
+
+	if s.UnsupportedFeatures == nil {
+		s.UnsupportedFeatures = make(FeatureSet)
+	}
+
+	s.completed = true
+}
+
+// Defines simple conformance tests that can be run against any issuer type.
+// If Complete has not been called on this Suite before Define, it will be
+// automatically called.
+func (s *Suite) Define() {
+	Describe("with issuer type "+s.Name, func() {
+		f := framework.NewDefaultFramework("certificates")
+		if !s.completed {
+			s.complete(f)
+		}
+
+		By("Running test suite with the following unsupported features: " + s.UnsupportedFeatures.String())
+		ctx := context.Background()
+		var issuerRef cmapi.ObjectReference
+
+		JustBeforeEach(func() {
+			By("Creating an issuer resource")
+			issuerRef = s.CreateIssuerFunc(f)
+		})
+
+		JustAfterEach(func() {
+			if s.DeleteIssuerFunc == nil {
+				By("Skipping cleanup as no DeleteIssuerFunc provided")
+				return
+			}
+
+			By("Cleaning up the issuer resource")
+			s.DeleteIssuerFunc(f, issuerRef)
+		})
+
+		It("should issue a basic, defaulted certificate for a single commonName and distinct dnsName", func() {
+			testCertificate := &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcert",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: cmapi.CertificateSpec{
+					SecretName: "testcert-tls",
+					CommonName: s.newDomain(),
+					DNSNames:   []string{s.newDomain()},
+					IssuerRef:  issuerRef,
+				},
+			}
+			By("Creating a Certificate")
+			err := f.CRClient.Create(ctx, testCertificate)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the Certificate to be issued...")
+			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should issue an ECDSA, defaulted certificate for a single commonName and distinct dnsName", func() {
+			testCertificate := &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcert",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: cmapi.CertificateSpec{
+					SecretName:   "testcert-tls",
+					KeyAlgorithm: cmapi.ECDSAKeyAlgorithm,
+					CommonName:   s.newDomain(),
+					DNSNames:     []string{s.newDomain()},
+					IssuerRef:    issuerRef,
+				},
+			}
+			By("Creating a Certificate")
+			err := f.CRClient.Create(ctx, testCertificate)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the Certificate to be issued...")
+			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should issue a certificate that defines a commonName and ipAddresses", func() {
+			s.checkFeatures(IPAddressFeature)
+
+			testCertificate := &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcert",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: cmapi.CertificateSpec{
+					SecretName:  "testcert-tls",
+					CommonName:  s.newDomain(),
+					IPAddresses: []string{"127.0.0.1"},
+					IssuerRef:   issuerRef,
+				},
+			}
+			By("Creating a Certificate")
+			err := f.CRClient.Create(ctx, testCertificate)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the Certificate to be issued...")
+			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+}
+
+// checkFeatures is a helper function that is used to ensure that the features
+// required for a given test case are supported by the suite.
+func (s *Suite) checkFeatures(fs ...Feature) {
+	unsupported := make(FeatureSet)
+	for _, f := range fs {
+		if s.UnsupportedFeatures.Contains(f) {
+			unsupported.Add(f)
+		}
+	}
+	// all features supported, return early!
+	if len(unsupported) == 0 {
+		return
+	}
+	Skip("skipping due to the following unsupported features: " + unsupported.String())
+}
+
+// newDomain will generate a new random subdomain of the DomainSuffix
+func (s *Suite) newDomain() string {
+	return s.newDomainDepth(1)
+}
+
+// newDomainDepth return a new domain name with the given number of subdomains
+// beneath the domain suffix.
+// If depth is zero, the domain suffix will be returned,
+// If depth is one, a random subdomain will be returned e.g. abcd.example.com,
+// If depth is two, a random sub-subdomain will be returned e.g. abcd.efgh.example.com,
+// and so on
+func (s *Suite) newDomainDepth(depth int) string {
+	subdomains := make([]string, depth)
+	for i := 0; i < depth; i++ {
+		subdomains[i] = util.RandStringRunes(4)
+	}
+	return strings.Join(append(subdomains, s.DomainSuffix), ".")
+}

--- a/test/e2e/suite/conformance/doc.go
+++ b/test/e2e/suite/conformance/doc.go
@@ -17,5 +17,8 @@ limitations under the License.
 package conformance
 
 import (
+	_ "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/acme"
+	_ "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/ca"
+	_ "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/selfsigned"
 	_ "github.com/jetstack/cert-manager/test/e2e/suite/conformance/rbac"
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a very simple set of conformance tests that can be run against any Issuer implementation.

Initially this covers a *very* basic set of functionality, but we can expand this suite and eventually move all issuer types to share a common set of tests 😄 

**Special notes for your reviewer**:

I'm still iterating on this, and opening it now to get some feedback from the e2e test job

**Release note**:
```release-note
NONE
```
