### PR TITLE
feat: permit running e2etests for py3 users

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,5 @@
 # Include git version info
 build --workspace_status_command hack/print-workspace-status.sh
+
+# bazel including rules_docker 0.12.0 may not need the following flag
+build --host_force_python=PY2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

See discussion in slack: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1567723028023900

> Hi, I'm trying to run ./hack/ci/run-e2e-kind.sh and getting the error below.  Any clues on how to fix it best? (I tried editing Makefiles to add the --host_force_python=PY2 flag that the error suggests on every bazel build I see, but I can't manage to get it to run. (Not familiar with Bazel)

See following issues for details
* https://github.com/bazelbuild/rules_docker/issues/842
* https://github.com/bazelbuild/rules_docker/issues/580
* https://github.com/bazelbuild/bazel/issues/7899

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
