### PR TITLE
Removes leaderelection ClusterRoleBinding

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -270,27 +270,6 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "cert-manager.fullname" . }}-leaderelection
-  labels:
-    app: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/name: {{ template "cert-manager.name" . }}
-    app.kubernetes.io/instance:  {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ template "cert-manager.chart" . }}
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: {{ template "cert-manager.fullname" . }}-leaderelection
-subjects:
-  - name: {{ template "cert-manager.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace | quote }}
-    kind: ServiceAccount
-
----
-
-apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: ClusterRoleBinding
-metadata:
   name: {{ template "cert-manager.fullname" . }}-controller-issuers
   labels:
     app: {{ template "cert-manager.name" . }}


### PR DESCRIPTION
This is done to give preference to the new leaderelection RoleBinding in 'kube-system'

Related to issue

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Depending on which of these 2 (cluster)rolebindings are picked up by cert-manager deployment:
1. `cert-manager:leaderelection` in RoleBindings - kube-system namespace
1. `cert-manager-leaderelection` in ClusterRoleBindings

'Cert-manager' deployment either works or crashes. If 'cert-manager' deployment picks `cert-manager-leaderelection` it crashes.


**Special notes for your reviewer**:
My suspicion is that helm based charts are working fine because of the order of resource application in deployment.

Affects v0.11.0 release.

Related to: kubeflow/manifests#369

/cc @munnerz 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
