### PR TITLE
Make vault issuer to point to resource namespace over certificaterequest

### DIFF
--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -58,7 +58,7 @@ func NewVaultTokenSecret(name string) *v1.Secret {
 func NewVaultAppRoleSecret(name, secretId string) *v1.Secret {
 	return &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			GenerateName: name,
 		},
 		StringData: map[string]string{
 			"secretkey": secretId,

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -127,8 +127,8 @@ func (a *acmeIssuerProvisioner) createHTTP01Issuer(f *framework.Framework) cmmet
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme HTTP01 issuer")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
 		Name:  issuer.Name,
 	}
 }
@@ -148,8 +148,8 @@ func (a *acmeIssuerProvisioner) createHTTP01ClusterIssuer(f *framework.Framework
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme HTTP01 cluster issuer")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.ClusterIssuerKind,
 		Name:  issuer.Name,
 	}
 }
@@ -200,8 +200,8 @@ func (a *acmeIssuerProvisioner) createDNS01Issuer(f *framework.Framework) cmmeta
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme DNS01 Issuer")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
 		Name:  issuer.Name,
 	}
 }
@@ -226,8 +226,8 @@ func (a *acmeIssuerProvisioner) createDNS01ClusterIssuer(f *framework.Framework)
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme DNS01 ClusterIssuer")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.ClusterIssuerKind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -118,7 +118,7 @@ func (a *acmeIssuerProvisioner) createHTTP01Issuer(f *framework.Framework) cmmet
 	By("Creating an ACME HTTP01 Issuer")
 	issuer := &cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "acme-issuer-http01",
+			GenerateName: "acme-issuer-http01-",
 		},
 		Spec: a.createHTTP01IssuerSpec(),
 	}
@@ -127,8 +127,8 @@ func (a *acmeIssuerProvisioner) createHTTP01Issuer(f *framework.Framework) cmmet
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme HTTP01 issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }
@@ -139,7 +139,7 @@ func (a *acmeIssuerProvisioner) createHTTP01ClusterIssuer(f *framework.Framework
 	By("Creating an ACME HTTP01 ClusterIssuer")
 	issuer := &cmapi.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "acme-issuer-http01",
+			GenerateName: "acme-cluster-issuer-http01-",
 		},
 		Spec: a.createHTTP01IssuerSpec(),
 	}
@@ -148,8 +148,8 @@ func (a *acmeIssuerProvisioner) createHTTP01ClusterIssuer(f *framework.Framework
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme HTTP01 cluster issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.ClusterIssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }
@@ -192,7 +192,7 @@ func (a *acmeIssuerProvisioner) createDNS01Issuer(f *framework.Framework) cmmeta
 	By("Creating an ACME DNS01 Issuer")
 	issuer := &cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "acme-issuer-dns01",
+			GenerateName: "acme-issuer-dns01-",
 		},
 		Spec: a.createDNS01IssuerSpec(),
 	}
@@ -200,8 +200,8 @@ func (a *acmeIssuerProvisioner) createDNS01Issuer(f *framework.Framework) cmmeta
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme DNS01 Issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }
@@ -218,7 +218,7 @@ func (a *acmeIssuerProvisioner) createDNS01ClusterIssuer(f *framework.Framework)
 	By("Creating an ACME DNS01 ClusterIssuer")
 	issuer := &cmapi.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "acme-issuer-dns01",
+			GenerateName: "acme-cluster-issuer-dns01-",
 		},
 		Spec: a.createDNS01IssuerSpec(),
 	}
