### PR TITLE
Upgrade to Pebble containing letsencrypt/pebble#294

### DIFF
--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -30,7 +30,9 @@ def install():
     ## field in this rule
     go_repository(
         name = "org_letsencrypt_pebble",
-        commit = "2e69bb16af048c491720f23cb284fce685e65fec",
+        commit = "2787c898960ca6326da21ab48b76b080f89a8fec",
+        remote = "https://github.com/munnerz/pebble",
+        vcs = "git",
         importpath = "github.com/letsencrypt/pebble",
         build_external = "vendored",
         # Expose the generated go_default_library as 'public' visibility


### PR DESCRIPTION
**What this PR does / why we need it**:

Upgrades to the latest version of Pebble, including letsencrypt/pebble#294 in order to fix issues with redirect tests.

**Release note**:
```release-note
NONE
```
