### PR TITLE
Catalina

### DIFF
--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -126,5 +126,7 @@ const (
 
 // DefaultKeyUsages contains the default list of key usages
 func DefaultKeyUsages() []KeyUsage {
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
+	// The serverAuth EKU is required as of Mac OS Catalina: https://support.apple.com/en-us/HT210176
+	// Without this usage, certificates will _always_ flag a warning in newer Mac OS browsers.
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth}
 }

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -45,17 +45,19 @@ func TestBuildUsages(t *testing.T) {
 	}
 	tests := []testT{
 		{
-			name:             "default",
-			usages:           []v1alpha2.KeyUsage{},
-			expectedKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-			expectedError:    false,
+			name:                "default",
+			usages:              []v1alpha2.KeyUsage{},
+			expectedKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			expectedError:       false,
 		},
 		{
-			name:             "isCa",
-			usages:           []v1alpha2.KeyUsage{},
-			isCa:             true,
-			expectedKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
-			expectedError:    false,
+			name:                "isCa",
+			usages:              []v1alpha2.KeyUsage{},
+			isCa:                true,
+			expectedKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			expectedError:       false,
 		},
 		{
 			name:             "existing keyusage",

--- a/test/e2e/framework/helper/certificaterequests.go
+++ b/test/e2e/framework/helper/certificaterequests.go
@@ -153,6 +153,8 @@ func (h *Helper) ValidateIssuedCertificateRequest(cr *cmapi.CertificateRequest, 
 	certificateKeyUsages |= defaultCertKeyUsages
 	certificateExtKeyUsages = append(certificateExtKeyUsages, defaultCertExtKeyUsages...)
 
+	certificateExtKeyUsages = h.deduplicateExtKeyUsages(certificateExtKeyUsages)
+
 	// If using ECDSA then ignore key encipherment
 	if keyAlg == cmapi.ECDSAKeyAlgorithm {
 		certificateKeyUsages &^= x509.KeyUsageKeyEncipherment

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -280,6 +280,19 @@ func (h *Helper) defaultKeyUsagesToAdd(ns string, issuerRef *cmmeta.ObjectRefere
 		extKeyUsages = append(extKeyUsages, x509.ExtKeyUsageServerAuth)
 	}
 
+	// De-duplicate list
+	extKeyUsagesMap := make(map[x509.ExtKeyUsage]bool)
+	for _, e := range extKeyUsages {
+		extKeyUsagesMap[e] = true
+	}
+
+	extKeyUsages = make([]x509.ExtKeyUsage, 0)
+	for e, ok := range extKeyUsagesMap {
+		if ok {
+			extKeyUsages = append(extKeyUsages, e)
+		}
+	}
+
 	return keyUsages, extKeyUsages, nil
 }
 


### PR DESCRIPTION
What this PR does / why we need it:

Updates the default list of keyUsages to include serverAuth. We previously copied these defaults from the core Kubernetes CertificateSigningRequest controller, which does not set this EKU by default.

Which issue this PR fixes: fixes #2168

Special notes for your reviewer:

Setting this EKU by default seems sensible to do, and I can't think of any reason this would cause an issue (famous last words). Without this, all certificates issued by cert-manager will fail validation in Mac OS Catalina unless the user explicitly requests this keyUsage.

Release note:
```release-note
Add serverAuth extended key usage to Certificates by default
```
/assign @munnerz 

In favour of https://github.com/jetstack/cert-manager/pull/2303