### PR TITLE
Fix-up manifests and upgrade guide for v0.10

### DIFF
--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -43,9 +43,11 @@ Create the name of the service account to use
 
 {{/*
 Expand the name of the chart.
+Manually fix the 'app' and 'name' labels to 'webhook' to maintain
+compatibility with the v0.9 deployment selector.
 */}}
 {{- define "webhook.name" -}}
-{{- printf "%s-webhook" (default .Chart.Name .Values.nameOverride) | trunc 63 | trimSuffix "-" -}}
+{{- printf "webhook" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -39,6 +39,7 @@ webhooks:
           - clusterissuers
           - certificaterequests
     failurePolicy: Fail
+    sideEffects: None
     clientConfig:
       service:
         name: kubernetes

--- a/docs/tasks/upgrading/upgrading-0.9-0.10.rst
+++ b/docs/tasks/upgrading/upgrading-0.9-0.10.rst
@@ -2,4 +2,21 @@
 Upgrading from v0.9 to v0.10
 ============================
 
-There are no special notes or considerations when upgrading from v0.9 to v0.10.
+Due to changes in the way the webhook component's TLS is bootstrapped in v0.10,
+you will need to delete your webhook's Certificate and Issuer resources.
+
+If you are using a deployment tool that automatically handles this (i.e. Helm),
+there should be no additional action to take.
+
+If you are using the 'static manifests' to install, you should run the following
+after upgrading:
+
+.. code-block:: shell
+
+   kubectl delete -n cert-manager issuer cert-manager-webhook-ca cert-manager-webhook-selfsign
+   kubectl delete -n cert-manager certificate cert-manager-webhook-ca cert-manager-webhook-webhook-tls
+   kubectl delete apiservice v1beta1.admission.certmanager.k8s.io
+
+The Secret resources used to contain TLS assets for the webhook are now
+automatically handled internally by cert-manager, so these resources are no
+longer required.

--- a/pkg/controller/acmeorders/selectors/BUILD.bazel
+++ b/pkg/controller/acmeorders/selectors/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -29,4 +29,14 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["dns_zones_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
 )

--- a/pkg/controller/acmeorders/selectors/dns_zones_test.go
+++ b/pkg/controller/acmeorders/selectors/dns_zones_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selectors
+
+import (
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+)
+
+func TestDNSZones(t *testing.T) {
+	tests := []struct {
+		name     string
+		selector cmapi.CertificateDNSNameSelector
+		meta     metav1.ObjectMeta
+		dnsName  string
+		matches  bool
+		score    int
+	}{
+		{
+			name:     "matching a domain with an empty selector",
+			selector: cmapi.CertificateDNSNameSelector{},
+			dnsName:  "www.example.com",
+			matches:  true,
+			score:    0,
+		},
+		{
+			name: "matching a domain in a zone",
+			selector: cmapi.CertificateDNSNameSelector{
+				DNSZones: []string{"example.com"},
+			},
+			dnsName: "www.example.com",
+			matches: true,
+			score:   2,
+		},
+		{
+			name: "matching a wildcard domain in a zone",
+			selector: cmapi.CertificateDNSNameSelector{
+				DNSZones: []string{"example.com"},
+			},
+			dnsName: "*.example.com",
+			matches: true,
+			score:   2,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			testSelector(t, DNSZones(test.selector), test.meta, test.dnsName, test.matches, test.score)
+		})
+	}
+}
+
+func testSelector(t *testing.T, sel Selector, meta metav1.ObjectMeta, dnsName string, expectMatch bool, expectedScore int) {
+	matches, score := sel.Matches(meta, dnsName)
+	if matches != expectMatch {
+		t.Errorf("expected match to be %t but it was %t", expectMatch, matches)
+	}
+	if score != expectedScore {
+		t.Errorf("expected score to be %d but it was %d", expectedScore, score)
+	}
+}

--- a/pkg/controller/certificates/certificate_request.go
+++ b/pkg/controller/certificates/certificate_request.go
@@ -603,7 +603,7 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 		// If it is not Ready _OR_ Failed then we return and wait for informer
 		// updates to re-trigger processing.
 	default:
-		log.Info("CertificateRequest is in state %q, waiting until CertificateRequest is issued", reason)
+		log.Info("CertificateRequest is not in a final state, waiting until CertificateRequest is complete", "state", reason)
 		return nil
 	}
 }
@@ -767,6 +767,7 @@ func (c *certificateRequestManager) buildCertificateRequest(log logr.Logger, crt
 			Annotations: map[string]string{
 				cmapi.CRPrivateKeyAnnotationKey: crt.Spec.SecretName,
 			},
+			Labels: crt.Labels,
 		},
 		Spec: cmapi.CertificateRequestSpec{
 			CSRPEM:    csrPEM,


### PR DESCRIPTION
**What this PR does / why we need it**:

Whilst going through the upgrade process myself, I encountered a couple of issues:

1) The name of the webhook chart has changed, meaning the label selector has changed again. I've simply switched this back to the old value for now to save extra pain for users upgrading.

2) If using the static manifest based install, there are a number of resources that need to be cleaned up else the old and new implementations will 'fight'.

**Release note**:
```release-note
NONE
```

/milestone v0.10