### PR TITLE
Add auditsinks in auditregistration.k8s.io/v1alpha1 to the supported injector targets

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -30,6 +30,9 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["get", "list", "watch", "update"]
+  - apiGroups: ["auditregistration.k8s.io"]
+    resources: ["auditsinks"]
+    verbs: ["get", "list", "watch", "update"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding

--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/certmanager/v1alpha3:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_api//auditregistration/v1alpha1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/pkg/api/scheme.go
+++ b/pkg/api/scheme.go
@@ -17,6 +17,7 @@ limitations under the License.
 package api
 
 import (
+	auditreg "k8s.io/api/auditregistration/v1alpha1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -56,6 +57,7 @@ var localSchemeBuilder = runtime.SchemeBuilder{
 	kscheme.AddToScheme,
 	apireg.AddToScheme,
 	apiext.AddToScheme,
+	auditreg.AddToScheme,
 }
 
 // AddToScheme adds all types of this clientset into the given scheme. This allows composition

--- a/pkg/controller/cainjector/BUILD.bazel
+++ b/pkg/controller/cainjector/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/logs:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//admissionregistration/v1beta1:go_default_library",
+        "@io_k8s_api//auditregistration/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -86,6 +86,8 @@ type Injectable interface {
 type CertInjector interface {
 	// NewTarget creates a new InjectTarget containing an empty underlying object.
 	NewTarget() InjectTarget
+	// IsAlpha tells clients of this interface to disregard errors if the
+	IsAlpha() bool
 }
 
 // genericInjectReconciler is a reconciler that knows how to check if a given object is

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -86,7 +86,7 @@ type Injectable interface {
 type CertInjector interface {
 	// NewTarget creates a new InjectTarget containing an empty underlying object.
 	NewTarget() InjectTarget
-	// IsAlpha tells clients of this interface to disregard errors if the
+	// IsAlpha tells the client to disregard "no matching kind" type of errors
 	IsAlpha() bool
 }
 

--- a/pkg/controller/cainjector/injectors.go
+++ b/pkg/controller/cainjector/injectors.go
@@ -149,7 +149,7 @@ func (i auditSinkTarget) NewTarget() InjectTarget {
 }
 
 func (i auditSinkTarget) IsAlpha() bool {
-	// TODO remove this when auditregistration goes GA
+	// TODO set this to false when auditregistration goes GA
 	return true
 }
 

--- a/pkg/controller/cainjector/injectors.go
+++ b/pkg/controller/cainjector/injectors.go
@@ -33,6 +33,10 @@ import (
 // mutatingWebhookInjector knows how to create an InjectTarget a MutatingWebhookConfiguration.
 type mutatingWebhookInjector struct{}
 
+func (i mutatingWebhookInjector) IsAlpha() bool {
+	return false
+}
+
 func (i mutatingWebhookInjector) NewTarget() InjectTarget {
 	return &mutatingWebhookTarget{}
 }
@@ -59,6 +63,10 @@ func (i validatingWebhookInjector) NewTarget() InjectTarget {
 	return &validatingWebhookTarget{}
 }
 
+func (i validatingWebhookInjector) IsAlpha() bool {
+	return false
+}
+
 // validatingWebhookTarget knows how to set CA data for all the webhooks
 // in a validatingWebhookConfiguration.
 type validatingWebhookTarget struct {
@@ -68,6 +76,7 @@ type validatingWebhookTarget struct {
 func (t *validatingWebhookTarget) AsObject() runtime.Object {
 	return &t.obj
 }
+
 func (t *validatingWebhookTarget) SetCA(data []byte) {
 	for ind := range t.obj.Webhooks {
 		t.obj.Webhooks[ind].ClientConfig.CABundle = data
@@ -81,6 +90,10 @@ func (i apiServiceInjector) NewTarget() InjectTarget {
 	return &apiServiceTarget{}
 }
 
+func (i apiServiceInjector) IsAlpha() bool {
+	return false
+}
+
 // apiServiceTarget knows how to set CA data for the CA bundle in
 // the APIService.
 type apiServiceTarget struct {
@@ -90,6 +103,7 @@ type apiServiceTarget struct {
 func (t *apiServiceTarget) AsObject() runtime.Object {
 	return &t.obj
 }
+
 func (t *apiServiceTarget) SetCA(data []byte) {
 	t.obj.Spec.CABundle = data
 }
@@ -102,6 +116,10 @@ func (i crdConversionInjector) NewTarget() InjectTarget {
 	return &crdConversionTarget{}
 }
 
+func (i crdConversionInjector) IsAlpha() bool {
+	return false
+}
+
 // crdConversionTarget knows how to set CA data for the conversion webhook in CRDs
 type crdConversionTarget struct {
 	obj apiext.CustomResourceDefinition
@@ -110,6 +128,7 @@ type crdConversionTarget struct {
 func (t *crdConversionTarget) AsObject() runtime.Object {
 	return &t.obj
 }
+
 func (t *crdConversionTarget) SetCA(data []byte) {
 	if t.obj.Spec.Conversion == nil || t.obj.Spec.Conversion.Strategy != apiext.WebhookConverter {
 		return
@@ -129,9 +148,15 @@ func (i auditSinkTarget) NewTarget() InjectTarget {
 	return &auditSinkTarget{}
 }
 
+func (i auditSinkTarget) IsAlpha() bool {
+	// TODO remove this when auditregistration goes GA
+	return true
+}
+
 func (t *auditSinkTarget) AsObject() runtime.Object {
 	return &t.obj
 }
+
 func (t *auditSinkTarget) SetCA(data []byte) {
 	t.obj.Spec.Webhook.ClientConfig.CABundle = data
 }

--- a/pkg/controller/cainjector/injectors.go
+++ b/pkg/controller/cainjector/injectors.go
@@ -18,6 +18,7 @@ package cainjector
 
 import (
 	admissionreg "k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/api/auditregistration/v1alpha1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -117,4 +118,20 @@ func (t *crdConversionTarget) SetCA(data []byte) {
 		t.obj.Spec.Conversion.WebhookClientConfig = &apiext.WebhookClientConfig{}
 	}
 	t.obj.Spec.Conversion.WebhookClientConfig.CABundle = data
+}
+
+// auditSinkTarget knows how to set CA data for the auditSink webhook
+type auditSinkTarget struct {
+	obj v1alpha1.AuditSink
+}
+
+func (i auditSinkTarget) NewTarget() InjectTarget {
+	return &auditSinkTarget{}
+}
+
+func (t *auditSinkTarget) AsObject() runtime.Object {
+	return &t.obj
+}
+func (t *auditSinkTarget) SetCA(data []byte) {
+	t.obj.Spec.Webhook.ClientConfig.CABundle = data
 }

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -75,19 +75,12 @@ var (
 func registerAllInjectors(mgr ctrl.Manager, sources ...caDataSource) error {
 	for _, setup := range injectorSetups {
 		if err := registerInjector(mgr, setup, sources...); err != nil {
-			if meta.IsNoMatchError(err) {
-				if setup.injector.IsAlpha() {
-					ctrl.Log.Info("unable to register injector which is still in an alpha phase."+
-						" Enable the feature on the API server in order to use this injector",
-						"injector", setup)
-				} else {
-					ctrl.Log.Error(err,
-						"failed to register certificate based injector.",
-						"injector", setup)
-				}
-			} else {
+			if !meta.IsNoMatchError(err) || !setup.injector.IsAlpha() {
 				return err
 			}
+			ctrl.Log.Info("unable to register injector which is still in an alpha phase."+
+				" Enable the feature on the API server in order to use this injector",
+				"injector", setup.resourceName)
 		}
 	}
 	return nil

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -74,7 +74,7 @@ var (
 // graduation state of the injector decides how to log no kind/resource match errors
 func registerAllInjectors(mgr ctrl.Manager, sources ...caDataSource) error {
 	for _, setup := range injectorSetups {
-		if err := registerInjector(mgr, setup, sources...); err != nil {
+		if err := Register(mgr, setup, sources...); err != nil {
 			if !meta.IsNoMatchError(err) || !setup.injector.IsAlpha() {
 				return err
 			}
@@ -86,8 +86,8 @@ func registerAllInjectors(mgr ctrl.Manager, sources ...caDataSource) error {
 	return nil
 }
 
-// registerInjector registers an injection controller with the given manager, and adds relevant indicies.
-func registerInjector(mgr ctrl.Manager, setup injectorSetup, sources ...caDataSource) error {
+// Register registers an injection controller with the given manager, and adds relevant indicies.
+func Register(mgr ctrl.Manager, setup injectorSetup, sources ...caDataSource) error {
 	typ := setup.injector.NewTarget().AsObject()
 	builder := ctrl.NewControllerManagedBy(mgr).For(typ)
 	for _, s := range sources {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds support for the `AuditSink` in `auditregistration.k8s.io/v1alpha1` to be a ca injector target. 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Support the `AuditSink` kind in `auditregistration.k8s.io/v1alpha1` to be a ca injector target. 
```
