### PR TITLE
 Add Bazel image targets with coverage enabled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,8 @@ APP_VERSION := canary
 HACK_DIR ?= hack
 
 SKIP_GLOBALS := false
-GINKGO_SKIP :=
+# Skip Venafi tests whilst there are issues with the TPP server
+GINKGO_SKIP := Venafi
 GINKGO_FOCUS :=
 
 ## e2e test vars

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -1,9 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack/build:docker.bzl", "image")
+load("//hack/build:docker.bzl", "covered_image", "image")
 
 image(
     name = "image",
     binary = ":acmesolver",
+    component = "acmesolver",
+    visibility = ["//visibility:public"],
+)
+
+covered_image(
+    name = "image.covered",
     component = "acmesolver",
     visibility = ["//visibility:public"],
 )

--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -1,9 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack/build:docker.bzl", "image")
+load("//hack/build:docker.bzl", "covered_image", "image")
 
 image(
     name = "image",
     binary = ":cainjector",
+    component = "cainjector",
+    visibility = ["//visibility:public"],
+)
+
+covered_image(
+    name = "image.covered",
     component = "cainjector",
     visibility = ["//visibility:public"],
 )

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -1,9 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack/build:docker.bzl", "image")
+load("//hack/build:docker.bzl", "covered_image", "image")
 
 image(
     name = "image",
     binary = ":controller",
+    component = "controller",
+    visibility = ["//visibility:public"],
+)
+
+covered_image(
+    name = "image.covered",
     component = "controller",
     visibility = ["//visibility:public"],
 )

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -135,7 +135,6 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) {
 	}
 
 	startLeaderElection(rootCtx, opts, leaderElectionClient, ctx.Recorder, run)
