### PR TITLE
Correct API group on Vault setup guide

### DIFF
--- a/docs/tasks/issuers/setup-vault.rst
+++ b/docs/tasks/issuers/setup-vault.rst
@@ -225,7 +225,7 @@ authentication method.
 
 .. code-block:: yaml
 
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: Issuer
     metadata:
       name: vault-issuer
@@ -249,7 +249,7 @@ the normal way.
 
 .. code-block:: yaml
 
-    apiVersion: certmanager.k8s.io/v1alpha1
+    apiVersion: cert-manager.io/v1alpha2
     kind: Certificate
     metadata:
       name: example-com


### PR DESCRIPTION
**What this PR does / why we need it**:

After adding the Vault k8s auth stuff, some of the documentation examples still referenced the old API group/version.

**Release note**:
```release-note
NONE
```

/milestone v0.11
/priority critical-urgent
/assign @JoshVanL 