@@ -226,8 +226,8 @@ func (a *acmeIssuerProvisioner) createDNS01ClusterIssuer(f *framework.Framework)
 	Expect(err).NotTo(HaveOccurred(), "failed to create acme DNS01 ClusterIssuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.ClusterIssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -210,7 +210,7 @@ func (a *acmeIssuerProvisioner) createDNS01ClusterIssuer(f *framework.Framework)
 	a.deployTiller(f, "dns01")
 
 	a.cloudflare = &dnsproviders.Cloudflare{
-		Namespace: f.Namespace.Name,
+		Namespace: addon.CertManager.Namespace,
 	}
 	Expect(a.cloudflare.Setup(f.Config)).NotTo(HaveOccurred(), "failed to setup cloudflare")
 	Expect(a.cloudflare.Provision()).NotTo(HaveOccurred(), "failed to provision cloudflare")

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -99,6 +99,11 @@ func (a *acmeIssuerProvisioner) delete(f *framework.Framework, ref cmmeta.Object
 		Expect(a.cloudflare.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision cloudflare")
 	}
 	Expect(a.tiller.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision tiller")
+
+	if ref.Kind == "ClusterIssuer" {
+		err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(ref.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+	}
 }
 
 // createXXX will deploy the required components to run an ACME issuer based test.

--- a/test/e2e/suite/conformance/certificates/ca/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/ca/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/suite/conformance/certificates:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/test/e2e/suite/conformance/certificates/ca/ca.go
+++ b/test/e2e/suite/conformance/certificates/ca/ca.go
@@ -50,7 +50,7 @@ func createCAIssuer(f *framework.Framework) cmmeta.ObjectReference {
 
 	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ca",
+			GenerateName: "ca-issuer-",
 		},
 		Spec: createCAIssuerSpec(rootCertSecret.Name),
 	})
@@ -58,8 +58,8 @@ func createCAIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	Expect(err).NotTo(HaveOccurred(), "failed to create ca issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }
@@ -72,7 +72,7 @@ func createCAClusterIssuer(f *framework.Framework) cmmeta.ObjectReference {
 
 	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(&cmapi.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "ca",
+			GenerateName: "ca-cluster-issuer-",
 		},
 		Spec: createCAIssuerSpec(rootCertSecret.Name),
 	})
@@ -80,8 +80,8 @@ func createCAClusterIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	Expect(err).NotTo(HaveOccurred(), "failed to create ca issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.ClusterIssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
+++ b/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
@@ -43,18 +43,18 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 func createSelfSignedIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	By("Creating a SelfSigned Issuer")
 
-	_, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "selfsigned",
+			GenerateName: "selfsigned-issuer-",
 		},
 		Spec: createSelfSignedIssuerSpec(),
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
-		Name:  "selfsigned",
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
+		Name:  issuer.Name,
 	}
 }
 
@@ -66,18 +66,18 @@ func deleteSelfSignedClusterIssuer(f *framework.Framework, issuer cmmeta.ObjectR
 func createSelfSignedClusterIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	By("Creating a SelfSigned ClusterIssuer")
 
-	_, err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(&cmapi.ClusterIssuer{
+	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(&cmapi.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "selfsigned",
+			GenerateName: "selfsigned-cluster-issuer-",
 		},
 		Spec: createSelfSignedIssuerSpec(),
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.ClusterIssuerKind,
-		Name:  "selfsigned",
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
+		Name:  issuer.Name,
 	}
 }
 

--- a/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
+++ b/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
@@ -36,6 +36,7 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 	(&certificates.Suite{
 		Name:             "SelfSigned ClusterIssuer",
 		CreateIssuerFunc: createSelfSignedClusterIssuer,
+		DeleteIssuerFunc: deleteSelfSignedClusterIssuer,
 	}).Define()
 })
 
@@ -57,10 +58,15 @@ func createSelfSignedIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	}
 }
 
+func deleteSelfSignedClusterIssuer(f *framework.Framework, issuer cmmeta.ObjectReference) {
+	err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(issuer.Name, nil)
+	Expect(err).NotTo(HaveOccurred())
+}
+
 func createSelfSignedClusterIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	By("Creating a SelfSigned ClusterIssuer")
 
-	_, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+	_, err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(&cmapi.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "selfsigned",
 		},

--- a/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
+++ b/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
@@ -52,8 +52,8 @@ func createSelfSignedIssuer(f *framework.Framework) cmmeta.ObjectReference {
 	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
 		Name:  issuer.Name,
 	}
 }
@@ -75,8 +75,8 @@ func createSelfSignedClusterIssuer(f *framework.Framework) cmmeta.ObjectReferenc
 	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.ClusterIssuerKind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
+++ b/test/e2e/suite/conformance/certificates/selfsigned/selfsigned.go
@@ -29,22 +29,24 @@ import (
 
 var _ = framework.ConformanceDescribe("Certificates", func() {
 	(&certificates.Suite{
-		Name:             "SelfSigned",
+		Name:             "SelfSigned Issuer",
 		CreateIssuerFunc: createSelfSignedIssuer,
+	}).Define()
+
+	(&certificates.Suite{
+		Name:             "SelfSigned ClusterIssuer",
+		CreateIssuerFunc: createSelfSignedClusterIssuer,
 	}).Define()
 })
 
 func createSelfSignedIssuer(f *framework.Framework) cmmeta.ObjectReference {
-	By("Creating a SelfSigned issuer")
+	By("Creating a SelfSigned Issuer")
+
 	_, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "selfsigned",
 		},
-		Spec: cmapi.IssuerSpec{
-			IssuerConfig: cmapi.IssuerConfig{
-				SelfSigned: &cmapi.SelfSignedIssuer{},
-			},
-		},
+		Spec: createSelfSignedIssuerSpec(),
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
 
@@ -52,5 +54,31 @@ func createSelfSignedIssuer(f *framework.Framework) cmmeta.ObjectReference {
 		Group: cmapi.SchemeGroupVersion.Group,
 		Kind:  cmapi.IssuerKind,
 		Name:  "selfsigned",
+	}
+}
+
+func createSelfSignedClusterIssuer(f *framework.Framework) cmmeta.ObjectReference {
+	By("Creating a SelfSigned ClusterIssuer")
+
+	_, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "selfsigned",
+		},
+		Spec: createSelfSignedIssuerSpec(),
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to create self signed issuer")
+
+	return cmmeta.ObjectReference{
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.ClusterIssuerKind,
+		Name:  "selfsigned",
+	}
+}
+
+func createSelfSignedIssuerSpec() cmapi.IssuerSpec {
+	return cmapi.IssuerSpec{
+		IssuerConfig: cmapi.IssuerConfig{
+			SelfSigned: &cmapi.SelfSignedIssuer{},
+		},
 	}
 }

