### PR TITLE
Allow secrets with legacy annotations for issuer name and kind to match

### DIFF
--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -28,6 +28,12 @@ const (
 	CertificateNameKey       = "cert-manager.io/certificate-name"
 )
 
+// Legacy annotation names for Secrets
+const (
+	LegacyIssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
+	LegacyIssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
+)
+
 const (
 	// issuerNameAnnotation can be used to override the issuer specified on the
 	// created Certificate resource.

--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -28,10 +28,10 @@ const (
 	CertificateNameKey       = "cert-manager.io/certificate-name"
 )
 
-// Legacy annotation names for Secrets
+// Deprecated annotation names for Secrets
 const (
-	LegacyIssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
-	LegacyIssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
+	DeprecatedIssuerNameAnnotationKey = "certmanager.k8s.io/issuer-name"
+	DeprecatedIssuerKindAnnotationKey = "certmanager.k8s.io/issuer-kind"
 )
 
 const (

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -487,6 +487,7 @@ func (c *certificateRequestManager) processCertificate(ctx context.Context, crt 
 // Otherwise, the existing resource will be updated.
 // The first return argument will be true if the resource was updated/created
 // without error.
+// updateSecretData will also update deprecated annotations if they exist.
 func (c *certificateRequestManager) updateSecretData(ctx context.Context, crt *cmapi.Certificate, existingSecret *corev1.Secret, data secretData) (bool, error) {
 	s := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -775,6 +776,7 @@ type secretData struct {
 // setSecretValues will NOT actually update the resource in the apiserver.
 // If updating an existing Secret resource returned by an api client 'lister',
 // make sure to DeepCopy the object first to avoid modifying data in-cache.
+// It will also update depreciated issuer name and kind annotations if they exist.
 func setSecretValues(ctx context.Context, crt *cmapi.Certificate, s *corev1.Secret, data secretData) error {
 	// initialize the `Data` field if it is nil
 	if s.Data == nil {
@@ -792,6 +794,15 @@ func setSecretValues(ctx context.Context, crt *cmapi.Certificate, s *corev1.Secr
 	s.Annotations[cmapi.CertificateNameKey] = crt.Name
 	s.Annotations[cmapi.IssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
 	s.Annotations[cmapi.IssuerKindAnnotationKey] = apiutil.IssuerKind(crt.Spec.IssuerRef)
+
+	// If deprecated annotations exist with any value, then they too shall be
+	// updated
+	if _, ok := s.Annotations[cmapi.DeprecatedIssuerNameAnnotationKey]; ok {
+		s.Annotations[cmapi.DeprecatedIssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
+	}
+	if _, ok := s.Annotations[cmapi.DeprecatedIssuerKindAnnotationKey]; ok {
+		s.Annotations[cmapi.DeprecatedIssuerKindAnnotationKey] = apiutil.IssuerKind(crt.Spec.IssuerRef)
+	}
 
 	// if the certificate data is empty, clear the subject related annotations
 	if len(data.cert) == 0 {

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -122,12 +122,14 @@ func certificateMatchesSpec(crt *v1alpha2.Certificate, key crypto.Signer, cert *
 	}
 
 	// validate that the issuer is correct
-	if crt.Spec.IssuerRef.Name != secret.Annotations[v1alpha2.IssuerNameAnnotationKey] {
+	if crt.Spec.IssuerRef.Name != secret.Annotations[v1alpha2.IssuerNameAnnotationKey] &&
+		crt.Spec.IssuerRef.Name != secret.Annotations[v1alpha2.LegacyIssuerNameAnnotationKey] {
 		errs = append(errs, fmt.Sprintf("Issuer of the certificate is not up to date: %q", secret.Annotations[v1alpha2.IssuerNameAnnotationKey]))
 	}
 
 	// validate that the issuer kind is correct
-	if apiutil.IssuerKind(crt.Spec.IssuerRef) != secret.Annotations[v1alpha2.IssuerKindAnnotationKey] {
+	if apiutil.IssuerKind(crt.Spec.IssuerRef) != secret.Annotations[v1alpha2.IssuerKindAnnotationKey] &&
+		apiutil.IssuerKind(crt.Spec.IssuerRef) != secret.Annotations[v1alpha2.LegacyIssuerKindAnnotationKey] {
 		errs = append(errs, fmt.Sprintf("Issuer kind of the certificate is not up to date: %q", secret.Annotations[v1alpha2.IssuerKindAnnotationKey]))
 	}
 

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -116,20 +116,154 @@ func TestCertificateMatchesSpec(t *testing.T) {
 			},
 		},
 
-		"if the issuer name and kind uses the lagacy annotation then it should still match the spec": {
-			cb: mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate,
-				gen.SetCertificateCommonName(""),
-			)),
-			certificate: gen.CertificateFrom(exampleBundle.certificate,
-				gen.SetCertificateCommonName(""),
-			),
+		"if the issuer name and kind uses v1alpha2 annotation then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
 			secret: gen.SecretFrom(secret,
 				gen.SetSecretAnnotations(map[string]string{
-					cmapi.LegacyIssuerNameAnnotationKey: "ca-issuer",
-					cmapi.LegacyIssuerKindAnnotationKey: "Issuer",
+					cmapi.IssuerNameAnnotationKey: "ca-issuer",
+					cmapi.IssuerKindAnnotationKey: "Issuer",
 				})),
 			expMatch:  true,
 			expErrors: nil,
+		},
+
+		"if the issuer name uses v1alpha2 annotation but kind uses depreicated then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.IssuerNameAnnotationKey:           "ca-issuer",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name uses deprecated annotation but kind uses v1alpha2 then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "ca-issuer",
+					cmapi.IssuerKindAnnotationKey:           "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name and kind uses the deprecated annotation then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "ca-issuer",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name uses v1alpha2 and kind uses both the deprecated and v1alpha2 annotation then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerKindAnnotationKey: "Issuer",
+					cmapi.IssuerNameAnnotationKey:           "ca-issuer",
+					cmapi.IssuerKindAnnotationKey:           "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name both the deprecated and v1alpha2 annotation and kind uses deprecated then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "Issuer",
+					cmapi.IssuerNameAnnotationKey:           "ca-issuer",
+					cmapi.IssuerKindAnnotationKey:           "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name and kind uses both the deprecated and v1alpha2 annotation then it should still match the spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "ca-issuer",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "Issuer",
+					cmapi.IssuerNameAnnotationKey:           "ca-issuer",
+					cmapi.IssuerKindAnnotationKey:           "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name and kind uses both the deprecated and v1alpha2 annotation but no values in deprecated annotations then should match spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "foo",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "bar",
+					cmapi.IssuerNameAnnotationKey:           "ca-issuer",
+					cmapi.IssuerKindAnnotationKey:           "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
+
+		"if the issuer name and kind deprecated annotations are correct but v1alpha2 values are wrong then should not match spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "ca-issuer",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "Issuer",
+					cmapi.IssuerNameAnnotationKey:           "foo",
+					cmapi.IssuerKindAnnotationKey:           "bar",
+				})),
+			expMatch: false,
+			expErrors: []string{
+				`Issuer "cert-manager.io/issuer-name" of the certificate is not up to date: "foo"`,
+				`Issuer "cert-manager.io/issuer-kind" of the certificate is not up to date: "bar"`,
+			},
+		},
+
+		"if the issuer name and kind deprecated annotations are correct but v1alpha2 values are empty but exist then should not match spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "ca-issuer",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "Issuer",
+					cmapi.IssuerNameAnnotationKey:           "",
+					cmapi.IssuerKindAnnotationKey:           "",
+				})),
+			expMatch: false,
+			expErrors: []string{
+				`Issuer "cert-manager.io/issuer-name" of the certificate is not up to date: ""`,
+				`Issuer "cert-manager.io/issuer-kind" of the certificate is not up to date: ""`,
+			},
+		},
+		"if the issuer name and kind deprecated annotations are wrong and no v1alpha2 values then should not match spec": {
+			cb:          mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.DeprecatedIssuerNameAnnotationKey: "foo",
+					cmapi.DeprecatedIssuerKindAnnotationKey: "bar",
+				})),
+			expMatch: false,
+			expErrors: []string{
+				`Issuer "certmanager.k8s.io/issuer-name" of the certificate is not up to date: "foo"`,
+				`Issuer "certmanager.k8s.io/issuer-kind" of the certificate is not up to date: "bar"`,
+			},
 		},
 	} {
 		t.Run(name, func(t *testing.T) {

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -63,6 +63,7 @@ func TestCertificateMatchesSpec(t *testing.T) {
 		"if all match then return matched": {
 			cb:          exampleBundle,
 			certificate: exampleBundle.certificate,
+			secret:      gen.SecretFrom(secret),
 			expMatch:    true,
 			expErrors:   nil,
 		},
@@ -74,6 +75,7 @@ func TestCertificateMatchesSpec(t *testing.T) {
 			certificate: gen.CertificateFrom(exampleBundle.certificate,
 				gen.SetCertificateCommonName(""),
 			),
+			secret:    gen.SecretFrom(secret),
 			expMatch:  true,
 			expErrors: nil,
 		},
@@ -84,6 +86,7 @@ func TestCertificateMatchesSpec(t *testing.T) {
 				gen.SetCertificateCommonName(""),
 			)),
 			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret:      gen.SecretFrom(secret),
 			expMatch:    true,
 			expErrors:   nil,
 		},
@@ -94,6 +97,7 @@ func TestCertificateMatchesSpec(t *testing.T) {
 				gen.SetCertificateCommonName("foobar"),
 			)),
 			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret:      gen.SecretFrom(secret),
 			expMatch:    true,
 			expErrors:   nil,
 		},
