### PR TITLE
Enable Certificate KeySize to be specified via ingress-shim when using Vault

### DIFF
--- a/pkg/apis/vault/BUILD.bazel
+++ b/pkg/apis/vault/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["doc.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/apis/vault",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/apis/vault/v1alpha2:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/apis/vault/doc.go
+++ b/pkg/apis/vault/doc.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +groupName=vault.cert-manager.io
+
+// Package vault contains types in the vault cert-manager API group
+package vault
+
+const GroupName = "vault.cert-manager.io"

--- a/pkg/apis/vault/v1alpha2/BUILD.bazel
+++ b/pkg/apis/vault/v1alpha2/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "doc.go",
+        "types.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/pkg/apis/vault/v1alpha2",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/vault:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/apis/vault/v1alpha2/doc.go
+++ b/pkg/apis/vault/v1alpha2/doc.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// +k8s:deepcopy-gen=package,register
+// +k8s:conversion-gen=github.com/jetstack/cert-manager/pkg/apis/vault
+// +k8s:openapi-gen=true
+// +k8s:defaulter-gen=TypeMeta
+
+// Package v1alpha2 is the v1alpha2 version of the API.
+// +groupName=vault.cert-manager.io
+package v1alpha2

--- a/pkg/apis/vault/v1alpha2/types.go
+++ b/pkg/apis/vault/v1alpha2/types.go
@@ -1,0 +1,7 @@
+package v1alpha2
+
+const (
+	// IngressCertificateKeySizeAnnotationKey is used to the key size of the certificate
+	// to be used with the ingress shim.
+	IngressCertificateKeySizeAnnotationKey = "vault.cert-manager.io/key-size"
+)

--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/acme/v1alpha2:go_default_library",
+        "//pkg/apis/vault/v1alpha2:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:
These changes add a new API group *vault.cert-manager.io* that contains a new annotation for the ingress-shim *vault.cert-manager.io/key-size*.  This annotation allows the key size of a certificate to be customized when using Vault as a Certificate Authority.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Enable Certificate KeySize to be specified via ingress-shim when using Vault
```
