### PR TITLE
test/acme/dns: poll interval and propagation limit configurable

### DIFF
--- a/test/acme/dns/fixture.go
+++ b/test/acme/dns/fixture.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"sync"
 	"testing"
+	"time"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/client-go/rest"
@@ -68,6 +69,9 @@ type fixture struct {
 	clientset    kubernetes.Interface
 	kubectl      *integration.KubeCtl
 	setupLock    sync.Mutex
+
+	pollInterval     time.Duration
+	propagationLimit time.Duration
 }
 
 var DefaultKubeAPIServerFlags = []string{

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -22,6 +22,7 @@ import (
 	"io/ioutil"
 	"os"
 	"strings"
+	"time"
 
 	extapi "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 
@@ -155,5 +156,17 @@ func SetDNSServer(s string) Option {
 func SetBinariesPath(s string) Option {
 	return func(f *fixture) {
 		f.binariesPath = s
+	}
+}
+
+func SetPollInterval(d time.Duration) Option {
+	return func(f *fixture) {
+		f.pollInterval = d
+	}
+}
+
+func SetPropagationLimit(d time.Duration) Option {
+	return func(f *fixture) {
+		f.propagationLimit = d
 	}
 }

--- a/test/acme/dns/suite.go
+++ b/test/acme/dns/suite.go
@@ -43,9 +43,9 @@ func (f *fixture) TestBasicPresentRecord(t *testing.T) {
 	defer f.testSolver.CleanUp(ch)
 
 	// wait until the record has propagated
-	if err := wait.PollUntil(defaultPollInterval,
+	if err := wait.PollUntil(f.getPollInterval(),
 		f.recordHasPropagatedCheck(ch.ResolvedFQDN, ch.Key),
-		closingStopCh(defaultPropagationLimit)); err != nil {
+		closingStopCh(f.getPropagationLimit())); err != nil {
 		t.Errorf("error waiting for DNS record propagation: %v", err)
 		return
 	}
@@ -56,9 +56,9 @@ func (f *fixture) TestBasicPresentRecord(t *testing.T) {
 	}
 
 	// wait until the record has been deleted
-	if err := wait.PollUntil(defaultPollInterval,
+	if err := wait.PollUntil(f.getPollInterval(),
 		f.recordHasBeenDeletedCheck(ch.ResolvedFQDN, ch.Key),
-		closingStopCh(defaultPropagationLimit)); err != nil {
+		closingStopCh(f.getPropagationLimit())); err != nil {
 		t.Errorf("error waiting for record to be deleted: %v", err)
 		return
 	}
@@ -94,12 +94,12 @@ func (f *fixture) TestExtendedDeletingOneRecordRetainsOthers(t *testing.T) {
 	defer f.testSolver.CleanUp(ch2)
 
 	// wait until all records have propagated
-	if err := wait.PollUntil(defaultPollInterval,
+	if err := wait.PollUntil(f.getPollInterval(),
 		allConditions(
 			f.recordHasPropagatedCheck(ch.ResolvedFQDN, ch.Key),
 			f.recordHasPropagatedCheck(ch2.ResolvedFQDN, ch2.Key),
 		),
-		closingStopCh(defaultPropagationLimit)); err != nil {
+		closingStopCh(f.getPropagationLimit())); err != nil {
 		t.Errorf("error waiting for DNS record propagation: %v", err)
 		return
 	}
@@ -110,12 +110,12 @@ func (f *fixture) TestExtendedDeletingOneRecordRetainsOthers(t *testing.T) {
 	}
 
 	// wait until the second record has been deleted and the first one remains
-	if err := wait.PollUntil(defaultPollInterval,
+	if err := wait.PollUntil(f.getPollInterval(),
 		allConditions(
 			f.recordHasBeenDeletedCheck(ch2.ResolvedFQDN, ch2.Key),
 			f.recordHasPropagatedCheck(ch.ResolvedFQDN, ch.Key),
 		),
-		closingStopCh(defaultPropagationLimit)); err != nil {
+		closingStopCh(f.getPropagationLimit())); err != nil {
 		t.Errorf("error waiting for DNS record propagation: %v", err)
 		return
 	}

--- a/test/acme/dns/util.go
+++ b/test/acme/dns/util.go
@@ -148,3 +148,19 @@ func (f *fixture) recordHasBeenDeletedCheck(fqdn, value string) func() (bool, er
 		return true, nil
 	}
 }
+
+func (f *fixture) getPollInterval() time.Duration {
+	if f.pollInterval != 0 {
+		return f.pollInterval
+	} else {
+		return defaultPollInterval
+	}
+}
+
+func (f *fixture) getPropagationLimit() time.Duration {
+	if f.propagationLimit != 0 {
+		return f.propagationLimit
+	} else {
+		return defaultPropagationLimit
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This makes the DNS conformance test's poll interval and propagation limit configurable on the fixture object by test authors. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Until now the poll interval was fixed to be 3 seconds and the propagation limit to be 2 minutes. Especially the latter value may be too short e.g. when waiting for the deletion of the created TXT record, leading to a test failure that can't really be fixed if the propagation limit can't be increased.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
