### PR TITLE
Add support for volumes and volume mounts to cert-manager chart

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -58,6 +58,10 @@ spec:
         fsGroup: {{ .Values.securityContext.fsGroup }}
         runAsUser: {{ .Values.securityContext.runAsUser }}
       {{- end }}
+      {{- if .Values.volumes }}
+      volumes:
+{{ toYaml .Values.volumes | indent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
@@ -93,6 +97,10 @@ spec:
           ports:
           - containerPort: 9402
             protocol: TCP
+          {{- if .Values.volumeMounts }}
+          volumeMounts:
+{{ toYaml .Values.volumeMounts | indent 12 }}
+          {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -77,6 +77,10 @@ securityContext:
   fsGroup: 1001
   runAsUser: 1001
 
+volumes: []
+
+volumeMounts: []
+
 deploymentAnnotations: {}
 
 podAnnotations: {}


### PR DESCRIPTION
**What this PR does / why we need it:**

The purpose of this PR is to add support for volumes and volume mounts in the cert-manager chart by adding the appropriate fields to the helm chart values file. This will allow for the use of AWS IAM roles for cert-manager service accounts (https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)

**Release note:**
```
Add volume and volume mounts field to cert-manager helm chart
```