### PR TITLE
Improve ServiceMonitor resource by adding custom namespace and custom labels

### DIFF
--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -104,12 +104,13 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `ingressShim.defaultACMEChallengeType` | Optional default challenge type to use for ingresses using ACME issuers |  |
 | `ingressShim.defaultACMEDNS01ChallengeProvider` | Optional default DNS01 challenge provider to use for ingresses using ACME issuers with DNS01 |  |
 | `prometheus.enabled` | Enable Prometheus monitoring | `true` |
-| `prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor
-monitoring | `false`
+| `prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor monitoring | `false`
+| `prometheus.servicemonitor.namespace` | Define namespace where to deploy the ServiceMonitor resource | (namespace where you are deploying) |
 | `prometheus.servicemonitor.prometheusInstance` | Prometheus Instance definition | `default` |
 | `prometheus.servicemonitor.targetPort` | Prometheus scrape port | `9402` |
 | `prometheus.servicemonitor.path` | Prometheus scrape path | `/metrics` |
 | `prometheus.servicemonitor.interval` | Prometheus scrape interval | `60s` |
+| `prometheus.servicemonitor.labels` | Add custom labels to ServiceMonitor | |
 | `prometheus.servicemonitor.scrapeTimeout` | Prometheus scrape timeout | `30s` |
 | `podAnnotations` | Annotations to add to the cert-manager pod | `{}` |
 | `podDnsPolicy` | Optional cert-manager pod [DNS policy](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#pods-dns-policy) |  |

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -3,7 +3,11 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ template "cert-manager.fullname" . }}
+{{- if .Values.prometheus.servicemonitor.namespace }}
+  namespace: {{ .Values.prometheus.servicemonitor.namespace }}
+{{- else }}
   namespace: {{ .Release.Namespace | quote }}
+{{- end }}
   labels:
     app: {{ template "cert-manager.name" . }}
     app.kubernetes.io/name: {{ template "cert-manager.name" . }}
@@ -11,12 +15,18 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "cert-manager.chart" . }}
     prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
+{{- if .Values.prometheus.servicemonitor.labels }}
+{{ toYaml .Values.prometheus.servicemonitor.labels | indent 4}}
+{{- end }}
 spec:
   jobLabel: {{ template "cert-manager.fullname" . }}
   selector:
     matchLabels:
       app.kubernetes.io/name: {{ template "cert-manager.name" . }}
       app.kubernetes.io/instance:  {{ .Release.Name }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
   endpoints:
   - targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
     path: {{ .Values.prometheus.servicemonitor.path }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -103,6 +103,7 @@ prometheus:
     path: /metrics
     interval: 60s
     scrapeTimeout: 30s
+    labels: {}
 
 webhook:
   enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds the possibility to specify the namespace where the serviceMonitor resource is going to be deployed. Sometimes we have prometheus monitoring from another namespace and we consolidate serviceMonitor resources there.

Also, it adds the possibility to specify custom labels for ServiceMonitor, some people (like us) use different labels so different prometheus can scan against this labels. 

**Which issue this PR fixes**: None

**Release notes**:

```release-note
Added variable to specify custom namespace where to deploy ServiceMonitor resource
```

**Special notes for your reviewer**: None
