### PR TITLE
feat: enable crt/csr keyusages and extended keyusages

### DIFF
--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -63,7 +63,7 @@ spec:
               type: string
             isCA:
               description: IsCA will mark the resulting certificate as valid for signing.
-                This implies that the 'signing' usage is set
+                This implies that the 'cert sign' usage is set
               type: boolean
             issuerRef:
               description: IssuerRef is a reference to the issuer for this CertificateRequest.  If
@@ -83,6 +83,39 @@ spec:
               required:
               - name
               type: object
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
           required:
           - issuerRef
           type: object
@@ -295,7 +328,7 @@ spec:
               type: array
             isCA:
               description: IsCA will mark this Certificate as valid for signing. This
-                implies that the 'signing' usage is set
+                implies that the 'cert sign' usage is set
               type: boolean
             issuerRef:
               description: IssuerRef is a reference to the issuer for this certificate.
@@ -353,6 +386,39 @@ spec:
               description: SecretName is the name of the secret resource to store
                 this secret in
               type: string
+            usages:
+              description: Usages is the set of x509 actions that are enabled for
+                a given key. Defaults are ('digital signature', 'key encipherment')
+                if empty
+              items:
+                description: 'KeyUsage specifies valid usage contexts for keys. See:
+                  https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12'
+                enum:
+                - signing
+                - digital signature
+                - content commitment
+                - key encipherment
+                - key agreement
+                - data encipherment
+                - cert sign
+                - crl sign
+                - encipher only
+                - decipher only
+                - any
+                - server auth
+                - client auth
+                - code signing
+                - email protection
+                - s/mime
+                - ipsec end system
+                - ipsec tunnel
+                - ipsec user
+                - timestamping
+                - ocsp signing
+                - microsoft sgc
+                - netscape sgc
+                type: string
+              type: array
           required:
           - issuerRef
           - secretName

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -101,7 +101,7 @@ Appears In:
 </tr>
 <tr>
 <td><code>isCA</code><br /> <em>boolean</em></td>
-<td>IsCA will mark this Certificate as valid for signing. This implies that the &#39;signing&#39; usage is set</td>
+<td>IsCA will mark this Certificate as valid for signing. This implies that the &#39;cert sign&#39; usage is set</td>
 </tr>
 <tr>
 <td><code>issuerRef</code><br /> *<a href="#objectreference-v1alpha1">ObjectReference</a>*</td>
@@ -130,6 +130,10 @@ Appears In:
 <tr>
 <td><code>secretName</code><br /> <em>string</em></td>
 <td>SecretName is the name of the secret resource to store this secret in</td>
