### PR TITLE
Add update permission to certificaterequests/finalizers to the cert-manager-controller-certificates clusterrole.

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -121,7 +121,7 @@ rules:
   # admission controller enabled:
   # https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement
   - apiGroups: ["cert-manager.io"]
-    resources: ["certificates/finalizers"]
+    resources: ["certificates/finalizers", "certificaterequests/finalizers"]
     verbs: ["update"]
   - apiGroups: ["acme.cert-manager.io"]
     resources: ["orders"]


### PR DESCRIPTION
fixes: #2305

Signed-off-by: Nils Cant <nils.cant@vargen.io>

```release-note
Fix issue causing certificates not to be issued when running with `OwnerReferencesPermissionEnforcement` admission controller enabled
```