### PR TITLE
Print 'kubectl apply' output during e2e tests

### DIFF
--- a/test/e2e/framework/addon/certmanager/BUILD.bazel
+++ b/test/e2e/framework/addon/certmanager/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//test/e2e/framework/addon/chart:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/config:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
     ],
 )
 

--- a/test/e2e/framework/addon/certmanager/addon.go
+++ b/test/e2e/framework/addon/certmanager/addon.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/chart"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	"github.com/jetstack/cert-manager/test/e2e/framework/config"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 )
 
 // Certmanager defines an addon that installs an instance of certmanager in the
@@ -95,7 +96,10 @@ func (p *Certmanager) Setup(cfg *config.Config) error {
 
 // Provision will actually deploy this instance of Pebble-ingress to the cluster.
 func (p *Certmanager) Provision() error {
-	if err := exec.Command(p.config.Kubectl, "apply", "--validate=false", "-f", p.config.RepoRoot+"/deploy/manifests/00-crds.yaml").Run(); err != nil {
+	cmd := exec.Command(p.config.Kubectl, "apply", "--validate=false", "-f", p.config.RepoRoot+"/deploy/manifests/00-crds.yaml")
+	cmd.Stdout = log.Writer
+	cmd.Stderr = log.Writer
+	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("error install cert-manager CRD manifests: %v", err)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This should help us debug persistent Kubernetes 1.11 e2e test failures: https://testgrid.k8s.io/jetstack-cert-manager-master#cert-manager-master-e2e-v1-11&sort-by-flakiness=

**Release note**:
```release-note
NONE
```
