### PR TITLE
Webhook cert bootsrap single reconcile

### DIFF
--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -38,6 +38,11 @@ type Builder struct {
 	// the actual controller implementation
 	impl queueingController
 
+	// runFirstFuncs are a list of functions that will be called immediately
+	// after the controller has been initialised, once. They are run in queue, sequentially,
+	// and block runDurationFuncs until complete.
+	runFirstFuncs []runFunc
+
 	// runDurationFuncs are a list of functions that will be called every
 	// 'duration'
 	runDurationFuncs []runDurationFunc
@@ -65,6 +70,14 @@ func (b *Builder) With(function func(context.Context), duration time.Duration) *
 		fn:       function,
 		duration: duration,
 	})
+	return b
+}
+
+// First will register a function that will be called once, after the
+// controller has been initialised. They are queued, run sequentially, and
+// block "With" runDurationFuncs from running until all are complete.
+func (b *Builder) First(function func(context.Context)) *Builder {
+	b.runFirstFuncs = append(b.runFirstFuncs, function)
 	return b
 }
 

--- a/pkg/controller/webhookbootstrap/BUILD.bazel
+++ b/pkg/controller/webhookbootstrap/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/controller/test:go_default_library",
+        "//pkg/logs:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/unit/gen:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/pkg/controller/webhookbootstrap/controller.go
+++ b/pkg/controller/webhookbootstrap/controller.go
@@ -540,7 +540,8 @@ func init() {
 		ctrl := &controller{}
 		return controllerpkg.NewBuilder(ctx, ControllerName).
 			For(ctrl).
-			With(ctrl.bootstrapSecrets, time.Second*10).
+			First(ctrl.bootstrapSecrets).
+			With(ctrl.bootstrapSecrets, time.Second*30).
 			Complete()
 	})
 }

--- a/pkg/controller/webhookbootstrap/controller_test.go
+++ b/pkg/controller/webhookbootstrap/controller_test.go
@@ -148,6 +148,25 @@ func TestProcessItem(t *testing.T) {
 					caSecret,
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						caSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: caSecret.Namespace,
+								Name:      caSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundleCA.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
@@ -189,6 +208,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						caSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: caSecret.Namespace,
+								Name:      caSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundleCA.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
@@ -267,6 +305,25 @@ func TestProcessItem(t *testing.T) {
 					servingSecret,
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						servingSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: servingSecret.Namespace,
+								Name:      servingSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundle.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
@@ -319,6 +376,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						servingSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: servingSecret.Namespace,
+								Name:      servingSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundle.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
@@ -359,6 +435,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						caSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: caSecret.Namespace,
+								Name:      caSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundleCA.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
@@ -400,6 +495,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						caSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: caSecret.Namespace,
+								Name:      caSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundleCA.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
@@ -455,6 +569,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						servingSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: servingSecret.Namespace,
+								Name:      servingSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundle.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
@@ -510,6 +643,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						servingSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: servingSecret.Namespace,
+								Name:      servingSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundle.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
@@ -567,6 +719,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						servingSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: servingSecret.Namespace,
+								Name:      servingSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundle.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
@@ -621,6 +792,25 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewCreateAction(
+						corev1.SchemeGroupVersion.WithResource("secrets"),
+						servingSecret.Namespace,
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: servingSecret.Namespace,
+								Name:      servingSecret.Name,
+								Annotations: map[string]string{
+									cmapi.AllowsInjectionFromSecretAnnotation: "true",
+								},
+							},
+							Data: map[string][]byte{
+								corev1.TLSCertKey:       exampleBundle.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBadDNSNameBundle.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
+							},
+							Type: corev1.SecretTypeTLS,
+						},
+					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,

--- a/pkg/controller/webhookbootstrap/controller_test.go
+++ b/pkg/controller/webhookbootstrap/controller_test.go
@@ -139,9 +139,10 @@ func TestProcessItem(t *testing.T) {
 				ExpectedEvents:  []string{},
 			},
 		},
