### PR TITLE
Make Order resource status & Challenge spec fields immutable

### DIFF
--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -14,12 +14,10 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/webhook",
     visibility = ["//visibility:private"],
     deps = [
-        "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/webhook:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
         "//pkg/webhook/server:go_default_library",
-        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@io_k8s_klog//klogr:go_default_library",
     ],

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -23,11 +23,9 @@ import (
 	"os/signal"
 	"syscall"
 
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/klog"
 	"k8s.io/klog/klogr"
 
-	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	"github.com/jetstack/cert-manager/pkg/logs"
 	"github.com/jetstack/cert-manager/pkg/webhook"
 	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
@@ -35,8 +33,6 @@ import (
 )
 
 var (
-	GroupName = "webhook." + v1alpha2.SchemeGroupVersion.Group
-
 	securePort  int
 	healthzPort int
 	tlsCertFile string
@@ -50,16 +46,7 @@ func init() {
 	flag.StringVar(&tlsKeyFile, "tls-private-key-file", "", "path to the file containing the TLS private key to serve with")
 }
 
-var (
-	validationFuncs = map[schema.GroupVersionKind]handlers.ValidationFunc{
-		v1alpha2.SchemeGroupVersion.WithKind(v1alpha2.CertificateKind):        webhook.ValidateCertificate,
-		v1alpha2.SchemeGroupVersion.WithKind(v1alpha2.CertificateRequestKind): webhook.ValidateCertificateRequest,
-		v1alpha2.SchemeGroupVersion.WithKind(v1alpha2.IssuerKind):             webhook.ValidateIssuer,
-		v1alpha2.SchemeGroupVersion.WithKind(v1alpha2.ClusterIssuerKind):      webhook.ValidateClusterIssuer,
-	}
-)
-
-var validationHook handlers.ValidatingAdmissionHook = handlers.NewFuncBackedValidator(logs.Log, webhook.Scheme, validationFuncs)
+var validationHook handlers.ValidatingAdmissionHook = handlers.NewFuncBackedValidator(logs.Log, webhook.Scheme, webhook.Validators)
 var mutationHook handlers.MutatingAdmissionHook = handlers.NewSchemeBackedDefaulter(logs.Log, webhook.Scheme)
 
 func main() {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -59,8 +59,8 @@ var (
 	}
 )
 
-var validationHook handlers.ValidatingAdmissionHook = handlers.NewFuncBackedValidator(logs.Log, GroupName, webhook.Scheme, validationFuncs)
-var mutationHook handlers.MutatingAdmissionHook = handlers.NewSchemeBackedDefaulter(logs.Log, GroupName, webhook.Scheme)
+var validationHook handlers.ValidatingAdmissionHook = handlers.NewFuncBackedValidator(logs.Log, webhook.Scheme, validationFuncs)
+var mutationHook handlers.MutatingAdmissionHook = handlers.NewSchemeBackedDefaulter(logs.Log, webhook.Scheme)
 
 func main() {
 	klog.InitFlags(flag.CommandLine)

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -36,6 +36,16 @@ webhooks:
           - issuers
           - clusterissuers
           - certificaterequests
+      - apiGroups:
+          - "acme.cert-manager.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - orders
+          - challenges
     failurePolicy: Fail
     sideEffects: None
     clientConfig:

--- a/pkg/apis/acme/v1alpha2/types.go
+++ b/pkg/apis/acme/v1alpha2/types.go
@@ -38,5 +38,6 @@ const (
 )
 
 const (
-	OrderKind = "Order"
+	OrderKind     = "Order"
+	ChallengeKind = "Challenge"
 )

--- a/pkg/internal/apis/acme/BUILD.bazel
+++ b/pkg/internal/apis/acme/BUILD.bazel
@@ -37,6 +37,7 @@ filegroup(
         "//pkg/internal/apis/acme/fuzzer:all-srcs",
         "//pkg/internal/apis/acme/install:all-srcs",
         "//pkg/internal/apis/acme/v1alpha2:all-srcs",
+        "//pkg/internal/apis/acme/validation:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/internal/apis/acme/validation/BUILD.bazel
+++ b/pkg/internal/apis/acme/validation/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "challenge.go",
+        "order.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/pkg/internal/apis/acme/validation",
+    visibility = ["//pkg:__subpackages__"],
+    deps = [
+        "//pkg/apis/acme/v1alpha2:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "challenge_test.go",
+        "order_test.go",
+    ],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/acme/v1alpha2:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/internal/apis/acme/validation/challenge.go
+++ b/pkg/internal/apis/acme/validation/challenge.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"reflect"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
+)
+
+func ValidateChallengeUpdate(oldObj, newObj runtime.Object) field.ErrorList {
+	old, ok := oldObj.(*cmacme.Challenge)
+	new := newObj.(*cmacme.Challenge)
+	// if oldObj is not set, the Update operation is always valid.
+	if !ok || old == nil {
+		return nil
+	}
+
+	el := field.ErrorList{}
+	if !reflect.DeepEqual(old.Spec, new.Spec) {
+		el = append(el, field.Forbidden(field.NewPath("spec"), "challenge spec is immutable after creation"))
+	}
+
+	return el
+}

--- a/pkg/internal/apis/acme/validation/challenge_test.go
+++ b/pkg/internal/apis/acme/validation/challenge_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
+)
+
+func TestValidateChallengeUpdate(t *testing.T) {
+	scenarios := map[string]struct {
+		old, new *cmacme.Challenge
+		errs     []*field.Error
+	}{
+		"allows setting challenge spec for the first time": {
+			new: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					URL: "testurl",
+				},
+			},
+		},
+		"disallow updating challenge spec": {
+			old: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					URL: "testurl",
+				},
+			},
+			new: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					URL: "newtesturl",
+				},
+			},
+			errs: []*field.Error{
+				field.Forbidden(field.NewPath("spec"), "challenge spec is immutable after creation"),
+			},
+		},
+		"allow updating challenge spec if no changes are made": {
+			old: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					URL: "testurl",
+				},
+			},
+			new: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					URL: "testurl",
+				},
+			},
+		},
+	}
+	for n, s := range scenarios {
+		t.Run(n, func(t *testing.T) {
+			errs := ValidateChallengeUpdate(s.old, s.new)
+			if len(errs) != len(s.errs) {
+				t.Errorf("Expected %v but got %v", s.errs, errs)
+				return
+			}
+			for i, e := range errs {
+				expectedErr := s.errs[i]
+				if !reflect.DeepEqual(e, expectedErr) {
+					t.Errorf("Expected %v but got %v", expectedErr, e)
+				}
+			}
+		})
+	}
+}

