### PR TITLE
Fix Helm chart cainjector.enabled

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -77,3 +78,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -14,4 +15,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "cainjector.fullname" . }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -16,4 +17,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "cainjector.fullname" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-psp.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -45,4 +46,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
-{{- end }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 {{- if .Values.global.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -93,4 +94,5 @@ subjects:
     namespace: {{ .Release.Namespace }}
 
 
+{{- end -}}
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.cainjector.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -12,3 +13,4 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}
+{{- end -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -203,6 +203,7 @@ webhook:
   securePort: 10250
 
 cainjector:
+  enabled: true
   replicaCount: 1
 
   strategy: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

cainjector previously disregarded the cainjector.enabled
value when passed in.  This commit leaves it defaulted to
enabled (per the docs) but causes cainjector to not be
deployed when cainjector.enabled = false.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2503 

**Special notes for your reviewer**:

It looks like there might be some magic in play for Chart version number incrementing. I'm not sure whether I need to do anything further!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix cainjector.enabled=False override being ignored by the Helm Chart
```
