### PR TITLE
Make the Venafi Cloud URL field optional

### DIFF
--- a/deploy/charts/cert-manager/crds/clusterissuers.yaml
+++ b/deploy/charts/cert-manager/crds/clusterissuers.yaml
@@ -1625,7 +1625,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for

--- a/deploy/charts/cert-manager/crds/issuers.yaml
+++ b/deploy/charts/cert-manager/crds/issuers.yaml
@@ -1625,7 +1625,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -3489,7 +3489,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for
@@ -5229,7 +5228,6 @@ spec:
                   type: object
                   required:
                   - apiTokenSecretRef
-                  - url
                   properties:
                     apiTokenSecretRef:
                       description: APITokenSecretRef is a secret key selector for

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -140,7 +140,8 @@ type VenafiTPP struct {
 // VenafiCloud defines connection configuration details for Venafi Cloud
 type VenafiCloud struct {
 	// URL is the base URL for Venafi Cloud
-	URL string `json:"url"`
+	// +optional
+	URL string `json:"url,omitempty"`
 
 	// APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
 	APITokenSecretRef cmmeta.SecretKeySelector `json:"apiTokenSecretRef"`

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -140,7 +140,8 @@ type VenafiTPP struct {
 // VenafiCloud defines connection configuration details for Venafi Cloud
 type VenafiCloud struct {
 	// URL is the base URL for Venafi Cloud
-	URL string `json:"url"`
+	// +optional
+	URL string `json:"url,omitempty"`
 
 	// APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
 	APITokenSecretRef cmmeta.SecretKeySelector `json:"apiTokenSecretRef"`

--- a/pkg/internal/apis/certmanager/types_issuer.go
+++ b/pkg/internal/apis/certmanager/types_issuer.go
@@ -128,7 +128,8 @@ type VenafiTPP struct {
 // VenafiCloud defines connection configuration details for Venafi Cloud
 type VenafiCloud struct {
 	// URL is the base URL for Venafi Cloud
-	URL string `json:"url"`
+	// +optional
+	URL string `json:"url,omitempty"`
 
 	// APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
 	APITokenSecretRef cmmeta.SecretKeySelector `json:"apiTokenSecretRef"`


### PR DESCRIPTION
**What this PR does / why we need it**:

This value is defaulted by the Venafi client as-per https://github.com/Venafi/vcert/blob/d4d4df569eec07f98bda84e99f8813a51d7f4650/config.go#L35-L36

I've avoided defaulting this value in order to prevent leaking implementation details of the Venafi client up to the API surface (i.e. if the default URL changes)

**Release note**:
```release-note
Fix Venafi Cloud URL field being marked required
```
