### PR TITLE
Re-enables venafi e2e tests

### DIFF
--- a/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/util/errors:go_default_library",
+        "//test/e2e/suite/conformance/certificates:go_default_library",
         "//test/e2e/suite/issuers/venafi/addon:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -24,28 +24,29 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/util/errors"
+	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
 	vaddon "github.com/jetstack/cert-manager/test/e2e/suite/issuers/venafi/addon"
 )
 
 var _ = framework.ConformanceDescribe("Certificates", func() {
-	//// unsupportedFeatures is a list of features that are not supported by the
-	//// Venafi issuer.
-	//var unsupportedFeatures = certificates.NewFeatureSet(
-	//	certificates.DurationFeature,
-	//	// Due to the current configuration of the test environment, it does not
-	//	// support signing certificates that pair with an elliptic curve private
-	//	// key or using the same private key multiple times.
-	//	certificates.ECDSAFeature,
-	//	certificates.ReusePrivateKeyFeature,
-	//)
-	//
-	//provisioner := new(venafiProvisioner)
-	//(&certificates.Suite{
-	//	Name:                "Venafi",
-	//	CreateIssuerFunc:    provisioner.create,
-	//	DeleteIssuerFunc:    provisioner.delete,
-	//	UnsupportedFeatures: unsupportedFeatures,
-	//}).Define()
+	// unsupportedFeatures is a list of features that are not supported by the
+	// Venafi issuer.
+	var unsupportedFeatures = certificates.NewFeatureSet(
+		certificates.DurationFeature,
+		// Due to the current configuration of the test environment, it does not
+		// support signing certificates that pair with an elliptic curve private
+		// key or using the same private key multiple times.
+		certificates.ECDSAFeature,
+		certificates.ReusePrivateKeyFeature,
+	)
+
+	provisioner := new(venafiProvisioner)
+	(&certificates.Suite{
+		Name:                "Venafi",
+		CreateIssuerFunc:    provisioner.create,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
 })
 
 type venafiProvisioner struct {


### PR DESCRIPTION
```release-note
NONE
```

/hold
