### PR TITLE
webhook: register http handlers for pprof debug endpoints

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -72,6 +72,7 @@ func main() {
 	srv := server.Server{
 		ListenAddr:        fmt.Sprintf(":%d", securePort),
 		HealthzAddr:       fmt.Sprintf(":%d", healthzPort),
+		EnablePprof:       true,
 		CertificateSource: source,
 		ValidationWebhook: validationHook,
 		MutationWebhook:   mutationHook,

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -42,6 +42,7 @@ filegroup(
         "//pkg/util/feature:all-srcs",
         "//pkg/util/kube:all-srcs",
         "//pkg/util/pki:all-srcs",
+        "//pkg/util/profiling:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/util/profiling/BUILD.bazel
+++ b/pkg/util/profiling/BUILD.bazel
@@ -1,0 +1,22 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["profiling.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/util/profiling",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package profiling
+
+import (
+	"net/http"
+	"net/http/pprof"
+)
+
+// Install adds the Profiling webservice to the given mux.
+func Install(mux *http.ServeMux) {
+	mux.HandleFunc("/debug/pprof", redirectTo("/debug/pprof/"))
+	mux.HandleFunc("/debug/pprof/", pprof.Index)
+	mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+	mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+	mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+}
+
+// redirectTo redirects request to a certain destination.
+func redirectTo(to string) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, req *http.Request) {
+		http.Redirect(rw, req, to, http.StatusFound)
+	}
+}

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/logs:go_default_library",
+        "//pkg/util/profiling:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//admission/v1beta1:go_default_library",


### PR DESCRIPTION
**What this PR does / why we need it**:

Register HTTP pprof handlers to make it easier to debug issues such as #2445 by grabbing running `go tool pprof`.

**Release note**:
```release-note
webhook: register http handlers for pprof debug endpoints
```

/assign @JoshVanL
