### PR TITLE
Update to use go 1.13.1

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,10 +19,10 @@ protobuf_deps()
 http_archive(
     name = "io_bazel_rules_go",
     urls = [
-        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
-        "https://github.com/bazelbuild/rules_go/releases/download/0.19.4/rules_go-0.19.4.tar.gz",
+        "https://storage.googleapis.com/bazel-mirror/github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.19.5/rules_go-v0.19.5.tar.gz",
     ],
-    sha256 = "ae8c36ff6e565f674c7a3692d6a9ea1096e4c1ade497272c2108a810fb39acd2",
+    sha256 = "513c12397db1bc9aa46dd62f02dd94b49a9b5d17444d49b5a04c5a89f3053c1c",
 )
 
 load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
@@ -30,7 +30,7 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_to
 go_rules_dependencies()
 
 go_register_toolchains(
-    go_version = "1.12.7",
+    go_version = "1.13.1",
 )
 
 ## Load gazelle and dependencies

--- a/go.mod
+++ b/go.mod
@@ -33,12 +33,10 @@ require (
 	github.com/go-openapi/spec v0.19.2
 	github.com/go-sql-driver/mysql v1.4.1 // indirect
 	github.com/gocql/gocql v0.0.0-20190402132108-0e1d5de854df // indirect
-	github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db // indirect
 	github.com/google/btree v1.0.0 // indirect
 	github.com/google/go-github v17.0.0+incompatible
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.0.0
-	github.com/gorilla/context v1.1.1 // indirect
 	github.com/gorilla/mux v1.6.2
 	github.com/gotestyourself/gotestyourself v2.2.0+incompatible // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.1 // indirect

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -35,6 +35,8 @@ KAZEL = "@io_k8s_repo_infra//cmd/kazel"
 
 GO = "@go_sdk//:bin/go"
 
+GOROOT = "@go_sdk//:files"
+
 JQ = "@com_github_jetstack_cert_manager//hack/bin:jq"
 
 # Bazel file generation rules
@@ -165,6 +167,7 @@ sh_binary(
     data = [
         ":update-bazel",
         GO,
+        GOROOT,
         GAZELLE,
         KAZEL,
         "@io_k8s_code_generator//cmd/client-gen",
@@ -196,6 +199,7 @@ sh_test(
         ":update-bazel",
         ":update-codegen",
         GO,
+        GOROOT,
         GAZELLE,
         KAZEL,
         "@//:all-srcs",

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -36,6 +36,8 @@ tmpfiles=$TEST_TMPDIR/files
   mkdir -p "$tmpfiles"
   rm -f bazel-*
   cp -aL "." "$tmpfiles"
+  # clean up 'external' directory copied from test runfiles
+  rm -rf "$tmpfiles"/external
   export BUILD_WORKSPACE_DIRECTORY=$tmpfiles
   export HOME=$(realpath "$TEST_TMPDIR/home")
   unset GOPATH
@@ -52,10 +54,7 @@ tmpfiles=$TEST_TMPDIR/files
 )
 # Avoid diff -N so we handle empty files correctly
 diff=$(diff -upr \
-  -x ".git" \
-  -x "bazel-*" \
-  -x "_output" \
-  "." "$tmpfiles" 2>/dev/null || true)
+  "./pkg" "$tmpfiles/pkg" 2>/dev/null || true)
 
 if [[ -n "${diff}" ]]; then
   echo "${diff}" >&2

--- a/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -211,7 +211,7 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 	if in.Duration != nil {
 		in, out := &in.Duration, &out.Duration
 		*out = new(v1.Duration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	out.IssuerRef = in.IssuerRef
 	if in.CSRPEM != nil {
@@ -285,12 +285,12 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 	if in.Duration != nil {
 		in, out := &in.Duration, &out.Duration
 		*out = new(v1.Duration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.RenewBefore != nil {
 		in, out := &in.RenewBefore, &out.RenewBefore
 		*out = new(v1.Duration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.DNSNames != nil {
 		in, out := &in.DNSNames, &out.DNSNames

--- a/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -211,7 +211,7 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 	if in.Duration != nil {
 		in, out := &in.Duration, &out.Duration
 		*out = new(v1.Duration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	out.IssuerRef = in.IssuerRef
 	if in.CSRPEM != nil {
@@ -285,12 +285,12 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 	if in.Duration != nil {
 		in, out := &in.Duration, &out.Duration
 		*out = new(v1.Duration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.RenewBefore != nil {
 		in, out := &in.RenewBefore, &out.RenewBefore
 		*out = new(v1.Duration)
-		(*in).DeepCopyInto(*out)
+		**out = **in
 	}
 	if in.DNSNames != nil {
 		in, out := &in.DNSNames, &out.DNSNames

--- a/repos.bzl
+++ b/repos.bzl
@@ -2140,3 +2140,75 @@ def go_repositories():
         sum = "h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=",
         version = "v0.0.0-20140225173054-000000000087",
     )
+    go_repository(
+        name = "com_github_apache_thrift",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/apache/thrift",
+        sum = "h1:pODnxUFNcjP9UTLZGTdeh+j16A8lJbRvD3rOtrk/7bs=",
+        version = "v0.12.0",
+    )
+    go_repository(
+        name = "com_github_eapache_go_resiliency",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/eapache/go-resiliency",
+        sum = "h1:1NtRmCAqadE2FN4ZcN6g90TP3uk8cg9rn9eNK2197aU=",
+        version = "v1.1.0",
+    )
+    go_repository(
+        name = "com_github_eapache_go_xerial_snappy",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/eapache/go-xerial-snappy",
+        sum = "h1:YEetp8/yCZMuEPMUDHG0CW/brkkEp8mzqk2+ODEitlw=",
+        version = "v0.0.0-20180814174437-776d5712da21",
+    )
+    go_repository(
+        name = "com_github_eapache_queue",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/eapache/queue",
+        sum = "h1:YOEu7KNc61ntiQlcEeUIoDTJ2o8mQznoNvUhiigpIqc=",
+        version = "v1.1.0",
+    )
+    go_repository(
+        name = "com_github_openzipkin_zipkin_go",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/openzipkin/zipkin-go",
+        sum = "h1:yXiysv1CSK7Q5yjGy1710zZGnsbMUIjluWBxtLXHPBo=",
+        version = "v0.1.6",
+    )
+    go_repository(
+        name = "com_github_pierrec_lz4",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/pierrec/lz4",
+        sum = "h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=",
+        version = "v2.0.5+incompatible",
+    )
+    go_repository(
+        name = "com_github_rcrowley_go_metrics",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/rcrowley/go-metrics",
+        sum = "h1:9ZKAASQSHhDYGoxY8uLVpewe1GDZ2vu2Tr/vTdVAkFQ=",
+        version = "v0.0.0-20181016184325-3113b8401b8a",
+    )
+    go_repository(
+        name = "com_github_shopify_sarama",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/Shopify/sarama",
+        sum = "h1:9oksLxC6uxVPHPVYUmq6xhr1BOF/hHobWH2UzO67z1s=",
+        version = "v1.19.0",
+    )
+    go_repository(
+        name = "com_github_shopify_toxiproxy",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/Shopify/toxiproxy",
+        sum = "h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=",
+        version = "v2.1.4+incompatible",
+    )


### PR DESCRIPTION
**What this PR does / why we need it**:

Use Golang 1.13.1.

We should also make a corresponding change to bump release-0.10 to go 1.12.10 separately 😄 

**Release note**:
```release-note
Build using Go 1.13.1
```