+</tr>
+<tr>
+<td><code>usages</code><br /> <em>string array</em></td>
+<td>Usages is the set of x509 actions that are enabled for a given key. Defaults are (&#39;digital signature&#39;, &#39;key encipherment&#39;) if empty</td>
 </tr>
 </tbody></table>
 <h3 id="certificatestatus-v1alpha1">CertificateStatus v1alpha1</h3>

--- a/pkg/api/util/BUILD.bazel
+++ b/pkg/api/util/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "conditions.go",
         "duration.go",
         "issuers.go",
+        "usages.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/api/util",
     visibility = ["//visibility:public"],

--- a/pkg/api/util/usages.go
+++ b/pkg/api/util/usages.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/x509"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+var keyUsages = map[cmapi.KeyUsage]x509.KeyUsage{
+	cmapi.UsageSigning:            x509.KeyUsageDigitalSignature,
+	cmapi.UsageDigitalSignature:   x509.KeyUsageDigitalSignature,
+	cmapi.UsageContentCommittment: x509.KeyUsageContentCommitment,
+	cmapi.UsageKeyEncipherment:    x509.KeyUsageKeyEncipherment,
+	cmapi.UsageKeyAgreement:       x509.KeyUsageKeyAgreement,
+	cmapi.UsageDataEncipherment:   x509.KeyUsageDataEncipherment,
+	cmapi.UsageCertSign:           x509.KeyUsageCertSign,
+	cmapi.UsageCRLSign:            x509.KeyUsageCRLSign,
+	cmapi.UsageEncipherOnly:       x509.KeyUsageEncipherOnly,
+	cmapi.UsageDecipherOnly:       x509.KeyUsageDecipherOnly,
+}
+
+var extKeyUsages = map[cmapi.KeyUsage]x509.ExtKeyUsage{
+	cmapi.UsageAny:             x509.ExtKeyUsageAny,
+	cmapi.UsageServerAuth:      x509.ExtKeyUsageServerAuth,
+	cmapi.UsageClientAuth:      x509.ExtKeyUsageClientAuth,
+	cmapi.UsageCodeSigning:     x509.ExtKeyUsageCodeSigning,
+	cmapi.UsageEmailProtection: x509.ExtKeyUsageEmailProtection,
+	cmapi.UsageSMIME:           x509.ExtKeyUsageEmailProtection,
+	cmapi.UsageIPsecEndSystem:  x509.ExtKeyUsageIPSECEndSystem,
+	cmapi.UsageIPsecTunnel:     x509.ExtKeyUsageIPSECTunnel,
+	cmapi.UsageIPsecUser:       x509.ExtKeyUsageIPSECUser,
+	cmapi.UsageTimestamping:    x509.ExtKeyUsageTimeStamping,
+	cmapi.UsageOCSPSigning:     x509.ExtKeyUsageOCSPSigning,
+	cmapi.UsageMicrosoftSGC:    x509.ExtKeyUsageMicrosoftServerGatedCrypto,
+	cmapi.UsageNetscapSGC:      x509.ExtKeyUsageNetscapeServerGatedCrypto,
+}
+
+// KeyUsageType returns the relevant x509.KeyUsage or false if not found
+func KeyUsageType(usage cmapi.KeyUsage) (x509.KeyUsage, bool) {
+	u, ok := keyUsages[usage]
+	return u, ok
+}
+
+// ExtKeyUsageType returns the relevant x509.ExtKeyUsage or false if not found
+func ExtKeyUsageType(usage cmapi.KeyUsage) (x509.ExtKeyUsage, bool) {
+	eu, ok := extKeyUsages[usage]
+	return eu, ok
+}

--- a/pkg/apis/certmanager/v1alpha1/types.go
+++ b/pkg/apis/certmanager/v1alpha1/types.go
@@ -111,3 +111,40 @@ const (
 	// the cainjector will refuse to inject the secret.
 	AllowsInjectionFromSecretAnnotation = "certmanager.k8s.io/allow-direct-injection"
 )
+
+// KeyUsage specifies valid usage contexts for keys.
+// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// +kubebuilder:validation:Enum="signing";"digital signature";"content commitment";"key encipherment";"key agreement";"data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";"code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";"ocsp signing";"microsoft sgc";"netscape sgc"
+type KeyUsage string
+
+const (
+	UsageSigning            KeyUsage = "signing"
+	UsageDigitalSignature   KeyUsage = "digital signature"
+	UsageContentCommittment KeyUsage = "content commitment"
+	UsageKeyEncipherment    KeyUsage = "key encipherment"
+	UsageKeyAgreement       KeyUsage = "key agreement"
+	UsageDataEncipherment   KeyUsage = "data encipherment"
+	UsageCertSign           KeyUsage = "cert sign"
+	UsageCRLSign            KeyUsage = "crl sign"
+	UsageEncipherOnly       KeyUsage = "encipher only"
+	UsageDecipherOnly       KeyUsage = "decipher only"
+	UsageAny                KeyUsage = "any"
+	UsageServerAuth         KeyUsage = "server auth"
+	UsageClientAuth         KeyUsage = "client auth"
+	UsageCodeSigning        KeyUsage = "code signing"
+	UsageEmailProtection    KeyUsage = "email protection"
+	UsageSMIME              KeyUsage = "s/mime"
+	UsageIPsecEndSystem     KeyUsage = "ipsec end system"
+	UsageIPsecTunnel        KeyUsage = "ipsec tunnel"
+	UsageIPsecUser          KeyUsage = "ipsec user"
+	UsageTimestamping       KeyUsage = "timestamping"
+	UsageOCSPSigning        KeyUsage = "ocsp signing"
+	UsageMicrosoftSGC       KeyUsage = "microsoft sgc"
+	UsageNetscapSGC         KeyUsage = "netscape sgc"
+)
+
+// DefaultKeyUsages contains the default list of key usages
+func DefaultKeyUsages() []KeyUsage {
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
+}

