### PR TITLE
Enable PodSecurityPolicies in end-to-end tests

### DIFF
--- a/test/fixtures/kind/config-v1alpha2.yaml
+++ b/test/fixtures/kind/config-v1alpha2.yaml
@@ -18,5 +18,7 @@ kubeadmConfigPatches:
       baseConfig:
         clusterDNS:
         - 10.0.0.10
+    featureGates:
+      PodSecurityPolicy: true
 nodes:
 - role: control-plane

--- a/test/fixtures/kind/config-v1alpha3.yaml
+++ b/test/fixtures/kind/config-v1alpha3.yaml
@@ -14,5 +14,7 @@ kubeadmConfigPatches:
       name: config
     networking:
       serviceSubnet: 10.0.0.0/16
+    featureGates:
+      PodSecurityPolicy: true
 nodes:
 - role: control-plane

--- a/test/fixtures/kind/config-v1beta1.yaml
+++ b/test/fixtures/kind/config-v1beta1.yaml
@@ -14,5 +14,7 @@ kubeadmConfigPatches:
       name: config
     networking:
       serviceSubnet: 10.0.0.0/16
+    featureGates:
+      PodSecurityPolicy: true
 nodes:
 - role: control-plane

--- a/test/fixtures/kind/config-v1beta2.yaml
+++ b/test/fixtures/kind/config-v1beta2.yaml
@@ -14,5 +14,7 @@ kubeadmConfigPatches:
       name: config
     networking:
       serviceSubnet: 10.0.0.0/16
+    featureGates:
+      PodSecurityPolicy: true
 nodes:
   - role: control-plane


### PR DESCRIPTION
**What this PR does / why we need it**:

Enable PodSecurityPolicy admission controller during end-to-end tests.

This PR can be used as a basis to help test #2234 properly.

We'll probably need to bind a permissive PSP policy to all pods by default, and incrementally enable PSPs throughout.

**Release note**:
```release-note
NONE
```