@@ -104,16 +108,33 @@ func TestCertificateMatchesSpec(t *testing.T) {
 				gen.SetCertificateCommonName("foobar"),
 			)),
 			certificate: gen.CertificateFrom(exampleBundle.certificate),
+			secret:      gen.SecretFrom(secret),
 			expMatch:    false,
 			expErrors: []string{
 				`Common Name on TLS certificate not up to date ("common.name.example.com"): [foobar]`,
 				"DNS names on TLS certificate not up to date: []",
 			},
 		},
+
+		"if the issuer name and kind uses the lagacy annotation then it should still match the spec": {
+			cb: mustCreateCryptoBundle(t, gen.CertificateFrom(exampleBundle.certificate,
+				gen.SetCertificateCommonName(""),
+			)),
+			certificate: gen.CertificateFrom(exampleBundle.certificate,
+				gen.SetCertificateCommonName(""),
+			),
+			secret: gen.SecretFrom(secret,
+				gen.SetSecretAnnotations(map[string]string{
+					cmapi.LegacyIssuerNameAnnotationKey: "ca-issuer",
+					cmapi.LegacyIssuerKindAnnotationKey: "Issuer",
+				})),
+			expMatch:  true,
+			expErrors: nil,
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			match, errs := certificateMatchesSpec(
-				test.certificate, test.cb.privateKey, test.cb.cert, secret)
+				test.certificate, test.cb.privateKey, test.cb.cert, test.secret)
 
 			if match != test.expMatch {
 				t.Errorf("got unexpected match bool, exp=%t got=%t",

--- a/test/unit/gen/BUILD.bazel
+++ b/test/unit/gen/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "issuer.go",
         "objectmeta.go",
         "order.go",
+        "secret.go",
     ],
     importpath = "github.com/jetstack/cert-manager/test/unit/gen",
     visibility = ["//visibility:public"],
@@ -19,6 +20,7 @@ go_library(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/test/unit/gen/secret.go
+++ b/test/unit/gen/secret.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+type SecretModifier func(*corev1.Secret)
+
+func Secret(name string, mods ...SecretModifier) *corev1.Secret {
+	c := &corev1.Secret{
+		ObjectMeta: ObjectMeta(name),
+	}
+	for _, mod := range mods {
+		mod(c)
+	}
+	return c
+}
+
+func SecretFrom(sec *corev1.Secret, mods ...SecretModifier) *corev1.Secret {
+	sec = sec.DeepCopy()
+	for _, mod := range mods {
+		mod(sec)
+	}
+	return sec
+}
+
+func SetSecretAnnotations(an map[string]string) SecretModifier {
+	return func(sec *corev1.Secret) {
+		sec.Annotations = make(map[string]string)
+		for k, v := range an {
+			sec.Annotations[k] = v
+		}
+	}
+}


### PR DESCRIPTION
This PR allows the certificate controller to accept a secret matches its spec if the secret is using legacy issuer annotations.

This is to ensure that during the upgrade process to 0.11, not all certificates are reissued due to the current Secret resources having the old annotations.

```release-note
Allow permissive acceptance for matching Certificates with Secrets that are using legacy annotations to reduce non-required certificate reissue. 
```

/milestone v0.12
/milestone v0.11
/cherry-pick release-0.11
/assign @munnerz 