### PR TITLE
Add cipher suites configuration and defaults

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"k8s.io/klog"
@@ -32,11 +33,24 @@ import (
 	"github.com/jetstack/cert-manager/pkg/webhook/server"
 )
 
+const (
+	defaultCipherSuites = "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256," +
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384," +
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305," +
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA," +
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA," +
+		"TLS_RSA_WITH_AES_128_GCM_SHA256," +
+		"TLS_RSA_WITH_AES_256_GCM_SHA384," +
+		"TLS_RSA_WITH_AES_128_CBC_SHA," +
+		"TLS_RSA_WITH_AES_256_CBC_SHA"
+)
+
 var (
-	securePort  int
-	healthzPort int
-	tlsCertFile string
-	tlsKeyFile  string
+	securePort      int
+	healthzPort     int
+	tlsCertFile     string
+	tlsKeyFile      string
+	tlsCipherSuites string
 )
 
 func init() {
@@ -44,6 +58,7 @@ func init() {
 	flag.IntVar(&securePort, "secure-port", 6443, "port number to listen on for secure TLS connections")
 	flag.StringVar(&tlsCertFile, "tls-cert-file", "", "path to the file containing the TLS certificate to serve with")
 	flag.StringVar(&tlsKeyFile, "tls-private-key-file", "", "path to the file containing the TLS private key to serve with")
+	flag.StringVar(&tlsCipherSuites, "tls-cipher-suites", defaultCipherSuites, "comma separated list of TLS 1.2 cipher suites to use (TLS 1.3 cipher suites are not configurable)")
 }
 
 var validationHook handlers.ValidatingAdmissionHook = handlers.NewRegistryBackedValidator(logs.Log, webhook.Scheme, webhook.ValidationRegistry)
@@ -68,12 +83,17 @@ func main() {
 			Log:      log,
 		}
 	}
+	var cipherSuites []string
+	if len(tlsCipherSuites) > 0 {
+		cipherSuites = strings.Split(tlsCipherSuites, ",")
+	}
 
 	srv := server.Server{
 		ListenAddr:        fmt.Sprintf(":%d", securePort),
 		HealthzAddr:       fmt.Sprintf(":%d", healthzPort),
 		EnablePprof:       true,
 		CertificateSource: source,
+		CipherSuites:      cipherSuites,
 		ValidationWebhook: validationHook,
 		MutationWebhook:   mutationHook,
 		ConversionWebhook: conversionHook,

--- a/devel/BUILD.bazel
+++ b/devel/BUILD.bazel
@@ -14,6 +14,7 @@ filegroup(
         "//devel/addon/pebble:all-srcs",
         "//devel/addon/samplewebhook:all-srcs",
         "//devel/addon/vault:all-srcs",
+        "//devel/bin:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/serializer/json:go_default_library",
+        "@io_k8s_component_base//cli/flag:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
     ],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a --tls-cipher-suites command line flag and set to sensible
defaults.

**Which issue this PR fixes** 
fixes #2559

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added --tls-cipher-suites command line flag to the webhook binary with sensible defaults
```
