### PR TITLE
Rename API group to cert-manager.io

### DIFF
--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -29,10 +29,10 @@ $ oc create \
 
 ## IMPORTANT: if the cert-manager namespace **already exists**, you MUST ensure
 ## it has an additional label on it in order for the deployment to succeed
-$ kubectl label namespace cert-manager certmanager.k8s.io/disable-validation="true"
+$ kubectl label namespace cert-manager cert-manager.io/disable-validation="true"
 
 ## For openshift:
-$ oc label namespace cert-manager certmanager.k8s.io/disable-validation=true
+$ oc label namespace cert-manager cert-manager.io/disable-validation=true
 
 ## Add the Jetstack Helm repository
 $ helm repo add jetstack https://charts.jetstack.io

--- a/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "cainjector.chart" . }}
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -30,10 +30,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "cert-manager.chart" . }}
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "issuers/status"]
     verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["issuers"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
@@ -57,10 +57,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "cert-manager.chart" . }}
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "clusterissuers/status"]
     verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
@@ -84,16 +84,16 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "cert-manager.chart" . }}
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificates/status", "certificaterequests", "certificaterequests/status"]
     verbs: ["update"]
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "clusterissuers", "issuers"]
     verbs: ["get", "list", "watch"]
   # We require these rules to support users with the OwnerReferencesPermissionEnforcement
   # admission controller enabled:
   # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates/finalizers"]
     verbs: ["update"]
   - apiGroups: ["acme.cert-manager.io"]
@@ -126,7 +126,7 @@ rules:
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders", "challenges"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["clusterissuers", "issuers"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["acme.cert-manager.io"]
@@ -168,7 +168,7 @@ rules:
     resources: ["challenges"]
     verbs: ["get", "list", "watch"]
   # Used to watch challenges, issuer and clusterissuer resources
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["issuers", "clusterissuers"]
     verbs: ["get", "list", "watch"]
   # Need to be able to retrieve ACME account private key to complete challenges
@@ -219,10 +219,10 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ template "cert-manager.chart" . }}
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests"]
     verbs: ["create", "update", "delete"]
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers", "clusterissuers"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["extensions"]
@@ -401,7 +401,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]
     verbs: ["get", "list", "watch"]
 
@@ -420,7 +420,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-edit: "true"
     rbac.authorization.k8s.io/aggregate-to-admin: "true"
 rules:
-  - apiGroups: ["certmanager.k8s.io"]
+  - apiGroups: ["cert-manager.io"]
     resources: ["certificates", "certificaterequests", "issuers"]
     verbs: ["create", "delete", "deletecollection", "patch", "update"]
 

--- a/deploy/charts/cert-manager/templates/webhook-apiservice.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-apiservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: apiregistration.k8s.io/v1beta1
 kind: APIService
 metadata:
-  name: v1beta1.webhook.certmanager.k8s.io
+  name: v1beta1.webhook.cert-manager.io
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     helm.sh/chart: {{ include "webhook.chart" . }}
   annotations:
-    certmanager.k8s.io/inject-ca-from-secret: "{{ .Release.Namespace }}/{{ include "webhook.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from-secret: "{{ .Release.Namespace }}/{{ include "webhook.servingCertificate" . }}"
 spec:
-  group: webhook.certmanager.k8s.io
+  group: webhook.cert-manager.io
   groupPriorityMinimum: 1000
   versionPriority: 15
   service:

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -11,13 +11,13 @@ metadata:
     helm.sh/chart: {{ include "webhook.chart" . }}
   annotations:
 {{- if .Values.webhook.injectAPIServerCA }}
-    certmanager.k8s.io/inject-apiserver-ca: "true"
+    cert-manager.io/inject-apiserver-ca: "true"
 {{- end }}
 webhooks:
-  - name: webhook.certmanager.k8s.io
+  - name: webhook.cert-manager.io
     rules:
       - apiGroups:
-          - "certmanager.k8s.io"
+          - "cert-manager.io"
         apiVersions:
           - v1alpha2
         operations:
@@ -35,5 +35,5 @@ webhooks:
       service:
         name: kubernetes
         namespace: default
-        path: /apis/webhook.certmanager.k8s.io/v1beta1/mutations
+        path: /apis/webhook.cert-manager.io/v1beta1/mutations
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -64,7 +64,7 @@ metadata:
     helm.sh/chart: {{ include "webhook.chart" . }}
 rules:
 - apiGroups:
-  - admission.certmanager.k8s.io
+  - admission.cert-manager.io
   resources:
   - certificates
   - certificaterequests

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -11,13 +11,13 @@ metadata:
     helm.sh/chart: {{ include "webhook.chart" . }}
   annotations:
 {{- if .Values.webhook.injectAPIServerCA }}
-    certmanager.k8s.io/inject-apiserver-ca: "true"
+    cert-manager.io/inject-apiserver-ca: "true"
 {{- end }}
 webhooks:
-  - name: webhook.certmanager.k8s.io
+  - name: webhook.cert-manager.io
     namespaceSelector:
       matchExpressions:
-      - key: "certmanager.k8s.io/disable-validation"
+      - key: "cert-manager.io/disable-validation"
         operator: "NotIn"
         values:
         - "true"
@@ -27,7 +27,7 @@ webhooks:
         - {{ .Release.Namespace }}
     rules:
       - apiGroups:
-          - "certmanager.k8s.io"
+          - "cert-manager.io"
         apiVersions:
           - v1alpha2
         operations:
@@ -44,5 +44,5 @@ webhooks:
       service:
         name: kubernetes
         namespace: default
-        path: /apis/webhook.certmanager.k8s.io/v1beta1/validations
+        path: /apis/webhook.cert-manager.io/v1beta1/validations
 {{- end -}}

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -1584,7 +1584,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: certificaterequests.certmanager.k8s.io
+  name: certificaterequests.cert-manager.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -1605,7 +1605,7 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
-  group: certmanager.k8s.io
+  group: cert-manager.io
   names:
     kind: CertificateRequest
     plural: certificaterequests
@@ -1652,7 +1652,7 @@ spec:
                 will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer
                 with the provided name will be used. The 'name' field in this stanza
                 is required at all times. The group field refers to the API group
-                of the issuer which defaults to 'certmanager.k8s.io' if empty.
+                of the issuer which defaults to 'cert-manager.io' if empty.
               properties:
                 group:
                   type: string
@@ -1771,7 +1771,7 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: certificates.certmanager.k8s.io
+  name: certificates.cert-manager.io
 spec:
   additionalPrinterColumns:
   - JSONPath: .status.conditions[?(@.type=="Ready")].status
@@ -1795,7 +1795,7 @@ spec:
       in RFC3339 form and is in UTC.
     name: Age
     type: date
-  group: certmanager.k8s.io
+  group: cert-manager.io
   names:
     kind: Certificate
     plural: certificates
@@ -2009,9 +2009,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: clusterissuers.certmanager.k8s.io
+  name: clusterissuers.cert-manager.io
 spec:
-  group: certmanager.k8s.io
+  group: cert-manager.io
   names:
     kind: ClusterIssuer
     plural: clusterissuers
@@ -3633,9 +3633,9 @@ apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
   creationTimestamp: null
-  name: issuers.certmanager.k8s.io
+  name: issuers.cert-manager.io
 spec:
-  group: certmanager.k8s.io
+  group: cert-manager.io
   names:
     kind: Issuer
     plural: issuers

--- a/deploy/manifests/01-namespace.yaml
+++ b/deploy/manifests/01-namespace.yaml
@@ -3,6 +3,6 @@ kind: Namespace
 metadata:
   name: cert-manager
   labels:
-    certmanager.k8s.io/disable-validation: "true"
+    cert-manager.io/disable-validation: "true"
 
 ---

--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -105,7 +105,7 @@ same code base and repository.
 ### API Changes
 
 This proposal will create the following new API types in the
