### PR TITLE
Ensure we check all the secrets that vault cluster issuers may be

### DIFF
--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -39,7 +39,12 @@ func (c *controller) issuersForSecret(secret *corev1.Secret) ([]*v1alpha2.Cluste
 		}
 		if (iss.Spec.ACME != nil && iss.Spec.ACME.PrivateKey.Name == secret.Name) ||
 			(iss.Spec.CA != nil && iss.Spec.CA.SecretName == secret.Name) ||
-			(iss.Spec.Vault != nil && iss.Spec.Vault.Auth.TokenSecretRef.Name == secret.Name) {
+			(iss.Spec.Vault != nil && iss.Spec.Vault.Auth.TokenSecretRef != nil &&
+				iss.Spec.Vault.Auth.TokenSecretRef.Name == secret.Name) ||
+			(iss.Spec.Vault != nil && iss.Spec.Vault.Auth.Kubernetes != nil &&
+				iss.Spec.Vault.Auth.Kubernetes.SecretRef.Name == secret.Name) ||
+			(iss.Spec.Vault != nil && iss.Spec.Vault.Auth.AppRole != nil &&
+				iss.Spec.Vault.Auth.AppRole.SecretRef.Name == secret.Name) {
 			affected = append(affected, iss)
 			continue
 		}


### PR DESCRIPTION
```release-note
NONE
```
fixes #2316 

/assign @munnerz 
/milestone v0.12
