### PR TITLE
Changes the vault issuer Kubernetes auth path to require the full *mount* path

### DIFF
--- a/deploy/charts/cert-manager/crds/clusterissuers.yaml
+++ b/deploy/charts/cert-manager/crds/clusterissuers.yaml
@@ -1473,11 +1473,10 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The value here will be used as part of the
-                            path used when authenticating with vault, for example
-                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
-                            If unspecified, the default value "kubernetes" will be
-                            used.
+                          description: The vault here is the path to use when authenticating
+                            with vault, for example setting a value to `/v1/auth/foo/login`.
+                            If unspecified, the default value "/v1/auth/kubernetes/login"
+                            will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role

--- a/deploy/charts/cert-manager/crds/clusterissuers.yaml
+++ b/deploy/charts/cert-manager/crds/clusterissuers.yaml
@@ -1473,10 +1473,11 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The vault here is the path to use when authenticating
-                            with vault, for example setting a value to `/v1/auth/foo/login`.
-                            If unspecified, the default value "/v1/auth/kubernetes/login"
-                            will be used.
+                          description: The Vault mountPath here is the mount path
+                            to use when authenticating with Vault. For example, setting
+                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                            to authenticate with Vault. If unspecified, the default
+                            value "/v1/auth/kubernetes" will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role

--- a/deploy/charts/cert-manager/crds/issuers.yaml
+++ b/deploy/charts/cert-manager/crds/issuers.yaml
@@ -1473,11 +1473,10 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The value here will be used as part of the
-                            path used when authenticating with vault, for example
-                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
-                            If unspecified, the default value "kubernetes" will be
-                            used.
+                          description: The vault here is the path to use when authenticating
+                            with vault, for example setting a value to `/v1/auth/foo/login`.
+                            If unspecified, the default value "/v1/auth/kubernetes/login"
+                            will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role

--- a/deploy/charts/cert-manager/crds/issuers.yaml
+++ b/deploy/charts/cert-manager/crds/issuers.yaml
@@ -1473,10 +1473,11 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The vault here is the path to use when authenticating
-                            with vault, for example setting a value to `/v1/auth/foo/login`.
-                            If unspecified, the default value "/v1/auth/kubernetes/login"
-                            will be used.
+                          description: The Vault mountPath here is the mount path
+                            to use when authenticating with Vault. For example, setting
+                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                            to authenticate with Vault. If unspecified, the default
+                            value "/v1/auth/kubernetes" will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -3257,10 +3257,11 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The vault here is the path to use when authenticating
-                            with vault, for example setting a value to `/v1/auth/foo/login`.
-                            If unspecified, the default value "/v1/auth/kubernetes/login"
-                            will be used.
+                          description: The Vault mountPath here is the mount path
+                            to use when authenticating with Vault. For example, setting
+                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                            to authenticate with Vault. If unspecified, the default
+                            value "/v1/auth/kubernetes" will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role
@@ -4911,10 +4912,11 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The vault here is the path to use when authenticating
-                            with vault, for example setting a value to `/v1/auth/foo/login`.
-                            If unspecified, the default value "/v1/auth/kubernetes/login"
-                            will be used.
+                          description: The Vault mountPath here is the mount path
+                            to use when authenticating with Vault. For example, setting
+                            a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login`
+                            to authenticate with Vault. If unspecified, the default
+                            value "/v1/auth/kubernetes" will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -3257,11 +3257,10 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The value here will be used as part of the
-                            path used when authenticating with vault, for example
-                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
-                            If unspecified, the default value "kubernetes" will be
-                            used.
+                          description: The vault here is the path to use when authenticating
+                            with vault, for example setting a value to `/v1/auth/foo/login`.
+                            If unspecified, the default value "/v1/auth/kubernetes/login"
+                            will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role
@@ -4912,11 +4911,10 @@ spec:
                       - secretRef
                       properties:
                         mountPath:
-                          description: The value here will be used as part of the
-                            path used when authenticating with vault, for example
-                            if you set a value of "foo", the path used will be `/v1/auth/foo/login`.
-                            If unspecified, the default value "kubernetes" will be
-                            used.
+                          description: The vault here is the path to use when authenticating
+                            with vault, for example setting a value to `/v1/auth/foo/login`.
+                            If unspecified, the default value "/v1/auth/kubernetes/login"
+                            will be used.
                           type: string
                         role:
                           description: A required field containing the Vault Role

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -2691,7 +2691,7 @@ Appears In:
 </thead>
 <tbody><tr>
 <td><code>mountPath</code><br /> <em>string</em></td>
-<td>The vault here is the path to use when authenticating with vault, for example setting a value to <code>/v1/auth/foo/login</code>. If unspecified, the default value &#34;/v1/auth/kubernetes/login&#34; will be used.</td>
+<td>The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to <code>/v1/auth/foo</code>, will use the path <code>/v1/auth/foo/login</code> to authenticate with Vault. If unspecified, the default value &#34;/v1/auth/kubernetes&#34; will be used.</td>
 </tr>
 <tr>
 <td><code>role</code><br /> <em>string</em></td>

--- a/docs/generated/reference/output/reference/api-docs/index.html
+++ b/docs/generated/reference/output/reference/api-docs/index.html
@@ -2691,7 +2691,7 @@ Appears In:
 </thead>
 <tbody><tr>
 <td><code>mountPath</code><br /> <em>string</em></td>
-<td>The value here will be used as part of the path used when authenticating with vault, for example if you set a value of &#34;foo&#34;, the path used will be <code>/v1/auth/foo/login</code>. If unspecified, the default value &#34;kubernetes&#34; will be used.</td>
+<td>The vault here is the path to use when authenticating with vault, for example setting a value to <code>/v1/auth/foo/login</code>. If unspecified, the default value &#34;/v1/auth/kubernetes/login&#34; will be used.</td>
 </tr>
 <tr>
 <td><code>role</code><br /> <em>string</em></td>

--- a/pkg/apis/certmanager/v1alpha2/const.go
+++ b/pkg/apis/certmanager/v1alpha2/const.go
@@ -38,5 +38,5 @@ const (
 
 	// Default mount path location for Kubernetes ServiceAccount authentication
 	// (/v1/auth/kubernetes/login)
-	DefaultVaultKubernetesAuthMountPath = "kubernetes"
+	DefaultVaultKubernetesAuthMountPath = "/v1/auth/kubernetes/login"
 )

--- a/pkg/apis/certmanager/v1alpha2/const.go
+++ b/pkg/apis/certmanager/v1alpha2/const.go
@@ -37,6 +37,7 @@ const (
 	DefaultVaultTokenAuthSecretKey = "token"
 
 	// Default mount path location for Kubernetes ServiceAccount authentication
-	// (/v1/auth/kubernetes/login)
-	DefaultVaultKubernetesAuthMountPath = "/v1/auth/kubernetes/login"
+	// (/v1/auth/kubernetes). The endpoint will then be called at `/login`, so
+	// left as the default, `/v1/auth/kubernetes/login` will be called.
+	DefaultVaultKubernetesAuthMountPath = "/v1/auth/kubernetes"
 )

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -193,10 +193,9 @@ type VaultAppRole struct {
 // Authenticate against Vault using a Kubernetes ServiceAccount token stored in
 // a Secret.
 type VaultKubernetesAuth struct {
-	// The value here will be used as part of the path used when authenticating
-	// with vault, for example if you set a value of "foo", the path used will be
-	// `/v1/auth/foo/login`. If unspecified, the default value "kubernetes" will
-	// be used.
+	// The vault here is the path to use when authenticating with vault, for
+	// example setting a value to `/v1/auth/foo/login`. If unspecified, the
+	// default value "/v1/auth/kubernetes/login" will be used.
 	// +optional
 	Path string `json:"mountPath,omitempty"`
 

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -193,9 +193,10 @@ type VaultAppRole struct {
 // Authenticate against Vault using a Kubernetes ServiceAccount token stored in
 // a Secret.
 type VaultKubernetesAuth struct {
-	// The vault here is the path to use when authenticating with vault, for
-	// example setting a value to `/v1/auth/foo/login`. If unspecified, the
-	// default value "/v1/auth/kubernetes/login" will be used.
+	// The Vault mountPath here is the mount path to use when authenticating with
+	// Vault. For example, setting a value to `/v1/auth/foo`, will use the path
+	// `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the
+	// default value "/v1/auth/kubernetes" will be used.
 	// +optional
 	Path string `json:"mountPath,omitempty"`
 

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"net/http"
 	"path"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -317,7 +318,8 @@ func (v *Vault) requestTokenWithKubernetesAuth(client Client, kubernetesAuth *v1
 		mountPath = v1alpha2.DefaultVaultKubernetesAuthMountPath
 	}
 