-`certmanager.k8s.io` group;
+`cert-manager.io` group;
 
 ```golang
 // CertificateRequestSpec defines the desired state of CertificateRequest
@@ -120,7 +120,7 @@ type CertificateRequestSpec struct {
 	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
 	// the provided name will be used. The 'name' field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'certmanager.k8s.io' if empty.
+	// issuer which defaults to 'cert-manager.io' if empty.
 	IssuerRef ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
@@ -227,7 +227,7 @@ name.
 ### Internal API Resource Behaviour
 
 The group name of `IssuerRef` inside `CertificateRequest`s is to be defaulted
-to "certmanager.k8s.io" if the field is empty, using a mutating webhook. This
+to "cert-manager.io" if the field is empty, using a mutating webhook. This
 means that if unspecified, `CertificateRequest` objects will be put into the
 ownership of the default pool of issuers in the cert-manager project.
 
@@ -243,7 +243,7 @@ value pairs. These annotations should be considered optional. Any
 fallback gracefully or be marked as failed in the event a required annotation is
 missing. The currently defined annotations are:
 
-- `certmanager.k8s.io/private-key-secret-name`: The name of the secret, in the
+- `cert-manager.io/private-key-secret-name`: The name of the secret, in the
   same namespace as the `CertificateRequest`, that stores the private key which
   was used to sign the x509 certificate signing request. This is required by the
   `SelfSigning` issuer to sign its own certificate. If this annotation is missing

--- a/docs/devel/develop-with-minikube.rst
+++ b/docs/devel/develop-with-minikube.rst
@@ -76,7 +76,7 @@ Deploy that version with helm
    # IMPORTANT: if you are deploying into a namespace that **already exists**,
    # you MUST ensure the namespace has an additional label on it in order for
    # the deployment to succeed
-   $ kubectl label namespace <deployment-namespace> certmanager.k8s.io/disable-validation="true"
+   $ kubectl label namespace <deployment-namespace> cert-manager.io/disable-validation="true"
 
    # Install our freshly built cert-manager image
    $ helm install \

--- a/docs/getting-started/install/kubernetes.rst
+++ b/docs/getting-started/install/kubernetes.rst
@@ -51,7 +51,7 @@ cert-manager runs in:
 .. code-block:: shell
 
    # Disable resource validation on the cert-manager namespace
-   kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   kubectl label namespace cert-manager cert-manager.io/disable-validation=true
 
 You can read more about the webhook on the :doc:`webhook document <../webhook>`.
 
@@ -126,7 +126,7 @@ In order to install the Helm chart, you must run:
    kubectl create namespace cert-manager
 
    # Label the cert-manager namespace to disable resource validation
-   kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   kubectl label namespace cert-manager cert-manager.io/disable-validation=true
 
    # Add the Jetstack Helm repository
    helm repo add jetstack https://charts.jetstack.io
@@ -178,7 +178,7 @@ to issue basic certificate types:
    metadata:
      name: cert-manager-test
    ---
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: test-selfsigned
@@ -186,7 +186,7 @@ to issue basic certificate types:
    spec:
      selfSigned: {}
    ---
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: selfsigned-cert

--- a/docs/getting-started/install/openshift.rst
+++ b/docs/getting-started/install/openshift.rst
@@ -64,7 +64,7 @@ cert-manager runs in:
 .. code-block:: shell
 
    # Disable resource validation on the cert-manager namespace
-   oc label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   oc label namespace cert-manager cert-manager.io/disable-validation=true
 
 You can read more about the webhook on the :doc:`webhook document <../webhook>`.
 

--- a/docs/getting-started/troubleshooting.rst
+++ b/docs/getting-started/troubleshooting.rst
@@ -32,17 +32,17 @@ label:
    kubectl describe namespace cert-manager
    
    Name:         cert-manager
-   Labels:       certmanager.k8s.io/disable-validation=true
+   Labels:       cert-manager.io/disable-validation=true
    Annotations:  <none>
    Status:       Active
    ...
 
-If you cannot see the ``certmanager.k8s.io/disable-validation=true`` label on
+If you cannot see the ``cert-manager.io/disable-validation=true`` label on
 your namespace, you should add it with:
 
 .. code-block:: shell
 
-   kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   kubectl label namespace cert-manager cert-manager.io/disable-validation=true
 
 Please continue reading this guide once you have added the label.
 
@@ -61,12 +61,12 @@ We can first check for the existence of the CustomResourceDefinition resources:
 
    kubectl get crd | grep certmanager
 
-   NAME                                          CREATED AT
-   certificates.certmanager.k8s.io               2018-08-17T20:12:26Z
-   challenges.certmanager.k8s.io                 2018-08-02T15:33:02Z
-   clusterissuers.certmanager.k8s.io             2018-08-17T20:12:26Z
-   issuers.certmanager.k8s.io                    2018-08-17T20:12:26Z
-   orders.certmanager.k8s.io                     2018-08-02T14:40:11Z
+   NAME                                       CREATED AT
+   certificates.cert-manager.io               2018-08-17T20:12:26Z
+   challenges.cert-manager.io                 2018-08-02T15:33:02Z
+   clusterissuers.cert-manager.io             2018-08-17T20:12:26Z
+   issuers.cert-manager.io                    2018-08-17T20:12:26Z
+   orders.cert-manager.io                     2018-08-02T14:40:11Z
 
 We should then also check for that the webhook's Issuer and Certificate
 resources exist and have been issued correctly:
@@ -75,13 +75,13 @@ resources exist and have been issued correctly:
 
    kubectl get issuer,certificate --namespace cert-manager
 
-   NAME                                                      AGE
-   issuer.certmanager.k8s.io/cert-manager-webhook-ca         22d
-   issuer.certmanager.k8s.io/cert-manager-webhook-selfsign   22d
+   NAME                                                   AGE
+   issuer.cert-manager.io/cert-manager-webhook-ca         22d
+   issuer.cert-manager.io/cert-manager-webhook-selfsign   22d
 
-   NAME                                                              READY   SECRET                             AGE
-   certificate.certmanager.k8s.io/cert-manager-webhook-ca            True    cert-manager-webhook-ca            22d
-   certificate.certmanager.k8s.io/cert-manager-webhook-webhook-tls   True    cert-manager-webhook-webhook-tls   22d
+   NAME                                                           READY   SECRET                             AGE
+   certificate.cert-manager.io/cert-manager-webhook-ca            True    cert-manager-webhook-ca            22d
+   certificate.cert-manager.io/cert-manager-webhook-webhook-tls   True    cert-manager-webhook-webhook-tls   22d
 
 If you do not see the CustomResourceDefinitions installed, or cannot see the
 webhook's Issuer and Certificate resources, please go back to the install guide

--- a/docs/getting-started/webhook.rst
+++ b/docs/getting-started/webhook.rst
@@ -81,8 +81,8 @@ injecting the two CA bundles above into the webhook's
 ValidatingWebhookConfiguration and APIService resource in order to allow the
 Kubernetes apiserver to 'trust' the webhook apiserver.
 
-This component is configured using the ``certmanager.k8s.io/inject-apiserver-ca: "true"``
-and ``certmanager.k8s.io/inject-apiserver-ca: "true"`` annotations on the
+This component is configured using the ``cert-manager.io/inject-apiserver-ca: "true"``
+and ``cert-manager.io/inject-apiserver-ca: "true"`` annotations on the
 APIService and ValidatingWebhookConfiguration resources.
 
 It copies across the CA defined in the 'cert-manager-webhook-ca' Secret
@@ -115,7 +115,7 @@ To apply the label, run:
 
 .. code-block:: shell
 
-   kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   kubectl label namespace cert-manager cert-manager.io/disable-validation=true
 
 You may need to wait a little while before cert-manager retries issuing the
 certificates if they have been failing for a while due to cert-manager's built

--- a/docs/reference/certificaterequests.rst
+++ b/docs/reference/certificaterequests.rst
@@ -20,7 +20,7 @@ A simple CertificateRequest looks like the following:
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: CertificateRequest
    metadata:
      name: my-ca-cr
@@ -33,10 +33,10 @@ A simple CertificateRequest looks like the following:
        # We can reference ClusterIssuers by changing the kind here.
        # The default value is Issuer (i.e. a locally namespaced Issuer)
        kind: Issuer
-       group: certmanager.k8s.io
+       group: cert-manager.io
 
 This CertificateRequest will make cert-manager attempt to make the Issuer
-``letsencrypt-prod`` in the default issuer pool ``certmanager.k8s.io``, return a
+``letsencrypt-prod`` in the default issuer pool ``cert-manager.io``, return a
 certificate based upon the certificate signing request. Other groups can be
 specified inside the ``issuerRef`` which will change the targeted issuers to other
 external, third party issuers you may have installed.

--- a/docs/reference/certificates.rst
+++ b/docs/reference/certificates.rst
@@ -12,7 +12,7 @@ A simple Certificate could be defined as:
    :linenos:
    :emphasize-lines: 17-20
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: acme-crt
@@ -97,7 +97,7 @@ expiration.
    :linenos:
    :emphasize-lines: 7,8
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example
@@ -134,7 +134,7 @@ its private key.
    :linenos:
    :emphasize-lines: 7
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-pkcs8-cert

--- a/docs/reference/clusterissuers.rst
+++ b/docs/reference/clusterissuers.rst
@@ -19,7 +19,7 @@ an Issuer to ``ClusterIssuer``, and removing the ``metadata.namespace`` attribut
 .. code-block:: yaml
    :emphasize-lines: 2
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-prod
@@ -32,7 +32,7 @@ the ``spec.issuerRef.kind`` field to ClusterIssuer:
 .. code-block:: yaml
    :emphasize-lines: 10
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: my-certificate

--- a/docs/reference/issuers.rst
+++ b/docs/reference/issuers.rst
@@ -13,7 +13,7 @@ An example of an Issuer type is ACME. A simple ACME issuer could be defined as:
    :linenos:
    :emphasize-lines: 11, 16
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: letsencrypt-prod
@@ -72,7 +72,7 @@ those credentials to perform the ACME DNS01 challenge with route53.
    :linenos:
    :emphasize-lines: 14-15
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-prod

--- a/docs/tasks/issuers/setup-acme/dns01/acme-dns.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/acme-dns.rst
@@ -5,7 +5,7 @@ ACME-DNS
 .. code-block:: yaml
    :emphasize-lines: 10-14
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer

--- a/docs/tasks/issuers/setup-acme/dns01/akamai.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/akamai.rst
@@ -5,7 +5,7 @@ Akamai FastDNS
 .. code-block:: yaml
    :emphasize-lines: 10-20
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer

--- a/docs/tasks/issuers/setup-acme/dns01/azuredns.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/azuredns.rst
@@ -42,7 +42,7 @@ You can configure the issuer like so:
 
 .. code-block:: yaml
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer

--- a/docs/tasks/issuers/setup-acme/dns01/cloudflare.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/cloudflare.rst
@@ -5,7 +5,7 @@ Cloudflare
 .. code-block:: yaml
    :emphasize-lines: 10-14
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer

--- a/docs/tasks/issuers/setup-acme/dns01/digitalocean.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/digitalocean.rst
@@ -13,7 +13,7 @@ Handy direct link: https://cloud.digitalocean.com/account/api/tokens/new
 .. code-block:: yaml
    :emphasize-lines: 10-13
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer

--- a/docs/tasks/issuers/setup-acme/dns01/google.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/google.rst
@@ -58,7 +58,7 @@ Next, create an Issuer (or ClusterIssuer) with a ``clouddns`` provider. An examp
    :linenos:
    :emphasize-lines: 10-16
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer
@@ -83,7 +83,7 @@ Once an Issuer (or ClusterIssuer) has been created successfully a Certificate ca
    :linenos:
    :emphasize-lines: 9-10
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-com

--- a/docs/tasks/issuers/setup-acme/dns01/index.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/index.rst
@@ -21,7 +21,7 @@ You can read about how the DNS01 challenge type works on the
    :linenos:
    :emphasize-lines: 12-17
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer
@@ -81,7 +81,7 @@ relevant `dns01` solver:
    :linenos:
    :emphasize-lines: 11
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      ...

--- a/docs/tasks/issuers/setup-acme/dns01/rfc2136.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/rfc2136.rst
@@ -118,7 +118,7 @@ sufficiently, let’s focus on the provider here.
 .. code:: yaml
    :emphasize-lines: 10-16
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: example-issuer

--- a/docs/tasks/issuers/setup-acme/dns01/route53.rst
+++ b/docs/tasks/issuers/setup-acme/dns01/route53.rst
@@ -87,7 +87,7 @@ Here is an example configuration for a ClusterIssuer:
 
 .. code:: yaml
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-prod

--- a/docs/tasks/issuers/setup-acme/http01/index.rst
+++ b/docs/tasks/issuers/setup-acme/http01/index.rst
@@ -84,7 +84,7 @@ An example of how you could configure the template is as so:
    :linenos:
    :emphasize-lines: 13-20
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: ...

--- a/docs/tasks/issuers/setup-acme/index.rst
+++ b/docs/tasks/issuers/setup-acme/index.rst
@@ -30,7 +30,7 @@ own email address.
    :linenos:
    :emphasize-lines: 7-10, 13-14, 19
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-staging
@@ -101,7 +101,7 @@ along with a DNS01 solver that can be used for wildcard certificates:
    :linenos:
    :emphasize-lines: 14-15
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-staging
@@ -140,7 +140,7 @@ For example:
    :linenos:
    :emphasize-lines: 14-15
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: letsencrypt-staging

--- a/docs/tasks/issuers/setup-ca.rst
+++ b/docs/tasks/issuers/setup-ca.rst
@@ -66,7 +66,7 @@ We can now create an Issuer referencing the Secret resource we just created:
    :linenos:
    :emphasize-lines: 8
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: ca-issuer
@@ -88,7 +88,7 @@ desired certificate. You can read more about the Certificate resource in
    :linenos:
    :emphasize-lines: 9, 10, 11, 12
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-com

--- a/docs/tasks/issuers/setup-selfsigned.rst
+++ b/docs/tasks/issuers/setup-selfsigned.rst
@@ -15,7 +15,7 @@ created with a resource like so:
 
 .. code-block:: yaml
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      name: selfsigning-issuer
@@ -31,7 +31,7 @@ referencing the newly created Issuer in your ``issuerRef``:
 
 .. code-block:: yaml
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-crt

--- a/docs/tasks/issuers/setup-vault.rst
+++ b/docs/tasks/issuers/setup-vault.rst
@@ -46,7 +46,7 @@ We can now create a cluster issuer referencing this secret:
 
 .. code-block:: yaml
 
-    apiVersion: certmanager.k8s.io/v1alpha2
+    apiVersion: cert-manager.io/v1alpha2
     kind: Issuer
     metadata:
       name: vault-issuer
@@ -83,7 +83,7 @@ Once we have created the above Issuer we can use it to obtain a certificate.
 
 .. code-block:: yaml
 
-    apiVersion: certmanager.k8s.io/v1alpha2
+    apiVersion: cert-manager.io/v1alpha2
     kind: Certificate
     metadata:
       name: example-com
@@ -147,7 +147,7 @@ We can now create an issuer referencing this secret:
 
 .. code-block:: yaml
 
-    apiVersion: certmanager.k8s.io/v1alpha2
+    apiVersion: cert-manager.io/v1alpha2
     kind: Issuer
     metadata:
       name: vault-issuer
@@ -176,7 +176,7 @@ Once we have created the above Issuer we can use it to obtain a certificate.
 
 .. code-block:: yaml
 
-    apiVersion: certmanager.k8s.io/v1alpha2
+    apiVersion: cert-manager.io/v1alpha2
     kind: Certificate
     metadata:
       name: example-com

--- a/docs/tasks/issuers/setup-venafi.rst
+++ b/docs/tasks/issuers/setup-venafi.rst
@@ -65,7 +65,7 @@ Save the below content after making your amendments to a file named
 
 .. code-block:: yaml
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: cloud-venafi-issuer
@@ -142,7 +142,7 @@ Save the below content after making your amendments to a file named
 
 .. code-block:: yaml
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: tpp-venafi-issuer

--- a/docs/tasks/issuing-certificates/index.rst
+++ b/docs/tasks/issuing-certificates/index.rst
@@ -28,7 +28,7 @@ DNS names that is valid for 90d and renews 15d before expiry is below:
    :linenos:
    :emphasize-lines: 9, 10, 11, 12
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-com

--- a/docs/tasks/issuing-certificates/ingress-shim.rst
+++ b/docs/tasks/issuing-certificates/ingress-shim.rst
@@ -22,7 +22,7 @@ as described on the Ingress exists. For example:
   metadata:
     annotations:
       # add an annotation indicating the issuer to use.
-      certmanager.k8s.io/cluster-issuer: nameOfClusterIssuer
+      cert-manager.io/cluster-issuer: nameOfClusterIssuer
     name: myIngress
     namespace: myIngress
   spec:
@@ -67,11 +67,11 @@ Supported annotations
 You can specify the following annotations on ingresses in order to trigger
 Certificate resources to be automatically created:
 
-* ``certmanager.k8s.io/issuer`` - the name of an Issuer to acquire the
+* ``cert-manager.io/issuer`` - the name of an Issuer to acquire the
   certificate required for this ingress from. The Issuer **must** be in the same
   namespace as the Ingress resource.
 
-* ``certmanager.k8s.io/cluster-issuer`` - the name of a ClusterIssuer to acquire
+* ``cert-manager.io/cluster-issuer`` - the name of a ClusterIssuer to acquire
   the certificate required for this ingress from. It does not matter which
   namespace your Ingress resides, as ClusterIssuers are non-namespaced resources.
 
@@ -79,7 +79,7 @@ Certificate resources to be automatically created:
   configuration of the ingress-shim (see above). Namely, a default issuer must be
   specified as arguments to the ingress-shim container.
 
-* ``certmanager.k8s.io/acme-http01-ingress-class`` - this annotation allows you
+* ``acme.cert-manager.io/http01-ingress-class`` - this annotation allows you
   to configure ingress class that will be used to solve challenges for this
   ingress. Customising this is useful when you are trying to secure internal
   services, and need to solve challenges using different ingress class to that
@@ -87,7 +87,7 @@ Certificate resources to be automatically created:
   annotation is not set, this defaults to the ingress class of the ingress
   resource.
 
-* ``certmanager.k8s.io/acme-http01-edit-in-place: "true"`` - this controls
+* ``acme.cert-manager.io/http01-edit-in-place: "true"`` - this controls
   whether the ingress is modified 'in-place', or a new one created specifically
   for the http01 challenge. If present, and set to "true" the existing ingress
   will be modified. Any other value, or the absence of the annotation assumes

--- a/docs/tasks/upgrading/index.rst
+++ b/docs/tasks/upgrading/index.rst
@@ -44,7 +44,7 @@ version number you want to install:
    # If you are upgrading from v0.5 or below, you should manually add this
    # label to your cert-manager namespace to ensure the `webhook component`_
    # can provision correctly.
-   kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   kubectl label namespace cert-manager cert-manager.io/disable-validation=true
 
    helm upgrade --version <version> <release_name> jetstack/cert-manager
 
@@ -74,7 +74,7 @@ version number you want to install:
    # If you are upgrading from v0.5 or below, you should manually add this
    # label to your cert-manager namespace to ensure the `webhook component`_
    # can provision correctly.
-   kubectl label namespace cert-manager certmanager.k8s.io/disable-validation=true
+   kubectl label namespace cert-manager cert-manager.io/disable-validation=true
 
    kubectl apply \
         -f https://github.com/jetstack/cert-manager/releases/download/<version>/cert-manager.yaml

--- a/docs/tutorials/acme/dns-validation.rst
+++ b/docs/tutorials/acme/dns-validation.rst
@@ -21,7 +21,7 @@ You can read more about the Issuer resource in the :doc:`Issuer reference docs <
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: letsencrypt-staging
@@ -86,7 +86,7 @@ Once we have created the above Issuer we can use it to obtain a certificate.
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-com

