### PR TITLE
Creates a proper wrapper for vault port-forwarding to keep it alive and healthy

### DIFF
--- a/test/e2e/framework/addon/vault/BUILD.bazel
+++ b/test/e2e/framework/addon/vault/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "proxy.go",
         "setup.go",
         "vault.go",
     ],
@@ -13,10 +14,12 @@ go_library(
         "//test/e2e/framework/addon/chart:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/config:go_default_library",
+        "//test/e2e/framework/log:go_default_library",
         "@com_github_hashicorp_vault//api:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//rbac/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
     ],
 )

--- a/test/e2e/framework/addon/vault/proxy.go
+++ b/test/e2e/framework/addon/vault/proxy.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vault
+
+import (
+	"crypto/x509"
+	"fmt"
+	"net"
+	"net/http"
+	"os/exec"
+	"sync"
+	"time"
+
+	vault "github.com/hashicorp/vault/api"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
+)
+
+type proxy struct {
+	client *vault.Client
+	cmd    *exec.Cmd
+
+	ns, podName string
+	kubectl     string
+	vaultCA     []byte
+
+	listenPort int
+	mu         sync.Mutex
+	closeCh    chan struct{}
+}
+
+func newProxy(ns, podName, kubectl string, vaultCA []byte) *proxy {
+	return &proxy{
+		ns:      ns,
+		podName: podName,
+		kubectl: kubectl,
+		vaultCA: vaultCA,
+		closeCh: make(chan struct{}),
+	}
+}
+
+func (p *proxy) init() (*vault.Client, error) {
+	listenPort, err := p.freePort()
+	if err != nil {
+		return nil, err
+	}
+	p.listenPort = listenPort
+
+	cfg := vault.DefaultConfig()
+	cfg.Address = fmt.Sprintf("https://40.0.0.1:%d", p.listenPort)
+
+	caCertPool := x509.NewCertPool()
+	ok := caCertPool.AppendCertsFromPEM(p.vaultCA)
+	if ok == false {
+		return nil, fmt.Errorf("error loading Vault CA bundle: %s", p.vaultCA)
+	}
+
+	cfg.HttpClient.Transport.(*http.Transport).TLSClientConfig.RootCAs = caCertPool
+
+	client, err := vault.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("unable to initialize vault client: %s", err)
+	}
+
+	client.SetToken(vaultToken)
+	p.client = client
+
+	if err := p.runProxy(); err != nil {
+		return nil, fmt.Errorf("failed to start vault port forward: %s", err)
+	}
+
+	go p.nurseProxy()
+
+	return client, nil
+}
+
+func (p *proxy) vaultCmd() *exec.Cmd {
+	args := []string{"port-forward", "-n", p.ns, p.podName, fmt.Sprintf("%d:8185", p.listenPort)}
+	return exec.Command(p.kubectl, args...)
+}
+
+func (p *proxy) nurseProxy() {
+	for {
+		kCh := make(chan struct{})
+		go func() {
+			_ = p.cmd.Wait()
+			close(kCh)
+		}()
+
+		select {
+		// if we are stopping the port forward completely then kill the process and exit
+		case <-p.closeCh:
+			return
+
+			// if the process died, then attempt to recover it
+		case <-kCh:
+			if err := p.runProxy(); err != nil {
+				log.Logf("failed to recover vault port forward: %s", err)
+				return
+			}
+
+			// new proxy started, loop again
+		}
+	}
+}
+
+func (p *proxy) callVault(method, url, field string, params map[string]string) (string, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	req := p.client.NewRequest(method, url)
+
+	err := req.SetJSONBody(params)
+	if err != nil {
+		return "", fmt.Errorf("error encoding Vault parameters: %s", err.Error())
+
+	}
+
+	resp, err := p.client.RawRequest(req)
+	if err != nil {
+		return "", fmt.Errorf("error calling Vault server: %s", err.Error())
+
+	}
+	defer resp.Body.Close()
+
+	result := map[string]interface{}{}
+	resp.DecodeJSON(&result)
+
+	fieldData := ""
+	if field != "" {
+		data := result["data"].(map[string]interface{})
+		fieldData = data[field].(string)
+	}
+
+	return fieldData, err
+}
+
+func (p *proxy) clean() {
+	close(p.closeCh)
+
+	if p.cmd != nil && p.cmd.Process != nil {
+		p.cmd.Process.Kill()
+		p.cmd.Process.Wait()
+	}
+}
+
+func (p *proxy) runProxy() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	err := wait.PollImmediate(time.Second, time.Second*10, func() (bool, error) {
+		p.cmd = p.vaultCmd()
+
+		err := p.cmd.Start()
+		if err != nil {
+			log.Logf("failed to start port-forward: %s", err)
+
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = wait.PollImmediate(time.Second, time.Second*10, func() (bool, error) {
+		// If the response is 400 or higher or can't connect then we get an error.
+		// Anything else is considered ready for serving.
+		_, err := p.client.Sys().Health()
+		if err != nil {
+			log.Logf("vault health failed: %s", err)
+			return false, nil
+		}
+
+		return true, nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *proxy) freePort() (int, error) {
+	l, err := net.ListenTCP("tcp", &net.TCPAddr{
+		IP:   net.ParseIP("127.0.0.1"),
+		Port: 0,
+	})
+	if err != nil {
+		return -1, err
+	}
+	defer l.Close()
+
+	return l.Addr().(*net.TCPAddr).Port, nil
+}

--- a/test/e2e/framework/addon/vault/proxy.go
+++ b/test/e2e/framework/addon/vault/proxy.go
@@ -62,7 +62,7 @@ func (p *proxy) init() (*vault.Client, error) {
 	p.listenPort = listenPort
 
 	cfg := vault.DefaultConfig()
-	cfg.Address = fmt.Sprintf("https://40.0.0.1:%d", p.listenPort)
+	cfg.Address = fmt.Sprintf("https://127.0.0.1:%d", p.listenPort)
 
 	caCertPool := x509.NewCertPool()
 	ok := caCertPool.AppendCertsFromPEM(p.vaultCA)
@@ -90,7 +90,7 @@ func (p *proxy) init() (*vault.Client, error) {
 }
 
 func (p *proxy) vaultCmd() *exec.Cmd {
-	args := []string{"port-forward", "-n", p.ns, p.podName, fmt.Sprintf("%d:8185", p.listenPort)}
+	args := []string{"port-forward", "-n", p.ns, p.podName, fmt.Sprintf("%d:8200", p.listenPort)}
 	return exec.Command(p.kubectl, args...)
 }
 
@@ -169,7 +169,6 @@ func (p *proxy) runProxy() error {
 		err := p.cmd.Start()
 		if err != nil {
 			log.Logf("failed to start port-forward: %s", err)
-
 			return false, nil
 		}
 
@@ -179,7 +178,7 @@ func (p *proxy) runProxy() error {
 		return err
 	}
 
-	err = wait.PollImmediate(time.Second, time.Second*10, func() (bool, error) {
+	err = wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
 		// If the response is 400 or higher or can't connect then we get an error.
 		// Anything else is considered ready for serving.
 		_, err := p.client.Sys().Health()

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -47,10 +47,10 @@ type Vault struct {
 	// Tiller is the tiller instance used to deploy the chart
 	Tiller *tiller.Tiller
 
-	// Name is a unique name for this Pebble deployment
+	// Name is a unique name for this Vault deployment
 	Name string
 
-	// Namespace is the namespace to deploy Pebble into
+	// Namespace is the namespace to deploy Vault into
 	Namespace string
 
 	details Details
@@ -60,7 +60,7 @@ type Details struct {
 	// Kubectl is the path to kubectl
 	Kubectl string
 
-	// Host is the hostname that can be used to connect to Pebble
+	// Host is the hostname that can be used to connect to Vault
 	Host string
 
 	// PodName is the name of the Vault pod
@@ -80,7 +80,7 @@ type Details struct {
 
 func (v *Vault) Setup(cfg *config.Config) error {
 	if v.Name == "" {
-		return fmt.Errorf("Name field must be set on Pebble addon")
+		return fmt.Errorf("Name field must be set on Vault addon")
 	}
 	if v.Namespace == "" {
 		// TODO: in non-global instances, we could generate a new namespace just
@@ -88,7 +88,7 @@ func (v *Vault) Setup(cfg *config.Config) error {
 		return fmt.Errorf("Namespace name must be specified")
 	}
 	if v.Tiller == nil {
-		return fmt.Errorf("Tiller field must be set on Pebble addon")
+		return fmt.Errorf("Tiller field must be set on Vault addon")
 	}
 
 	var err error
@@ -134,7 +134,7 @@ func (v *Vault) Setup(cfg *config.Config) error {
 	return nil
 }
 
-// Provision will actually deploy this instance of Pebble-ingress to the cluster.
+// Provision will actually deploy this instance of Vault to the cluster.
 func (v *Vault) Provision() error {
 	err := v.chart.Provision()
 	if err != nil {
@@ -178,12 +178,12 @@ func (v *Vault) Provision() error {
 	return nil
 }
 
-// Details returns details that can be used to utilise the instance of Pebble.
+// Details returns details that can be used to utilise the instance of Vault.
 func (v *Vault) Details() *Details {
 	return &v.details
 }
 
-// Deprovision will destroy this instance of Pebble
+// Deprovision will destroy this instance of Vault
 func (v *Vault) Deprovision() error {
 	return v.chart.Deprovision()
 }

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -87,7 +87,7 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole)", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		By("Cleaning up")
 		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -89,6 +89,7 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole)", func() {
 
 	AfterEach(func() {
 		By("Cleaning up")
+		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(vaultSecretAppRoleName, nil)
 	})

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -87,7 +87,7 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom 
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		By("Cleaning up")
 		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -89,6 +89,7 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom 
 
 	AfterEach(func() {
 		By("Cleaning up")
+		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(vaultSecretAppRoleName, nil)
 	})

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -94,7 +94,7 @@ var _ = framework.CertManagerDescribe("Vault CertificateRequest (AppRole)", func
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		By("Cleaning up")
 		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -96,6 +96,7 @@ var _ = framework.CertManagerDescribe("Vault CertificateRequest (AppRole)", func
 
 	AfterEach(func() {
 		By("Cleaning up")
+		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(vaultSecretAppRoleName, nil)
 	})

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
@@ -97,6 +97,7 @@ var _ = framework.CertManagerDescribe("Vault CertificateRequest (AppRole with a 
 
 	AfterEach(func() {
 		By("Cleaning up")
+		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(vaultSecretAppRoleName, nil)
 	})

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
@@ -95,7 +95,7 @@ var _ = framework.CertManagerDescribe("Vault CertificateRequest (AppRole with a 
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		By("Cleaning up")
 		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -108,7 +108,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		vaultInit.CleanKubernetesRole(f.KubeClientSet, f.Namespace.Name, vaultKubernetesRoleName, vaultSecretServiceAccount)
 
 		By("Cleaning up Vault")
-		vaultInit.Clean()
+		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
 	})
 
 	const vaultDefaultDuration = time.Hour * 24 * 90

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -98,7 +98,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 	})
 
-	AfterEach(func() {
+	JustAfterEach(func() {
 		By("Cleaning up AppRole")
 		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
 		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(vaultSecretAppRoleName, nil)


### PR DESCRIPTION
fixed #2226

```release-note
NONE
```

Creates a proper wrapper for the port forward for vault connections in e2e tests. This ideally eliminate flakes occurring during to relying on time.Sleep
