### PR TITLE
No longer use arch-specific acmesolver image

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -19,7 +19,6 @@ package options
 import (
 	"fmt"
 	"net"
-	"runtime"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -137,16 +136,8 @@ var (
 	}
 )
 
-func computeACMEHTTP01SolverImage(arch string) string {
-	if arch == "amd64" {
-		return fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
-	} else {
-		return fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver-%s:%s", runtime.GOARCH, util.AppVersion)
-	}
-}
-
 var (
-	defaultACMEHTTP01SolverImage                 = computeACMEHTTP01SolverImage(runtime.GOARCH)
+	defaultACMEHTTP01SolverImage                 = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
 	defaultACMEHTTP01SolverResourceRequestCPU    = "10m"
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"


### PR DESCRIPTION
**What this PR does / why we need it**:

Now that we publish multi-arch manifest lists, this hackery (that could cause issues for users running homogenous clusters) can be removed :tada:

**Release note**:
```release-note
No longer use architecture specific acmesolver images
```

/milestone v0.12
/assign @JoshVanL 