### PR TITLE
Remove deprecated arguments from helm chart deployment

### DIFF
--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -97,8 +97,6 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `tolerations` | Node tolerations for pod assignment | `[]` |
 | `ingressShim.defaultIssuerName` | Optional default issuer to use for ingress resources |  |
 | `ingressShim.defaultIssuerKind` | Optional default issuer kind to use for ingress resources |  |
-| `ingressShim.defaultACMEChallengeType` | Optional default challenge type to use for ingresses using ACME issuers |  |
-| `ingressShim.defaultACMEDNS01ChallengeProvider` | Optional default DNS01 challenge provider to use for ingresses using ACME issuers with DNS01 |  |
 | `prometheus.enabled` | Enable Prometheus monitoring | `true` |
 | `prometheus.servicemonitor.enabled` | Enable Prometheus Operator ServiceMonitor monitoring | `false` |
 | `prometheus.servicemonitor.namespace` | Define namespace where to deploy the ServiceMonitor resource | (namespace where you are deploying) |

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -78,12 +78,6 @@ spec:
           {{- if .defaultIssuerGroup }}
           - --default-issuer-group={{ .defaultIssuerGroup }}
           {{- end }}
-          {{- if .defaultACMEChallengeType }}
-          - --default-acme-issuer-challenge-type={{ .defaultACMEChallengeType }}
-          {{- end }}
-          {{- if .defaultACMEDNS01ChallengeProvider }}
-          - --default-acme-issuer-dns01-provider-name={{ .defaultACMEDNS01ChallengeProvider }}
-          {{- end }}
           {{- end }}
           - --webhook-namespace=$(POD_NAMESPACE)
           - --webhook-ca-secret={{ include "webhook.rootCACertificate" . }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -97,8 +97,6 @@ ingressShim: {}
   # defaultIssuerName: ""
   # defaultIssuerKind: ""
   # defaultIssuerGroup: ""
-  # defaultACMEChallengeType: ""
-  # defaultACMEDNS01ChallengeProvider: ""
 
 prometheus:
   enabled: true


### PR DESCRIPTION
**What this PR does / why we need it**:

The controller arguments `--default-acme-issuer-challenge-type` and `--default-acme-issuer-dns01-provider-name` are not available in version 0.11.

This causes the deployment pod to fail in a CrashLoopBackOff when a value was defined.

This PR removes the ability to define these deprecated arguments. 


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Release note**:
```NONE
```
