### PR TITLE
Advise users to set --validate=false when installing with kubectl

### DIFF
--- a/docs/getting-started/install/kubernetes.rst
+++ b/docs/getting-started/install/kubernetes.rst
@@ -61,12 +61,13 @@ are included in a single YAML manifest file:
    kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v0.11.0/cert-manager.yaml
 
 .. note::
-   If you are running kubectl v1.12 or below, you will need to add the
+   If you are running Kubernetes v1.15 or below, you will need to add the
    ``--validate=false`` flag to your ``kubectl apply`` command above else you
-   will receive a validation error relating to the ``caBundle`` field of the
-   ``ValidatingWebhookConfiguration`` resource.
-   This issue is resolved in Kubernetes 1.13 onwards. More details can be found
-   in `kubernetes/kubernetes#69590`_.
+   will receive a validation error relating to the
+   ``x-kubernetes-preserve-unknown-fields`` field in our
+   ``CustomResourceDefinition`` resources.
+   This is a benign error and occurs due to the way ``kubectl`` performs
+   resource validation.
 
 .. note::
    When running on GKE (Google Kubernetes Engine), you may encounter a
@@ -116,7 +117,7 @@ In order to install the Helm chart, you must run:
 .. code-block:: shell
 
    # Install the CustomResourceDefinition resources separately
-   kubectl apply -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
+   kubectl apply --validate=false -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml
 
    # Create the namespace for cert-manager
    kubectl create namespace cert-manager

--- a/docs/tasks/upgrading/index.rst
+++ b/docs/tasks/upgrading/index.rst
@@ -33,6 +33,7 @@ version number you want to install:
    # Install the cert-manager CustomResourceDefinition resources before
    # upgrading the Helm chart
    kubectl apply \
+        --validate=false \
         -f https://raw.githubusercontent.com/jetstack/cert-manager/<version>/deploy/manifests/00-crds.yaml
 
    # Add the Jetstack Helm repository if you haven't already
@@ -67,15 +68,17 @@ version number you want to install:
 .. code:: shell
 
    kubectl apply \
+        --validate=false \
         -f https://github.com/jetstack/cert-manager/releases/download/<version>/cert-manager.yaml
 
 .. note::
-   If you are running kubectl v1.12 or below, you will need to add the
+   If you are running Kubernetes v1.15 or below, you will need to add the
    ``--validate=false`` flag to your ``kubectl apply`` command above else you
-   will receive a validation error relating to the ``caBundle`` field of the
-   ``ValidatingWebhookConfiguration`` resource.
-   This issue is resolved in Kubernetes 1.13 onwards. More details can be found
-   in `kubernetes/kubernetes#69590`_.
+   will receive a validation error relating to the
+   ``x-kubernetes-preserve-unknown-fields`` field in our
+   ``CustomResourceDefinition`` resources.
+   This is a benign error and occurs due to the way ``kubectl`` performs
+   resource validation.
 
 .. toctree::
    :maxdepth: 1


### PR DESCRIPTION
**What this PR does / why we need it**:

This is to avoid errors like:

```
error: error validating "https://raw.githubusercontent.com/jetstack/cert-manager/release-0.11/deploy/manifests/00-crds.yaml": error validating data: ValidationError(CustomResourceDefinition.spec.validation.openAPIV3Schema.properties.spec.properties.solver.properties.dns01.properties.webhook.properties.config): unknown field "x-kubernetes-preserve-unknown-fields" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.JSONSchemaProps; if you choose to ignore these errors, turn validation off with --validate=false
```

When installing our CRD resources against a Kubernetes apiserver running 1.14 or below.

**Release note**:
```release-note
NONE
```

/milestone v0.11
/assign @JoshVanL 