### PR TITLE
Remove use of deprecated client.MatchingField

### DIFF
--- a/pkg/controller/cainjector/indexers.go
+++ b/pkg/controller/cainjector/indexers.go
@@ -42,7 +42,7 @@ func buildCertToInjectableFunc(listTyp runtime.Object, resourceName string) cert
 	return func(log logr.Logger, cl client.Client, certName types.NamespacedName) []ctrl.Request {
 		log = log.WithValues("type", resourceName)
 		objs := listTyp.DeepCopyObject()
-		if err := cl.List(context.Background(), objs, client.MatchingField(injectFromPath, certName.String())); err != nil {
+		if err := cl.List(context.Background(), objs, client.MatchingFields{injectFromPath: certName.String()}); err != nil {
 			log.Error(err, "unable to fetch injectables associated with certificate")
 			return nil
 		}
@@ -145,7 +145,7 @@ func buildSecretToInjectableFunc(listTyp runtime.Object, resourceName string) se
 	return func(log logr.Logger, cl client.Client, secretName types.NamespacedName) []ctrl.Request {
 		log = log.WithValues("type", resourceName)
 		objs := listTyp.DeepCopyObject()
-		if err := cl.List(context.Background(), objs, client.MatchingField(injectFromSecretPath, secretName.String())); err != nil {
+		if err := cl.List(context.Background(), objs, client.MatchingFields{injectFromSecretPath: secretName.String()}); err != nil {
 			log.Error(err, "unable to fetch injectables associated with secret")
 			return nil
 		}


### PR DESCRIPTION
Signed-off-by: Ingo Gottwald <in.gottwald@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Removes the use of a deprecated function.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
