### PR TITLE
fix: updateSecretData injecting AllowsInjectionFromSecretAnnotation 

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -495,6 +495,9 @@ func (c *certificateRequestManager) updateSecretData(ctx context.Context, crt *c
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      crt.Spec.SecretName,
 			Namespace: crt.Namespace,
+			Annotations: map[string]string{
+				cmapi.AllowsInjectionFromSecretAnnotation: "true",
+			},
 		},
 		Type: corev1.SecretTypeTLS,
 	}


### PR DESCRIPTION
- This solves https://github.com/jetstack/cert-manager/issues/2492
- This allows self-signed certificates automation on validating/mutating webhooks

**What this PR does / why we need it**:

Adds the `cert-manager.io/allow-direct-injection: "true"` annotation to generated secrets to allow self-signed cert update validating/mutating webhook configurations

**Which issue this PR fixes**: 

This PR fixes #2492 

**Special notes for your reviewer**:

**Release note**:
```release-note
fix: updateSecretData injecting AllowsInjectionFromSecretAnnotation. Fixes issue #2492 
```
