### PR TITLE
Chart.yaml: add missing apiVersion

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: cert-manager
 # The version and appVersion fields are set automatically by the release tool
 version: v0.1.0


### PR DESCRIPTION
**What this PR does / why we need it**:
Add missing `apiVersion` to `Chart.yaml`.

**Which issue this PR fixes**:
fixes #2269

**Special notes for your reviewer**:
https://helm.sh/docs/developing_charts/#the-chart-yaml-file

**Release note**:
```release-note
Add missing apiVersion to Chart.yaml
```