--- a/test/e2e/suite/conformance/certificates/vault/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/vault/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
         "//test/e2e/suite/conformance/certificates:go_default_library",

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -76,6 +76,14 @@ func (v *vaultAppRoleProvisioner) delete(f *framework.Framework, ref cmmeta.Obje
 	Expect(v.vaultInit.Clean()).NotTo(HaveOccurred(), "failed to deprovision vault initializer")
 	Expect(v.vault.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision vault")
 	Expect(v.tiller.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision tiller")
+
+	if ref.Kind == "ClusterIssuer" {
+		err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(ref.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = f.KubeClientSet.CoreV1().Secrets(addon.CertManager.Namespace).Delete(vaultSecretAppRoleName, nil)
+		Expect(err).NotTo(HaveOccurred())
+	}
 }
 
 func (v *vaultAppRoleProvisioner) createIssuer(f *framework.Framework) cmmeta.ObjectReference {

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -26,9 +26,17 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vault "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
+)
+
+const (
+	intermediateMount      = "intermediate-ca"
+	role                   = "kubernetes-vault"
+	vaultSecretAppRoleName = "vault-role"
+	authPath               = "approle"
 )
 
 var _ = framework.ConformanceDescribe("Certificates", func() {
@@ -39,8 +47,15 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 	provisioner := new(vaultAppRoleProvisioner)
 
 	(&certificates.Suite{
-		Name:                "VaultAppRole",
-		CreateIssuerFunc:    provisioner.create,
+		Name:                "VaultAppRole Issuer",
+		CreateIssuerFunc:    provisioner.createIssuer,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
+
+	(&certificates.Suite{
+		Name:                "VaultAppRole ClusterIssuer",
+		CreateIssuerFunc:    provisioner.createClusterIssuer,
 		DeleteIssuerFunc:    provisioner.delete,
 		UnsupportedFeatures: unsupportedFeatures,
 	}).Define()
@@ -52,15 +67,64 @@ type vaultAppRoleProvisioner struct {
 	vaultInit *vault.VaultInitializer
 }
 
+type vaultSecrets struct {
+	roleID   string
+	secretID string
+}
+
 func (v *vaultAppRoleProvisioner) delete(f *framework.Framework, ref cmmeta.ObjectReference) {
 	Expect(v.vaultInit.Clean()).NotTo(HaveOccurred(), "failed to deprovision vault initializer")
 	Expect(v.vault.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision vault")
 	Expect(v.tiller.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision tiller")
 }
 
-func (v *vaultAppRoleProvisioner) create(f *framework.Framework) cmmeta.ObjectReference {
-	By("Creating a VaultAppRole issuer")
+func (v *vaultAppRoleProvisioner) createIssuer(f *framework.Framework) cmmeta.ObjectReference {
+	By("Creating a VaultAppRole Issuer")
 
+	vaultSecrets := v.initVault(f)
+
+	_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(vault.NewVaultAppRoleSecret(vaultSecretAppRoleName, vaultSecrets.secretID))
+	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
+
+	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vault-issuer",
+		},
+		Spec: v.createIssuerSpec(f, vaultSecrets),
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
+
+	return cmmeta.ObjectReference{
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
+		Name:  issuer.Name,
+	}
+}
+
+func (v *vaultAppRoleProvisioner) createClusterIssuer(f *framework.Framework) cmmeta.ObjectReference {
+	By("Creating a VaultAppRole ClusterIssuer")
+
+	vaultSecrets := v.initVault(f)
+
+	_, err := f.KubeClientSet.CoreV1().Secrets(addon.CertManager.Namespace).Create(vault.NewVaultAppRoleSecret(vaultSecretAppRoleName, vaultSecrets.secretID))
+	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
+
+	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "vault-issuer",
+		},
+		Spec: v.createIssuerSpec(f, vaultSecrets),
+	})
+	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
+
+	return cmmeta.ObjectReference{
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.ClusterIssuerKind,
+		Name:  issuer.Name,
+	}
+}
+
+func (v *vaultAppRoleProvisioner) initVault(f *framework.Framework) *vaultSecrets {
 	v.tiller = &tiller.Tiller{
 		Name:               "tiller-deploy",
 		Namespace:          f.Namespace.Name,
@@ -77,12 +141,6 @@ func (v *vaultAppRoleProvisioner) create(f *framework.Framework) cmmeta.ObjectRe
 	Expect(v.vault.Setup(f.Config)).NotTo(HaveOccurred(), "failed to setup vault")
 	Expect(v.vault.Provision()).NotTo(HaveOccurred(), "failed to provision vault")
 
-	intermediateMount := "intermediate-ca"
-	role := "kubernetes-vault"
-	vaultSecretAppRoleName := "vault-role"
-	vaultPath := path.Join(intermediateMount, "sign", role)
-	authPath := "approle"
-
 	By("Configuring the VaultAppRole server")
 	v.vaultInit = &vault.VaultInitializer{
 		Details:           *v.vault.Details(),
@@ -97,40 +155,34 @@ func (v *vaultAppRoleProvisioner) create(f *framework.Framework) cmmeta.ObjectRe
 	roleID, secretID, err := v.vaultInit.CreateAppRole()
 	Expect(err).NotTo(HaveOccurred(), "vault to create app role from vault")
 
-	_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(vault.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretID))
-	Expect(err).NotTo(HaveOccurred(), "vault to store app role secret from vault")
+	return &vaultSecrets{
+		roleID:   roleID,
+		secretID: secretID,
+	}
+}
 
-	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "vault-issuer",
-		},
-		Spec: cmapi.IssuerSpec{
-			IssuerConfig: cmapi.IssuerConfig{
-				Vault: &cmapi.VaultIssuer{
-					Server:   v.vault.Details().Host,
-					Path:     vaultPath,
-					CABundle: v.vault.Details().VaultCA,
-					Auth: cmapi.VaultAuth{
-						AppRole: &cmapi.VaultAppRole{
-							Path:   authPath,
-							RoleId: roleID,
-							SecretRef: cmmeta.SecretKeySelector{
-								Key: "secretkey",
-								LocalObjectReference: cmmeta.LocalObjectReference{
-									Name: vaultSecretAppRoleName,
-								},
+func (v *vaultAppRoleProvisioner) createIssuerSpec(f *framework.Framework, secs *vaultSecrets) cmapi.IssuerSpec {
+	vaultPath := path.Join(intermediateMount, "sign", role)
+
+	return cmapi.IssuerSpec{
+		IssuerConfig: cmapi.IssuerConfig{
+			Vault: &cmapi.VaultIssuer{
+				Server:   v.vault.Details().Host,
+				Path:     vaultPath,
+				CABundle: v.vault.Details().VaultCA,
+				Auth: cmapi.VaultAuth{
+					AppRole: &cmapi.VaultAppRole{
+						Path:   authPath,
+						RoleId: secs.roleID,
+						SecretRef: cmmeta.SecretKeySelector{
+							Key: "secretkey",
+							LocalObjectReference: cmmeta.LocalObjectReference{
+								Name: vaultSecretAppRoleName,
 							},
 						},
 					},
 				},
 			},
 		},
-	})
-	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
-
-	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
-		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -96,15 +96,15 @@ func (v *vaultAppRoleProvisioner) createIssuer(f *framework.Framework) cmmeta.Ob
 
 	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "vault-issuer",
+			GenerateName: "vault-issuer-",
 		},
 		Spec: v.createIssuerSpec(f, vaultSecrets),
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }
@@ -119,15 +119,15 @@ func (v *vaultAppRoleProvisioner) createClusterIssuer(f *framework.Framework) cm
 
 	issuer, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(&cmapi.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "vault-issuer",
+			GenerateName: "vault-cluster-issuer-",
 		},
 		Spec: v.createIssuerSpec(f, vaultSecrets),
 	})
 	Expect(err).NotTo(HaveOccurred(), "failed to create vault issuer")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.ClusterIssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/util/errors:go_default_library",
         "//test/e2e/suite/issuers/venafi/addon:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",

--- a/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/venafi",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",

--- a/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates/venafi",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -62,6 +62,11 @@ type venafiProvisioner struct {
 
 func (v *venafiProvisioner) delete(f *framework.Framework, ref cmmeta.ObjectReference) {
 	Expect(v.tpp.Deprovision()).NotTo(HaveOccurred(), "failed to deprovision tpp venafi")
+
+	if ref.Kind == "ClusterIssuer" {
+		err := f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(ref.Name, nil)
+		Expect(err).NotTo(HaveOccurred())
+	}
 }
 
 func (v *venafiProvisioner) createIssuer(f *framework.Framework) cmmeta.ObjectReference {

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -20,7 +20,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
@@ -89,8 +88,8 @@ func (v *venafiProvisioner) createIssuer(f *framework.Framework) cmmeta.ObjectRe
 	Expect(err).NotTo(HaveOccurred(), "failed to create issuer for venafi")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.IssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }
@@ -115,8 +114,8 @@ func (v *venafiProvisioner) createClusterIssuer(f *framework.Framework) cmmeta.O
 	Expect(err).NotTo(HaveOccurred(), "failed to create issuer for venafi")
 
 	return cmmeta.ObjectReference{
-		Group: cmapi.SchemeGroupVersion.Group,
-		Kind:  cmapi.ClusterIssuerKind,
+		Group: issuer.GroupVersionKind().Group,
+		Kind:  issuer.Kind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
@@ -88,8 +89,8 @@ func (v *venafiProvisioner) createIssuer(f *framework.Framework) cmmeta.ObjectRe
 	Expect(err).NotTo(HaveOccurred(), "failed to create issuer for venafi")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.IssuerKind,
 		Name:  issuer.Name,
 	}
 }
@@ -114,8 +115,8 @@ func (v *venafiProvisioner) createClusterIssuer(f *framework.Framework) cmmeta.O
 	Expect(err).NotTo(HaveOccurred(), "failed to create issuer for venafi")
 
 	return cmmeta.ObjectReference{
-		Group: issuer.GroupVersionKind().Group,
-		Kind:  issuer.Kind,
+		Group: cmapi.SchemeGroupVersion.Group,
+		Kind:  cmapi.ClusterIssuerKind,
 		Name:  issuer.Name,
 	}
 }

--- a/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
         "//test/e2e/util:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -78,14 +78,14 @@ func runVaultAppRoleTests(issuerKind string) {
 
 	var vaultSecretNamespace string
 
-	if issuerKind == cmapi.IssuerKind {
-		vaultSecretNamespace = f.Namespace.Name
-	} else {
-		vaultSecretNamespace = "kube-system"
-	}
-
 	BeforeEach(func() {
 		By("Configuring the Vault server")
+		if issuerKind == cmapi.IssuerKind {
+			vaultSecretNamespace = f.Namespace.Name
+		} else {
+			vaultSecretNamespace = "kube-system"
+		}
+
 		vaultInit = &vaultaddon.VaultInitializer{
 			Details:           *vault.Details(),
 			RootMount:         rootMount,

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -26,6 +26,7 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
@@ -83,7 +84,7 @@ func runVaultAppRoleTests(issuerKind string) {
 		if issuerKind == cmapi.IssuerKind {
 			vaultSecretNamespace = f.Namespace.Name
 		} else {
-			vaultSecretNamespace = "kube-system"
+			vaultSecretNamespace = addon.CertManager.Namespace
 		}
 
 		vaultInit = &vaultaddon.VaultInitializer{

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -73,8 +73,7 @@ func runVaultAppRoleTests(issuerKind string) {
 	vaultSecretAppRoleName := "vault-role"
 	vaultPath := path.Join(intermediateMount, "sign", role)
 	authPath := "approle"
-	var roleId string
-	var secretId string
+	var roleId, secretId, vaultSecretName string
 	var vaultInit *vaultaddon.VaultInitializer
 
 	var vaultSecretNamespace string
@@ -100,8 +99,10 @@ func runVaultAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 		roleId, secretId, err = vaultInit.CreateAppRole()
 		Expect(err).NotTo(HaveOccurred())
-		_, err = f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Create(vaultaddon.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretId))
+		sec, err := f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Create(vaultaddon.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretId))
 		Expect(err).NotTo(HaveOccurred())
+
+		vaultSecretName = sec.Name
 	})
 
 	JustAfterEach(func() {
@@ -114,7 +115,7 @@ func runVaultAppRoleTests(issuerKind string) {
 			f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(issuerName, nil)
 		}
 
-		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(vaultSecretAppRoleName, nil)
+		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(vaultSecretName, nil)
 	})
 
 	It("should generate a new valid certificate", func() {
@@ -125,9 +126,9 @@ func runVaultAppRoleTests(issuerKind string) {
 
 		var err error
 		if issuerKind == cmapi.IssuerKind {
-			_, err = f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+			_, err = f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA))
 		} else {
-			_, err = f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(util.NewCertManagerVaultClusterIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+			_, err = f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(util.NewCertManagerVaultClusterIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA))
 		}
 
 		Expect(err).NotTo(HaveOccurred())
@@ -201,9 +202,9 @@ func runVaultAppRoleTests(issuerKind string) {
 
 			var err error
 			if issuerKind == cmapi.IssuerKind {
-				_, err = f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+				_, err = f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA))
 			} else {
-				_, err = f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(util.NewCertManagerVaultClusterIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+				_, err = f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(util.NewCertManagerVaultClusterIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA))
 			}
 			Expect(err).NotTo(HaveOccurred())
 

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -26,6 +26,7 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
@@ -82,7 +83,7 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 		if issuerKind == cmapi.IssuerKind {
 			vaultSecretNamespace = f.Namespace.Name
 		} else {
-			vaultSecretNamespace = "kube-system"
+			vaultSecretNamespace = addon.CertManager.Namespace
 		}
 
 		vaultInit = &vaultaddon.VaultInitializer{

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -73,18 +73,18 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 	vaultPath := path.Join(intermediateMount, "sign", role)
 	var roleId string
 	var secretId string
+	var vaultSecretNamespace string
 
 	var vaultInit *vaultaddon.VaultInitializer
 
-	var vaultSecretNamespace string
-	if issuerKind == cmapi.IssuerKind {
-		vaultSecretNamespace = f.Namespace.Name
-	} else {
-		vaultSecretNamespace = "kube-system"
-	}
-
 	BeforeEach(func() {
 		By("Configuring the Vault server")
+		if issuerKind == cmapi.IssuerKind {
+			vaultSecretNamespace = f.Namespace.Name
+		} else {
+			vaultSecretNamespace = "kube-system"
+		}
+
 		vaultInit = &vaultaddon.VaultInitializer{
 			Details:           *vault.Details(),
 			RootMount:         rootMount,

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -23,7 +23,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
@@ -31,7 +31,15 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/util"
 )
 
-var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom mount path)", func() {
+var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole with a custom mount path)", func() {
+	runVaultCustomAppRoleTests(cmapi.IssuerKind)
+})
+
+var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole with a custom mount path)", func() {
+	runVaultCustomAppRoleTests(cmapi.ClusterIssuerKind)
+})
+
+func runVaultCustomAppRoleTests(issuerKind string) {
 	f := framework.NewDefaultFramework("create-vault-certificate")
 	h := f.Helper()
 
@@ -68,6 +76,13 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom 
 
 	var vaultInit *vaultaddon.VaultInitializer
 
+	var vaultSecretNamespace string
+	if issuerKind == cmapi.IssuerKind {
+		vaultSecretNamespace = f.Namespace.Name
+	} else {
+		vaultSecretNamespace = "kube-system"
+	}
+
 	BeforeEach(func() {
 		By("Configuring the Vault server")
 		vaultInit = &vaultaddon.VaultInitializer{
@@ -83,15 +98,21 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom 
 		Expect(err).NotTo(HaveOccurred())
 		roleId, secretId, err = vaultInit.CreateAppRole()
 		Expect(err).NotTo(HaveOccurred())
-		_, err = f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(vaultaddon.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretId))
+		_, err = f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Create(vaultaddon.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretId))
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	JustAfterEach(func() {
 		By("Cleaning up")
 		Expect(vaultInit.Clean()).NotTo(HaveOccurred())
-		f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(vaultSecretAppRoleName, nil)
+
+		if issuerKind == cmapi.IssuerKind {
+			f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Delete(issuerName, nil)
+		} else {
+			f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(issuerName, nil)
+		}
+
+		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(vaultSecretAppRoleName, nil)
 	})
 
 	It("should generate a new valid certificate", func() {
@@ -100,23 +121,39 @@ var _ = framework.CertManagerDescribe("Vault Certificate (AppRole with a custom 
 
 		certClient := f.CertManagerClientSet.CertmanagerV1alpha2().Certificates(f.Namespace.Name)
 
-		_, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+		var err error
+		if issuerKind == cmapi.IssuerKind {
+			_, err = f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+		} else {
+			_, err = f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Create(util.NewCertManagerVaultClusterIssuerAppRole(issuerName, vaultURL, vaultPath, roleId, vaultSecretAppRoleName, authPath, vault.Details().VaultCA))
+		}
+
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
-		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name),
-			issuerName,
-			v1alpha2.IssuerCondition{
-				Type:   v1alpha2.IssuerConditionReady,
-				Status: cmmeta.ConditionTrue,
-			})
+		if issuerKind == cmapi.IssuerKind {
+			err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name),
+				issuerName,
+				cmapi.IssuerCondition{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				})
+		} else {
+			err = util.WaitForClusterIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers(),
+				issuerName,
+				cmapi.IssuerCondition{
+					Type:   cmapi.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				})
+		}
+
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Creating a Certificate")
-		_, err = certClient.Create(util.NewCertManagerVaultCertificate(certificateName, certificateSecretName, issuerName, v1alpha2.IssuerKind, nil, nil))
+		_, err = certClient.Create(util.NewCertManagerVaultCertificate(certificateName, certificateSecretName, issuerName, issuerKind, nil, nil))
 		Expect(err).NotTo(HaveOccurred())
 
 		err = h.WaitCertificateIssuedValid(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 	})
-})
+}

