### PR TITLE
Update default leader election namespace to be kube-system

### DIFF
--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -77,7 +77,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `global.rbac.create` | If `true`, create and use RBAC resources (includes sub-charts) | `true` |
 | `global.priorityClassName`| Priority class name for cert-manager and webhook pods | `""` |
 | `global.podSecurityPolicy.enabled` | If `true`, create and use PodSecurityPolicy (includes sub-charts) | `false` |
-| `global.leaderElection.namespace` | Override the namespace used to store the ConfigMap for leader election | Same namespace as cert-manager pod |
+| `global.leaderElection.namespace` | Override the namespace used to store the ConfigMap for leader election | `kube-system` |
 | `image.repository` | Image repository | `quay.io/jetstack/cert-manager-controller` |
 | `image.tag` | Image tag | `v0.11.0-beta.0` |
 | `image.pullPolicy` | Image pull policy | `IfNotPresent` |

--- a/deploy/charts/cert-manager/cainjector/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/cainjector/templates/deployment.yaml
@@ -46,11 +46,7 @@ spec:
           {{- if .Values.global.logLevel }}
           - --v={{ .Values.global.logLevel }}
           {{- end }}
-          {{- if .Values.global.leaderElection.namespace }}
           - --leader-election-namespace={{ .Values.global.leaderElection.namespace }}
-          {{- else }}
-          - --leader-election-namespace=$(POD_NAMESPACE)
-          {{- end }}
           {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
           {{- end }}

--- a/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/cainjector/templates/rbac.yaml
@@ -17,7 +17,7 @@ rules:
     resources: ["secrets"]
     verbs: ["get", "list", "watch"]
   - apiGroups: [""]
-    resources: ["configmaps", "events"]
+    resources: ["events"]
     verbs: ["get", "create", "update", "patch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations", "mutatingwebhookconfigurations"]
@@ -47,4 +47,51 @@ subjects:
   - name: {{ include "cainjector.fullname" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+
+---
+# leader election rules
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  name: {{ template "cainjector.fullname" . }}:leaderelection
+  namespace: {{ .Values.global.leaderElection.namespace }}
+  labels:
+    app: {{ template "cainjector.name" . }}
+    app.kubernetes.io/name: {{ template "cainjector.name" . }}
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ template "cainjector.chart" . }}
+rules:
+  # Used for leader election by the controller
+  # TODO: refine the permission to *just* the leader election configmap
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+
+---
+
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ include "cainjector.fullname" . }}:leaderelection
+  namespace: {{ .Values.global.leaderElection.namespace }}
+  labels:
+    app: {{ include "cainjector.name" . }}
+    app.kubernetes.io/name: {{ include "cainjector.name" . }}
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "cainjector.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "cainjector.fullname" . }}:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "cainjector.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+
+
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -64,11 +64,7 @@ spec:
         {{- else }}
           - --cluster-resource-namespace=$(POD_NAMESPACE)
         {{- end }}
-        {{- if .Values.global.leaderElection.namespace }}
           - --leader-election-namespace={{ .Values.global.leaderElection.namespace }}
-        {{- else }}
-          - --leader-election-namespace=$(POD_NAMESPACE)
-        {{- end }}
         {{- if .Values.extraArgs }}
 {{ toYaml .Values.extraArgs | indent 10 }}
         {{- end }}

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -1,9 +1,10 @@
 {{- if .Values.global.rbac.create -}}
 
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRole
+kind: Role
 metadata:
-  name: {{ template "cert-manager.fullname" . }}-leaderelection
+  name: {{ template "cert-manager.fullname" . }}:leaderelection
+  namespace: {{ .Values.global.leaderElection.namespace }}
   labels:
     app: {{ template "cert-manager.name" . }}
     app.kubernetes.io/name: {{ template "cert-manager.name" . }}
@@ -12,9 +13,35 @@ metadata:
     helm.sh/chart: {{ template "cert-manager.chart" . }}
 rules:
   # Used for leader election by the controller
+  # TODO: refine the permission to *just* the leader election configmap
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "create", "update", "patch"]
+
+---
+
+# grant cert-manager permission to manage the leaderelection configmap in the
+# leader election namespace
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: {{ include "cert-manager.fullname" . }}:leaderelection
+  namespace: {{ .Values.global.leaderElection.namespace }}
+  labels:
+    app: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/name: {{ include "cert-manager.name" . }}
+    app.kubernetes.io/instance:  {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "cert-manager.chart" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "cert-manager.fullname" . }}:leaderelection
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: {{ include "cert-manager.fullname" . }}
+    namespace: {{ .Release.Namespace }}
 
 ---
 

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -21,7 +21,7 @@ global:
 
   leaderElection:
     # Override the namespace used to store the ConfigMap for leader election
-    namespace: ""
+    namespace: "kube-system"
 
 replicaCount: 1
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes the default leader election namespace to no longer be the same namespace as cert-manager is running within.

In practice, this has caused issues such as #2150, and potential #1948 too.

Setting this to always be kube-system unless manually overridden will mean that unless a user *explicitly* tries to run multiple copies per cluster, leader election will be performed properly.

**Which issue this PR fixes**: fixes # (potentially 1948)

**Special notes for your reviewer**:

We *may* want to consider backporting this to v0.10, even though it is a more substantial change that we'd normally backport. On the other hand, we should be encouraging users to upgrade regularly anyway (and v0.11 contains *further* changes to the ACME flow which should improve its performance).

**Release note**:
```release-note
Change the default leader election namespace to 'kube-system' instead of the same namespace as the cert-manager pod, to avoid multiple copies of cert-manager accidentally being run at once
```

cc @jsha @cpu
/milestone v0.11