--- a/docs/tutorials/acme/http-validation.rst
+++ b/docs/tutorials/acme/http-validation.rst
@@ -18,7 +18,7 @@ You can read more about the Issuer resource in the :doc:`Issuer reference docs <
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: letsencrypt-staging
@@ -60,7 +60,7 @@ Once we have created the above Issuer we can use it to obtain a certificate.
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-com

--- a/docs/tutorials/acme/migrating-from-kube-lego.rst
+++ b/docs/tutorials/acme/migrating-from-kube-lego.rst
@@ -146,7 +146,7 @@ Create a file named ``cluster-issuer.yaml``:
    :linenos:
    :emphasize-lines: 11
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: ClusterIssuer
    metadata:
      # Adjust the name here accordingly

--- a/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml
+++ b/docs/tutorials/acme/quick-start/example/ingress-tls-final.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuard
   annotations:
     kubernetes.io/ingress.class: "nginx"    
-    certmanager.k8s.io/issuer: "letsencrypt-prod"
+    cert-manager.io/issuer: "letsencrypt-prod"
 
 spec:
   tls:

--- a/docs/tutorials/acme/quick-start/example/ingress-tls.yaml
+++ b/docs/tutorials/acme/quick-start/example/ingress-tls.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuard
   annotations:
     kubernetes.io/ingress.class: "nginx"    
-    certmanager.k8s.io/issuer: "letsencrypt-staging"
+    cert-manager.io/issuer: "letsencrypt-staging"
 
 spec:
   tls:

--- a/docs/tutorials/acme/quick-start/example/ingress.yaml
+++ b/docs/tutorials/acme/quick-start/example/ingress.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuard
   annotations:
     kubernetes.io/ingress.class: "nginx"    
-    #certmanager.k8s.io/issuer: "letsencrypt-staging"
+    #cert-manager.io/issuer: "letsencrypt-staging"
 
 spec:
   tls:

--- a/docs/tutorials/acme/quick-start/example/production-issuer.yaml
+++ b/docs/tutorials/acme/quick-start/example/production-issuer.yaml
@@ -1,4 +1,4 @@
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: letsencrypt-prod

--- a/docs/tutorials/acme/quick-start/example/staging-issuer.yaml
+++ b/docs/tutorials/acme/quick-start/example/staging-issuer.yaml
@@ -1,4 +1,4 @@
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: letsencrypt-staging

--- a/docs/tutorials/acme/quick-start/index.rst
+++ b/docs/tutorials/acme/quick-start/index.rst
@@ -410,7 +410,7 @@ Once edited, apply the custom resource:
 .. code-block:: shell
 
     $ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/docs/tutorials/acme/quick-start/example/staging-issuer.yaml
-    issuer.certmanager.k8s.io "letsencrypt-staging" created
+    issuer.cert-manager.io "letsencrypt-staging" created
 
 Also create a production issuer and deploy it. As with the staging issuer, you
 will need to update this example and add in your own email address.
@@ -426,7 +426,7 @@ will need to update this example and add in your own email address.
 .. code-block:: shell
 
     $ kubectl create --edit -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.10/docs/tutorials/acme/quick-start/example/production-issuer.yaml
-    issuer.certmanager.k8s.io "letsencrypt-prod" created
+    issuer.cert-manager.io "letsencrypt-prod" created
 
 Both of these issuers are configured to use the
 :doc:`HTTP01 </tasks/issuers/setup-acme/http01/index>` challenge provider.
@@ -441,15 +441,15 @@ Check on the status of the issuer after you create it:
     Name:         letsencrypt-staging
     Namespace:    default
     Labels:       <none>
-    Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"certmanager.k8s.io/v1alpha2","kind":"Issuer","metadata":{"annotations":{},"name":"letsencrypt-staging","namespace":"default"},"spec":{"a...
-    API Version:  certmanager.k8s.io/v1alpha2
+    Annotations:  kubectl.kubernetes.io/last-applied-configuration={"apiVersion":"cert-manager.io/v1alpha2","kind":"Issuer","metadata":{"annotations":{},"name":"letsencrypt-staging","namespace":"default"},"spec":{"a...
+    API Version:  cert-manager.io/v1alpha2
     Kind:         Issuer
     Metadata:
       Cluster Name:
       Creation Timestamp:  2018-11-17T18:03:54Z
       Generation:          0
       Resource Version:    9092
-      Self Link:           /apis/certmanager.k8s.io/v1alpha2/namespaces/default/issuers/letsencrypt-staging
+      Self Link:           /apis/cert-manager.io/v1alpha2/namespaces/default/issuers/letsencrypt-staging
       UID:                 25b7ae77-ea93-11e8-82f8-42010a8a00b5
     Spec:
       Acme:
@@ -537,7 +537,7 @@ certificate object. You can view this information using the
     Namespace:    default
     Labels:       <none>
     Annotations:  <none>
-    API Version:  certmanager.k8s.io/v1alpha2
+    API Version:  cert-manager.io/v1alpha2
     Kind:         Certificate
     Metadata:
       Cluster Name:
@@ -551,7 +551,7 @@ certificate object. You can view this information using the
         Name:                  kuard
         UID:                   a3e9f935-ea87-11e8-82f8-42010a8a00b5
       Resource Version:        9295
-      Self Link:               /apis/certmanager.k8s.io/v1alpha2/namespaces/default/certificates/quickstart-example-tls
+      Self Link:               /apis/cert-manager.io/v1alpha2/namespaces/default/certificates/quickstart-example-tls
       UID:                     68d43400-ea92-11e8-82f8-42010a8a00b5
     Spec:
       Dns Names:
@@ -593,11 +593,11 @@ use the describe command as well to see some details:
 
     Name:         quickstart-example-tls
     Namespace:    default
-    Labels:       certmanager.k8s.io/certificate-name=quickstart-example-tls
-    Annotations:  certmanager.k8s.io/alt-names=example.your-domain.com
-                  certmanager.k8s.io/common-name=example.your-domain.com
-                  certmanager.k8s.io/issuer-kind=Issuer
-                  certmanager.k8s.io/issuer-name=letsencrypt-staging
+    Labels:       cert-manager.io/certificate-name=quickstart-example-tls
+    Annotations:  cert-manager.io/alt-names=example.your-domain.com
+                  cert-manager.io/common-name=example.your-domain.com
+                  cert-manager.io/issuer-kind=Issuer
+                  cert-manager.io/issuer-name=letsencrypt-staging
 
     Type:  kubernetes.io/tls
 
@@ -646,7 +646,7 @@ certificate.
     Namespace:    default
     Labels:       <none>
     Annotations:  <none>
-    API Version:  certmanager.k8s.io/v1alpha2
+    API Version:  cert-manager.io/v1alpha2
     Kind:         Certificate
     Metadata:
       Cluster Name:
@@ -660,7 +660,7 @@ certificate.
         Name:                  kuard
         UID:                   a3e9f935-ea87-11e8-82f8-42010a8a00b5
       Resource Version:        283686
-      Self Link:               /apis/certmanager.k8s.io/v1alpha2/namespaces/default/certificates/quickstart-example-tls
+      Self Link:               /apis/cert-manager.io/v1alpha2/namespaces/default/certificates/quickstart-example-tls
       UID:                     bdd93b32-ea97-11e8-82f8-42010a8a00b5
     Spec:
       Dns Names:

--- a/docs/tutorials/venafi/securing-ingress.rst
+++ b/docs/tutorials/venafi/securing-ingress.rst
@@ -282,7 +282,7 @@ Save the following YAML into a file named ``venafi-issuer.yaml``:
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: venafi-issuer
@@ -349,7 +349,7 @@ Save the following YAML into a file named ``venafi-issuer.yaml``:
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Issuer
    metadata:
      name: venafi-issuer
@@ -409,7 +409,7 @@ For now, we will create a basic x509 Certificate that is valid for our domain,
 .. code-block:: yaml
    :linenos:
 
-   apiVersion: certmanager.k8s.io/v1alpha2
+   apiVersion: cert-manager.io/v1alpha2
    kind: Certificate
    metadata:
      name: example-com-tls

--- a/pkg/acme/webhook/apis/acme/doc.go
+++ b/pkg/acme/webhook/apis/acme/doc.go
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +groupName=acme.webhook.certmanager.k8s.io
+// +groupName=webhook.acme.cert-manager.io
 
 // Package acme contains type definitions for ACME ChallengePayload resources
 package acme
 
-const GroupName = "acme.webhook.certmanager.k8s.io"
+const (
+	GroupName = "webhook.acme.cert-manager.io"
+)

--- a/pkg/acme/webhook/apis/acme/v1alpha1/doc.go
+++ b/pkg/acme/webhook/apis/acme/v1alpha1/doc.go
@@ -18,5 +18,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // Package v1alpha1 is the v1alpha1 version of the API.
-// +groupName=acme.webhook.certmanager.k8s.io
+// +groupName=webhook.acme.cert-manager.io
 package v1alpha1

--- a/pkg/apis/certmanager/doc.go
+++ b/pkg/apis/certmanager/doc.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// +groupName=certmanager.k8s.io
+// +groupName=cert-manager.io
+// +groupGoName=Certmanager
 
 // Package certmanager is the internal version of the API.
 package certmanager
 
-const GroupName = "certmanager.k8s.io"
+const GroupName = "cert-manager.io"

--- a/pkg/apis/certmanager/v1alpha2/doc.go
+++ b/pkg/apis/certmanager/v1alpha2/doc.go
@@ -20,5 +20,6 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 
 // Package v1alpha2 is the v1alpha2 version of the API.
-// +groupName=certmanager.k8s.io
+// +groupName=cert-manager.io
+// +groupGoName=Certmanager
 package v1alpha2

--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -18,17 +18,17 @@ package v1alpha2
 
 // Annotation names for Secrets
 const (
-	AltNamesAnnotationKey   = "certmanager.k8s.io/alt-names"
-	IPSANAnnotationKey      = "certmanager.k8s.io/ip-sans"
-	CommonNameAnnotationKey = "certmanager.k8s.io/common-name"
-	IssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
-	IssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
-	CertificateNameKey      = "certmanager.k8s.io/certificate-name"
+	AltNamesAnnotationKey   = "cert-manager.io/alt-names"
+	IPSANAnnotationKey      = "cert-manager.io/ip-sans"
+	CommonNameAnnotationKey = "cert-manager.io/common-name"
+	IssuerNameAnnotationKey = "cert-manager.io/issuer-name"
+	IssuerKindAnnotationKey = "cert-manager.io/issuer-kind"
+	CertificateNameKey      = "cert-manager.io/certificate-name"
 )
 
 // Annotation names for CertificateRequests
 const (
-	CRPrivateKeyAnnotationKey = "certmanager.k8s.io/private-key-secret-name"
+	CRPrivateKeyAnnotationKey = "cert-manager.io/private-key-secret-name"
 )
 
 const (
@@ -37,7 +37,7 @@ const (
 	// If it is present, a temporary internally signed certificate will be
 	// stored in the target Secret resource whilst the real Issuer is processing
 	// the certificate request.
-	IssueTemporaryCertificateAnnotation = "certmanager.k8s.io/issue-temporary-certificate"
+	IssueTemporaryCertificateAnnotation = "cert-manager.io/issue-temporary-certificate"
 )
 
 const (
@@ -51,25 +51,25 @@ const (
 	// WantInjectAnnotation is the annotation that specifies that a particular
 	// object wants injection of CAs.  It takes the form of a reference to a certificate
 	// as namespace/name.  The certificate is expected to have the is-serving-for annotations.
-	WantInjectAnnotation = "certmanager.k8s.io/inject-ca-from"
+	WantInjectAnnotation = "cert-manager.io/inject-ca-from"
 
 	// WantInjectAPIServerCAAnnotation, if set to "true", will make the cainjector
 	// inject the CA certificate for the Kubernetes apiserver into the resource.
 	// It discovers the apiserver's CA by inspecting the service account credentials
 	// mounted into the cainjector pod.
-	WantInjectAPIServerCAAnnotation = "certmanager.k8s.io/inject-apiserver-ca"
+	WantInjectAPIServerCAAnnotation = "cert-manager.io/inject-apiserver-ca"
 
 	// WantInjectFromSecretAnnotation is the annotation that specifies that a particular
 	// object wants injection of CAs.  It takes the form of a reference to a Secret
 	// as namespace/name.
-	WantInjectFromSecretAnnotation = "certmanager.k8s.io/inject-ca-from-secret"
+	WantInjectFromSecretAnnotation = "cert-manager.io/inject-ca-from-secret"
 
 	// AllowsInjectionFromSecretAnnotation is an annotation that must be added
 	// to Secret resource that want to denote that they can be directly
 	// injected into injectables that have a `inject-ca-from-secret` annotation.
 	// If an injectable references a Secret that does NOT have this annotation,
 	// the cainjector will refuse to inject the secret.
-	AllowsInjectionFromSecretAnnotation = "certmanager.k8s.io/allow-direct-injection"
+	AllowsInjectionFromSecretAnnotation = "cert-manager.io/allow-direct-injection"
 )
 
 // KeyUsage specifies valid usage contexts for keys.

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -68,7 +68,7 @@ type CertificateRequestSpec struct {
 	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
 	// the provided name will be used. The 'name' field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'certmanager.k8s.io' if empty.
+	// issuer which defaults to 'cert-manager.io' if empty.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest

--- a/pkg/apis/doc.go
+++ b/pkg/apis/doc.go
@@ -15,6 +15,6 @@ limitations under the License.
 */
 
 //
-// +domain=k8s.io
+// +domain=cert-manager.io
 
 package apis

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/certmanager_client.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/certmanager_client.go
@@ -32,7 +32,7 @@ type CertmanagerV1alpha2Interface interface {
 	IssuersGetter
 }
 
-// CertmanagerV1alpha2Client is used to interact with features provided by the certmanager.k8s.io group.
+// CertmanagerV1alpha2Client is used to interact with features provided by the cert-manager.io group.
 type CertmanagerV1alpha2Client struct {
 	restClient rest.Interface
 }

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_certificate.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_certificate.go
@@ -34,9 +34,9 @@ type FakeCertificates struct {
 	ns   string
 }
 
-var certificatesResource = schema.GroupVersionResource{Group: "certmanager.k8s.io", Version: "v1alpha2", Resource: "certificates"}
+var certificatesResource = schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1alpha2", Resource: "certificates"}
 
-var certificatesKind = schema.GroupVersionKind{Group: "certmanager.k8s.io", Version: "v1alpha2", Kind: "Certificate"}
+var certificatesKind = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1alpha2", Kind: "Certificate"}
 
 // Get takes name of the certificate, and returns the corresponding certificate object, and an error if there is any.
 func (c *FakeCertificates) Get(name string, options v1.GetOptions) (result *v1alpha2.Certificate, err error) {

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_certificaterequest.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_certificaterequest.go
@@ -34,9 +34,9 @@ type FakeCertificateRequests struct {
 	ns   string
 }
 
-var certificaterequestsResource = schema.GroupVersionResource{Group: "certmanager.k8s.io", Version: "v1alpha2", Resource: "certificaterequests"}
+var certificaterequestsResource = schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1alpha2", Resource: "certificaterequests"}
 
-var certificaterequestsKind = schema.GroupVersionKind{Group: "certmanager.k8s.io", Version: "v1alpha2", Kind: "CertificateRequest"}
+var certificaterequestsKind = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1alpha2", Kind: "CertificateRequest"}
 
 // Get takes name of the certificateRequest, and returns the corresponding certificateRequest object, and an error if there is any.
 func (c *FakeCertificateRequests) Get(name string, options v1.GetOptions) (result *v1alpha2.CertificateRequest, err error) {

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_clusterissuer.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_clusterissuer.go
@@ -33,9 +33,9 @@ type FakeClusterIssuers struct {
 	Fake *FakeCertmanagerV1alpha2
 }
 
-var clusterissuersResource = schema.GroupVersionResource{Group: "certmanager.k8s.io", Version: "v1alpha2", Resource: "clusterissuers"}
+var clusterissuersResource = schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1alpha2", Resource: "clusterissuers"}
 
-var clusterissuersKind = schema.GroupVersionKind{Group: "certmanager.k8s.io", Version: "v1alpha2", Kind: "ClusterIssuer"}
+var clusterissuersKind = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1alpha2", Kind: "ClusterIssuer"}
 
 // Get takes name of the clusterIssuer, and returns the corresponding clusterIssuer object, and an error if there is any.
 func (c *FakeClusterIssuers) Get(name string, options v1.GetOptions) (result *v1alpha2.ClusterIssuer, err error) {

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_issuer.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha2/fake/fake_issuer.go
@@ -34,9 +34,9 @@ type FakeIssuers struct {
 	ns   string
 }
 
-var issuersResource = schema.GroupVersionResource{Group: "certmanager.k8s.io", Version: "v1alpha2", Resource: "issuers"}
+var issuersResource = schema.GroupVersionResource{Group: "cert-manager.io", Version: "v1alpha2", Resource: "issuers"}
 
-var issuersKind = schema.GroupVersionKind{Group: "certmanager.k8s.io", Version: "v1alpha2", Kind: "Issuer"}
+var issuersKind = schema.GroupVersionKind{Group: "cert-manager.io", Version: "v1alpha2", Kind: "Issuer"}
 
 // Get takes name of the issuer, and returns the corresponding issuer object, and an error if there is any.
 func (c *FakeIssuers) Get(name string, options v1.GetOptions) (result *v1alpha2.Issuer, err error) {

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -59,7 +59,7 @@ func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource
 	case v1alpha2.SchemeGroupVersion.WithResource("orders"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Acme().V1alpha2().Orders().Informer()}, nil
 
-		// Group=certmanager.k8s.io, Version=v1alpha2
+		// Group=cert-manager.io, Version=v1alpha2
 	case certmanagerv1alpha2.SchemeGroupVersion.WithResource("certificates"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Certmanager().V1alpha2().Certificates().Informer()}, nil
 	case certmanagerv1alpha2.SchemeGroupVersion.WithResource("certificaterequests"):

--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -55,7 +55,7 @@ type caDataSource interface {
 }
 
 // kubeconfigDataSource reads the ca bundle provided as part of the struct
-// instantiation if it has the 'certmanager.k8s.io/inject-apiserver-ca'
+// instantiation if it has the 'cert-manager.io/inject-apiserver-ca'
 // annotation.
 type kubeconfigDataSource struct {
 	apiserverCABundle []byte
@@ -80,7 +80,7 @@ func (c *kubeconfigDataSource) ApplyTo(mgr ctrl.Manager, setup injectorSetup, bu
 }
 
 // certificateDataSource reads a CA bundle by fetching the Certificate named in
-// the 'certmanager.k8s.io/inject-ca-from' annotation in the form
+// the 'cert-manager.io/inject-ca-from' annotation in the form
 // 'namespace/name'.
 type certificateDataSource struct {
 	client client.Client
@@ -162,7 +162,7 @@ func (c *certificateDataSource) ApplyTo(mgr ctrl.Manager, setup injectorSetup, b
 }
 
 // secretDataSource reads a CA bundle from a Secret resource named using the
-// 'certmanager.k8s.io/inject-ca-from-secret' annotation in the form
+// 'cert-manager.io/inject-ca-from-secret' annotation in the form
 // 'namespace/name'.
 type secretDataSource struct {
 	client client.Client

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -158,7 +158,7 @@ func TestSign(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer.DeepCopy()},
 				ExpectedEvents: []string{
-					"Normal OrderCreated Created Order resource default-unit-test-ns/test-cr-1108683324",
+					"Normal OrderCreated Created Order resource default-unit-test-ns/test-cr-1049712215",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewCreateAction(
@@ -174,7 +174,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonPending,
-								Message:            "Created Order resource default-unit-test-ns/test-cr-1108683324",
+								Message:            "Created Order resource default-unit-test-ns/test-cr-1049712215",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 						),
@@ -187,7 +187,7 @@ func TestSign(t *testing.T) {
 			certificateRequest: baseCR.DeepCopy(),
 			builder: &testpkg.Builder{
 				ExpectedEvents: []string{
-					"Normal OrderGetError Failed to get order resource default-unit-test-ns/test-cr-1108683324: this is a network error",
+					"Normal OrderGetError Failed to get order resource default-unit-test-ns/test-cr-1049712215: this is a network error",
 				},
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer.DeepCopy()},
 				ExpectedActions: []testpkg.Action{
@@ -199,7 +199,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonPending,
-								Message:            "Failed to get order resource default-unit-test-ns/test-cr-1108683324: this is a network error",
+								Message:            "Failed to get order resource default-unit-test-ns/test-cr-1049712215: this is a network error",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 						),
@@ -222,7 +222,7 @@ func TestSign(t *testing.T) {
 			certificateRequest: baseCR.DeepCopy(),
 			builder: &testpkg.Builder{
 				ExpectedEvents: []string{
-					`Warning OrderFailed Failed to wait for order resource default-unit-test-ns/test-cr-1108683324 to become ready: order is in "invalid" state`,
+					`Warning OrderFailed Failed to wait for order resource default-unit-test-ns/test-cr-1049712215 to become ready: order is in "invalid" state`,
 				},
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer.DeepCopy(),
 					gen.OrderFrom(baseOrder,
@@ -238,7 +238,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonFailed,
-								Message:            `Failed to wait for order resource default-unit-test-ns/test-cr-1108683324 to become ready: order is in "invalid" state`,
+								Message:            `Failed to wait for order resource default-unit-test-ns/test-cr-1049712215 to become ready: order is in "invalid" state`,
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
@@ -252,7 +252,7 @@ func TestSign(t *testing.T) {
 			certificateRequest: baseCR.DeepCopy(),
 			builder: &testpkg.Builder{
 				ExpectedEvents: []string{
-					`Normal OrderPending Waiting on certificate issuance from order default-unit-test-ns/test-cr-1108683324: "pending"`,
+					`Normal OrderPending Waiting on certificate issuance from order default-unit-test-ns/test-cr-1049712215: "pending"`,
 				},
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer.DeepCopy(),
 					gen.OrderFrom(baseOrder,
@@ -268,7 +268,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonPending,
-								Message:            `Waiting on certificate issuance from order default-unit-test-ns/test-cr-1108683324: "pending"`,
+								Message:            `Waiting on certificate issuance from order default-unit-test-ns/test-cr-1049712215: "pending"`,
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 						),

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
@@ -165,7 +165,7 @@ func TestSign(t *testing.T) {
 	}
 
 	tests := map[string]testT{
-		"a CertificateRequest with no certmanager.k8s.io/selfsigned-private-key annotation should fail": {
+		"a CertificateRequest with no cert-manager.io/selfsigned-private-key annotation should fail": {
 			certificateRequest: gen.CertificateRequestFrom(baseCR,
 				// no annotation
 				gen.SetCertificateRequestAnnotations(map[string]string{}),
@@ -177,7 +177,7 @@ func TestSign(t *testing.T) {
 					gen.SetCertificateRequestAnnotations(map[string]string{}),
 				), baseIssuer},
 				ExpectedEvents: []string{
-					`Warning MissingAnnotation Annotation "certmanager.k8s.io/private-key-secret-name" missing or reference empty: secret name missing`,
+					`Warning MissingAnnotation Annotation "cert-manager.io/private-key-secret-name" missing or reference empty: secret name missing`,
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateAction(
@@ -189,7 +189,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonFailed,
-								Message:            `Annotation "certmanager.k8s.io/private-key-secret-name" missing or reference empty: secret name missing`,
+								Message:            `Annotation "cert-manager.io/private-key-secret-name" missing or reference empty: secret name missing`,
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
@@ -198,7 +198,7 @@ func TestSign(t *testing.T) {
 				},
 			},
 		},
-		"a CertificateRequest with a certmanager.k8s.io/private-key-secret-name annotation but empty string should fail": {
+		"a CertificateRequest with a cert-manager.io/private-key-secret-name annotation but empty string should fail": {
 			certificateRequest: gen.CertificateRequestFrom(baseCR,
 				// no data in annotation
 				gen.SetCertificateRequestAnnotations(map[string]string{cmapi.CRPrivateKeyAnnotationKey: ""}),
@@ -210,7 +210,7 @@ func TestSign(t *testing.T) {
 					gen.SetCertificateRequestAnnotations(map[string]string{cmapi.CRPrivateKeyAnnotationKey: ""}),
 				), baseIssuer},
 				ExpectedEvents: []string{
-					`Warning MissingAnnotation Annotation "certmanager.k8s.io/private-key-secret-name" missing or reference empty: secret name missing`,
+					`Warning MissingAnnotation Annotation "cert-manager.io/private-key-secret-name" missing or reference empty: secret name missing`,
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateAction(
@@ -222,7 +222,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonFailed,
-								Message:            `Annotation "certmanager.k8s.io/private-key-secret-name" missing or reference empty: secret name missing`,
+								Message:            `Annotation "cert-manager.io/private-key-secret-name" missing or reference empty: secret name missing`,
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
@@ -262,7 +262,7 @@ func TestSign(t *testing.T) {
 				KubeObjects:        []runtime.Object{invalidKeySecret},
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer},
 				ExpectedEvents: []string{
-					`Normal ErrorParsingKey Failed to get key "test-rsa-key" referenced in annotation "certmanager.k8s.io/private-key-secret-name": error decoding private key PEM block`,
+					`Normal ErrorParsingKey Failed to get key "test-rsa-key" referenced in annotation "cert-manager.io/private-key-secret-name": error decoding private key PEM block`,
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateAction(
@@ -273,7 +273,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonPending,
-								Message:            `Failed to get key "test-rsa-key" referenced in annotation "certmanager.k8s.io/private-key-secret-name": error decoding private key PEM block`,
+								Message:            `Failed to get key "test-rsa-key" referenced in annotation "cert-manager.io/private-key-secret-name": error decoding private key PEM block`,
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 						),

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -136,10 +136,10 @@ func TestSync(t *testing.T) {
 	certECPEMExpired := generateSelfSignedCert(t, baseCR, skEC, fixedClockStart.Add(-time.Hour*13), fixedClockStart.Add(-time.Hour*12))
 
 	tests := map[string]testT{
-		"should return nil (no action) if group name if not 'certmanager.k8s.io' or ''": {
+		"should return nil (no action) if group name if not 'cert-manager.io' or ''": {
 			certificateRequest: gen.CertificateRequestFrom(baseCR,
 				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
-					Group: "not-certmanager.k8s.io",
+					Group: "not-cert-manager.io",
 				}),
 			),
 			builder: &testpkg.Builder{
@@ -185,7 +185,7 @@ func TestSync(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseCR},
 				ExpectedEvents: []string{
-					`Normal IssuerNotFound Referenced "Issuer" not found: issuer.certmanager.k8s.io "test-issuer" not found`,
+					`Normal IssuerNotFound Referenced "Issuer" not found: issuer.cert-manager.io "test-issuer" not found`,
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateAction(
@@ -196,7 +196,7 @@ func TestSync(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             "Pending",
-								Message:            `Referenced "Issuer" not found: issuer.certmanager.k8s.io "test-issuer" not found`,
+								Message:            `Referenced "Issuer" not found: issuer.cert-manager.io "test-issuer" not found`,
 								LastTransitionTime: &nowMetaTime,
 							}),
 						),

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -40,17 +40,17 @@ import (
 const (
 	// editInPlaceAnnotation is used to toggle the use of ingressClass instead
 	// of ingress on the created Certificate resource
-	editInPlaceAnnotation = "certmanager.k8s.io/acme-http01-edit-in-place"
+	editInPlaceAnnotation = "acme.cert-manager.io/http01-edit-in-place"
 	// issuerNameAnnotation can be used to override the issuer specified on the
 	// created Certificate resource.
-	issuerNameAnnotation = "certmanager.k8s.io/issuer"
+	issuerNameAnnotation = "cert-manager.io/issuer"
 	// clusterIssuerNameAnnotation can be used to override the issuer specified on the
 	// created Certificate resource. The Certificate will reference the
 	// specified *ClusterIssuer* instead of normal issuer.
-	clusterIssuerNameAnnotation = "certmanager.k8s.io/cluster-issuer"
+	clusterIssuerNameAnnotation = "cert-manager.io/cluster-issuer"
 	// acmeIssuerHTTP01IngressClassAnnotation can be used to override the http01 ingressClass
 	// if the challenge type is set to http01
-	acmeIssuerHTTP01IngressClassAnnotation = "certmanager.k8s.io/acme-http01-ingress-class"
+	acmeIssuerHTTP01IngressClassAnnotation = "acme.cert-manager.io/http01-ingress-class"
 
 	ingressClassAnnotation = util.IngressKey
 )

--- a/pkg/internal/apis/certmanager/doc.go
+++ b/pkg/internal/apis/certmanager/doc.go
@@ -17,5 +17,5 @@ limitations under the License.
 // +k8s:deepcopy-gen=package,register
 
 // Package certmanager is the internal version of the API.
-// +groupName=certmanager.k8s.io
+// +groupName=cert-manager.io
 package certmanager

--- a/pkg/internal/apis/certmanager/types.go
+++ b/pkg/internal/apis/certmanager/types.go
@@ -18,17 +18,17 @@ package certmanager
 
 // Annotation names for Secrets
 const (
-	AltNamesAnnotationKey   = "certmanager.k8s.io/alt-names"
-	IPSANAnnotationKey      = "certmanager.k8s.io/ip-sans"
-	CommonNameAnnotationKey = "certmanager.k8s.io/common-name"
-	IssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
-	IssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
-	CertificateNameKey      = "certmanager.k8s.io/certificate-name"
+	AltNamesAnnotationKey   = "cert-manager.io/alt-names"
+	IPSANAnnotationKey      = "cert-manager.io/ip-sans"
+	CommonNameAnnotationKey = "cert-manager.io/common-name"
+	IssuerNameAnnotationKey = "cert-manager.io/issuer-name"
+	IssuerKindAnnotationKey = "cert-manager.io/issuer-kind"
+	CertificateNameKey      = "cert-manager.io/certificate-name"
 )
 
 // Annotation names for CertificateRequests
 const (
-	CRPrivateKeyAnnotationKey = "certmanager.k8s.io/private-key-secret-name"
+	CRPrivateKeyAnnotationKey = "cert-manager.io/private-key-secret-name"
 )
 
 const (
@@ -42,25 +42,25 @@ const (
 	// WantInjectAnnotation is the annotation that specifies that a particular
 	// object wants injection of CAs.  It takes the form of a reference to a certificate
 	// as namespace/name.  The certificate is expected to have the is-serving-for annotations.
-	WantInjectAnnotation = "certmanager.k8s.io/inject-ca-from"
+	WantInjectAnnotation = "cert-manager.io/inject-ca-from"
 
 	// WantInjectAPIServerCAAnnotation, if set to "true", will make the cainjector
 	// inject the CA certificate for the Kubernetes apiserver into the resource.
 	// It discovers the apiserver's CA by inspecting the service account credentials
 	// mounted into the cainjector pod.
-	WantInjectAPIServerCAAnnotation = "certmanager.k8s.io/inject-apiserver-ca"
+	WantInjectAPIServerCAAnnotation = "cert-manager.io/inject-apiserver-ca"
 
 	// WantInjectFromSecretAnnotation is the annotation that specifies that a particular
 	// object wants injection of CAs.  It takes the form of a reference to a Secret
 	// as namespace/name.
-	WantInjectFromSecretAnnotation = "certmanager.k8s.io/inject-ca-from-secret"
+	WantInjectFromSecretAnnotation = "cert-manager.io/inject-ca-from-secret"
 
 	// AllowsInjectionFromSecretAnnotation is an annotation that must be added
 	// to Secret resource that want to denote that they can be directly
 	// injected into injectables that have a `inject-ca-from-secret` annotation.
 	// If an injectable references a Secret that does NOT have this annotation,
 	// the cainjector will refuse to inject the secret.
-	AllowsInjectionFromSecretAnnotation = "certmanager.k8s.io/allow-direct-injection"
+	AllowsInjectionFromSecretAnnotation = "cert-manager.io/allow-direct-injection"
 )
 
 // KeyUsage specifies valid usage contexts for keys.

--- a/pkg/internal/apis/certmanager/types_certificaterequest.go
+++ b/pkg/internal/apis/certmanager/types_certificaterequest.go
@@ -61,7 +61,7 @@ type CertificateRequestSpec struct {
 	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
 	// the provided name will be used. The 'name' field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'certmanager.k8s.io' if empty.
+	// issuer which defaults to 'cert-manager.io' if empty.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest

--- a/pkg/internal/apis/certmanager/v1alpha2/doc.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/doc.go
@@ -19,5 +19,5 @@ limitations under the License.
 // +k8s:defaulter-gen=TypeMeta
 // +k8s:defaulter-gen-input=../../../../apis/certmanager/v1alpha2
 
-// +groupName=certmanager.k8s.io
+// +groupName=cert-manager.io
 package v1alpha2

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -43,9 +43,9 @@ const (
 	// acmeSolverListenPort is the port acmesolver should listen on
 	acmeSolverListenPort = 8089
 
-	domainLabelKey               = "certmanager.k8s.io/acme-http-domain"
-	tokenLabelKey                = "certmanager.k8s.io/acme-http-token"
-	solverIdentificationLabelKey = "certmanager.k8s.io/acme-http01-solver"
+	domainLabelKey               = "acme.cert-manager.io/http-domain"
+	tokenLabelKey                = "acme.cert-manager.io/http-token"
+	solverIdentificationLabelKey = "acme.cert-manager.io/http01-solver"
 )
 
 var (

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -277,8 +277,8 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 								PodTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressPodTemplate{
 									ObjectMeta: metav1.ObjectMeta{
 										Labels: map[string]string{
-											"this is a":                           "label",
-											"certmanager.k8s.io/acme-http-domain": "44655555555",
+											"this is a":                        "label",
+											"acme.cert-manager.io/http-domain": "44655555555",
 										},
 										Annotations: map[string]string{
 											"sidecar.istio.io/inject": "true",
@@ -306,10 +306,10 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
 				resultingPod.Labels = map[string]string{
-					"this is a":                             "label",
-					"certmanager.k8s.io/acme-http-domain":   "44655555555",
-					"certmanager.k8s.io/acme-http-token":    "1",
-					"certmanager.k8s.io/acme-http01-solver": "true",
+					"this is a":                          "label",
+					"acme.cert-manager.io/http-domain":   "44655555555",
+					"acme.cert-manager.io/http-token":    "1",
+					"acme.cert-manager.io/http01-solver": "true",
 				}
 				resultingPod.Annotations = map[string]string{
 					"sidecar.istio.io/inject": "true",

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/apiservice.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/apiservice.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
   annotations:
-    certmanager.k8s.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
+    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "example-webhook.servingCertificate" . }}"
 spec:
   group: {{ .Values.groupName }}
   groupPriorityMinimum: 1000

--- a/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/pki.yaml
+++ b/test/e2e/framework/addon/samplewebhook/sample/chart/example-webhook/templates/pki.yaml
@@ -1,7 +1,7 @@
 ---
 # Create a selfsigned Issuer, in order to create a root CA certificate for
 # signing webhook serving certificates
-apiVersion: certmanager.k8s.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "example-webhook.selfSignedIssuer" . }}
@@ -17,7 +17,7 @@ spec:
 ---
 
 # Generate a CA Certificate used to sign certificates for the webhook
-apiVersion: certmanager.k8s.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "example-webhook.rootCACertificate" . }}
@@ -38,7 +38,7 @@ spec:
 ---
 
 # Create an Issuer that uses the above generated CA certificate to issue certs
-apiVersion: certmanager.k8s.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha2
 kind: Issuer
 metadata:
   name: {{ include "example-webhook.rootCAIssuer" . }}
@@ -55,7 +55,7 @@ spec:
 ---
 
 # Finally, generate a serving certificate for the webhook to use
-apiVersion: certmanager.k8s.io/v1alpha2
+apiVersion: cert-manager.io/v1alpha2
 kind: Certificate
 metadata:
   name: {{ include "example-webhook.servingCertificate" . }}

--- a/test/e2e/framework/util.go
+++ b/test/e2e/framework/util.go
@@ -98,7 +98,7 @@ func RbacClusterRoleHasAccessToResource(f *Framework, clusterRole string, verb s
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Namespace: f.Namespace.Name,
 				Verb:      verb,
-				Group:     "certmanager.k8s.io",
+				Group:     "cert-manager.io",
 				Resource:  resource,
 			},
 		},

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -60,7 +60,7 @@ type acmeIssuerProvisioner struct {
 	tiller *tiller.Tiller
 	pebble *pebble.Pebble
 	// if setGroupName is true, the 'group name' field on the IssuerRef will be
-	// set the 'certmanager.k8s.io'.
+	// set the 'cert-manager.io'.
 	// Setting the group name will cause the new 'certificate requests' based
 	// implementation to be used, however this is not implemented for ACME yet
 	// See: https://github.com/jetstack/cert-manager/pull/1943

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -288,7 +288,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 		By("Creating an Ingress with the issuer name annotation set")
 		_, err := ingClient.Create(util.NewIngress(certificateSecretName, certificateSecretName, map[string]string{
-			"certmanager.k8s.io/issuer": issuerName,
+			"cert-manager.io/issuer": issuerName,
 		}, acmeIngressDomain))
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -390,13 +390,13 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 			someURL := "https://localhost:8675"
 			return &apiext.CustomResourceDefinition{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "objs." + namePrefix + ".testing.certmanager.k8s.io",
+					Name: "objs." + namePrefix + ".testing.cert-manager.io",
 					Annotations: map[string]string{
 						certmanager.WantInjectAnnotation: types.NamespacedName{Name: "serving-certs", Namespace: f.Namespace.Name}.String(),
 					},
 				},
 				Spec: apiext.CustomResourceDefinitionSpec{
-					Group:   namePrefix + ".testing.certmanager.k8s.io",
+					Group:   namePrefix + ".testing.cert-manager.io",
 					Version: "v1",
 					Conversion: &apiext.CustomResourceConversion{
 						Strategy: apiext.WebhookConverter,
@@ -425,7 +425,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 		makeInjectable: func(namePrefix string) runtime.Object {
 			return &apireg.APIService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "v1." + namePrefix + ".testing.certmanager.k8s.io",
+					Name: "v1." + namePrefix + ".testing.cert-manager.io",
 					Annotations: map[string]string{
 						certmanager.WantInjectAnnotation: types.NamespacedName{Name: "serving-certs", Namespace: f.Namespace.Name}.String(),
 					},
@@ -435,7 +435,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 						Name:      "does-not-exit",
 						Namespace: "default",
 					},
-					Group:                namePrefix + ".testing.certmanager.k8s.io",
+					Group:                namePrefix + ".testing.cert-manager.io",
 					Version:              "v1",
 					GroupPriorityMinimum: 1,
 					VersionPriority:      1,


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the use of certmanager.k8s.io in favour of cert-manager.io.

This also changes all annotation keys we support too, meaning it'll require users to update all references across all their resources upon upgrading to 0.11.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1847 

**Release note**:
```release-note
ACTION REQUIRED: Rename `certmanager.k8s.io` API group to `cert-manager.io`
```

/area api
