### PR TITLE
Fix ownerReference GVK used during HTTP01 challenge solving

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -49,7 +49,7 @@ const (
 )
 
 var (
-	challengeGvk = v1alpha2.SchemeGroupVersion.WithKind("Challenge")
+	challengeGvk = cmacme.SchemeGroupVersion.WithKind("Challenge")
 )
 
 // Solver is an implementation of the acme http-01 challenge solver protocol


### PR DESCRIPTION
**What this PR does / why we need it**:

Corrects the GVK of the OwnerReference set on resources created by the HTTP01 challenge solver.

Since moving the Challenge resource to a new API group, this bug went unnoticed.

**Which issue this PR fixes**: fixes #2475

**Release note**:
```release-note
Fix GroupVersionKind set on OwnerReference of resources created by HTTP01 challenge solver, causing HTTP01 validations to fail on OpenShift 4.x
```

/cherrypick release-0.13