--- a/pkg/internal/apis/acme/validation/order.go
+++ b/pkg/internal/apis/acme/validation/order.go
@@ -1,0 +1,120 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"bytes"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
+)
+
+func ValidateOrderUpdate(oldObj, newObj runtime.Object) field.ErrorList {
+	old, ok := oldObj.(*cmacme.Order)
+	new := newObj.(*cmacme.Order)
+	// if oldObj is not set, the Update operation is always valid.
+	if !ok || old == nil {
+		return nil
+	}
+
+	el := field.ErrorList{}
+	el = append(el, ValidateOrderSpecUpdate(old.Spec, new.Spec, field.NewPath("spec"))...)
+	el = append(el, ValidateOrderStatusUpdate(old.Status, new.Status, field.NewPath("status"))...)
+	return el
+}
+
+func ValidateOrderSpecUpdate(old, new cmacme.OrderSpec, fldPath *field.Path) field.ErrorList {
+	el := field.ErrorList{}
+	if len(old.CSR) > 0 && bytes.Compare(old.CSR, new.CSR) != 0 {
+		el = append(el, field.Forbidden(fldPath.Child("csr"), "field is immutable once set"))
+	}
+	return el
+}
+
+func ValidateOrderStatusUpdate(old, new cmacme.OrderStatus, fldPath *field.Path) field.ErrorList {
+	el := field.ErrorList{}
+	// once the order URL has been set, it cannot be changed
+	if old.URL != "" && old.URL != new.URL {
+		el = append(el, field.Forbidden(fldPath.Child("url"), "field is immutable once set"))
+	}
+	// once the FinalizeURL has been set, it cannot be changed
+	if old.FinalizeURL != "" && old.FinalizeURL != new.FinalizeURL {
+		el = append(el, field.Forbidden(fldPath.Child("finalizeURL"), "field is immutable once set"))
+	}
+	// once the Certificate has been issued, it cannot be changed
+	if len(old.Certificate) > 0 && bytes.Compare(old.Certificate, new.Certificate) != 0 {
+		el = append(el, field.Forbidden(fldPath.Child("certificate"), "field is immutable once set"))
+	}
+
+	if len(old.Authorizations) > 0 {
+		fldPath := fldPath.Child("authorizations")
+
+		// once at least one Authorization has been inserted, no more can be added
+		// or deleted from the Order
+		if len(old.Authorizations) != len(new.Authorizations) {
+			el = append(el, field.Forbidden(fldPath, "field is immutable once set"))
+		}
+
+		// here we know that len(old) == len(new), so we proceed to validate
+		// the updates that the user requested on each Authorization.
+		// fields on Authorization's cannot be changed after being set from
+		// their zero value.
+		for i := range old.Authorizations {
+			fldPath := fldPath.Index(i)
+			old := old.Authorizations[i]
+			new := new.Authorizations[i]
+			if old.URL != "" && old.URL != new.URL {
+				el = append(el, field.Forbidden(fldPath.Child("url"), "field is immutable once set"))
+			}
+			if old.Identifier != "" && old.Identifier != new.Identifier {
+				el = append(el, field.Forbidden(fldPath.Child("identifier"), "field is immutable once set"))
+			}
+			// don't allow the value of the Wildcard field to change unless the
+			// old value is nil
+			if old.Wildcard != nil && (new.Wildcard == nil || *old.Wildcard != *new.Wildcard) {
+				el = append(el, field.Forbidden(fldPath.Child("wildcard"), "field is immutable once set"))
+			}
+
+			if len(old.Challenges) > 0 {
+				fldPath := fldPath.Child("challenges")
+				if len(old.Challenges) != len(new.Challenges) {
+					el = append(el, field.Forbidden(fldPath, "field is immutable once set"))
+				}
+
+				for i := range old.Challenges {
+					fldPath := fldPath.Index(i)
+					old := old.Challenges[i]
+					new := new.Challenges[i]
+
+					if old.URL != "" && old.URL != new.URL {
+						el = append(el, field.Forbidden(fldPath.Child("url"), "field is immutable once set"))
+					}
+					if old.Type != "" && old.Type != new.Type {
+						el = append(el, field.Forbidden(fldPath.Child("type"), "field is immutable once set"))
+					}
+					if old.Token != "" && old.Token != new.Token {
+						el = append(el, field.Forbidden(fldPath.Child("token"), "field is immutable once set"))
+					}
+				}
+			}
+		}
+	}
+
+	return el
+}

