### PR TITLE
[DOCS] vault issuer - fix example to match correct schema

### DIFF
--- a/docs/tasks/issuers/setup-vault.rst
+++ b/docs/tasks/issuers/setup-vault.rst
@@ -237,7 +237,7 @@ authentication method.
         caBundle: <base64 encoded caBundle PEM file>
         auth:
           kubernetes:
-            path: /kubernetes/cluster-1
+            mountPath: /kubernetes/cluster-1
             role: my-app-1
             secretRef:
               name: my-service-account-secret


### PR DESCRIPTION
The field to select the mount point for the kubernetes auth backend is `mountPath` rather than `path`



**What this PR does / why we need it**:

Documentation fix

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

None

**Special notes for your reviewer**:

None 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
