### PR TITLE
Update kubectl output result with kubectl 12+

### DIFF
--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -636,8 +636,8 @@ which you can request and see:
 .. code-block:: shell
 
     $ kubectl get certificate
-    NAME                     AGE
-    quickstart-example-tls   38s
+    NAME                     READY   SECRET                   AGE
+    quickstart-example-tls   True    quickstart-example-tls   16m
 
 Cert-manager reflects the state of the process for every request in the
 certificate object. You can view this information using the


### PR DESCRIPTION
Hi community,

When I learn `cert-manager` I find `kubectl get certificate` output is outdated.

Best,
Alpha