-		"generate a new private key for the CA secret if none exists": {
+		"generate a new private key and certificate for the CA secret if no private key exists": {
 			key:                     caSecretKey,
-			generatePrivateKeyBytes: testGeneratePrivateKeyBytesFn(exampleBundle.privateKeyBytes),
+			generatePrivateKeyBytes: testGeneratePrivateKeyBytesFn(exampleBundleCA.privateKeyBytes),
+			signCertificate:         testSignCertificateFn(exampleBundleCA.certBytes),
 			builder: &testpkg.Builder{
 				KubeObjects: []runtime.Object{
 					caSecret,
@@ -159,9 +160,9 @@ func TestProcessItem(t *testing.T) {
 								},
 							},
 							Data: map[string][]byte{
-								corev1.TLSCertKey:       nil,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
+								corev1.TLSCertKey:       exampleBundleCA.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -170,9 +171,10 @@ func TestProcessItem(t *testing.T) {
 				ExpectedEvents: []string{},
 			},
 		},
-		"generate a new private key for the CA secret if existing private key is garbage": {
+		"generate a new private key for the CA secret and sign a certificate if existing private key is garbage": {
 			key:                     caSecretKey,
-			generatePrivateKeyBytes: testGeneratePrivateKeyBytesFn(exampleBundle.privateKeyBytes),
+			generatePrivateKeyBytes: testGeneratePrivateKeyBytesFn(exampleBundleCA.privateKeyBytes),
+			signCertificate:         testSignCertificateFn(exampleBundleCA.certBytes),
 			builder: &testpkg.Builder{
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
@@ -199,9 +201,9 @@ func TestProcessItem(t *testing.T) {
 								},
 							},
 							Data: map[string][]byte{
-								corev1.TLSCertKey:       nil,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
+								corev1.TLSCertKey:       exampleBundleCA.certBytes,
+								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -245,9 +247,10 @@ func TestProcessItem(t *testing.T) {
 			},
 			expectedErr: true,
 		},
-		"generate a new private key for the serving secret if none exists": {
+		"generate a new private key for the serving secret if none exists and sign certificate": {
 			key:                     servingSecretKey,
 			generatePrivateKeyBytes: testGeneratePrivateKeyBytesFn(exampleBundle.privateKeyBytes),
+			signCertificate:         testSignCertificateFn(exampleBundle.certBytes),
 			builder: &testpkg.Builder{
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
@@ -276,9 +279,9 @@ func TestProcessItem(t *testing.T) {
 								},
 							},
 							Data: map[string][]byte{
-								corev1.TLSCertKey:       nil,
+								corev1.TLSCertKey:       exampleBundle.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -287,9 +290,10 @@ func TestProcessItem(t *testing.T) {
 				ExpectedEvents: []string{},
 			},
 		},
-		"generate a new private key for the serving secret if existing private key is garbage": {
+		"generate a new private key for the serving secret if existing private key is garbage and sign certificate": {
 			key:                     servingSecretKey,
 			generatePrivateKeyBytes: testGeneratePrivateKeyBytesFn(exampleBundle.privateKeyBytes),
+			signCertificate:         testSignCertificateFn(exampleBundle.certBytes),
 			builder: &testpkg.Builder{
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
@@ -327,9 +331,9 @@ func TestProcessItem(t *testing.T) {
 								},
 							},
 							Data: map[string][]byte{
-								corev1.TLSCertKey:       nil,
+								corev1.TLSCertKey:       exampleBundle.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
+								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
 							},
 							Type: corev1.SecretTypeTLS,
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In the current implementation of the webhook boot strap controller, it relies on creating empty secrets in order to reconcile over those secrets in the main loop. Creating empty Secrets causes issues further upstream where mounting fails on the webhook pod and therefore can significantly increase the start time.

This PR changes this behavior by manually adding the target secrets at boot time, even though they do not yet exist. The controller is able to either create or update the target Secret, depending on whether it exists. The controller will also only atomically create/update the secret with the private key _and_ signed certificate.

This PR adds a `First` func to controllers which are able to register functions that will be run after the controller initialization, in a queue, sequentially, and will block Wait funcs until complete.

 fixes #2537 
/assign @munnerz 

```release-note
Improve startup time for webhook pod.
```
