### PR TITLE
#1931 clarify you have to manually add the jetstack helm repo

### DIFF
--- a/docs/tasks/upgrading/index.rst
+++ b/docs/tasks/upgrading/index.rst
@@ -35,6 +35,9 @@ version number you want to install:
    kubectl apply \
         -f https://raw.githubusercontent.com/jetstack/cert-manager/<version>/deploy/manifests/00-crds.yaml
 
+   # Add the Jetstack Helm repository if you haven't already
+   helm repo add jetstack https://charts.jetstack.io
+
    # Ensure the local Helm chart repository cache is up to date
    helm repo update
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Addresses question from user about inability to find cert-manager helm package.

It's a minor doc update to the upgrade procedure that could potentially save some headaches.

**Which issue this PR fixes**

fixes #1931

