### PR TITLE
add secret in different namespace logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 bazel-*
 /.settings/
 /.project
+/vendor/

--- a/pkg/api/util/BUILD.bazel
+++ b/pkg/api/util/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
         "duration.go",
         "issuers.go",
         "names.go",
+        "secrets.go",
         "usages.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/api/util",

--- a/pkg/api/util/secret.go
+++ b/pkg/api/util/secret.go
@@ -1,0 +1,13 @@
+package util
+
+import "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+
+func GetSecretsNamespace(crt *v1alpha2.Certificate) string {
+	namespace, ok := crt.Annotations[v1alpha2.SecretsNamespaceAnnotationKey]
+
+	if !ok {
+		return crt.Namespace
+	}
+
+	return namespace
+}

--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -26,6 +26,7 @@ const (
 	IssuerKindAnnotationKey  = "cert-manager.io/issuer-kind"
 	IssuerGroupAnnotationKey = "cert-manager.io/issuer-group"
 	CertificateNameKey       = "cert-manager.io/certificate-name"
+	CertificateNamespaceKey  = "cert-manager.io/certificate-namespace"
 )
 
 // Deprecated annotation names for Secrets
@@ -64,6 +65,10 @@ const (
 	// stored in the target Secret resource whilst the real Issuer is processing
 	// the certificate request.
 	IssueTemporaryCertificateAnnotation = "cert-manager.io/issue-temporary-certificate"
+
+	// SecretsNamespaceAnnotation can be used to override base secrets namespace location
+	// default location - together with certificate resource
+	SecretsNamespaceAnnotationKey = "cert-manager.io/secret-namespace"
 )
 
 const (

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -49,13 +49,19 @@ func dropNotFound(err error) error {
 // Right now, this actually uses a label instead of owner refs,
 // since certmanager doesn't set owner refs on secrets.
 func OwningCertForSecret(secret *corev1.Secret) *types.NamespacedName {
-	lblVal, hasLbl := secret.Annotations[certmanager.CertificateNameKey]
-	if !hasLbl {
+	name, has := secret.Annotations[certmanager.CertificateNameKey]
+	if !has {
 		return nil
 	}
+
+	namespace, has := secret.Annotations[certmanager.CertificateNamespaceKey]
+	if !has {
+		return nil
+	}
+
 	return &types.NamespacedName{
-		Name:      lblVal,
-		Namespace: secret.Namespace,
+		Name:      name,
+		Namespace: namespace,
 	}
 }
 

--- a/pkg/controller/certificates/checks.go
+++ b/pkg/controller/certificates/checks.go
@@ -18,6 +18,7 @@ package certificates
 
 import (
 	"fmt"
+	"github.com/jetstack/cert-manager/pkg/api/util"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -66,7 +67,7 @@ func certificatesForSecret(certificateLister cmlisters.CertificateLister, secret
 
 	var affected []*cmapi.Certificate
 	for _, crt := range crts {
-		if crt.Namespace != secret.Namespace {
+		if util.GetSecretsNamespace(crt) != secret.Namespace {
 			continue
 		}
 		if crt.Spec.SecretName == secret.Name {

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -114,6 +114,8 @@ func createCryptoBundle(crt *cmapi.Certificate) (*cryptoBundle, error) {
 	}
 	annotations[cmapi.CRPrivateKeyAnnotationKey] = crt.Spec.SecretName
 	annotations[cmapi.CertificateNameKey] = crt.Name
+	annotations[cmapi.CertificateNamespaceKey] = crt.Namespace
+
 	certificateRequest := &cmapi.CertificateRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            reqName,
@@ -341,6 +343,7 @@ func TestBuildCertificateRequest(t *testing.T) {
 
 			expectedCertificateRequestAnnotations: map[string]string{
 				cmapi.CRPrivateKeyAnnotationKey: baseCert.Spec.SecretName,
+				cmapi.CertificateNamespaceKey:   baseCert.Namespace,
 				cmapi.CertificateNameKey:        baseCert.Name,
 			},
 		},
@@ -404,6 +407,7 @@ func TestProcessCertificate(t *testing.T) {
 								Name:      "output",
 								Annotations: map[string]string{
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								},
@@ -450,6 +454,7 @@ func TestProcessCertificate(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								},
@@ -499,6 +504,7 @@ func TestProcessCertificate(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								},
@@ -548,6 +554,7 @@ func TestProcessCertificate(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								},
@@ -576,6 +583,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 							},
@@ -613,6 +621,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 							},
@@ -662,6 +671,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: "Issuer",
 								cmapi.IssuerNameAnnotationKey: "test",
 							},
@@ -692,6 +702,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -732,6 +743,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -789,6 +801,7 @@ func TestProcessCertificate(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -820,6 +833,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 							},
@@ -847,6 +861,7 @@ func TestProcessCertificate(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -878,6 +893,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      exampleBundle1.certificate.Name,
+								cmapi.CertificateNamespaceKey: exampleBundle1.certificate.Name,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -911,6 +927,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -942,6 +959,7 @@ func TestProcessCertificate(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -973,6 +991,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -1017,6 +1036,7 @@ func TestProcessCertificate(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -1171,6 +1191,7 @@ func TestProcessCertificate(t *testing.T) {
 								Name:      "output",
 								Annotations: map[string]string{
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								},
@@ -1221,6 +1242,7 @@ func TestProcessCertificate(t *testing.T) {
 								Name:      "output",
 								Annotations: map[string]string{
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								},
@@ -1278,6 +1300,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 							},
@@ -1304,6 +1327,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -1335,6 +1359,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 							},
@@ -1362,6 +1387,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -1393,6 +1419,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 							},
@@ -1420,6 +1447,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -1451,6 +1479,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -1482,6 +1511,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -1513,6 +1543,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -1544,6 +1575,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",
@@ -1576,6 +1608,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Annotations: map[string]string{
 								"custom-annotation":           "value",
 								cmapi.CertificateNameKey:      "test",
+								cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 								cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 								cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 								cmapi.IPSANAnnotationKey:      "",
@@ -1645,6 +1678,7 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								Annotations: map[string]string{
 									"custom-annotation":           "value",
 									cmapi.CertificateNameKey:      "test",
+									cmapi.CertificateNamespaceKey: gen.DefaultTestNamespace,
 									cmapi.IssuerKindAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Kind,
 									cmapi.IssuerNameAnnotationKey: exampleBundle1.certificate.Spec.IssuerRef.Name,
 									cmapi.IPSANAnnotationKey:      "",

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -151,9 +151,11 @@ func certificateMatchesSpec(crt *v1alpha2.Certificate, key crypto.Signer, cert *
 
 func scheduleRenewal(ctx context.Context, lister corelisters.SecretLister, calc calculateDurationUntilRenewFn, queueFn func(interface{}, time.Duration), crt *v1alpha2.Certificate) {
 	log := logf.FromContext(ctx)
+	secretNamespace := apiutil.GetSecretsNamespace(crt)
+
 	log = log.WithValues(
 		logf.RelatedResourceNameKey, crt.Spec.SecretName,
-		logf.RelatedResourceNamespaceKey, crt.Namespace,
+		logf.RelatedResourceNamespaceKey, secretNamespace,
 		logf.RelatedResourceKindKey, "Secret",
 	)
 
@@ -163,7 +165,7 @@ func scheduleRenewal(ctx context.Context, lister corelisters.SecretLister, calc 
 		return
 	}
 
-	cert, err := kube.SecretTLSCert(ctx, lister, crt.Namespace, crt.Spec.SecretName)
+	cert, err := kube.SecretTLSCert(ctx, lister, secretNamespace, crt.Spec.SecretName)
 	if err != nil {
 		if !errors.IsInvalidData(err) {
 			log.Error(err, "error getting secret for certificate resource")

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/metrics",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/listers/certmanager/v1alpha2:go_default_library",

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -176,13 +176,22 @@ func (h *Helper) ValidateIssuedCertificate(certificate *cmapi.Certificate, rootC
 		return nil, fmt.Errorf("Expected certificate expiry date to be %v, but got %v", certificate.Status.NotAfter, cert.NotAfter)
 	}
 
-	label, ok := secret.Annotations[cmapi.CertificateNameKey]
+	name, ok := secret.Annotations[cmapi.CertificateNameKey]
 	if !ok {
-		return nil, fmt.Errorf("Expected secret to have certificate-name label, but had none")
+		return nil, fmt.Errorf("Expected secret to have certificate-name annotation, but had none")
 	}
 
-	if label != certificate.Name {
-		return nil, fmt.Errorf("Expected secret to have certificate-name label with a value of %q, but got %q", certificate.Name, label)
+	if name != certificate.Name {
+		return nil, fmt.Errorf("Expected secret to have certificate-name annotation with a value of %q, but got %q", certificate.Name, name)
+	}
+
+	namespace, ok := secret.Annotations[cmapi.CertificateNamespaceKey]
+	if !ok {
+		return nil, fmt.Errorf("Expected secret to have certificate-namespace annotation, but had none")
+	}
+
+	if namespace != certificate.Namespace {
+		return nil, fmt.Errorf("Expected secret to have certificate-namespace annotation with a value of %q, but got %q", certificate.Namespace, namespace)
 	}
 
 	certificateKeyUsages, certificateExtKeyUsages, err := pki.BuildKeyUsages(certificate.Spec.Usages, certificate.Spec.IsCA)


### PR DESCRIPTION
```release-note
add optional secret namespace annotation to cert resource (cert-manager.io/secret-namespace)
add cert resource namespace annotation for cert request and cert secret (cert-manager.io/certificate-namespace)
```
Description in https://github.com/jetstack/cert-manager/issues/2522
