### PR TITLE
Mark 'csr' field as required in CertificateRequest

### DIFF
--- a/deploy/charts/cert-manager/crds/certificaterequests.yaml
+++ b/deploy/charts/cert-manager/crds/certificaterequests.yaml
@@ -56,6 +56,7 @@ spec:
           description: CertificateRequestSpec defines the desired state of CertificateRequest
           type: object
           required:
+          - csr
           - issuerRef
           properties:
             csr:

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -56,6 +56,7 @@ spec:
           description: CertificateRequestSpec defines the desired state of CertificateRequest
           type: object
           required:
+          - csr
           - issuerRef
           properties:
             csr:

--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -124,8 +124,7 @@ type CertificateRequestSpec struct {
 	IssuerRef ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
-	// +optional
-	CSRPEM []byte `json:"csr,omitempty"`
+	CSRPEM []byte `json:"csr"`
 
 	// IsCA will mark the resulting certificate as valid for signing. This
 	// implies that the 'signing' usage is set

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -73,8 +73,7 @@ type CertificateRequestSpec struct {
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
-	// +optional
-	CSRPEM []byte `json:"csr,omitempty"`
+	CSRPEM []byte `json:"csr"`
 
 	// IsCA will mark the resulting certificate as valid for signing. This
 	// implies that the 'cert sign' usage is set

--- a/pkg/internal/apis/certmanager/types_certificaterequest.go
+++ b/pkg/internal/apis/certmanager/types_certificaterequest.go
@@ -65,8 +65,7 @@ type CertificateRequestSpec struct {
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
-	// +optional
-	CSRPEM []byte `json:"csr,omitempty"`
+	CSRPEM []byte `json:"csr"`
 
 	// IsCA will mark the resulting certificate as valid for signing. This
 	// implies that the 'signing' usage is set


### PR DESCRIPTION
**What this PR does / why we need it**:

This field is currently marked as required by our validating webhook, but not by our CRD schema.

This should be safe to do, as:

1) it was required anyway
2) very few users manually create CertificateRequest resources

**Release note**:
```release-note
Mark `certificaterequest.spec.csr` field as required in OpenAPI schema
```
