### PR TITLE
Cleanup clouddns package

### DIFF
--- a/pkg/issuer/acme/dns/clouddns/BUILD.bazel
+++ b/pkg/issuer/acme/dns/clouddns/BUILD.bazel
@@ -9,8 +9,8 @@ go_library(
         "//pkg/issuer/acme/dns/util:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@org_golang_google_api//dns/v1:go_default_library",
+        "@org_golang_google_api//option:go_default_library",
         "@org_golang_x_net//context:go_default_library",
-        "@org_golang_x_oauth2//:go_default_library",
         "@org_golang_x_oauth2//google:go_default_library",
     ],
 )

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -17,9 +17,9 @@ import (
 	"time"
 
 	"golang.org/x/net/context"
-	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
+	"google.golang.org/api/option"
 
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"k8s.io/klog"
@@ -71,11 +71,12 @@ func NewDNSProviderCredentials(project string, dns01Nameservers []string) (*DNSP
 		return nil, fmt.Errorf("Google Cloud project name missing")
 	}
 
-	client, err := google.DefaultClient(context.Background(), dns.NdevClouddnsReadwriteScope)
+	ctx := context.Background()
+	client, err := google.DefaultClient(ctx, dns.NdevClouddnsReadwriteScope)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to get Google Cloud client: %v", err)
 	}
-	svc, err := dns.New(client)
+	svc, err := dns.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create Google Cloud DNS service: %v", err)
 	}
@@ -117,9 +118,11 @@ func NewDNSProviderServiceAccountBytes(project string, saBytes []byte, dns01Name
 	if err != nil {
 		return nil, fmt.Errorf("Unable to acquire config: %v", err)
 	}
-	client := conf.Client(oauth2.NoContext)
 
-	svc, err := dns.New(client)
+	ctx := context.Background()
+	client := conf.Client(ctx)
+
+	svc, err := dns.NewService(ctx, option.WithHTTPClient(client))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create Google Cloud DNS service: %v", err)
 	}

--- a/pkg/issuer/acme/dns/clouddns/clouddns_test.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns_test.go
@@ -89,6 +89,7 @@ func TestLiveGoogleCloudPresentMultiple(t *testing.T) {
 
 	// Check that we're able to create multiple entries
 	err = provider.Present(gcloudDomain, "_acme-challenge."+gcloudDomain+".", "123d==")
+	assert.NoError(t, err)
 	err = provider.Present(gcloudDomain, "_acme-challenge."+gcloudDomain+".", "1123d==")
 	assert.NoError(t, err)
 }


### PR DESCRIPTION
- Replace deprecated dns.New function with dns.NewService
- Remove deprecated oauth2.NoContext
- Fix unused err value in test

Signed-off-by: Ingo Gottwald <in.gottwald@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Code maintenance in the clouddns package (see above)

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
