### PR TITLE
Bump Helm and Tiller to 2.15.1

### DIFF
--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -109,8 +109,8 @@ def install_helm():
     ## the version numbers in these rules.
     http_archive(
         name = "helm_darwin",
-        sha256 = "9469da75bb357bc325c985dead224480bbacc7aa8aecff74089dff97e64655d0",
-        urls = ["https://get.helm.sh/helm-v2.14.2-darwin-amd64.tar.gz"],
+        sha256 = "f51830036f746b7f758a40bf49e02527cc5a9f1b78c5809023e570d318eaff5c",
+        urls = ["https://get.helm.sh/helm-v2.15.1-darwin-amd64.tar.gz"],
         build_file_content =
             """
 filegroup(
@@ -125,8 +125,8 @@ filegroup(
 
     http_archive(
         name = "helm_linux",
-        sha256 = "9f50e69cf5cfa7268b28686728ad0227507a169e52bf59c99ada872ddd9679f0",
-        urls = ["https://get.helm.sh/helm-v2.14.2-linux-amd64.tar.gz"],
+        sha256 = "b4d366bd6625477b2954941aeb7b601946aa4226af6728e3a84eac4e62a84042",
+        urls = ["https://get.helm.sh/helm-v2.15.1-linux-amd64.tar.gz"],
         build_file_content =
             """
 filegroup(

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -21,8 +21,8 @@ def install():
         name = "io_gcr_helm_tiller",
         registry = "gcr.io",
         repository = "kubernetes-helm/tiller",
-        tag = "v2.14.2",
-        digest = "sha256:be79aff05025bd736f027eaf4a1b2716ac1e09b88e0e9493c962642519f19d9c",
+        tag = "v2.15.1",
+        digest = "sha256:39bb81aa9299390ef1d9e472531da24e98234db46664e431001a5fd6d0611114",
     )
 
     ## Fetch pebble for use during e2e tests


### PR DESCRIPTION
**What this PR does / why we need it**:

Bumps the version of Helm and Tiller used to 2.15.1, the last feature release before 3.0!

**Release note**:
```release-note
Bump Helm & Tiller version used during end-to-end tests to 2.15.1
```