--- a/test/e2e/suite/issuers/vault/certificaterequest/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/certificaterequest/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
+        "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/tiller:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
         "//test/e2e/util:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -29,6 +29,7 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
@@ -90,7 +91,7 @@ func runVaultAppRoleTests(issuerKind string) {
 		if issuerKind == cmapi.IssuerKind {
 			vaultSecretNamespace = f.Namespace.Name
 		} else {
-			vaultSecretNamespace = "kube-system"
+			vaultSecretNamespace = addon.CertManager.Namespace
 		}
 
 		vaultInit = &vaultaddon.VaultInitializer{

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -84,14 +84,15 @@ func runVaultAppRoleTests(issuerKind string) {
 	var vaultInit *vaultaddon.VaultInitializer
 
 	var vaultSecretNamespace string
-	if issuerKind == cmapi.IssuerKind {
-		vaultSecretNamespace = f.Namespace.Name
-	} else {
-		vaultSecretNamespace = "kube-system"
-	}
 
 	BeforeEach(func() {
 		By("Configuring the Vault server")
+		if issuerKind == cmapi.IssuerKind {
+			vaultSecretNamespace = f.Namespace.Name
+		} else {
+			vaultSecretNamespace = "kube-system"
+		}
+
 		vaultInit = &vaultaddon.VaultInitializer{
 			Details:           *vault.Details(),
 			RootMount:         rootMount,

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
@@ -85,14 +85,16 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 	var vaultInit *vaultaddon.VaultInitializer
 
 	var vaultSecretNamespace string
-	if issuerKind == cmapi.IssuerKind {
-		vaultSecretNamespace = f.Namespace.Name
-	} else {
-		vaultSecretNamespace = "kube-system"
-	}
 
 	BeforeEach(func() {
 		By("Configuring the Vault server")
+
+		if issuerKind == cmapi.IssuerKind {
+			vaultSecretNamespace = f.Namespace.Name
+		} else {
+			vaultSecretNamespace = "kube-system"
+		}
+
 		vaultInit = &vaultaddon.VaultInitializer{
 			Details:           *vault.Details(),
 			RootMount:         rootMount,

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
@@ -78,10 +78,9 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 	role := "kubernetes-vault"
 	issuerName := "test-vault-issuer"
 	certificateRequestName := "test-vault-certificaterequest"
-	vaultSecretAppRoleName := "vault-role"
+	vaultSecretAppRoleName := "vault-role-"
 	vaultPath := path.Join(intermediateMount, "sign", role)
-	var roleId string
-	var secretId string
+	var roleId, secretId, vaultSecretName string
 
 	var vaultInit *vaultaddon.VaultInitializer
 
@@ -109,8 +108,10 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 		roleId, secretId, err = vaultInit.CreateAppRole()
 		Expect(err).NotTo(HaveOccurred())
-		_, err = f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Create(vaultaddon.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretId))
+		sec, err := f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Create(vaultaddon.NewVaultAppRoleSecret(vaultSecretAppRoleName, secretId))
 		Expect(err).NotTo(HaveOccurred())
+
+		vaultSecretName = sec.Name
 	})
 
 	JustAfterEach(func() {
@@ -123,7 +124,7 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 			f.CertManagerClientSet.CertmanagerV1alpha2().ClusterIssuers().Delete(issuerName, nil)
 		}
 
-		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(vaultSecretAppRoleName, nil)
+		f.KubeClientSet.CoreV1().Secrets(vaultSecretNamespace).Delete(vaultSecretName, nil)
 	})
 
 	It("should generate a new valid certificate", func() {

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
@@ -29,6 +29,7 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon/tiller"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
@@ -92,7 +93,7 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 		if issuerKind == cmapi.IssuerKind {
 			vaultSecretNamespace = f.Namespace.Name
 		} else {
-			vaultSecretNamespace = "kube-system"
+			vaultSecretNamespace = addon.CertManager.Namespace
 		}
 
 		vaultInit = &vaultaddon.VaultInitializer{

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -119,12 +119,12 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 		vaultSecretName = sec.Name
 
-		_, err = f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretName, appRoleAuthPath, vault.Details().VaultCA))
+		iss, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretName, appRoleAuthPath, vault.Details().VaultCA))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name),
-			issuerName,
+			iss.Name,
 			v1alpha2.IssuerCondition{
 				Type:   v1alpha2.IssuerConditionReady,
 				Status: cmmeta.ConditionTrue,
@@ -134,12 +134,12 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init with missing Vault AppRole", func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretAppRoleName, appRoleAuthPath, vault.Details().VaultCA))
+		iss, err := f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name).Create(util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretAppRoleName, appRoleAuthPath, vault.Details().VaultCA))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1alpha2().Issuers(f.Namespace.Name),
-			issuerName,
+			iss.Name,
 			v1alpha2.IssuerCondition{
 				Type:   v1alpha2.IssuerConditionReady,
 				Status: cmmeta.ConditionFalse,

--- a/test/e2e/suite/issuers/venafi/addon/tpp.go
+++ b/test/e2e/suite/issuers/venafi/addon/tpp.go
@@ -126,3 +126,16 @@ func (t *TPPDetails) BuildIssuer() *cmapi.Issuer {
 		},
 	}
 }
+
+func (t *TPPDetails) BuildClusterIssuer() *cmapi.ClusterIssuer {
+	return &cmapi.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "venafi-tpp-",
+		},
+		Spec: cmapi.IssuerSpec{
+			IssuerConfig: cmapi.IssuerConfig{
+				Venafi: &t.issuerTemplate,
+			},
+		},
+	}
+}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -488,7 +488,7 @@ func NewCertManagerVaultIssuerToken(name, vaultURL, vaultPath, vaultSecretToken,
 func NewCertManagerVaultIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) *v1alpha2.Issuer {
 	return &v1alpha2.Issuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			GenerateName: name,
 		},
 		Spec: newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole, authPath, caBundle),
 	}
