### PR TITLE
Set serverAuth EKU by default for better Mac OS Catalina compatibility

### DIFF
--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -126,5 +126,7 @@ const (
 
 // DefaultKeyUsages contains the default list of key usages
 func DefaultKeyUsages() []KeyUsage {
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
+	// The serverAuth EKU is required as of Mac OS Catalina: https://support.apple.com/en-us/HT210176
+	// Without this usage, certificates will _always_ flag a warning in newer Mac OS browsers.
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates the default list of keyUsages to include `serverAuth`. We previously copied these defaults from the core Kubernetes CertificateSigningRequest controller, which does _not_ set this EKU by default.

**Which issue this PR fixes**: fixes #2168 

**Special notes for your reviewer**:

Setting this EKU by default seems sensible to do, and I can't think of any reason this would cause an issue (famous last words). Without this, all certificates issued by cert-manager will fail validation in Mac OS Catalina unless the user explicitly requests this keyUsage.

**Release note**:
```release-note
Add serverAuth extended key usage to Certificates by default
```

/assign @JoshVanL 

