### PR TITLE
Adds CertificateRequest FailureTime

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -134,6 +134,11 @@ spec:
                 - type
                 type: object
               type: array
+            failureTime:
+              description: FailureTime stores the time that this CertificateRequest
+                failed. This is used to influence garbage collection and back-off.
+              format: date-time
+              type: string
           type: object
       type: object
   versions:

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -222,14 +222,15 @@ func CertificateRequestHasCondition(cr *cmapi.CertificateRequest, c cmapi.Certif
 
 // This returns the status reason of a CertificateRequest. The order of reason
 // hierarchy is 'Failed' -> 'Ready' -> 'Pending' -> ''
-func CertificateRequestStatusReason(cr *cmapi.CertificateRequest) string {
+func CertificateRequestReadyReason(cr *cmapi.CertificateRequest) string {
 	for _, reason := range []string{
 		cmapi.CertificateRequestReasonFailed,
 		cmapi.CertificateRequestReasonIssued,
 		cmapi.CertificateRequestReasonPending,
 	} {
 		for _, con := range cr.Status.Conditions {
-			if con.Reason == reason {
+			if con.Type == cmapi.CertificateRequestConditionReady &&
+				con.Reason == reason {
 				return reason
 			}
 		}

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -222,7 +222,7 @@ func CertificateRequestHasCondition(cr *cmapi.CertificateRequest, c cmapi.Certif
 
 func CertificateRequestHasFailed(cr *cmapi.CertificateRequest) bool {
 	for _, con := range cr.Status.Conditions {
-		if con.Reason == "Failed" {
+		if con.Reason == cmapi.CertificateRequestReasonFailed {
 			return true
 		}
 	}

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -220,12 +220,20 @@ func CertificateRequestHasCondition(cr *cmapi.CertificateRequest, c cmapi.Certif
 	return false
 }
 
-func CertificateRequestHasFailed(cr *cmapi.CertificateRequest) bool {
-	for _, con := range cr.Status.Conditions {
-		if con.Reason == cmapi.CertificateRequestReasonFailed {
-			return true
+// This returns the status reason of a CertificateRequest. The order of reason
+// hierarchy is 'Failed' -> 'Ready' -> 'Pending' -> ''
+func CertificateRequestStatusReason(cr *cmapi.CertificateRequest) string {
+	for _, reason := range []string{
+		cmapi.CertificateRequestReasonFailed,
+		cmapi.CertificateRequestReasonIssued,
+		cmapi.CertificateRequestReasonPending,
+	} {
+		for _, con := range cr.Status.Conditions {
+			if con.Reason == reason {
+				return reason
+			}
 		}
 	}
 
-	return false
+	return ""
 }

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -162,7 +162,7 @@ func SetCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.Certifi
 // - If a condition of the same type and different state already exists, the
 //   condition will be updated and the LastTransitionTime set to the current
 //   time.
-func SetCertificateRequestCondition(csr *cmapi.CertificateRequest, conditionType cmapi.CertificateRequestConditionType, status cmapi.ConditionStatus, reason, message string) {
+func SetCertificateRequestCondition(cr *cmapi.CertificateRequest, conditionType cmapi.CertificateRequestConditionType, status cmapi.ConditionStatus, reason, message string) {
 	newCondition := cmapi.CertificateRequestCondition{
 		Type:    conditionType,
 		Status:  status,
@@ -174,7 +174,7 @@ func SetCertificateRequestCondition(csr *cmapi.CertificateRequest, conditionType
 	newCondition.LastTransitionTime = &nowTime
 
 	// Search through existing conditions
-	for idx, cond := range csr.Status.Conditions {
+	for idx, cond := range cr.Status.Conditions {
 		// Skip unrelated conditions
 		if cond.Type != conditionType {
 			continue
@@ -185,18 +185,18 @@ func SetCertificateRequestCondition(csr *cmapi.CertificateRequest, conditionType
 		if cond.Status == status {
 			newCondition.LastTransitionTime = cond.LastTransitionTime
 		} else {
-			klog.Infof("Found status change for CertificateRequest %q condition %q: %q -> %q; setting lastTransitionTime to %v", csr.Name, conditionType, cond.Status, status, nowTime.Time)
+			klog.Infof("Found status change for CertificateRequest %q condition %q: %q -> %q; setting lastTransitionTime to %v", cr.Name, conditionType, cond.Status, status, nowTime.Time)
 		}
 
 		// Overwrite the existing condition
-		csr.Status.Conditions[idx] = newCondition
+		cr.Status.Conditions[idx] = newCondition
 		return
 	}
 
 	// If we've not found an existing condition of this type, we simply insert
 	// the new condition into the slice.
-	csr.Status.Conditions = append(csr.Status.Conditions, newCondition)
-	klog.Infof("Setting lastTransitionTime for CertificateRequest %q condition %q to %v", csr.Name, conditionType, nowTime.Time)
+	cr.Status.Conditions = append(cr.Status.Conditions, newCondition)
+	klog.Infof("Setting lastTransitionTime for CertificateRequest %q condition %q to %v", cr.Name, conditionType, nowTime.Time)
 }
 
 // CertificateRequestHasCondition will return true if the given
@@ -217,5 +217,15 @@ func CertificateRequestHasCondition(cr *cmapi.CertificateRequest, c cmapi.Certif
 			}
 		}
 	}
+	return false
+}
+
+func CertificateRequestHasFailed(cr *cmapi.CertificateRequest) bool {
+	for _, con := range cr.Status.Conditions {
+		if con.Reason == "Failed" {
+			return true
+		}
+	}
+
 	return false
 }

--- a/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
@@ -94,6 +94,11 @@ type CertificateRequestStatus struct {
 	// certificate.
 	// +optional
 	CA []byte `json:"ca,omitempty"`
+
+	// FailureTime stores the time that this order failed.
+	// This is used to influence garbage collection and back-off.
+	// +optional
+	FailureTime *metav1.Time `json:"failureTime,omitempty"`
 }
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.

--- a/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
@@ -95,8 +95,8 @@ type CertificateRequestStatus struct {
 	// +optional
 	CA []byte `json:"ca,omitempty"`
 
-	// FailureTime stores the time that this order failed.
-	// This is used to influence garbage collection and back-off.
+	// FailureTime stores the time that this CertificateRequest failed. This is
+	// used to influence garbage collection and back-off.
 	// +optional
 	FailureTime *metav1.Time `json:"failureTime,omitempty"`
 }

--- a/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
@@ -809,6 +809,10 @@ func (in *CertificateRequestStatus) DeepCopyInto(out *CertificateRequestStatus) 
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.FailureTime != nil {
+		in, out := &in.FailureTime, &out.FailureTime
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/controller/certificaterequests/BUILD.bazel
+++ b/pkg/controller/certificaterequests/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//vendor/github.com/kr/pretty:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/controller/certificaterequests/BUILD.bazel
+++ b/pkg/controller/certificaterequests/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/listers/certmanager/v1alpha1:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/certificaterequests/util:go_default_library",
         "//pkg/issuer:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/metrics:go_default_library",

--- a/pkg/controller/certificaterequests/BUILD.bazel
+++ b/pkg/controller/certificaterequests/BUILD.bazel
@@ -25,11 +25,13 @@ go_library(
         "//vendor/github.com/kr/pretty:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/labels:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",
+        "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificaterequests/ca/BUILD.bazel
+++ b/pkg/controller/certificaterequests/ca/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificaterequests/ca/BUILD.bazel
+++ b/pkg/controller/certificaterequests/ca/BUILD.bazel
@@ -18,8 +18,6 @@ go_library(
         "//pkg/util/pki:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
-        "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -22,8 +22,6 @@ import (
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	corelisters "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/record"
-	"k8s.io/utils/clock"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
@@ -42,14 +40,10 @@ const (
 )
 
 type CA struct {
-	// used to record Events about resources to the API
-	recorder record.EventRecorder
-
 	issuerOptions controllerpkg.IssuerOptions
 	secretsLister corelisters.SecretLister
 
-	// Clock used to set constant time for testing
-	clock clock.Clock
+	reporter *crutil.Reporter
 }
 
 func init() {
@@ -70,16 +64,14 @@ func init() {
 
 func NewCA(ctx *controllerpkg.Context) *CA {
 	return &CA{
-		recorder:      ctx.Recorder,
 		issuerOptions: ctx.IssuerOptions,
 		secretsLister: ctx.KubeSharedInformerFactory.Core().V1().Secrets().Lister(),
-		clock:         ctx.Clock,
+		reporter:      crutil.NewReporter(ctx.Clock, ctx.Recorder),
 	}
 }
 
 func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest, issuerObj v1alpha1.GenericIssuer) (*issuerpkg.IssueResponse, error) {
 	log := logf.FromContext(ctx, "sign")
-	reporter := crutil.NewReporter(cr, c.clock, c.recorder)
 
 	secretName := issuerObj.GetSpec().CA.SecretName
 	resourceNamespace := c.issuerOptions.ResourceNamespace(issuerObj)
@@ -92,7 +84,7 @@ func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest, issuerOb
 		if k8sErrors.IsNotFound(err) {
 			message := fmt.Sprintf("Referenced secret %s/%s not found", resourceNamespace, secretName)
 
-			reporter.Pending(err, "MissingSecret", message)
+			c.reporter.Pending(cr, err, "MissingSecret", message)
 			log.Error(err, message)
 
 			return nil, nil
@@ -101,14 +93,14 @@ func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest, issuerOb
 		if cmerrors.IsInvalidData(err) {
 			message := fmt.Sprintf("Failed to parse signing CA keypair from secret %s/%s", resourceNamespace, secretName)
 
-			reporter.Pending(err, "ErrorParsingSecret", message)
+			c.reporter.Pending(cr, err, "ErrorParsingSecret", message)
 			log.Error(err, message)
 			return nil, nil
 		}
 
 		// We are probably in a network error here so we should backoff and retry
 		message := fmt.Sprintf("Failed to get certificate key pair from secret %s/%s", resourceNamespace, secretName)
-		reporter.Pending(err, "ErrorGettingSecret", message)
+		c.reporter.Pending(cr, err, "ErrorGettingSecret", message)
 		log.Error(err, message)
 		return nil, err
 	}
@@ -116,7 +108,7 @@ func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest, issuerOb
 	template, err := pki.GenerateTemplateFromCertificateRequest(cr)
 	if err != nil {
 		message := "Error generating certificate template"
-		reporter.Failed(err, "ErrorSigning", message)
+		c.reporter.Failed(cr, err, "ErrorSigning", message)
 		log.Error(err, message)
 		return nil, nil
 	}
@@ -124,7 +116,7 @@ func (c *CA) Sign(ctx context.Context, cr *v1alpha1.CertificateRequest, issuerOb
 	certPEM, caPEM, err := pki.SignCSRTemplate(caCerts, caKey, template)
 	if err != nil {
 		message := "Error signing certificate"
-		reporter.Failed(err, "ErrorSigning", message)
+		c.reporter.Failed(cr, err, "ErrorSigning", message)
 		log.Error(err, message)
 		return nil, err
 	}

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -30,6 +30,7 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/controller/certificaterequests/util"
 	"github.com/jetstack/cert-manager/pkg/issuer"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 	"github.com/jetstack/cert-manager/pkg/metrics"
@@ -73,6 +74,8 @@ type Controller struct {
 
 	// used for testing
 	clock clock.Clock
+
+	reporter *util.Reporter
 }
 
 func New(issuerType string, issuer Issuer) *Controller {
@@ -132,6 +135,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.clock = ctx.Clock
 	// recorder records events about resources to the Kubernetes api
 	c.recorder = ctx.Recorder
+	c.reporter = util.NewReporter(c.clock, c.recorder)
 	c.cmClient = ctx.CMClient
 
 	c.log.Info("new certificate request controller registered",

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -24,6 +24,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
@@ -69,6 +70,9 @@ type Controller struct {
 
 	// Issuer to call sign function
 	issuer Issuer
+
+	// used for testing
+	clock clock.Clock
 }
 
 func New(issuerType string, issuer Issuer) *Controller {
@@ -124,6 +128,8 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	// create an issuer helper for reading generic issuers
 	c.helper = issuer.NewHelper(c.issuerLister, c.clusterIssuerLister)
 
+	// clock is used to set the FailureTime of failed CertificateRequests
+	c.clock = ctx.Clock
 	// recorder records events about resources to the Kubernetes api
 	c.recorder = ctx.Recorder
 	c.cmClient = ctx.CMClient

--- a/pkg/controller/certificaterequests/selfsigned/BUILD.bazel
+++ b/pkg/controller/certificaterequests/selfsigned/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificaterequests/selfsigned/BUILD.bazel
+++ b/pkg/controller/certificaterequests/selfsigned/BUILD.bazel
@@ -18,8 +18,6 @@ go_library(
         "//pkg/util/pki:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/client-go/listers/core/v1:go_default_library",
-        "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -47,7 +47,7 @@ func (c *Controller) Sync(ctx context.Context, cr *v1alpha1.CertificateRequest) 
 		return nil
 	}
 
-	if apiutil.CertificateRequestHasFailed(cr) {
+	if apiutil.CertificateRequestStatusReason(cr) == v1alpha1.CertificateRequestReasonFailed {
 		dbg.Info("certificate request condition failed so skipping processing")
 		return nil
 	}

--- a/pkg/controller/certificaterequests/util/BUILD.bazel
+++ b/pkg/controller/certificaterequests/util/BUILD.bazel
@@ -9,7 +9,9 @@ go_library(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
+        "//vendor/k8s.io/utils/clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificaterequests/util/BUILD.bazel
+++ b/pkg/controller/certificaterequests/util/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -27,4 +27,19 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["reporter_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/controller/test:go_default_library",
+        "//pkg/util:go_default_library",
+        "//test/unit/gen:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/utils/clock/testing:go_default_library",
+    ],
 )

--- a/pkg/controller/certificaterequests/util/reporter.go
+++ b/pkg/controller/certificaterequests/util/reporter.go
@@ -29,35 +29,33 @@ import (
 )
 
 type Reporter struct {
-	cr       *v1alpha1.CertificateRequest
 	clock    clock.Clock
 	recorder record.EventRecorder
 }
 
-func NewReporter(cr *v1alpha1.CertificateRequest, clock clock.Clock, recorder record.EventRecorder) *Reporter {
+func NewReporter(clock clock.Clock, recorder record.EventRecorder) *Reporter {
 	return &Reporter{
-		cr:       cr,
 		clock:    clock,
 		recorder: recorder,
 	}
 }
 
-func (r *Reporter) Failed(err error, reason, message string) {
+func (r *Reporter) Failed(cr *v1alpha1.CertificateRequest, err error, reason, message string) {
 	// Set the FailureTime to c.clock.Now(), only if it has not been already set.
-	if r.cr.Status.FailureTime == nil {
+	if cr.Status.FailureTime == nil {
 		nowTime := metav1.NewTime(r.clock.Now())
-		r.cr.Status.FailureTime = &nowTime
+		cr.Status.FailureTime = &nowTime
 	}
 
 	message = fmt.Sprintf("%s: %v", message, err)
-	r.recorder.Event(r.cr, corev1.EventTypeWarning, reason, message)
-	apiutil.SetCertificateRequestCondition(r.cr, v1alpha1.CertificateRequestConditionReady,
+	r.recorder.Event(cr, corev1.EventTypeWarning, reason, message)
+	apiutil.SetCertificateRequestCondition(cr, v1alpha1.CertificateRequestConditionReady,
 		v1alpha1.ConditionFalse, v1alpha1.CertificateRequestReasonFailed, message)
 }
 
-func (r *Reporter) Pending(err error, reason, message string) {
+func (r *Reporter) Pending(cr *v1alpha1.CertificateRequest, err error, reason, message string) {
 	message = fmt.Sprintf("%s: %v", message, err)
-	r.recorder.Event(r.cr, corev1.EventTypeNormal, reason, message)
-	apiutil.SetCertificateRequestCondition(r.cr, v1alpha1.CertificateRequestConditionReady,
+	r.recorder.Event(cr, corev1.EventTypeNormal, reason, message)
+	apiutil.SetCertificateRequestCondition(cr, v1alpha1.CertificateRequestConditionReady,
 		v1alpha1.ConditionFalse, v1alpha1.CertificateRequestReasonPending, message)
 }

--- a/pkg/controller/certificaterequests/util/reporter_test.go
+++ b/pkg/controller/certificaterequests/util/reporter_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clocktesting "k8s.io/utils/clock/testing"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	controllertest "github.com/jetstack/cert-manager/pkg/controller/test"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+var (
+	fixedClockStart = time.Now()
+	fixedClock      = clocktesting.NewFakeClock(fixedClockStart)
+)
+
+type reporterT struct {
+	certificateRequest *cmapi.CertificateRequest
+
+	err             error
+	message, reason string
+
+	runFailedNotPending bool
+
+	expectedEvents      []string
+	expectedConditions  []cmapi.CertificateRequestCondition
+	expectedFailureTime *metav1.Time
+}
+
+func TestReporter(t *testing.T) {
+	nowMetaTime := metav1.NewTime(fixedClockStart)
+	oldMetaTime := metav1.NewTime(time.Time{})
+
+	baseCR := gen.CertificateRequest("test")
+
+	exampleErr := errors.New("this is an error")
+	exampleMessage := "this is a message"
+	exampleReason := "ThisIsAReason"
+
+	failedCondition := cmapi.CertificateRequestCondition{
+		Type:               cmapi.CertificateRequestConditionReady,
+		Reason:             "Failed",
+		Message:            exampleMessage + ": " + exampleErr.Error(),
+		Status:             "False",
+		LastTransitionTime: &nowMetaTime,
+	}
+
+	pendingCondition := cmapi.CertificateRequestCondition{
+		Type:               cmapi.CertificateRequestConditionReady,
+		Reason:             "Pending",
+		Message:            exampleMessage + ": " + exampleErr.Error(),
+		Status:             "False",
+		LastTransitionTime: &nowMetaTime,
+	}
+
+	existingPendingCondition := cmapi.CertificateRequestCondition{
+		Type:               cmapi.CertificateRequestConditionReady,
+		Reason:             "Pending",
+		Message:            "Exisitng Pending Message",
+		Status:             "False",
+		LastTransitionTime: &nowMetaTime,
+	}
+
+	tests := map[string]reporterT{
+		"a failed report should update the conditions and set FailureTime as it is nil": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR),
+			err:                exampleErr,
+			message:            exampleMessage,
+			reason:             exampleReason,
+
+			expectedEvents: []string{
+				"Warning ThisIsAReason this is a message: this is an error",
+			},
+			expectedConditions:  []cmapi.CertificateRequestCondition{failedCondition},
+			expectedFailureTime: &nowMetaTime,
+
+			runFailedNotPending: true,
+		},
+
+		"a failed report should update the conditions and not FailureTime as it is not nil": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR,
+				gen.SetCertificateRequestFailureTime(oldMetaTime),
+			),
+			err:     exampleErr,
+			message: exampleMessage,
+			reason:  exampleReason,
+
+			expectedEvents: []string{
+				"Warning ThisIsAReason this is a message: this is an error",
+			},
+			expectedConditions:  []cmapi.CertificateRequestCondition{failedCondition},
+			expectedFailureTime: &oldMetaTime,
+
+			runFailedNotPending: true,
+		},
+
+		"a pending report should update the conditions and send an event as a Pending condition already exists": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR),
+			err:                exampleErr,
+			message:            exampleMessage,
+			reason:             exampleReason,
+
+			expectedEvents: []string{
+				"Normal ThisIsAReason this is a message: this is an error",
+			},
+			expectedConditions:  []cmapi.CertificateRequestCondition{pendingCondition},
+			expectedFailureTime: nil,
+
+			runFailedNotPending: false,
+		},
+
+		"a pending report should update the conditions and not send an event as a Pending condition already exists": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR,
+				gen.SetCertificateRequestStatusCondition(existingPendingCondition),
+			),
+			err:     exampleErr,
+			message: exampleMessage,
+			reason:  exampleReason,
+
+			// No event sent
+			expectedEvents:      []string{},
+			expectedConditions:  []cmapi.CertificateRequestCondition{pendingCondition},
+			expectedFailureTime: nil,
+
+			runFailedNotPending: false,
+		},
+		"a pending report should update the conditions and send an event as only a non Pending condition already exists": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR,
+				gen.SetCertificateRequestStatusCondition(failedCondition),
+			),
+			err:     exampleErr,
+			message: exampleMessage,
+			reason:  exampleReason,
+
+			// No event sent
+			expectedEvents: []string{
+				"Normal ThisIsAReason this is a message: this is an error",
+			},
+			expectedConditions:  []cmapi.CertificateRequestCondition{pendingCondition},
+			expectedFailureTime: nil,
+
+			runFailedNotPending: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			fixedClock.SetTime(fixedClockStart)
+			apiutil.Clock = fixedClock
+			test.runTest(t)
+		})
+	}
+}
+
+func (tt *reporterT) runTest(t *testing.T) {
+	recorder := new(controllertest.FakeRecorder)
+	reporter := NewReporter(fixedClock, recorder)
+
+	if tt.runFailedNotPending {
+		reporter.Failed(tt.certificateRequest, tt.err,
+			tt.reason, tt.message)
+	} else {
+		reporter.Pending(tt.certificateRequest, tt.err,
+			tt.reason, tt.message)
+	}
+
+	expConditions := conditionsToString(tt.expectedConditions)
+	gotConditions := conditionsToString(tt.certificateRequest.Status.Conditions)
+	if expConditions != gotConditions {
+		t.Errorf("got unexpected conditions response exp=%+v got=%+v",
+			expConditions, gotConditions)
+	}
+
+	if !util.EqualSorted(tt.expectedEvents, recorder.Events) {
+		t.Errorf("got unexpected events, exp=%+v got=%+v",
+			tt.expectedEvents, recorder.Events)
+	}
+
+	if tt.expectedFailureTime == nil {
+		if tt.certificateRequest.Status.FailureTime != nil {
+			t.Errorf("got unexpected failure time, exp=nil got=%+v",
+				tt.certificateRequest.Status.FailureTime)
+		}
+
+	} else {
+		if tt.certificateRequest.Status.FailureTime.String() !=
+			tt.expectedFailureTime.String() {
+			t.Errorf("got unexpected failure time, exp=%+v got=%+v",
+				tt.expectedFailureTime.String(),
+				tt.certificateRequest.Status.FailureTime.String())
+		}
+	}
+}
+
+func conditionsToString(conds []cmapi.CertificateRequestCondition) string {
+	return fmt.Sprintf("%+v", conds)
+}

--- a/pkg/controller/certificates/certificate_request.go
+++ b/pkg/controller/certificates/certificate_request.go
@@ -554,9 +554,8 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 				return nil
 			}
 
+			// We don't fire an event here as this could be called multiple times in quick succession
 			c.scheduledWorkQueue.Add(key, time.Hour)
-
-			c.recorder.Eventf(crt, corev1.EventTypeNormal, "CertificateRequestReschedule", "The CertificateRequest %q has failed and is scheduled for a retry in 1 hour", existingReq.Name)
 			return nil
 		}
 

--- a/pkg/controller/certificates/certificate_request_test.go
+++ b/pkg/controller/certificates/certificate_request_test.go
@@ -137,6 +137,7 @@ func createCryptoBundle(crt *cmapi.Certificate) (*cryptoBundle, error) {
 		gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 			Type:   cmapi.CertificateRequestConditionReady,
 			Status: cmapi.ConditionTrue,
+			Reason: cmapi.CertificateRequestReasonIssued,
 		}),
 	)
 

--- a/pkg/controller/certificates/certificate_request_test.go
+++ b/pkg/controller/certificates/certificate_request_test.go
@@ -1128,7 +1128,8 @@ func TestProcessCertificate(t *testing.T) {
 						})),
 				},
 				ExpectedActions: []testpkg.Action{},
-				ExpectedEvents:  []string{`Normal CertificateRequestReschedule The CertificateRequest "test-850937773" has failed and is scheduled for a retry in 1 hour`},
+				// We don't fire an event here as this could be called multiple times in quick succession
+				ExpectedEvents: []string{},
 			},
 		},
 	}

--- a/test/unit/gen/certificaterequest.go
+++ b/test/unit/gen/certificaterequest.go
@@ -120,3 +120,9 @@ func AddCertificateRequestAnnotations(annotations map[string]string) Certificate
 		cr.SetAnnotations(annotationsNew)
 	}
 }
+
+func SetCertificateRequestFailureTime(p metav1.Time) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Status.FailureTime = &p
+	}
+}


### PR DESCRIPTION
Adds FailureTime to CertificateRequet Status.

Time set to now on the CertificateRequest if failed and the FailureTime is not currently set.

The Certificate controller will re-try CertificateRequests that have failed and have a FailureTime of at least one hour in the past. If the FailureTime is less than one hour, the Certificate is rescheduled for syncing in one hour.

```release-note
Adds CertificateRequest FailureTime. The Certificate controller will re-try failed CertificateRequests at least one hour after this failed time.
```

/assign @munnerz 