@@ -497,7 +497,7 @@ func NewCertManagerVaultIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSe
 func NewCertManagerVaultClusterIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) *v1alpha2.ClusterIssuer {
 	return &v1alpha2.ClusterIssuer{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
+			GenerateName: name,
 		},
 		Spec: newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole, authPath, caBundle),
 	}

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -490,21 +490,34 @@ func NewCertManagerVaultIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSe
 		ObjectMeta: metav1.ObjectMeta{
 			Name: name,
 		},
-		Spec: v1alpha2.IssuerSpec{
-			IssuerConfig: v1alpha2.IssuerConfig{
-				Vault: &v1alpha2.VaultIssuer{
-					Server:   vaultURL,
-					Path:     vaultPath,
-					CABundle: caBundle,
-					Auth: v1alpha2.VaultAuth{
-						AppRole: &v1alpha2.VaultAppRole{
-							Path:   authPath,
-							RoleId: roleId,
-							SecretRef: cmmeta.SecretKeySelector{
-								Key: "secretkey",
-								LocalObjectReference: cmmeta.LocalObjectReference{
-									Name: vaultSecretAppRole,
-								},
+		Spec: newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole, authPath, caBundle),
+	}
+}
+
+func NewCertManagerVaultClusterIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) *v1alpha2.ClusterIssuer {
+	return &v1alpha2.ClusterIssuer{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+		Spec: newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole, authPath, caBundle),
+	}
+}
+
+func newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) v1alpha2.IssuerSpec {
+	return v1alpha2.IssuerSpec{
+		IssuerConfig: v1alpha2.IssuerConfig{
+			Vault: &v1alpha2.VaultIssuer{
+				Server:   vaultURL,
+				Path:     vaultPath,
+				CABundle: caBundle,
+				Auth: v1alpha2.VaultAuth{
+					AppRole: &v1alpha2.VaultAppRole{
+						Path:   authPath,
+						RoleId: roleId,
+						SecretRef: cmmeta.SecretKeySelector{
+							Key: "secretkey",
+							LocalObjectReference: cmmeta.LocalObjectReference{
+								Name: vaultSecretAppRole,
 							},
 						},
 					},


### PR DESCRIPTION
fixes #2231 

Points the vault client to the correct secret when using a cluster issuer. Previously it used the same namespace as the CertificateRequest which has now been changed to the cluster resource namespace (kube-system)

```release-note
NONE
```
