### PR TITLE
Fix concurrent map write panic

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -374,7 +374,11 @@ func (c *controller) updateSecret(ctx context.Context, crt *v1alpha1.Certificate
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return nil, err
 	}
-
+	// create a deep copy of the secret before modifying it as we fetched it
+	// from the lister's cache.
+	if secret != nil {
+		secret = secret.DeepCopy()
+	}
 	// if the resource does not already exist, we will create a new one
 	if secret == nil {
 		secret = &corev1.Secret{


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we did not DeepCopy Secret resources before updating them in the apiserver, despite fetching them from a shared cache.

This is simply using the lister improperly, so it's clear it needs to be fixed.

I think this manifested itself in #1951, as the lister and our own controller both modify the labels/annotations list simultaneously in certain cases.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1951

**Release note**:
```release-note
Fix concurrent map write panic in certificates controller
```

/cc @JoshVanL 