--- a/pkg/internal/apis/acme/validation/order_test.go
+++ b/pkg/internal/apis/acme/validation/order_test.go
@@ -1,0 +1,226 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/utils/pointer"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
+)
+
+type testValue string
+
+const (
+	testValueNone      = ""
+	testValueOptionOne = "one"
+	testValueOptionTwo = "two"
+)
+
+// testImmutableOrderField will test that the field at path fldPath does
+// not allow changes after being set, but does allow changes if the old field
+// is not set.
+func testImmutableOrderField(t *testing.T, fldPath *field.Path, setter func(*cmacme.Order, testValue)) {
+	t.Run("should reject updates to "+fldPath.String(), func(t *testing.T) {
+		expectedErrs := []*field.Error{
+			field.Forbidden(fldPath, "field is immutable once set"),
+		}
+		old := &cmacme.Order{}
+		new := &cmacme.Order{}
+		setter(old, testValueOptionOne)
+		setter(new, testValueOptionTwo)
+		errs := ValidateOrderUpdate(old, new)
+		if len(errs) != len(expectedErrs) {
+			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			return
+		}
+		for i, e := range errs {
+			expectedErr := expectedErrs[i]
+			if !reflect.DeepEqual(e, expectedErr) {
+				t.Errorf("Expected %v but got %v", expectedErr, e)
+			}
+		}
+	})
+	t.Run("should allow updates to "+fldPath.String()+" if not already set", func(t *testing.T) {
+		expectedErrs := []*field.Error{}
+		old := &cmacme.Order{}
+		new := &cmacme.Order{}
+		setter(old, testValueNone)
+		setter(new, testValueOptionOne)
+		errs := ValidateOrderUpdate(old, new)
+		if len(errs) != len(expectedErrs) {
+			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			return
+		}
+		for i, e := range errs {
+			expectedErr := expectedErrs[i]
+			if !reflect.DeepEqual(e, expectedErr) {
+				t.Errorf("Expected %v but got %v", expectedErr, e)
+			}
+		}
+	})
+}
+
+func TestValidateCertificateUpdate(t *testing.T) {
+	authorizationsFldPath := field.NewPath("status", "authorizations")
+	challengesFldPath := authorizationsFldPath.Index(0).Child("challenges")
+
+	testImmutableOrderField(t, field.NewPath("spec", "csr"), func(o *cmacme.Order, s testValue) {
+		if s == testValueNone {
+			o.Spec.CSR = nil
+		}
+		o.Spec.CSR = []byte(s)
+	})
+	testImmutableOrderField(t, field.NewPath("status", "url"), func(o *cmacme.Order, s testValue) {
+		o.Status.URL = string(s)
+	})
+	testImmutableOrderField(t, field.NewPath("status", "finalizeURL"), func(o *cmacme.Order, s testValue) {
+		o.Status.FinalizeURL = string(s)
+	})
+	testImmutableOrderField(t, field.NewPath("status", "certificate"), func(o *cmacme.Order, s testValue) {
+		if s == testValueNone {
+			o.Status.Certificate = nil
+		}
+		o.Status.Certificate = []byte(s)
+	})
+	testImmutableOrderField(t, authorizationsFldPath, func(o *cmacme.Order, s testValue) {
+		switch s {
+		case testValueNone:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{}
+		case testValueOptionOne:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{},
+			}
+		case testValueOptionTwo:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{},
+				{},
+			}
+		}
+	})
+	testImmutableOrderField(t, authorizationsFldPath.Index(0).Child("url"), func(o *cmacme.Order, s testValue) {
+		o.Status.Authorizations = []cmacme.ACMEAuthorization{
+			{URL: string(s)},
+		}
+	})
+	testImmutableOrderField(t, authorizationsFldPath.Index(0).Child("identifier"), func(o *cmacme.Order, s testValue) {
+		o.Status.Authorizations = []cmacme.ACMEAuthorization{
+			{Identifier: string(s)},
+		}
+	})
+	testImmutableOrderField(t, authorizationsFldPath.Index(0).Child("wildcard"), func(o *cmacme.Order, s testValue) {
+		switch s {
+		case testValueNone:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{Wildcard: nil},
+			}
+		case testValueOptionOne:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{Wildcard: pointer.BoolPtr(false)},
+			}
+		case testValueOptionTwo:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{Wildcard: pointer.BoolPtr(true)},
+			}
+		}
+	})
+	testImmutableOrderField(t, challengesFldPath.Index(0).Child("url"), func(o *cmacme.Order, s testValue) {
+		o.Status.Authorizations = []cmacme.ACMEAuthorization{
+			{
+				Challenges: []cmacme.ACMEChallenge{
+					{URL: string(s)},
+				},
+			},
+		}
+	})
+	testImmutableOrderField(t, challengesFldPath.Index(0).Child("token"), func(o *cmacme.Order, s testValue) {
+		o.Status.Authorizations = []cmacme.ACMEAuthorization{
+			{
+				Challenges: []cmacme.ACMEChallenge{
+					{Token: string(s)},
+				},
+			},
+		}
+	})
+	testImmutableOrderField(t, challengesFldPath.Index(0).Child("type"), func(o *cmacme.Order, s testValue) {
+		o.Status.Authorizations = []cmacme.ACMEAuthorization{
+			{
+				Challenges: []cmacme.ACMEChallenge{
+					{Type: cmacme.ACMEChallengeType(s)},
+				},
+			},
+		}
+	})
+	testImmutableOrderField(t, challengesFldPath, func(o *cmacme.Order, s testValue) {
+		switch s {
+		case testValueNone:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{
+					Challenges: []cmacme.ACMEChallenge{},
+				},
+			}
+		case testValueOptionOne:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{
+					Challenges: []cmacme.ACMEChallenge{
+						{},
+					},
+				},
+			}
+		case testValueOptionTwo:
+			o.Status.Authorizations = []cmacme.ACMEAuthorization{
+				{
+					Challenges: []cmacme.ACMEChallenge{
+						{},
+						{},
+					},
+				},
+			}
+		}
+	})
+
+	scenarios := map[string]struct {
+		old, new *cmacme.Order
+		errs     []*field.Error
+	}{
+		"allows all updates if old is nil": {
+			new: &cmacme.Order{
+				Spec: cmacme.OrderSpec{
+					CSR: []byte("testing"),
+				},
+			},
+		},
+	}
+	for n, s := range scenarios {
+		t.Run(n, func(t *testing.T) {
+			errs := ValidateOrderUpdate(s.old, s.new)
+			if len(errs) != len(s.errs) {
+				t.Errorf("Expected %v but got %v", s.errs, errs)
+				return
+			}
+			for i, e := range errs {
+				expectedErr := s.errs[i]
+				if !reflect.DeepEqual(e, expectedErr) {
+					t.Errorf("Expected %v but got %v", expectedErr, e)
+				}
+			}
+		})
+	}
+}

