### PR TITLE
Move TLSCAKey to v1alpha1 package

### DIFF
--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -82,3 +82,7 @@ type SecretKeySelector struct {
 	// +optional
 	Key string `json:"key,omitempty"`
 }
+
+const (
+	TLSCAKey = "ca.crt"
+)

--- a/pkg/controller/cainjector/BUILD.bazel
+++ b/pkg/controller/cainjector/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
-        "//pkg/controller/certificates:go_default_library",
         "//pkg/logs:go_default_library",
         "//vendor/github.com/go-logr/logr:go_default_library",
         "//vendor/k8s.io/api/admissionregistration/v1beta1:go_default_library",

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
-	certctrl "github.com/jetstack/cert-manager/pkg/controller/certificates"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 )
 
@@ -214,7 +213,7 @@ func (r *genericInjectReconciler) Reconcile(req ctrl.Request) (ctrl.Result, erro
 	}
 
 	// inject the CA data
-	caData, hasCAData := secret.Data[certctrl.TLSCAKey]
+	caData, hasCAData := secret.Data[certmanager.TLSCAKey]
 	if !hasCAData {
 		log.Error(nil, "certificate has no CA data")
 		// don't requeue, we'll get called when the secret gets updated

--- a/pkg/controller/certificates/certificate_request.go
+++ b/pkg/controller/certificates/certificate_request.go
@@ -624,7 +624,7 @@ func (c *certificateRequestManager) updateSecretData(ctx context.Context, crt *c
 func (c *certificateRequestManager) ensureSecretMetadataUpToDate(ctx context.Context, s *corev1.Secret, crt *cmapi.Certificate) (bool, error) {
 	pk := s.Data[corev1.TLSPrivateKeyKey]
 	cert := s.Data[corev1.TLSCertKey]
-	ca := s.Data[TLSCAKey]
+	ca := s.Data[cmapi.TLSCAKey]
 
 	updated, err := c.updateSecretData(ctx, crt, s, secretData{pk: pk, cert: cert, ca: ca})
 	if err != nil || !updated {
@@ -891,7 +891,7 @@ func setSecretValues(ctx context.Context, crt *cmapi.Certificate, s *corev1.Secr
 
 	s.Data[corev1.TLSPrivateKeyKey] = data.pk
 	s.Data[corev1.TLSCertKey] = data.cert
-	s.Data[TLSCAKey] = data.ca
+	s.Data[cmapi.TLSCAKey] = data.ca
 
 	if s.Annotations == nil {
 		s.Annotations = make(map[string]string)

--- a/pkg/controller/certificates/certificate_request_test.go
+++ b/pkg/controller/certificates/certificate_request_test.go
@@ -392,7 +392,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -438,7 +438,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -487,7 +487,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -536,7 +536,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -564,7 +564,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -601,7 +601,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -650,7 +650,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -683,7 +683,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.generateCertificateExpiring1H(exampleBundle1.certificate),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -722,7 +722,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.certBytes,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -749,7 +749,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.certBytes,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -778,7 +778,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -805,7 +805,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -835,7 +835,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -865,7 +865,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.generateTestCertificate(exampleBundle1.certificate, nil),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -897,7 +897,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       []byte("invalid"),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -927,7 +927,7 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -957,7 +957,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.generateCertificateExpiring1H(exampleBundle1.certificate),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1000,7 +1000,7 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.generateCertificateExpiring1H(exampleBundle1.certificate),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1063,7 +1063,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1092,7 +1092,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1119,7 +1119,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1149,7 +1149,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1176,7 +1176,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       nil,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1206,7 +1206,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1236,7 +1236,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1266,7 +1266,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1296,7 +1296,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       []byte("invalid"),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1326,7 +1326,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1360,7 +1360,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								),
 							),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1389,7 +1389,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1415,7 +1415,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1444,7 +1444,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -68,10 +68,6 @@ const (
 	messageErrorSavingCertificate = "Error saving TLS certificate: "
 )
 
-const (
-	TLSCAKey = "ca.crt"
-)
-
 var (
 	certificateGvk = v1alpha1.SchemeGroupVersion.WithKind("Certificate")
 )
@@ -464,7 +460,7 @@ func (c *controller) updateSecret(ctx context.Context, crt *v1alpha1.Certificate
 	// set the actual values in the secret
 	secret.Data[corev1.TLSCertKey] = cert
 	secret.Data[corev1.TLSPrivateKeyKey] = key
-	secret.Data[TLSCAKey] = ca
+	secret.Data[v1alpha1.TLSCAKey] = ca
 
 	// if it is a new resource
 	if secret.SelfLink == "" {

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -233,7 +233,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       localTempCert,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 						},
 					)),
@@ -300,7 +300,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       localTempCert,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 						},
 					)),
@@ -350,7 +350,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       cert1PEM,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -418,7 +418,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       cert1PEM,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 						},
 					)),
@@ -456,7 +456,7 @@ func TestSync(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       cert2PEM,
 							corev1.TLSPrivateKeyKey: pk1PEM,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 					},
 				},
@@ -502,7 +502,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       cert1PEM,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 						},
 					)),
@@ -542,7 +542,7 @@ func TestSync(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       cert1PEM,
 							corev1.TLSPrivateKeyKey: pk1PEM,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 					},
 				},
@@ -598,7 +598,7 @@ func TestSync(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       localTempCert,
 							corev1.TLSPrivateKeyKey: pk1PEM,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 					},
 				},
@@ -630,7 +630,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       localTempCert,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 						},
 					)),
@@ -671,7 +671,7 @@ func TestSync(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       cert1PEM,
 							corev1.TLSPrivateKeyKey: pk1PEM,
-							TLSCAKey:                nil,
+							cmapi.TLSCAKey:          nil,
 						},
 					},
 				},
@@ -717,7 +717,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       cert1PEM,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 						},
 					)),
@@ -808,7 +808,7 @@ func TestSync(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       cert1PEM,
 								corev1.TLSPrivateKeyKey: pk1PEM,
-								TLSCAKey:                nil,
+								cmapi.TLSCAKey:          nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:

This key is essentially part of our API, and should be represented as such.

This is part of the effort to implement conversion webhooks (#1984)

**Release note**:
```release-note
NONE
```
