### PR TITLE
Fix regression in certificates controller setting owner references

### DIFF
--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller:go_default_library",
         "//pkg/controller/test:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/pki:go_default_library",

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -76,6 +76,12 @@ type certificateRequestManager struct {
 
 	// localTemporarySigner signs a certificate that is stored temporarily
 	localTemporarySigner localTemporarySignerFn
+
+	// if true, Secret resources created by the controller will have an
+	// 'owner reference' set, meaning when the Certificate is deleted, the
+	// Secret resource will be automatically deleted.
+	// This option is disabled by default.
+	enableSecretOwnerReferences bool
 }
 
 type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, error)
@@ -131,6 +137,7 @@ func (c *certificateRequestManager) Register(ctx *controllerpkg.Context) (workqu
 	// the localTemporarySigner is used to sign 'temporary certificates' during
 	// asynchronous certificate issuance flows
 	c.localTemporarySigner = generateLocallySignedTemporaryCertificate
+	c.enableSecretOwnerReferences = ctx.CertificateOptions.EnableOwnerRef
 
 	c.cmClient = ctx.CMClient
 	c.kubeClient = ctx.Client

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -129,7 +129,7 @@ type IngressShimOptions struct {
 }
 
 type CertificateOptions struct {
-	// EnableOwnerRef controls wheter wheter the certificate is configured as an owner of
+	// EnableOwnerRef controls whether the certificate is configured as an owner of
 	// secret where the effective TLS certificate is stored.
 	EnableOwnerRef bool
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Properly implements and tests the setting owner reference functionality on secret resources.

Thanks to @jcassee for spotting this in the beta ahead of release 🎉 

**Which issue this PR fixes**: fixes #2172 

**Special notes for your reviewer**:

**Release note**:
```release-note
NONE
```

/milestone v0.11
/assign @JoshVanL 
/cc @jcassee