### PR TITLE
Adds a flag to specify Acme Solver Namespace

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -232,6 +232,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 			HTTP01SolverResourceRequestMemory: HTTP01SolverResourceRequestMemory,
 			HTTP01SolverResourceLimitsCPU:     HTTP01SolverResourceLimitsCPU,
 			HTTP01SolverResourceLimitsMemory:  HTTP01SolverResourceLimitsMemory,
+			HTTP01SolverNamespace:             opts.ACMEHTTP01SolverNamespace,
 			DNS01CheckAuthoritative:           !opts.DNS01RecursiveNameserversOnly,
 			DNS01Nameservers:                  nameservers,
 		},

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -53,6 +53,7 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverResourceRequestMemory string
 	ACMEHTTP01SolverResourceLimitsCPU     string
 	ACMEHTTP01SolverResourceLimitsMemory  string
+	ACMEHTTP01SolverNamespace             string
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
@@ -231,6 +232,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ACMEHTTP01SolverResourceLimitsMemory, "acme-http01-solver-resource-limits-memory", defaultACMEHTTP01SolverResourceLimitsMemory, ""+
 		"Defines the resource limits Memory size when spawning new ACME HTTP01 challenge solver pods.")
+
+	fs.StringVar(&s.ACMEHTTP01SolverNamespace, "acme-http01-solver-namespace", *new(string), ""+
+		"If set, defines in which namespace the Solver Objects will be created "+
+		"If not specified, the namespace containing the watched objects will be used")
 
 	fs.BoolVar(&s.ClusterIssuerAmbientCredentials, "cluster-issuer-ambient-credentials", defaultClusterIssuerAmbientCredentials, ""+
 		"Whether a cluster-issuer may make use of ambient credentials for issuers. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the ClusterIssuer API object. "+

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -111,6 +111,9 @@ type ACMEOptions struct {
 	// HTTP01SolverResourceLimitsMemory defines the ACME pod's resource limits Memory size
 	HTTP01SolverResourceLimitsMemory resource.Quantity
 
+	// HTTP01SolverNamespace defines in which namespace solver objects will be created
+	HTTP01SolverNamespace string
+
 	// DNS01CheckAuthoritative is a flag for controlling if auth nss are used
 	// for checking propogation of an RR. This is the ideal scenario
 	DNS01CheckAuthoritative bool

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -112,6 +112,11 @@ func httpDomainCfgForChallenge(issuer v1alpha1.GenericIssuer, ch *v1alpha1.Chall
 func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 	ctx = http01LogCtx(ctx)
 
+	// TODO: Can this be created in some other part of the code, so it doesn't repeat
+	if s.ACMEOptions.HTTP01SolverNamespace != "" {
+		ch.Namespace = s.ACMEOptions.HTTP01SolverNamespace
+	}
+
 	_, podErr := s.ensurePod(ctx, ch)
 	svc, svcErr := s.ensureService(ctx, issuer, ch)
 	if svcErr != nil {
@@ -124,6 +129,11 @@ func (s *Solver) Present(ctx context.Context, issuer v1alpha1.GenericIssuer, ch 
 func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 	ctx = logf.NewContext(http01LogCtx(ctx), nil, "selfCheck")
 	log := logf.FromContext(ctx)
+
+	// TODO: Can this be created in some other part of the code, so it doesn't repeat
+	if s.ACMEOptions.HTTP01SolverNamespace != "" {
+		ch.Namespace = s.ACMEOptions.HTTP01SolverNamespace
+	}
 
 	// HTTP Present is idempotent and the state of the system may have
 	// changed since present was called by the controllers (killed pods, drained nodes)
@@ -164,6 +174,11 @@ func (s *Solver) Check(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v
 // cert-manager created data.
 func (s *Solver) CleanUp(ctx context.Context, issuer v1alpha1.GenericIssuer, ch *v1alpha1.Challenge) error {
 	var errs []error
+
+	// TODO: Can this be created in some other part of the code, so it doesn't repeat
+	if s.ACMEOptions.HTTP01SolverNamespace != "" {
+		ch.Namespace = s.ACMEOptions.HTTP01SolverNamespace
+	}
 	errs = append(errs, s.cleanupPods(ctx, ch))
 	errs = append(errs, s.cleanupServices(ctx, ch))
 	errs = append(errs, s.cleanupIngresses(ctx, issuer, ch))


### PR DESCRIPTION
Signed-off-by: Ricardo Pchevuzinske Katz <ricardo.katz@serpro.gov.br>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: This PR adds a flag to specify a common namespace for Solver.

This behavior is the same as existed in kube-lego and is necessary in cases where a user namespace doesn't have enough access to resources, as the following example:

* The environment have restrictive Network Policies, not allowing the user namespace to receive external/ingress connections
* The environment have restrictive RBAC, not allowing cert-manager to create and delete objects as Pods, Services and Ingress in other users namespaces

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
There are some TODOs in the code, I hope in the review of this PR we can improve the cases with some better implementation


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
New flag --acme-http01-solver-namespace allowing the Cluster Admin to specify if there is a namespace to create the solver resources
```