--- a/pkg/webhook/BUILD.bazel
+++ b/pkg/webhook/BUILD.bazel
@@ -9,11 +9,14 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/webhook",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/internal/apis/acme/install:go_default_library",
         "//pkg/internal/apis/certmanager/install:go_default_library",
         "//pkg/internal/apis/certmanager/validation:go_default_library",
         "//pkg/internal/apis/meta/install:go_default_library",
+        "//pkg/webhook/handlers:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
     ],
 )
 

--- a/pkg/webhook/BUILD.bazel
+++ b/pkg/webhook/BUILD.bazel
@@ -9,8 +9,10 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/webhook",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/acme/v1alpha2:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/internal/apis/acme/install:go_default_library",
+        "//pkg/internal/apis/acme/validation:go_default_library",
         "//pkg/internal/apis/certmanager/install:go_default_library",
         "//pkg/internal/apis/certmanager/validation:go_default_library",
         "//pkg/internal/apis/meta/install:go_default_library",

--- a/pkg/webhook/certmanager.go
+++ b/pkg/webhook/certmanager.go
@@ -19,7 +19,9 @@ package webhook
 import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	acmeval "github.com/jetstack/cert-manager/pkg/internal/apis/acme/validation"
 	"github.com/jetstack/cert-manager/pkg/internal/apis/certmanager/validation"
 	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
 )
@@ -29,6 +31,8 @@ var Validators = map[schema.GroupKind]handlers.Validator{
 	gk(cmapi.SchemeGroupVersion, cmapi.CertificateRequestKind): certificateRequestValidator,
 	gk(cmapi.SchemeGroupVersion, cmapi.IssuerKind):             issuerValidator,
 	gk(cmapi.SchemeGroupVersion, cmapi.ClusterIssuerKind):      clusterIssuerValidator,
+	gk(cmacme.SchemeGroupVersion, cmacme.OrderKind):            orderValidator,
+	gk(cmacme.SchemeGroupVersion, cmacme.ChallengeKind):        challengeValidator,
 }
 
 var (
@@ -36,6 +40,8 @@ var (
 	certificateRequestValidator = handlers.ValidatorFunc(&cmapi.CertificateRequest{}, validation.ValidateCertificateRequest, nil)
 	issuerValidator             = handlers.ValidatorFunc(&cmapi.Issuer{}, validation.ValidateIssuer, nil)
 	clusterIssuerValidator      = handlers.ValidatorFunc(&cmapi.ClusterIssuer{}, validation.ValidateClusterIssuer, nil)
+	orderValidator              = handlers.ValidatorFunc(&cmacme.Order{}, nil, acmeval.ValidateOrderUpdate)
+	challengeValidator          = handlers.ValidatorFunc(&cmacme.Challenge{}, nil, acmeval.ValidateChallengeUpdate)
 )
 
 func gk(gv schema.GroupVersion, kind string) schema.GroupKind {

--- a/pkg/webhook/certmanager.go
+++ b/pkg/webhook/certmanager.go
@@ -16,11 +16,31 @@ limitations under the License.
 
 package webhook
 
-import "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager/validation"
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	"github.com/jetstack/cert-manager/pkg/internal/apis/certmanager/validation"
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
+)
+
+var Validators = map[schema.GroupKind]handlers.Validator{
+	gk(cmapi.SchemeGroupVersion, cmapi.CertificateKind):        certificateValidator,
+	gk(cmapi.SchemeGroupVersion, cmapi.CertificateRequestKind): certificateRequestValidator,
+	gk(cmapi.SchemeGroupVersion, cmapi.IssuerKind):             issuerValidator,
+	gk(cmapi.SchemeGroupVersion, cmapi.ClusterIssuerKind):      clusterIssuerValidator,
+}
 
 var (
-	ValidateCertificate        = validation.ValidateCertificate
-	ValidateCertificateRequest = validation.ValidateCertificateRequest
-	ValidateIssuer             = validation.ValidateIssuer
-	ValidateClusterIssuer      = validation.ValidateClusterIssuer
+	certificateValidator        = handlers.ValidatorFunc(&cmapi.Certificate{}, validation.ValidateCertificate, nil)
+	certificateRequestValidator = handlers.ValidatorFunc(&cmapi.CertificateRequest{}, validation.ValidateCertificateRequest, nil)
+	issuerValidator             = handlers.ValidatorFunc(&cmapi.Issuer{}, validation.ValidateIssuer, nil)
+	clusterIssuerValidator      = handlers.ValidatorFunc(&cmapi.ClusterIssuer{}, validation.ValidateClusterIssuer, nil)
 )
+
+func gk(gv schema.GroupVersion, kind string) schema.GroupKind {
+	return schema.GroupKind{
+		Group: gv.Group,
+		Kind:  kind,
+	}
+}

--- a/pkg/webhook/handlers/BUILD.bazel
+++ b/pkg/webhook/handlers/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/serializer:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/serializer/json:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
-        "@io_k8s_client_go//rest:go_default_library",
     ],
 )
 
