### PR TITLE
Disable atomicalign vet check due to panic on linux/arm

### DIFF
--- a/hack/build/BUILD.bazel
+++ b/hack/build/BUILD.bazel
@@ -31,7 +31,12 @@ nogo(
         "@org_golang_x_tools//go/analysis/passes/buildtag:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/buildssa:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/bools:go_tool_library",
-        "@org_golang_x_tools//go/analysis/passes/atomicalign:go_tool_library",
+        ## Disable atomicalign check as it fails when building with linux/arm
+        ## --platforms flag.
+        ## To reproduce, run:
+        ## bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm @io_k8s_apiserver//pkg/server:go_default_library
+        ## using ref eb61adf0fc3a38b0767df8d3cde16d4ed9e61d3d (HEAD of master).
+        # "@org_golang_x_tools//go/analysis/passes/atomicalign:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/atomic:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/assign:go_tool_library",
         "@org_golang_x_tools//go/analysis/passes/inspect:go_tool_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

Not too sure why, but running the follow fails to govet check due to a panic in the atomicalign plugin:

```
$ bazel build --platforms=@io_bazel_rules_go//go/toolchain:linux_arm @io_k8s_apiserver//pkg/server:go_default_library
INFO: Analyzed target @io_k8s_apiserver//pkg/server:go_default_library (0 packages loaded, 10000 targets configured).
INFO: Found 1 target...
ERROR: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/external/io_k8s_apiserver/pkg/server/BUILD.bazel:3:1: GoCompilePkg external/io_k8s_apiserver/pkg/server/linux_arm_pure_stripped/go_default_library%/k8s.io/apiserver/pkg/server.a failed (Exit 1) builder failed: error executing command bazel-out/host/bin/external/go_sdk/builder compilepkg -sdk external/go_sdk -installsuffix linux_arm -src external/io_k8s_apiserver/pkg/server/config.go -src ... (remaining 155 argument(s) skipped)

Use --sandbox_debug to see verbose messages from the sandbox
compilepkg: panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x12c20d2]

goroutine 74 [running]:
go/types.(*Selection).Obj(...)
	GOROOT/src/go/types/selection.go:56
golang.org/x/tools/go/analysis/passes/atomicalign.check64BitAlignment(0xc0012a8b40, 0xc000019dc6, 0x9, 0x13fb7a0, 0xc0001a9160)
	external/org_golang_x_tools/go/analysis/passes/atomicalign/atomicalign.go:87 +0xb2
golang.org/x/tools/go/analysis/passes/atomicalign.run.func1(0x13f6720, 0xc0001a4640)
	external/org_golang_x_tools/go/analysis/passes/atomicalign/atomicalign.go:65 +0x172
golang.org/x/tools/go/ast/inspector.(*Inspector).Preorder(0xc001287800, 0xc0012d6d48, 0x1, 0x1, 0xc0012d6d38)
	external/org_golang_x_tools/go/ast/inspector/inspector.go:77 +0x9f
golang.org/x/tools/go/analysis/passes/atomicalign.run(0xc0012a8b40, 0xc001352ea0, 0x1601dc0, 0xc00083d7d8, 0x56fe002d65636976)
	external/org_golang_x_tools/go/analysis/passes/atomicalign/atomicalign.go:42 +0x158
main.(*action).execOnce(0xc000160f30)
	external/io_bazel_rules_go/go/tools/builders/nogo_main.go:275 +0x578
sync.(*Once).doSlow(0xc000160f30, 0xc0012a2790)
	GOROOT/src/sync/once.go:66 +0xe3
sync.(*Once).Do(...)
	GOROOT/src/sync/once.go:57
main.(*action).exec(0xc000160f30)
	external/io_bazel_rules_go/go/tools/builders/nogo_main.go:225 +0x60
main.execAll.func1(0xc00112d110, 0xc000160f30)
	external/io_bazel_rules_go/go/tools/builders/nogo_main.go:218 +0x2b
created by main.execAll
	external/io_bazel_rules_go/go/tools/builders/nogo_main.go:217 +0x87
Target @io_k8s_apiserver//pkg/server:go_default_library failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 3.823s, Critical Path: 1.97s
INFO: 0 processes.
```

This caused the v0.11.0-alpha.0 release to fail as we had not run the release smoke test presubmit/periodic job ahead of cutting the release.

**Special notes for your reviewer**:

I'm not sure what's causing this, and it only seems to occur with the `k8s.io/apiserver/pkg/server` package (using the `kubernetes-1.16.0` tag of `k8s.io/apiserver`).

**Release note**:
```release-note
NONE
```
