### PR TITLE
Add '// +gencrdrefdocs:force' to meta/v1 package

### DIFF
--- a/pkg/apis/meta/v1/doc.go
+++ b/pkg/apis/meta/v1/doc.go
@@ -17,7 +17,7 @@ limitations under the License.
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
-
+// +gencrdrefdocs:force
 // +groupName=meta.cert-manager.io
 
 package v1


### PR DESCRIPTION
**What this PR does / why we need it**:

This _should_ allow us to generate reference docs using this patch in `gen-crd-api-reference-docs`: https://github.com/munnerz/gen-crd-api-reference-docs/commit/60e15c17c527d79dbb88deb8e4e39a37cc517154

**Release note**:
```release-note
NONE
```