@@ -28,7 +27,6 @@ go_test(
     srcs = ["mutation_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/webhook/handlers/testdata/apis/testgroup:go_default_library",
         "//pkg/webhook/handlers/testdata/apis/testgroup/install:go_default_library",
         "@com_github_mattbaird_jsonpatch//:go_default_library",
         "@io_k8s_api//admission/v1beta1:go_default_library",

--- a/pkg/webhook/handlers/BUILD.bazel
+++ b/pkg/webhook/handlers/BUILD.bazel
@@ -24,14 +24,21 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["mutation_test.go"],
+    srcs = [
+        "mutation_test.go",
+        "validation_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/webhook/handlers/testdata/apis/testgroup:go_default_library",
         "//pkg/webhook/handlers/testdata/apis/testgroup/install:go_default_library",
+        "//pkg/webhook/handlers/testdata/apis/testgroup/v1:go_default_library",
+        "//pkg/webhook/handlers/testdata/apis/testgroup/validation:go_default_library",
         "@com_github_mattbaird_jsonpatch//:go_default_library",
         "@io_k8s_api//admission/v1beta1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
-        "@io_k8s_klog//:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_klog//klogr:go_default_library",
         "@io_k8s_utils//diff:go_default_library",
     ],

--- a/pkg/webhook/handlers/interfaces.go
+++ b/pkg/webhook/handlers/interfaces.go
@@ -18,37 +18,16 @@ package handlers
 
 import (
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	restclient "k8s.io/client-go/rest"
 )
 
-type AdmissionHook interface {
-	// Initialize is called as a post-start hook
-	Initialize(kubeClientConfig *restclient.Config, stopCh <-chan struct{}) error
-}
-
 type ValidatingAdmissionHook interface {
-	AdmissionHook
-
-	// ValidatingResource is the resource to use for hosting your admission webhook. If the hook implements
-	// MutatingAdmissionHook as well, the two resources for validating and mutating admission must be different.
-	// Note: this is (usually) not the same as the payload resource!
-	ValidatingResource() (plural schema.GroupVersionResource, singular string)
-
 	// Validate is called to decide whether to accept the admission request. The returned AdmissionResponse
 	// must not use the Patch field.
 	Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
 }
 
 type MutatingAdmissionHook interface {
-	AdmissionHook
-
-	// MutatingResource is the resource to use for hosting your admission webhook. If the hook implements
-	// ValidatingAdmissionHook as well, the two resources for validating and mutating admission must be different.
-	// Note: this is (usually) not the same as the payload resource!
-	MutatingResource() (plural schema.GroupVersionResource, singular string)
-
 	// Admit is called to decide whether to accept the admission request. The returned AdmissionResponse may
 	// use the Patch field to mutate the object from the passed AdmissionRequest.
-	Admit(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
+	Mutate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
 }

--- a/pkg/webhook/handlers/mutation_test.go
+++ b/pkg/webhook/handlers/mutation_test.go
@@ -18,14 +18,12 @@ package handlers
 
 import (
 	"encoding/json"
-	"flag"
 	"reflect"
 	"testing"
 
 	"github.com/mattbaird/jsonpatch"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/klog"
 	"k8s.io/klog/klogr"
 	"k8s.io/utils/diff"
 
@@ -50,7 +48,6 @@ func TestDefaultCertificate(t *testing.T) {
 	install.Install(scheme)
 
 	log := klogr.New()
-	klog.InitFlags(flag.CommandLine)
 	c := NewSchemeBackedDefaulter(log, scheme)
 	tests := map[string]testT{
 		"apply defaults to TestType": {
@@ -75,6 +72,11 @@ func TestDefaultCertificate(t *testing.T) {
 					jsonpatch.JsonPatchOperation{
 						Operation: "add",
 						Path:      "/testField",
+						Value:     "",
+					},
+					jsonpatch.JsonPatchOperation{
+						Operation: "add",
+						Path:      "/testFieldImmutable",
 						Value:     "",
 					},
 					jsonpatch.JsonPatchOperation{

--- a/pkg/webhook/handlers/mutation_test.go
+++ b/pkg/webhook/handlers/mutation_test.go
@@ -29,7 +29,6 @@ import (
 	"k8s.io/klog/klogr"
 	"k8s.io/utils/diff"
 
-	"github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
 	"github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/install"
 )
 
@@ -52,7 +51,7 @@ func TestDefaultCertificate(t *testing.T) {
 
 	log := klogr.New()
 	klog.InitFlags(flag.CommandLine)
-	c := NewSchemeBackedDefaulter(log, testgroup.GroupName, scheme)
+	c := NewSchemeBackedDefaulter(log, scheme)
 	tests := map[string]testT{
 		"apply defaults to TestType": {
 			inputRequest: admissionv1beta1.AdmissionRequest{
@@ -91,7 +90,7 @@ func TestDefaultCertificate(t *testing.T) {
 
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
-			runTest(t, c.Admit, test)
+			runTest(t, c.Mutate, test)
 		})
 	}
 }
@@ -101,9 +100,9 @@ type testT struct {
 	expectedResponse admissionv1beta1.AdmissionResponse
 }
 
-type mutateFn func(request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
+type admitFn func(request *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse
 
-func runTest(t *testing.T, fn mutateFn, test testT) {
+func runTest(t *testing.T, fn admitFn, test testT) {
 	resp := fn(&test.inputRequest)
 	if !reflect.DeepEqual(&test.expectedResponse, resp) {
 		t.Errorf("Response was not as expected: %v", diff.ObjectGoPrintSideBySide(&test.expectedResponse, resp))

--- a/pkg/webhook/handlers/testdata/apis/testgroup/BUILD.bazel
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/BUILD.bazel
@@ -31,6 +31,7 @@ filegroup(
         "//pkg/webhook/handlers/testdata/apis/testgroup/fuzzer:all-srcs",
         "//pkg/webhook/handlers/testdata/apis/testgroup/install:all-srcs",
         "//pkg/webhook/handlers/testdata/apis/testgroup/v1:all-srcs",
+        "//pkg/webhook/handlers/testdata/apis/testgroup/validation:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/webhook/handlers/testdata/apis/testgroup/types.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/types.go
@@ -26,6 +26,11 @@ type TestType struct {
 	metav1.TypeMeta
 	metav1.ObjectMeta
 
+	// TestField is used in tests.
+	// Validation doesn't allow this to be set to the value of TestFieldValueNotAllowed.
 	TestField    string
 	TestFieldPtr *string
+
+	// TestFieldImmutable cannot be changed after being set to a non-zero value
+	TestFieldImmutable string
 }

--- a/pkg/webhook/handlers/testdata/apis/testgroup/v1/types.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/v1/types.go
@@ -26,6 +26,15 @@ type TestType struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata"`
 
+	// TestField is used in tests.
+	// Validation doesn't allow this to be set to the value of TestFieldValueNotAllowed.
 	TestField    string  `json:"testField"`
 	TestFieldPtr *string `json:"testFieldPtr"`
+
+	// TestFieldImmutable cannot be changed after being set to a non-zero value
+	TestFieldImmutable string `json:"testFieldImmutable"`
 }
+
+const (
+	TestFieldValueNotAllowed = "not-allowed-value"
+)

--- a/pkg/webhook/handlers/testdata/apis/testgroup/v1/zz_generated.conversion.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/v1/zz_generated.conversion.go
@@ -52,6 +52,7 @@ func autoConvert_v1_TestType_To_testgroup_TestType(in *TestType, out *testgroup.
 	out.ObjectMeta = in.ObjectMeta
 	out.TestField = in.TestField
 	out.TestFieldPtr = (*string)(unsafe.Pointer(in.TestFieldPtr))
+	out.TestFieldImmutable = in.TestFieldImmutable
 	return nil
 }
 
@@ -64,6 +65,7 @@ func autoConvert_testgroup_TestType_To_v1_TestType(in *testgroup.TestType, out *
 	out.ObjectMeta = in.ObjectMeta
 	out.TestField = in.TestField
 	out.TestFieldPtr = (*string)(unsafe.Pointer(in.TestFieldPtr))
+	out.TestFieldImmutable = in.TestFieldImmutable
 	return nil
 }
 

--- a/pkg/webhook/handlers/testdata/apis/testgroup/validation/BUILD.bazel
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/validation/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["validation.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/validation",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/webhook/handlers/testdata/apis/testgroup/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["validation_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/webhook/handlers/testdata/apis/testgroup/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
+)
+
+func ValidateTestType(obj runtime.Object) field.ErrorList {
+	testType := obj.(*v1.TestType)
+	el := field.ErrorList{}
+	if testType.TestField == v1.TestFieldValueNotAllowed {
+		el = append(el, field.Invalid(field.NewPath("testField"), testType.TestField, "invalid value"))
+	}
+	return el
+}
+
+func ValidateTestTypeUpdate(oldObj, newObj runtime.Object) field.ErrorList {
+	old, ok := oldObj.(*v1.TestType)
+	new := newObj.(*v1.TestType)
+	// if oldObj is not set, the Update operation is always valid.
+	if !ok || old == nil {
+		return nil
+	}
+	el := field.ErrorList{}
+	if old.TestFieldImmutable != "" && old.TestFieldImmutable != new.TestFieldImmutable {
+		el = append(el, field.Forbidden(field.NewPath("testFieldImmutable"), "field is immutable once set"))
+	}
+	return el
+}

--- a/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation_test.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	v1 "github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
+)
+
+func TestValidateTestType(t *testing.T) {
+	scenarios := map[string]struct {
+		obj  *v1.TestType
+		errs []*field.Error
+	}{
+		"does not allow testField to be TestFieldValueNotAllowed": {
+			obj: &v1.TestType{
+				TestField: v1.TestFieldValueNotAllowed,
+			},
+			errs: []*field.Error{
+				field.Invalid(field.NewPath("testField"), v1.TestFieldValueNotAllowed, "invalid value"),
+			},
+		},
+	}
+	for n, s := range scenarios {
+		t.Run(n, func(t *testing.T) {
+			errs := ValidateTestType(s.obj)
+			if len(errs) != len(s.errs) {
+				t.Errorf("Expected %v but got %v", s.errs, errs)
+				return
+			}
+			for i, e := range errs {
+				expectedErr := s.errs[i]
+				if !reflect.DeepEqual(e, expectedErr) {
+					t.Errorf("Expected %v but got %v", expectedErr, e)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateTestTypeUpdate(t *testing.T) {
+	testImmutableTestTypeField(t, field.NewPath("testFieldImmutable"), func(obj *v1.TestType, s testValue) {
+		obj.TestFieldImmutable = string(s)
+	})
+
+	scenarios := map[string]struct {
+		old, new *v1.TestType
+		errs     []*field.Error
+	}{
+		"allows all updates if old is nil": {
+			new: &v1.TestType{
+				TestFieldImmutable: "abc",
+			},
+		},
+	}
+	for n, s := range scenarios {
+		t.Run(n, func(t *testing.T) {
+			errs := ValidateTestTypeUpdate(s.old, s.new)
+			if len(errs) != len(s.errs) {
+				t.Errorf("Expected %v but got %v", s.errs, errs)
+				return
+			}
+			for i, e := range errs {
+				expectedErr := s.errs[i]
+				if !reflect.DeepEqual(e, expectedErr) {
+					t.Errorf("Expected %v but got %v", expectedErr, e)
+				}
+			}
+		})
+	}
+}
+
+type testValue string
+
+const (
+	testValueNone      = ""
+	testValueOptionOne = "one"
+	testValueOptionTwo = "two"
+)
+
+// testImmutableOrderField will test that the field at path fldPath does
+// not allow changes after being set, but does allow changes if the old field
+// is not set.
+func testImmutableTestTypeField(t *testing.T, fldPath *field.Path, setter func(*v1.TestType, testValue)) {
+	t.Run("should reject updates to "+fldPath.String(), func(t *testing.T) {
+		expectedErrs := []*field.Error{
+			field.Forbidden(fldPath, "field is immutable once set"),
+		}
+		old := &v1.TestType{}
+		new := &v1.TestType{}
+		setter(old, testValueOptionOne)
+		setter(new, testValueOptionTwo)
+		errs := ValidateTestTypeUpdate(old, new)
+		if len(errs) != len(expectedErrs) {
+			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			return
+		}
+		for i, e := range errs {
+			expectedErr := expectedErrs[i]
+			if !reflect.DeepEqual(e, expectedErr) {
+				t.Errorf("Expected %v but got %v", expectedErr, e)
+			}
+		}
+	})
+	t.Run("should allow updates to "+fldPath.String()+" if not already set", func(t *testing.T) {
+		expectedErrs := []*field.Error{}
+		old := &v1.TestType{}
+		new := &v1.TestType{}
+		setter(old, testValueNone)
+		setter(new, testValueOptionOne)
+		errs := ValidateTestTypeUpdate(old, new)
+		if len(errs) != len(expectedErrs) {
+			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			return
+		}
+		for i, e := range errs {
+			expectedErr := expectedErrs[i]
+			if !reflect.DeepEqual(e, expectedErr) {
+				t.Errorf("Expected %v but got %v", expectedErr, e)
+			}
+		}
+	})
+}

--- a/pkg/webhook/handlers/validation.go
+++ b/pkg/webhook/handlers/validation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package handlers
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -29,29 +28,79 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-type funcBackedValidator struct {
-	log         logr.Logger
-	decoder     runtime.Decoder
-	validations map[schema.GroupVersionKind]ValidationFunc
+type Validator interface {
+	// NewObject should return the runtime.Object that should be decoded into
+	// before validating the resource.
+	NewObject() runtime.Object
+
+	// Validate will validate the given resource
+	Validate(runtime.Object) field.ErrorList
+
+	// ValidateUpdate will validate the given resource for an update
+	ValidateUpdate(old, new runtime.Object) field.ErrorList
 }
 
-func NewFuncBackedValidator(log logr.Logger, scheme *runtime.Scheme, fns map[schema.GroupVersionKind]ValidationFunc) *funcBackedValidator {
-	factory := serializer.NewCodecFactory(scheme)
-	return &funcBackedValidator{
-		log: log,
-		// TODO: switch to using UniversalDecoder and make validation functions
-		//       run against the internal apiversion
-		decoder:     factory.UniversalDeserializer(),
-		validations: fns,
+type validatorFunc struct {
+	obj            runtime.Object
+	validate       func(runtime.Object) field.ErrorList
+	validateUpdate func(runtime.Object, runtime.Object) field.ErrorList
+}
+
+var _ Validator = &validatorFunc{}
+
+func (v *validatorFunc) NewObject() runtime.Object {
+	return v.obj.DeepCopyObject()
+}
+
+func (v *validatorFunc) Validate(obj runtime.Object) field.ErrorList {
+	if v.validate == nil {
+		return nil
+	}
+	return v.validate(obj)
+}
+
+func (v *validatorFunc) ValidateUpdate(old, new runtime.Object) field.ErrorList {
+	if v.validateUpdate == nil {
+		return nil
+	}
+	return v.validateUpdate(old, new)
+}
+
+func ValidatorFunc(obj runtime.Object, validate func(runtime.Object) field.ErrorList, validateUpdate func(runtime.Object, runtime.Object) field.ErrorList) Validator {
+	return &validatorFunc{
+		obj:            obj,
+		validate:       validate,
+		validateUpdate: validateUpdate,
 	}
 }
 
-type ValidationFunc func(runtime.Object) field.ErrorList
+type funcBackedValidator struct {
+	log        logr.Logger
+	decoder    runtime.Decoder
+	validators map[schema.GroupKind]Validator
+}
+
+func NewFuncBackedValidator(log logr.Logger, scheme *runtime.Scheme, validators map[schema.GroupKind]Validator) *funcBackedValidator {
+	factory := serializer.NewCodecFactory(scheme)
+	return &funcBackedValidator{
+		log:        log,
+		decoder:    factory.UniversalDecoder(),
+		validators: validators,
+	}
+}
+
+type ValidationFunc func(obj runtime.Object) field.ErrorList
+type UpdateValidationFunc func(old, new runtime.Object) field.ErrorList
 
 func (c *funcBackedValidator) Validate(admissionSpec *admissionv1beta1.AdmissionRequest) *admissionv1beta1.AdmissionResponse {
 	status := &admissionv1beta1.AdmissionResponse{}
 
-	obj, gvk, err := c.decoder.Decode(admissionSpec.Object.Raw, nil, nil)
+	gk := schema.GroupKind{Group: admissionSpec.Kind.Group, Kind: admissionSpec.Kind.Kind}
+	validator := c.validators[gk]
+
+	obj := validator.NewObject()
+	// decode new version of object
+	_, _, err := c.decoder.Decode(admissionSpec.Object.Raw, nil, obj)
 	if err != nil {
 		status.Allowed = false
 		status.Result = &metav1.Status{
@@ -61,18 +110,29 @@ func (c *funcBackedValidator) Validate(admissionSpec *admissionv1beta1.Admission
 		return status
 	}
 
-	validate, ok := c.validations[*gvk]
-	if !ok {
-		status.Allowed = false
-		status.Result = &metav1.Status{
-			Status: metav1.StatusFailure, Code: http.StatusInternalServerError, Reason: metav1.StatusReasonInternalError,
-			Message: fmt.Sprintf("No validation function registered for GVK: %v", gvk.String()),
+	// attempt to decode old object
+	var oldObj runtime.Object
+	if len(admissionSpec.OldObject.Raw) > 0 {
+		oldObj = validator.NewObject()
+		_, _, err = c.decoder.Decode(admissionSpec.OldObject.Raw, nil, oldObj)
+		if err != nil {
+			status.Allowed = false
+			status.Result = &metav1.Status{
+				Status: metav1.StatusFailure, Code: http.StatusBadRequest, Reason: metav1.StatusReasonBadRequest,
+				Message: err.Error(),
+			}
+			return status
 		}
-		return status
 	}
 
-	err = validate(obj).ToAggregate()
-	if err != nil {
+	errs := field.ErrorList{}
+	// perform validation on new version of resource
+	errs = append(errs, validator.Validate(obj)...)
+	// perform update validation on resource
+	errs = append(errs, validator.ValidateUpdate(oldObj, obj)...)
+
+	// return with allowed = false if any errors occurred
+	if err := errs.ToAggregate(); err != nil {
 		status.Allowed = false
 		status.Result = &metav1.Status{
 			Status: metav1.StatusFailure, Code: http.StatusNotAcceptable, Reason: metav1.StatusReasonNotAcceptable,
@@ -82,6 +142,5 @@ func (c *funcBackedValidator) Validate(admissionSpec *admissionv1beta1.Admission
 	}
 
 	status.Allowed = true
-
 	return status
 }

--- a/pkg/webhook/handlers/validation_test.go
+++ b/pkg/webhook/handlers/validation_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	admissionv1beta1 "k8s.io/api/admission/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/klog/klogr"
+
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup"
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/install"
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/validation"
+)
+
+func TestFuncBackedValidator(t *testing.T) {
+	scheme := runtime.NewScheme()
+	install.Install(scheme)
+
+	log := klogr.New()
+	c := NewFuncBackedValidator(log, scheme, map[schema.GroupKind]Validator{
+		{Group: testgroup.GroupName, Kind: "TestType"}: ValidatorFunc(&v1.TestType{}, validation.ValidateTestType, validation.ValidateTestTypeUpdate),
+	})
+	testTypeGVK := metav1.GroupVersionKind{
+		Group:   v1.SchemeGroupVersion.Group,
+		Version: v1.SchemeGroupVersion.Version,
+		Kind:    "TestType",
+	}
+	tests := map[string]testT{
+		"should not allow invalid value for 'testField' field": {
+			inputRequest: admissionv1beta1.AdmissionRequest{
+				Kind: testTypeGVK,
+				Object: runtime.RawExtension{
+					Raw: []byte(fmt.Sprintf(`
+{
+	"apiVersion": "testgroup.testing.cert-manager.io/v1",
+	"kind": "TestType",
+	"metadata": {
+		"name": "testing",
+		"namespace": "abc",
+		"creationTimestamp": null
+	},
+	"testField": "%s"
+}
+`, v1.TestFieldValueNotAllowed)),
+				},
+			},
+			expectedResponse: admissionv1beta1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Status: metav1.StatusFailure, Code: http.StatusNotAcceptable, Reason: metav1.StatusReasonNotAcceptable,
+					Message: "testField: Invalid value: \"not-allowed-value\": invalid value",
+				},
+			},
+		},
+		"should allow setting immutable field if it is not already set": {
+			inputRequest: admissionv1beta1.AdmissionRequest{
+				Kind: testTypeGVK,
+				OldObject: runtime.RawExtension{
+					Raw: []byte(fmt.Sprintf(`
+{
+	"apiVersion": "testgroup.testing.cert-manager.io/v1",
+	"kind": "TestType",
+	"metadata": {
+		"name": "testing",
+		"namespace": "abc",
+		"creationTimestamp": null
+	}
+}
+`)),
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(fmt.Sprintf(`
+{
+	"apiVersion": "testgroup.testing.cert-manager.io/v1",
+	"kind": "TestType",
+	"metadata": {
+		"name": "testing",
+		"namespace": "abc",
+		"creationTimestamp": null
+	},
+	"testFieldImmutable": "abc"
+}
+`)),
+				},
+			},
+			expectedResponse: admissionv1beta1.AdmissionResponse{
+				Allowed: true,
+			},
+		},
+		"should not allow setting immutable field if it is already set": {
+			inputRequest: admissionv1beta1.AdmissionRequest{
+				Kind: testTypeGVK,
+				OldObject: runtime.RawExtension{
+					Raw: []byte(fmt.Sprintf(`
+{
+	"apiVersion": "testgroup.testing.cert-manager.io/v1",
+	"kind": "TestType",
+	"metadata": {
+		"name": "testing",
+		"namespace": "abc",
+		"creationTimestamp": null
+	},
+	"testFieldImmutable": "oldvalue"
+}
+`)),
+				},
+				Object: runtime.RawExtension{
+					Raw: []byte(fmt.Sprintf(`
+{
+	"apiVersion": "testgroup.testing.cert-manager.io/v1",
+	"kind": "TestType",
+	"metadata": {
+		"name": "testing",
+		"namespace": "abc",
+		"creationTimestamp": null
+	},
+	"testFieldImmutable": "abc"
+}
+`)),
+				},
+			},
+			expectedResponse: admissionv1beta1.AdmissionResponse{
+				Allowed: false,
+				Result: &metav1.Status{
+					Status: metav1.StatusFailure, Code: http.StatusNotAcceptable, Reason: metav1.StatusReasonNotAcceptable,
+					Message: "testFieldImmutable: Forbidden: field is immutable once set",
+				},
+			},
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			runTest(t, c.Validate, test)
+		})
+	}
+}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -240,7 +240,7 @@ func (s *Server) validate(obj runtime.Object) runtime.Object {
 
 func (s *Server) mutate(obj runtime.Object) runtime.Object {
 	review := obj.(*admissionv1beta1.AdmissionReview)
-	resp := s.MutationWebhook.Admit(review.Request)
+	resp := s.MutationWebhook.Mutate(review.Request)
 	review.Response = resp
 	return review
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Makes the following fields on Order resources immutable:

* `spec.csr`
* `status.url`
* `status.finalizeURL`
* `status.certificate`
* `status.authorizations`
* `status.authorizations[].url`
* `status.authorizations[].identifier`
* `status.authorizations[].wildcard`
* `status.authorizations[].challenges`
* `status.authorizations[].challenges[].url`
* `status.authorizations[].challenges[].type`
* `status.authorizations[].challenges[].token`

Also make the entirety of `challenge.spec` immutable after creation

This should help reduce 'fighting' between resources when users run multiple instances of cert-manager, as well as enforces an 'unwritten rule' (currently the behaviour if you change these fields after creation is ~undefined).

**Special notes for your reviewer**:

Should help fix #1948 

**Release note**:
```release-note
Make `spec.csr`, `status.url`, `status.finalizeURL`, `status.certificate`, `status.authorizations`, `status.authorizations[].url`, `status.authorizations[].identifier`, `status.authorizations[].wildcard`, `status.authorizations[].challenges`, `status.authorizations[].challenges[].url`, `status.authorizations[].challenges[].type`, `status.authorizations[].challenges[].token` fields on Order resources immutable
```

/area api
/assign @JoshVanL 
/milestone v0.12