-	request := client.NewRequest("POST", mountPath)
+	url := filepath.Join(mountPath, "login")
+	request := client.NewRequest("POST", url)
 	err = request.SetJSONBody(parameters)
 	if err != nil {
 		return "", fmt.Errorf("error encoding Vault parameters: %s", err.Error())

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net/http"
 	"path"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -318,8 +317,7 @@ func (v *Vault) requestTokenWithKubernetesAuth(client Client, kubernetesAuth *v1
 		mountPath = v1alpha2.DefaultVaultKubernetesAuthMountPath
 	}
 
-	url := filepath.Join("/v1", "auth", mountPath, "login")
-	request := client.NewRequest("POST", url)
+	request := client.NewRequest("POST", mountPath)
 	err = request.SetJSONBody(parameters)
 	if err != nil {
 		return "", fmt.Errorf("error encoding Vault parameters: %s", err.Error())

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -63,7 +63,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	vaultKubernetesRoleName := "kubernetes-role"
 	vaultPath := path.Join(intermediateMount, "sign", role)
 	appRoleAuthPath := "approle"
-	kubernetesAuthPath := "kubernetes"
+	kubernetesAuthPath := "/v1/auth/kubernetes/login"
 	var roleId, secretId string
 	var vaultInit *vaultaddon.VaultInitializer
 

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -63,7 +63,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 	vaultKubernetesRoleName := "kubernetes-role"
 	vaultPath := path.Join(intermediateMount, "sign", role)
 	appRoleAuthPath := "approle"
-	kubernetesAuthPath := "/v1/auth/kubernetes/login"
+	kubernetesAuthPath := "/v1/auth/kubernetes"
 	var roleId, secretId string
 	var vaultInit *vaultaddon.VaultInitializer
 


### PR DESCRIPTION
```release-note
ACTION REQUIRED
Users who have previously set the Kubernetes Auth Mount Path will need to update their manifests to include the entire mount path. The `/login` endpoint is added for you.

Changes the Vault Kubernetes Auth Path to require the entire mount path. `/login` is added to all mount paths when authenticating.
The default auth path has now changed from `kubernetes` to `/v1/auth/kubernetes`
```

fixes #2205 