--- a/pkg/apis/certmanager/v1alpha1/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificate.go
@@ -109,9 +109,13 @@ type CertificateSpec struct {
 	IssuerRef ObjectReference `json:"issuerRef"`
 
 	// IsCA will mark this Certificate as valid for signing.
-	// This implies that the 'signing' usage is set
+	// This implies that the 'cert sign' usage is set
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
+
+	// Usages is the set of x509 actions that are enabled for a given key. Defaults are ('digital signature', 'key encipherment') if empty
+	// +optional
+	Usages []KeyUsage `json:"usages,omitempty"`
 
 	// ACME contains configuration specific to ACME Certificates.
 	// Notably, this contains details on how the domain names listed on this

--- a/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha1/types_certificaterequest.go
@@ -74,9 +74,14 @@ type CertificateRequestSpec struct {
 	CSRPEM []byte `json:"csr,omitempty"`
 
 	// IsCA will mark the resulting certificate as valid for signing. This
-	// implies that the 'signing' usage is set
+	// implies that the 'cert sign' usage is set
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
+
+	// Usages is the set of x509 actions that are enabled for a given key.
+	// Defaults are ('digital signature', 'key encipherment') if empty
+	// +optional
+	Usages []KeyUsage `json:"usages,omitempty"`
 }
 
 // CertificateStatus defines the observed state of CertificateRequest and

--- a/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha1/zz_generated.deepcopy.go
@@ -776,6 +776,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.Usages != nil {
+		in, out := &in.Usages, &out.Usages
+		*out = make([]KeyUsage, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -855,6 +860,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		copy(*out, *in)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.Usages != nil {
+		in, out := &in.Usages, &out.Usages
+		*out = make([]KeyUsage, len(*in))
+		copy(*out, *in)
+	}
 	if in.ACME != nil {
 		in, out := &in.ACME, &out.ACME
 		*out = new(ACMECertificateConfig)

--- a/pkg/internal/apis/certmanager/types.go
+++ b/pkg/internal/apis/certmanager/types.go
@@ -111,3 +111,40 @@ const (
 	// the cainjector will refuse to inject the secret.
 	AllowsInjectionFromSecretAnnotation = "certmanager.k8s.io/allow-direct-injection"
 )
+
+// KeyUsage specifies valid usage contexts for keys.
+// See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
+//      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
+// +kubebuilder:validation:Enum="signing";"digital signature";"content commitment";"key encipherment";"key agreement";"data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";"code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";"ocsp signing";"microsoft sgc";"netscape sgc"
+type KeyUsage string
+
+const (
+	UsageSigning            KeyUsage = "signing"
+	UsageDigitalSignature   KeyUsage = "digital signature"
+	UsageContentCommittment KeyUsage = "content commitment"
+	UsageKeyEncipherment    KeyUsage = "key encipherment"
+	UsageKeyAgreement       KeyUsage = "key agreement"
+	UsageDataEncipherment   KeyUsage = "data encipherment"
+	UsageCertSign           KeyUsage = "cert sign"
+	UsageCRLSign            KeyUsage = "crl sign"
+	UsageEncipherOnly       KeyUsage = "encipher only"
+	UsageDecipherOnly       KeyUsage = "decipher only"
+	UsageAny                KeyUsage = "any"
+	UsageServerAuth         KeyUsage = "server auth"
+	UsageClientAuth         KeyUsage = "client auth"
+	UsageCodeSigning        KeyUsage = "code signing"
+	UsageEmailProtection    KeyUsage = "email protection"
+	UsageSMIME              KeyUsage = "s/mime"
+	UsageIPsecEndSystem     KeyUsage = "ipsec end system"
+	UsageIPsecTunnel        KeyUsage = "ipsec tunnel"
+	UsageIPsecUser          KeyUsage = "ipsec user"
+	UsageTimestamping       KeyUsage = "timestamping"
+	UsageOCSPSigning        KeyUsage = "ocsp signing"
+	UsageMicrosoftSGC       KeyUsage = "microsoft sgc"
+	UsageNetscapSGC         KeyUsage = "netscape sgc"
+)
+
+// DefaultKeyUsages contains the default list of key usages
+func DefaultKeyUsages() []KeyUsage {
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
+}

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -103,6 +103,10 @@ type CertificateSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// Usages is the set of x509 actions that are enabled for a given key. Defaults are ('digital signature', 'key encipherment') if empty
+	// +optional
+	Usages []KeyUsage `json:"usages,omitempty"`
+
 	// ACME contains configuration specific to ACME Certificates.
 	// Notably, this contains details on how the domain names listed on this
 	// Certificate resource should be 'solved', i.e. mapping HTTP01 and DNS01

--- a/pkg/internal/apis/certmanager/types_certificaterequest.go
+++ b/pkg/internal/apis/certmanager/types_certificaterequest.go
@@ -70,6 +70,11 @@ type CertificateRequestSpec struct {
 	// implies that the 'signing' usage is set
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
+
+	// Usages is the set of x509 actions that are enabled for a given key.
+	// Defaults are ('digital signature', 'key encipherment') if empty
+	// +optional
+	Usages []KeyUsage `json:"usages,omitempty"`
 }
 
 // CertificateStatus defines the observed state of CertificateRequest and

--- a/pkg/internal/apis/certmanager/v1alpha1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha1/zz_generated.conversion.go
@@ -1465,6 +1465,7 @@ func autoConvert_v1alpha1_CertificateRequestSpec_To_certmanager_CertificateReque
 	}
 	out.CSRPEM = *(*[]byte)(unsafe.Pointer(&in.CSRPEM))
 	out.IsCA = in.IsCA
+	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	return nil
 }
 
@@ -1480,6 +1481,7 @@ func autoConvert_certmanager_CertificateRequestSpec_To_v1alpha1_CertificateReque
 	}
 	out.CSRPEM = *(*[]byte)(unsafe.Pointer(&in.CSRPEM))
 	out.IsCA = in.IsCA
+	out.Usages = *(*[]v1alpha1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	return nil
 }
 
@@ -1526,6 +1528,7 @@ func autoConvert_v1alpha1_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.ACME = (*certmanager.ACMECertificateConfig)(unsafe.Pointer(in.ACME))
 	out.KeySize = in.KeySize
 	out.KeyAlgorithm = certmanager.KeyAlgorithm(in.KeyAlgorithm)
@@ -1550,6 +1553,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha1_CertificateSpec(in *cer
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.Usages = *(*[]v1alpha1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.ACME = (*v1alpha1.ACMECertificateConfig)(unsafe.Pointer(in.ACME))
 	out.KeySize = in.KeySize
 	out.KeyAlgorithm = v1alpha1.KeyAlgorithm(in.KeyAlgorithm)

--- a/pkg/internal/apis/certmanager/validation/certificate_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_test.go
@@ -457,6 +457,39 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 		},
+		"valid certificate with basic keyusage": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					Usages:     []v1alpha1.KeyUsage{"signing"},
+				},
+			},
+		},
+		"valid certificate with multiple keyusage": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					Usages:     []v1alpha1.KeyUsage{"signing", "s/mime"},
+				},
+			},
+		},
+		"invalid certificate with nonexistant keyusage": {
+			cfg: &v1alpha1.Certificate{
+				Spec: v1alpha1.CertificateSpec{
+					CommonName: "testcn",
+					SecretName: "abc",
+					IssuerRef:  validIssuerRef,
+					Usages:     []v1alpha1.KeyUsage{"nonexistant"},
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("usages").Index(0), v1alpha1.KeyUsage("nonexistant"), "unknown keyusage"),
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -776,6 +776,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.Usages != nil {
+		in, out := &in.Usages, &out.Usages
+		*out = make([]KeyUsage, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 
@@ -855,6 +860,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		copy(*out, *in)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.Usages != nil {
+		in, out := &in.Usages, &out.Usages
+		*out = make([]KeyUsage, len(*in))
+		copy(*out, *in)
+	}
 	if in.ACME != nil {
 		in, out := &in.ACME, &out.ACME
 		*out = new(ACMECertificateConfig)

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -109,6 +109,29 @@ func OrganizationForCertificate(crt *v1alpha1.Certificate) []string {
 
 var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
 
+func buildUsages(usages []v1alpha1.KeyUsage, isCA bool) (ku x509.KeyUsage, eku []x509.ExtKeyUsage, err error) {
+	var unk []v1alpha1.KeyUsage
+	if isCA {
+		ku |= x509.KeyUsageCertSign
+	}
+	if len(usages) == 0 {
+		usages = append(usages, v1alpha1.DefaultKeyUsages()...)
+	}
+	for _, u := range usages {
+		if kuse, ok := apiutil.KeyUsageType(u); ok {
+			ku |= kuse
+		} else if ekuse, ok := apiutil.ExtKeyUsageType(u); ok {
+			eku = append(eku, ekuse)
+		} else {
+			unk = append(unk, u)
+		}
+	}
+	if len(unk) > 0 {
+		err = fmt.Errorf("unknown key usages: %v", unk)
+	}
+	return
+}
+
 // GenerateCSR will generate a new *x509.CertificateRequest template to be used
 // by issuers that utilise CSRs to obtain Certificates.
 // The CSR will not be signed, and should be passed to either EncodeCSR or
@@ -152,6 +175,10 @@ func GenerateTemplate(crt *v1alpha1.Certificate) (*x509.Certificate, error) {
 	dnsNames := DNSNamesForCertificate(crt)
 	ipAddresses := IPAddressesForCertificate(crt)
 	organization := OrganizationForCertificate(crt)
+	keyUsages, extKeyUsages, err := buildUsages(crt.Spec.Usages, crt.Spec.IsCA)
+	if err != nil {
+		return nil, err
+	}
 
 	if len(commonName) == 0 && len(dnsNames) == 0 {
 		return nil, fmt.Errorf("no domains specified on certificate")
@@ -182,29 +209,33 @@ func GenerateTemplate(crt *v1alpha1.Certificate) (*x509.Certificate, error) {
 		NotBefore: time.Now(),
 		NotAfter:  time.Now().Add(certDuration),
 		// see http://golang.org/pkg/crypto/x509/#KeyUsage
-		KeyUsage:    keyUsage(crt.Spec.IsCA),
+		KeyUsage:    keyUsages,
+		ExtKeyUsage: extKeyUsages,
 		DNSNames:    dnsNames,
 		IPAddresses: ipAddresses,
 	}, nil
-}
-
-func keyUsage(isCA bool) x509.KeyUsage {
-	keyUsages := x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
-	if isCA {
-		keyUsages |= x509.KeyUsageCertSign
-	}
-
-	return keyUsages
 }
 
 // GenerateTemplate will create a x509.Certificate for the given
 // CertificateRequest resource
 func GenerateTemplateFromCertificateRequest(cr *v1alpha1.CertificateRequest) (*x509.Certificate, error) {
 	certDuration := apiutil.DefaultCertDuration(cr.Spec.Duration)
-	return GenerateTemplateFromCSRPEM(cr.Spec.CSRPEM, certDuration, cr.Spec.IsCA)
+	keyUsage, extKeyUsage, err := buildUsages(cr.Spec.Usages, cr.Spec.IsCA)
+	if err != nil {
+		return nil, err
+	}
+	return GenerateTemplateFromCSRPEMWithUsages(cr.Spec.CSRPEM, certDuration, cr.Spec.IsCA, keyUsage, extKeyUsage)
 }
 
 func GenerateTemplateFromCSRPEM(csrPEM []byte, duration time.Duration, isCA bool) (*x509.Certificate, error) {
+	var (
+		ku  x509.KeyUsage
+		eku []x509.ExtKeyUsage
+	)
+	return GenerateTemplateFromCSRPEMWithUsages(csrPEM, duration, isCA, ku, eku)
+}
+
+func GenerateTemplateFromCSRPEMWithUsages(csrPEM []byte, duration time.Duration, isCA bool, keyUsage x509.KeyUsage, extKeyUsage []x509.ExtKeyUsage) (*x509.Certificate, error) {
 	block, _ := pem.Decode(csrPEM)
 	if block == nil {
 		return nil, errors.New("failed to decode csr")
@@ -235,15 +266,11 @@ func GenerateTemplateFromCSRPEM(csrPEM []byte, duration time.Duration, isCA bool
 		NotBefore:             time.Now(),
 		NotAfter:              time.Now().Add(duration),
 		// see http://golang.org/pkg/crypto/x509/#KeyUsage
-		KeyUsage:    keyUsage(isCA),
+		KeyUsage:    keyUsage,
+		ExtKeyUsage: extKeyUsage,
 		DNSNames:    csr.DNSNames,
 		IPAddresses: csr.IPAddresses,
 		URIs:        csr.URIs,
-		// TODO: we should expose ExtKeyUsage via the API and not set x509.ExtKeyUsageClientAuth
-		// by default. This is a known change in behaviour between the Certificate and CertificateRequest
-		// controller and should be rectified before the CertificateRequest feature exits
-		// alpha.
-		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 	}, nil
 }
 

--- a/test/e2e/suite/issuers/ca/BUILD.bazel
+++ b/test/e2e/suite/issuers/ca/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "//vendor/github.com/onsi/ginkgo:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -155,8 +156,8 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 		It("should generate a signed keypair", func() {
 			certClient := f.CertManagerClientSet.CertmanagerV1alpha1().Certificates(f.Namespace.Name)
 
-			By("Creating a Certificate")
-			_, err := certClient.Create(util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1alpha1.IssuerKind, nil, nil))
+			By("Creating a Certificate with Usages")
+			_, err := certClient.Create(gen.Certificate(certificateName, gen.SetCertificateNamespace(f.Namespace.Name), gen.SetCertificateCommonName("test.domain.com"), gen.SetCertificateSecretName(certificateSecretName), gen.SetCertificateIssuer(v1alpha1.ObjectReference{Name: issuerName, Kind: v1alpha1.IssuerKind}), gen.SetCertificateKeyUsages(v1alpha1.UsageServerAuth, v1alpha1.UsageClientAuth)))
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")
 			err = h.WaitCertificateIssuedValidTLS(f.Namespace.Name, certificateName, time.Second*30, []byte(rootCert))

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -29,7 +29,7 @@ import (
 	"time"
 
 	intscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	apiextcs "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -255,6 +255,7 @@ func NewCertManagerCAClusterIssuer(name, secretName string) *v1alpha1.ClusterIss
 	}
 }
 
+// Deprecated: use test/unit/gen/Certificate in future
 func NewCertManagerBasicCertificate(name, secretName, issuerName string, issuerKind string, duration, renewBefore *metav1.Duration, dnsNames ...string) *v1alpha1.Certificate {
 	cn := "test.domain.com"
 	if len(dnsNames) > 0 {
@@ -279,6 +280,7 @@ func NewCertManagerBasicCertificate(name, secretName, issuerName string, issuerK
 	}
 }
 
+// Deprecated: use test/unit/gen/CertificateRequest in future
 func NewCertManagerBasicCertificateRequest(name, issuerName string, issuerKind string, duration *metav1.Duration,
 	dnsNames []string, ips []net.IP, uris []string, keyAlgorithm x509.PublicKeyAlgorithm) (*v1alpha1.CertificateRequest, crypto.Signer, error) {
 	cn := "test.domain.com"

--- a/test/unit/gen/BUILD.bazel
+++ b/test/unit/gen/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "certificate.go",
         "certificaterequest.go",
         "challenge.go",
+        "csr.go",
         "doc.go",
         "issuer.go",
         "objectmeta.go",
@@ -15,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//pkg/util/pki:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -150,3 +150,9 @@ func SetCertificateNamespace(namespace string) CertificateModifier {
 		crt.ObjectMeta.Namespace = namespace
 	}
 }
+
+func SetCertificateKeyUsages(usages ...v1alpha1.KeyUsage) CertificateModifier {
+	return func(cr *v1alpha1.Certificate) {
+		cr.Spec.Usages = usages
+	}
+}

--- a/test/unit/gen/certificaterequest.go
+++ b/test/unit/gen/certificaterequest.go
@@ -107,6 +107,12 @@ func SetCertificateRequestName(name string) CertificateRequestModifier {
 	}
 }
 
+func SetCertificateRequestKeyUsages(usages ...v1alpha1.KeyUsage) CertificateRequestModifier {
+	return func(cr *v1alpha1.CertificateRequest) {
+		cr.Spec.Usages = usages
+	}
+}
+
 func AddCertificateRequestAnnotations(annotations map[string]string) CertificateRequestModifier {
 	return func(cr *v1alpha1.CertificateRequest) {
 		// Make sure to do a merge here with new annotations overriding.

--- a/test/unit/gen/csr.go
+++ b/test/unit/gen/csr.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"net/url"
+
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+type CSRModifier func(*x509.CertificateRequest)
+
+func CSR(keyAlgorithm x509.PublicKeyAlgorithm, mods ...CSRModifier) (csr []byte, sk crypto.Signer, err error) {
+	var signatureAlgorithm x509.SignatureAlgorithm
+
+	switch keyAlgorithm {
+	case x509.RSA:
+		sk, err = pki.GenerateRSAPrivateKey(2048)
+		if err != nil {
+			return nil, nil, err
+		}
+		signatureAlgorithm = x509.SHA256WithRSA
+	case x509.ECDSA:
+		sk, err = pki.GenerateECPrivateKey(pki.ECCurve256)
+		if err != nil {
+			return nil, nil, err
+		}
+		signatureAlgorithm = x509.ECDSAWithSHA256
+	default:
+		return nil, nil, fmt.Errorf("unrecognised key algorithm: %s", err)
+	}
+
+	cr := &x509.CertificateRequest{
+		Version:            3,
+		SignatureAlgorithm: signatureAlgorithm,
+		PublicKeyAlgorithm: keyAlgorithm,
+		PublicKey:          sk.Public(),
+	}
+	for _, mod := range mods {
+		mod(cr)
+	}
+	cn := "test.domain.com"
+	if len(cr.DNSNames) > 0 {
+		cn = cr.DNSNames[0]
+	}
+	cr.Subject = pkix.Name{
+		CommonName: cn,
+	}
+
+	csrBytes, err := pki.EncodeCSR(cr, sk)
+	if err != nil {
+		return nil, nil, err
+	}
+	csr = pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrBytes,
+	})
+	return
+}
+
+func SetCSRDNSNames(dnsNames ...string) CSRModifier {
+	return func(c *x509.CertificateRequest) {
+		c.DNSNames = dnsNames
+	}
+}
+
+func SetCSRIPAddresses(ips ...net.IP) CSRModifier {
+	return func(c *x509.CertificateRequest) {
+		c.IPAddresses = ips
+	}
+}
+
+func SetCSRURIs(uris ...*url.URL) CSRModifier {
+	return func(c *x509.CertificateRequest) {
+		c.URIs = uris
+	}
+}


### PR DESCRIPTION
Signed-off-by: stuart.warren <stuart.warren@ocado.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enable users to request x509 key usages and extended key usages when defining a certificate or certificate signing request

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes: #301

**Special notes for your reviewer**:

Happy to move things around, not sure if the apis/certmanager/v1alpha1/key_usages.go should be there, or contents better added to another file?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add ability to specify key usages and extended key usages in certificates
```
