### PR TITLE
Fix up whitespace around doc.go in apis package

### DIFF
--- a/pkg/apis/acme/v1alpha2/doc.go
+++ b/pkg/apis/acme/v1alpha2/doc.go
@@ -14,11 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha2 is the v1alpha2 version of the API.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/jetstack/cert-manager/pkg/apis/acme
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
-
-// Package v1alpha2 is the v1alpha2 version of the API.
 // +groupName=acme.cert-manager.io
 package v1alpha2

--- a/pkg/apis/certmanager/v1alpha2/doc.go
+++ b/pkg/apis/certmanager/v1alpha2/doc.go
@@ -14,12 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package v1alpha2 is the v1alpha2 version of the API.
 // +k8s:deepcopy-gen=package,register
 // +k8s:conversion-gen=github.com/jetstack/cert-manager/pkg/apis/certmanager
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
-
-// Package v1alpha2 is the v1alpha2 version of the API.
 // +groupName=cert-manager.io
 // +groupGoName=Certmanager
 package v1alpha2

--- a/pkg/apis/meta/v1/doc.go
+++ b/pkg/apis/meta/v1/doc.go
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Package meta contains meta types for cert-manager APIs
 // +k8s:deepcopy-gen=package
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 // +gencrdrefdocs:force
 // +groupName=meta.cert-manager.io
-
 package v1


### PR DESCRIPTION
**What this PR does / why we need it**:

Follows up on #2372 

**Release note**:
```release-note
NONE
```
