### PR TITLE
Remove IP address validation on dns01-recursive-nameservers to allow domain names

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -261,7 +261,7 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Group of the Issuer to use when the tls is requested but issuer group is not specified on the ingress resource.")
 	fs.StringSliceVar(&s.DNS01RecursiveNameservers, "dns01-recursive-nameservers",
 		[]string{}, "A list of comma seperated dns server endpoints used for "+
-			"DNS01 check requests. This should be a list containing IP address and "+
+			"DNS01 check requests. This should be a list containing host and "+
 			"port, for example 8.8.8.8:53,8.8.4.4:53")
 	fs.BoolVar(&s.DNS01RecursiveNameserversOnly, "dns01-recursive-nameservers-only",
 		defaultDNS01RecursiveNameserversOnly,
@@ -272,8 +272,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 			"due to caching performed by the recursive nameservers.")
 	fs.StringSliceVar(&s.DNS01RecursiveNameservers, "dns01-self-check-nameservers",
 		[]string{}, "A list of comma seperated dns server endpoints used for "+
-			"DNS01 check requests. This should be a list containing IP address and "+
-			"port, for example 8.8.8.8:53,8.8.4.4:53")
+			"DNS01 check requests. This should be a list containing host and port, "+
+			"for example 8.8.8.8:53,8.8.4.4:53")
 	fs.MarkDeprecated("dns01-self-check-nameservers", "Deprecated in favour of dns01-recursive-nameservers")
 	fs.BoolVar(&s.EnableCertificateOwnerRef, "enable-certificate-owner-ref", defaultEnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+
@@ -301,13 +301,9 @@ func (o *ControllerOptions) Validate() error {
 
 	for _, server := range o.DNS01RecursiveNameservers {
 		// ensure all servers have a port number
-		host, _, err := net.SplitHostPort(server)
+		_, _, err := net.SplitHostPort(server)
 		if err != nil {
 			return fmt.Errorf("invalid DNS server (%v): %v", err, server)
-		}
-		ip := net.ParseIP(host)
-		if ip == nil {
-			return fmt.Errorf("invalid IP address: %v", host)
 		}
 	}
 	return nil


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove the requirement that the `--dns01-recursive-nameservers` option must be specified as IP address.

We're issuing a certificate to be used on a cluster running in a VPC with a private DNS zone in AWS. There's also a public zone for the domain, and we write the DNS01 challenge records to that zone so that Let's Encrypt can see them. However, inside the VPC, the records in the public zone don't resolve using the default nameserver, because AWS has intercepted the request and attempted to resolve them in the private zone. cert-manager then spins waiting for them to resolve.

We fixed this by specifying the nameservers of the public zone, i.e. `--dns01-recursive-nameservers=ns-1234.awsdns-56.co.uk:53,ns-789.awsdns-10.org:53,ns-11.awsdns-12.com:53,ns-13.awsdns-14.net:53`.

This works, but causes a validation error `invalid IP address: ns-1234.awsdns-56.co.uk` on startup.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove IP address validation on dns01-recursive-nameservers to allow domain names
```
