### PR TITLE
Extend cainjector to support injecting from secrets

### DIFF
--- a/cmd/cainjector/start.go
+++ b/cmd/cainjector/start.go
@@ -35,7 +35,6 @@ type InjectorControllerOptions struct {
 	Namespace               string
 	LeaderElect             bool
 	LeaderElectionNamespace string
-	LeaderElectionID        string
 
 	StdOut io.Writer
 	StdErr io.Writer
@@ -52,8 +51,6 @@ func (o *InjectorControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", "", ""+
 		"Namespace used to perform leader election (defaults to controller's namespace). "+
 		"Only used if leader election is enabled")
-	fs.StringVar(&o.LeaderElectionID, "leader-election-id", "", ""+
-		"Override the identifier to use in leader election.  Only used if leader election is enabled")
 }
 
 func NewInjectorControllerOptions(out, errOut io.Writer) *InjectorControllerOptions {
@@ -94,12 +91,27 @@ servers and webhook servers.`,
 }
 
 func (o InjectorControllerOptions) RunInjectorController(stopCh <-chan struct{}) {
+	eitherStopCh := make(chan struct{})
+	go func() {
+		defer close(eitherStopCh)
+		o.runCertificateBasedInjector(stopCh)
+	}()
+	go func() {
+		defer close(eitherStopCh)
+		o.runSecretBasedInjector(stopCh)
+	}()
+
+	<-eitherStopCh
+}
+
+func (o InjectorControllerOptions) runCertificateBasedInjector(stopCh <-chan struct{}) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  api.Scheme,
 		Namespace:               o.Namespace,
 		LeaderElection:          o.LeaderElect,
 		LeaderElectionNamespace: o.LeaderElectionNamespace,
-		LeaderElectionID:        o.LeaderElectionID,
+		LeaderElectionID:        "cert-manager-cainjector-leader-election",
+		MetricsBindAddress:      "0",
 	})
 
 	if err != nil {
@@ -107,11 +119,35 @@ func (o InjectorControllerOptions) RunInjectorController(stopCh <-chan struct{})
 	}
 
 	// TODO(directxman12): enabled controllers for separate injectors?
-	if err := cainjector.RegisterAll(mgr); err != nil {
+	if err := cainjector.RegisterCertificateBased(mgr); err != nil {
 		klog.Fatalf("error registering controllers: %v", err)
 	}
 
 	if err := mgr.Start(stopCh); err != nil {
 		klog.Fatalf("error running manager: %v", err)
+	}
+}
+
+func (o InjectorControllerOptions) runSecretBasedInjector(stopCh <-chan struct{}) {
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                  api.Scheme,
+		Namespace:               o.Namespace,
+		LeaderElection:          o.LeaderElect,
+		LeaderElectionNamespace: o.LeaderElectionNamespace,
+		LeaderElectionID:        "cert-manager-cainjector-leader-election-core",
+		MetricsBindAddress:      "0",
+	})
+
+	if err != nil {
+		klog.Fatalf("error creating core-only manager: %v", err)
+	}
+
+	// TODO(directxman12): enabled controllers for separate injectors?
+	if err := cainjector.RegisterSecretBased(mgr); err != nil {
+		klog.Fatalf("error registering core-only controllers: %v", err)
+	}
+
+	if err := mgr.Start(stopCh); err != nil {
+		klog.Fatalf("error running core-only manager: %v", err)
 	}
 }

--- a/pkg/controller/cainjector/BUILD.bazel
+++ b/pkg/controller/cainjector/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "indexers.go",
         "injectors.go",
         "setup.go",
+        "sources.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/controller/cainjector",
     visibility = ["//visibility:public"],

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -31,7 +31,7 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
-var (
+const (
 	// WantInjectAnnotation is the annotation that specifies that a particular
 	// object wants injection of CAs.  It takes the form of a reference to a certificate
 	// as namespace/name.  The certificate is expected to have the is-serving-for annotations.
@@ -40,7 +40,7 @@ var (
 	// WantInjectAPIServerCAAnnotation, if set to "true", will make the cainjector
 	// inject the CA certificate for the Kubernetes apiserver into the resource.
 	// It discovers the apiserver's CA by inspecting the service account credentials
-	// mounted into the
+	// mounted into the cainjector pod.
 	WantInjectAPIServerCAAnnotation = "certmanager.k8s.io/inject-apiserver-ca"
 
 	// WantInjectFromSecretAnnotation is the annotation that specifies that a particular

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cainjector
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+var (
+	// WantInjectAnnotation is the annotation that specifies that a particular
+	// object wants injection of CAs.  It takes the form of a reference to a certificate
+	// as namespace/name.  The certificate is expected to have the is-serving-for annotations.
+	WantInjectAnnotation = "certmanager.k8s.io/inject-ca-from"
+
+	// WantInjectFromSecretAnnotation is the annotation that specifies that a particular
+	// object wants injection of CAs.  It takes the form of a reference to a Secret
+	// as namespace/name.
+	WantInjectFromSecretAnnotation = "certmanager.k8s.io/inject-ca-from-secret"
+
+	// WantInjectAPIServerCAAnnotation, if set to "true", will make the cainjector
+	// inject the CA certificate for the Kubernetes apiserver into the resource.
+	// It discovers the apiserver's CA by inspecting the service account credentials
+	// mounted into the
+	WantInjectAPIServerCAAnnotation = "certmanager.k8s.io/inject-apiserver-ca"
+)
+
+// caDataSource knows how to extract CA data given a provided InjectTarget.
+// This allows adaptable implementations of fetching CA data based on
+// configuration given on the injection target (e.g. annotations).
+
+type caDataSource interface {
+	// Configured returns true if this data source should be used for the given
+	// InjectTarget, i.e. if it has appropriate annotations enabled to use the
+	// annotations.
+	Configured(log logr.Logger, metaObj metav1.Object) bool
+
+	// ReadCA reads the CA that should be injected into the InjectTarget based
+	// on the configuration provided in the InjectTarget.
+	// ReadCA may return nil, nil if the CA data cannot be read.
+	// In this case, the caller should not retry the operation.
+	// It is up to the ReadCA implementation to inform the user why the CA
+	// failed to read.
+	ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object) (ca []byte, err error)
+
+	// ApplyTo applies any required watchers to the given controller builder.
+	ApplyTo(mgr ctrl.Manager, setup injectorSetup, builder *ctrl.Builder) error
+}
+
+// kubeconfigDataSource reads the ca bundle provided as part of the struct
+// instantiation if it has the 'certmanager.k8s.io/inject-apiserver-ca'
+// annotation.
+type kubeconfigDataSource struct {
+	apiserverCABundle []byte
+}
+
+func (c *kubeconfigDataSource) Configured(log logr.Logger, metaObj metav1.Object) bool {
+	return metaObj.GetAnnotations()[WantInjectAPIServerCAAnnotation] == "true"
+}
+
+func (c *kubeconfigDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object) (ca []byte, err error) {
+	return c.apiserverCABundle, nil
+}
+
+func (c *kubeconfigDataSource) ApplyTo(mgr ctrl.Manager, setup injectorSetup, builder *ctrl.Builder) error {
+	cfg := mgr.GetConfig()
+	caBundle, err := dataFromSliceOrFile(cfg.CAData, cfg.CAFile)
+	if err != nil {
+		return err
+	}
+	c.apiserverCABundle = caBundle
+	return nil
+}
+
+// certificateDataSource reads a CA bundle by fetching the Certificate named in
+// the 'certmanager.k8s.io/inject-ca-from' annotation in the form
+// 'namespace/name'.
+type certificateDataSource struct {
+	client client.Client
+}
+
+func (c *certificateDataSource) Configured(log logr.Logger, metaObj metav1.Object) bool {
+	certNameRaw, ok := metaObj.GetAnnotations()[WantInjectAnnotation]
+	if !ok {
+		return false
+	}
+	log.Info("Extracting CA from Certificate resource", "certificate", certNameRaw)
+	return true
+}
+
+func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object) (ca []byte, err error) {
+	certNameRaw := metaObj.GetAnnotations()[WantInjectAnnotation]
+	certName := splitNamespacedName(certNameRaw)
+	log = log.WithValues("certificate", certName)
+	if certName.Namespace == "" {
+		log.Error(nil, "invalid certificate name")
+		// don't return an error, requeuing won't help till this is changed
+		return nil, nil
+	}
+
+	var cert cmapi.Certificate
+	if err := c.client.Get(ctx, certName, &cert); err != nil {
+		log.Error(err, "unable to fetch associated certificate")
+		// don't requeue if we're just not found, we'll get called when the secret gets created
+		return nil, dropNotFound(err)
+	}
+
+	secretName := &types.NamespacedName{Namespace: cert.Namespace, Name: cert.Spec.SecretName}
+	// grab the associated secret, and ensure it's owned by the cert
+	log = log.WithValues("secret", secretName)
+	var secret corev1.Secret
+	if err := c.client.Get(ctx, *secretName, &secret); err != nil {
+		log.Error(err, "unable to fetch associated secret")
+		// don't requeue if we're just not found, we'll get called when the secret gets created
+		return nil, dropNotFound(err)
+	}
+	owner := OwningCertForSecret(&secret)
+	if owner == nil || *owner != certName {
+		log.Info("refusing to target secret not owned by certificate", "owner", metav1.GetControllerOf(&secret))
+		return nil, nil
+	}
+
+	// inject the CA data
+	caData, hasCAData := secret.Data[cmapi.TLSCAKey]
+	if !hasCAData {
+		log.Error(nil, "certificate has no CA data")
+		// don't requeue, we'll get called when the secret gets updated
+		return nil, nil
+	}
+
+	return caData, nil
+}
+
+func (c *certificateDataSource) ApplyTo(mgr ctrl.Manager, setup injectorSetup, builder *ctrl.Builder) error {
+	typ := setup.injector.NewTarget().AsObject()
+	if err := mgr.GetFieldIndexer().IndexField(typ, injectFromPath, injectableCAFromIndexer); err != nil {
+		return err
+	}
+
+	builder.Watches(&source.Kind{Type: &cmapi.Certificate{}},
+		&handler.EnqueueRequestsFromMapFunc{ToRequests: &certMapper{
+			Client:       mgr.GetClient(),
+			log:          ctrl.Log.WithName("cert-mapper"),
+			toInjectable: buildCertToInjectableFunc(setup.listType, setup.resourceName),
+		}},
+	).
+		Watches(&source.Kind{Type: &corev1.Secret{}},
+			&handler.EnqueueRequestsFromMapFunc{ToRequests: &secretForCertificateMapper{
+				Client:                  mgr.GetClient(),
+				log:                     ctrl.Log.WithName("secret-for-certificate-mapper"),
+				certificateToInjectable: buildCertToInjectableFunc(setup.listType, setup.resourceName),
+			}},
+		)
+	return nil
+}
+
+// secretDataSource reads a CA bundle from a Secret resource named using the
+// 'certmanager.k8s.io/inject-ca-from-secret' annotation in the form
+// 'namespace/name'.
+type secretDataSource struct {
+	client client.Client
+}
+
+func (c *secretDataSource) Configured(log logr.Logger, metaObj metav1.Object) bool {
+	secretNameRaw, ok := metaObj.GetAnnotations()[WantInjectFromSecretAnnotation]
+	if !ok {
+		return false
+	}
+	log.Info("Extracting CA from Secret resource", "secret", secretNameRaw)
+	return true
+}
+
+func (c *secretDataSource) ReadCA(ctx context.Context, log logr.Logger, metaObj metav1.Object) ([]byte, error) {
+	secretNameRaw := metaObj.GetAnnotations()[WantInjectFromSecretAnnotation]
+	secretName := splitNamespacedName(secretNameRaw)
+	log = log.WithValues("secret", secretName)
+	if secretName.Namespace == "" {
+		log.Error(nil, "invalid certificate name")
+		// don't return an error, requeuing won't help till this is changed
+		return nil, nil
+	}
+
+	// grab the associated secret
+	var secret corev1.Secret
+	if err := c.client.Get(ctx, secretName, &secret); err != nil {
+		log.Error(err, "unable to fetch associated secret")
+		// don't requeue if we're just not found, we'll get called when the secret gets created
+		return nil, dropNotFound(err)
+	}
+
+	// inject the CA data
+	caData, hasCAData := secret.Data[cmapi.TLSCAKey]
+	if !hasCAData {
+		log.Error(nil, "certificate has no CA data")
+		// don't requeue, we'll get called when the secret gets updated
+		return nil, nil
+	}
+
+	return caData, nil
+}
+
+func (c *secretDataSource) ApplyTo(mgr ctrl.Manager, setup injectorSetup, builder *ctrl.Builder) error {
+	typ := setup.injector.NewTarget().AsObject()
+	if err := mgr.GetFieldIndexer().IndexField(typ, injectFromSecretPath, injectableCAFromSecretIndexer); err != nil {
+		return err
+	}
+
+	builder.Watches(&source.Kind{Type: &corev1.Secret{}},
+		&handler.EnqueueRequestsFromMapFunc{ToRequests: &secretForInjectableMapper{
+			Client:             mgr.GetClient(),
+			log:                ctrl.Log.WithName("secret-mapper"),
+			secretToInjectable: buildSecretToInjectableFunc(setup.listType, setup.resourceName),
+		}},
+	)
+	return nil
+}

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -46,6 +46,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 	f := framework.NewDefaultFramework("ca-injector")
 
 	issuerName := "inject-cert-issuer"
+	secretName := "serving-certs-data"
 
 	injectorContext := func(subj string, test *injectableTest) {
 		Context("for "+subj+"s", func() {
@@ -73,14 +74,13 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				}
 				Expect(f.CRClient.Delete(context.Background(), toCleanup)).To(Succeed())
 			})
-			generalSetup := func(namePrefix string) (runtime.Object, certmanager.Certificate, corev1.Secret) {
+			generalSetup := func(injectable runtime.Object) (runtime.Object, certmanager.Certificate, corev1.Secret) {
 				By("creating a " + subj + " pointing to a cert")
-				injectable := test.makeInjectable(namePrefix)
 				Expect(f.CRClient.Create(context.Background(), injectable)).To(Succeed())
 				toCleanup = injectable
 
 				By("creating a certificate")
-				secretName := types.NamespacedName{Name: "serving-certs-data", Namespace: f.Namespace.Name}
+				secretName := types.NamespacedName{Name: secretName, Namespace: f.Namespace.Name}
 				cert := util.NewCertManagerBasicCertificate("serving-certs", secretName.Name, issuerName, certmanager.IssuerKind, nil, nil)
 				cert.Namespace = f.Namespace.Name
 				Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
@@ -113,7 +113,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 					Skip(test.disabled)
 				}
 
-				generalSetup("injected")
+				generalSetup(test.makeInjectable("injected"))
 			})
 
 			It("should not inject CA into non-annotated objects", func() {
@@ -141,14 +141,14 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				if test.disabled != "" {
 					Skip(test.disabled)
 				}
-				injectable, cert, _ := generalSetup("changed")
+				injectable, cert, _ := generalSetup(test.makeInjectable("changed"))
 
 				By("grabbing the latest copy of the cert")
 				Expect(f.CRClient.Get(context.Background(), types.NamespacedName{Name: cert.Name, Namespace: cert.Namespace}, &cert)).To(Succeed())
 
 				By("changing the name of the corresponding secret in the cert")
-				secretName := types.NamespacedName{Name: "other-data", Namespace: f.Namespace.Name}
-				cert.Spec.SecretName = secretName.Name
+				secretName := types.NamespacedName{Name: cert.Spec.SecretName, Namespace: f.Namespace.Name}
+				cert.Spec.DNSNames = append(cert.Spec.DNSNames, "something.com")
 				Expect(f.CRClient.Update(context.Background(), &cert)).To(Succeed())
 
 				By("grabbing the new secret")
@@ -201,7 +201,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				if len(f.KubeClientConfig.CAData) == 0 {
 					Skip("skipping test as the kube client CA bundle is not set")
 				}
-				By("creating a vaidating webhook with the inject-apiserver-ca annotation")
+				By("creating an injectable with the inject-apiserver-ca annotation")
 				injectable := test.makeInjectable("apiserver-ca")
 				injectable.(metav1.Object).SetAnnotations(map[string]string{
 					injctrl.WantInjectAPIServerCAAnnotation: "true",
@@ -217,6 +217,77 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 					expectedCAs[i] = caData
 				}
 				Eventually(func() ([][]byte, error) {
+					newInjectable := injectable.DeepCopyObject()
+					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
+						return nil, err
+					}
+					return test.getCAs(newInjectable), nil
+				}, "10s", "2s").Should(Equal(expectedCAs))
+			})
+
+			It("should inject a CA directly from a secret if the inject-ca-from-secret annotation is present", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+				secretName := types.NamespacedName{Name: secretName, Namespace: f.Namespace.Name}
+				annotatedSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName.Name,
+						Namespace: secretName.Namespace,
+						Annotations: map[string]string{
+							injctrl.AllowsInjectionFromSecretAnnotation: "true",
+						},
+					},
+				}
+				Expect(f.CRClient.Create(context.Background(), &annotatedSecret)).To(Succeed())
+
+				injectable := test.makeInjectable("from-secret")
+				injectable.(metav1.Object).SetAnnotations(map[string]string{
+					injctrl.WantInjectFromSecretAnnotation: secretName.String(),
+				})
+				generalSetup(injectable)
+			})
+
+			It("should refuse to inject a CA directly from a secret if the allow-direct-injection annotation is not 'true'", func() {
+				if test.disabled != "" {
+					Skip(test.disabled)
+				}
+				secretName := types.NamespacedName{Name: secretName, Namespace: f.Namespace.Name}
+				annotatedSecret := corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      secretName.Name,
+						Namespace: secretName.Namespace,
+						Annotations: map[string]string{
+							injctrl.AllowsInjectionFromSecretAnnotation: "false",
+						},
+					},
+				}
+				Expect(f.CRClient.Create(context.Background(), &annotatedSecret)).To(Succeed())
+
+				By("creating a " + subj + " pointing to a secret")
+				injectable := test.makeInjectable("from-secret-not-allowed")
+				injectable.(metav1.Object).SetAnnotations(map[string]string{
+					injctrl.WantInjectFromSecretAnnotation: secretName.String(),
+				})
+				Expect(f.CRClient.Create(context.Background(), injectable)).To(Succeed())
+				toCleanup = injectable
+
+				By("creating a certificate")
+				cert := util.NewCertManagerBasicCertificate("serving-certs", secretName.Name, issuerName, certmanager.IssuerKind, nil, nil)
+				cert.Namespace = f.Namespace.Name
+				Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
+
+				By("grabbing the corresponding secret")
+				var secret corev1.Secret
+				Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
+
+				By("checking that all webhooks have an empty CA")
+				expectedLen := len(test.getCAs(injectable))
+				expectedCAs := make([][]byte, expectedLen)
+				for i := range expectedCAs {
+					expectedCAs[i] = []byte{}
+				}
+				Consistently(func() ([][]byte, error) {
 					newInjectable := injectable.DeepCopyObject()
 					if err := f.CRClient.Get(context.Background(), types.NamespacedName{Name: injectable.(metav1.Object).GetName()}, newInjectable); err != nil {
 						return nil, err
@@ -369,4 +440,5 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 			return [][]byte{apiSvc.Spec.CABundle}
 		},
 	})
+
 })

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -285,7 +285,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				expectedLen := len(test.getCAs(injectable))
 				expectedCAs := make([][]byte, expectedLen)
 				for i := range expectedCAs {
-					expectedCAs[i] = []byte{}
+					expectedCAs[i] = nil
 				}
 				Consistently(func() ([][]byte, error) {
 					newInjectable := injectable.DeepCopyObject()


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of #1984, we need to be able to inject directly from secrets as we are unable to create Certificate resources during cert-manager's installation phase.

This PR extends the cainjector to support injecting from secrets with the new `inject-ca-from-secret` annotation, similar to the existing `inject-ca-from` one.

**Release note**:
```release-note
cainjector: allow injecting CAs directly from Secret resources
```