-	panic("unreachable")
 }
 
 func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *options.ControllerOptions) (*controller.Context, *rest.Config, error) {
@@ -267,7 +266,7 @@ func startLeaderElection(ctx context.Context, opts *options.ControllerOptions, l
 	}
 
 	// Try and become the leader and start controller manager loops
-	leaderelection.RunOrDie(context.TODO(), leaderelection.LeaderElectionConfig{
+	leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 		Lock:          &rl,
 		LeaseDuration: opts.LeaderElectionLeaseDuration,
 		RenewDeadline: opts.LeaderElectionRenewDeadline,

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -37,7 +37,7 @@ func main() {
 
 	flag.CommandLine.Parse([]string{})
 	if err := cmd.Execute(); err != nil {
-		klog.Fatal(err)
+		klog.Info(err)
 	}
 }
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -1,9 +1,15 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("//hack/build:docker.bzl", "image")
+load("//hack/build:docker.bzl", "covered_image", "image")
 
 image(
     name = "image",
     binary = ":webhook",
+    component = "webhook",
+    visibility = ["//visibility:public"],
+)
+
+covered_image(
+    name = "image.covered",
     component = "webhook",
     visibility = ["//visibility:public"],
 )

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -37,6 +37,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/util/coverage:all-srcs",
         "//pkg/util/errors:all-srcs",
         "//pkg/util/feature:all-srcs",
         "//pkg/util/kube:all-srcs",

--- a/pkg/util/coverage/BUILD.bazel
+++ b/pkg/util/coverage/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "coverage.go",
+        "faketestdeps.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/pkg/util/coverage",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/coverage/coverage.go
+++ b/pkg/util/coverage/coverage.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package coverage provides tools for coverage-instrumented binaries to collect and
+// flush coverage information.
+package coverage
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog"
+)
+
+var coverageFile string
+
+// tempCoveragePath returns a temporary file to write coverage information to.
+// The file is in the same directory as the destination, ensuring os.Rename will work.
+func tempCoveragePath() string {
+	return coverageFile + ".tmp"
+}
+
+// InitCoverage is called from the dummy unit test to prepare Go's coverage framework.
+// Clients should never need to call it.
+func InitCoverage(name string) {
+	// We read the coverage destination in from the COVERPROFILE env var,
+	// or if it's empty we just use a default in /tmp
+	coverageFile = os.Getenv("COVERPROFILE")
+	if coverageFile == "" {
+		coverageFile = "/tmp/cm-" + name + ".cov"
+	}
+	fmt.Println("Dumping coverage information to " + coverageFile)
+
+	flushInterval := 5 * time.Second
+	requestedInterval := os.Getenv("COVERAGE_FLUSH_INTERVAL")
+	if requestedInterval != "" {
+		if duration, err := time.ParseDuration(requestedInterval); err == nil {
+			flushInterval = duration
+		} else {
+			panic("Invalid COVERAGE_FLUSH_INTERVAL value; try something like '30s'.")
+		}
+	}
+
+	// Set up the unit test framework with the required arguments to activate test coverage.
+	flag.CommandLine.Parse([]string{"-test.coverprofile", tempCoveragePath()})
+
+	// Begin periodic logging
+	go wait.Forever(FlushCoverage, flushInterval)
+}
+
+// FlushCoverage flushes collected coverage information to disk.
+// The destination file is configured at startup and cannot be changed.
+// Calling this function also sends a line like "coverage: 5% of statements" to stdout.
+func FlushCoverage() {
+	// We're not actually going to run any tests, but we need Go to think we did so it writes
+	// coverage information to disk. To achieve this, we create a bunch of empty test suites and
+	// have it "run" them.
+	tests := []testing.InternalTest{}
+	benchmarks := []testing.InternalBenchmark{}
+	examples := []testing.InternalExample{}
+
+	var deps fakeTestDeps
+
+	dummyRun := testing.MainStart(deps, tests, benchmarks, examples)
+	dummyRun.Run()
+
+	// Once it writes to the temporary path, we move it to the intended path.
+	// This gets us atomic updates from the perspective of another process trying to access
+	// the file.
+	if err := os.Rename(tempCoveragePath(), coverageFile); err != nil {
+		klog.Errorf("Couldn't move coverage file from %s to %s", coverageFile, tempCoveragePath())
+	}
+}

--- a/pkg/util/coverage/faketestdeps.go
+++ b/pkg/util/coverage/faketestdeps.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package coverage
+
+import (
+	"io"
+)
+
+// This is an implementation of testing.testDeps. It doesn't need to do anything, because
+// no tests are actually run. It does need a concrete implementation of at least ImportPath,
+// which is called unconditionally when running tests.
+type fakeTestDeps struct{}
+
+func (fakeTestDeps) ImportPath() string {
+	return ""
+}
+
+func (fakeTestDeps) MatchString(pat, str string) (bool, error) {
+	return false, nil
+}
+
+func (fakeTestDeps) StartCPUProfile(io.Writer) error {
+	return nil
+}
+
+func (fakeTestDeps) StopCPUProfile() {}
+
+func (fakeTestDeps) StartTestLog(io.Writer) {}
+
+func (fakeTestDeps) StopTestLog() error {
+	return nil
+}
+
+func (fakeTestDeps) WriteHeapProfile(io.Writer) error {
+	return nil
+}
+
+func (fakeTestDeps) WriteProfileTo(string, io.Writer, int) error {
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This allows us to build binaries that can be used for gathering coverage data during end-to-end tests.

A later PR will actually wire up the e2e framework to use these images and gather the coverage results from pods.

**Which issue this PR fixes**: fixes #

**Special notes for your reviewer**:

You can build a binary to test this using:

```shell
bazel run //cmd/controller:image.covered --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 --collect_code_coverage --instrumentation_filter='^//'
```

Then running with something like:

```shell
docker run -v $(pwd)/coverprofiles:/cover -e COVERPROFILE=/cover/cm.cover -v $HOME/.kube:/.kube bazel/cmd/controller:image.covered
```

**Release note**:
```release-note
Fix bug causing SIGTERM and SIGINT signals to not be respected whilst the controller is performing leader election
```

/assign @JoshVanL 