### PR TITLE
Enable Venafi TPP e2e tests

### DIFF
--- a/devel/ci-run-e2e.sh
+++ b/devel/ci-run-e2e.sh
@@ -45,7 +45,6 @@ echo "Ensuring all e2e test dependencies are installed..."
 echo "Running e2e test suite..."
 # Skip Venafi end-to-end tests in CI
 FLAKE_ATTEMPTS=2 "${SCRIPT_ROOT}/run-e2e.sh" \
-  --ginkgo.skip=Venafi \
   "$@"
 
 export_logs

--- a/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/util/errors:go_default_library",
+        "//test/e2e/suite/conformance/certificates:go_default_library",
         "//test/e2e/suite/issuers/venafi/addon:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -24,35 +24,36 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/util/errors"
+	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
 	vaddon "github.com/jetstack/cert-manager/test/e2e/suite/issuers/venafi/addon"
 )
 
 var _ = framework.ConformanceDescribe("Certificates", func() {
-	//// unsupportedFeatures is a list of features that are not supported by the
-	//// Venafi issuer.
-	//var unsupportedFeatures = certificates.NewFeatureSet(
-	//	certificates.DurationFeature,
-	//	// Due to the current configuration of the test environment, it does not
-	//	// support signing certificates that pair with an elliptic curve private
-	//	// key or using the same private key multiple times.
-	//	certificates.ECDSAFeature,
-	//	certificates.ReusePrivateKeyFeature,
-	//)
-	//
-	//provisioner := new(venafiProvisioner)
-	//(&certificates.Suite{
-	//	Name:                "Venafi Issuer",
-	//	CreateIssuerFunc:    provisioner.createIssuer,
-	//	DeleteIssuerFunc:    provisioner.delete,
-	//	UnsupportedFeatures: unsupportedFeatures,
-	//}).Define()
+	// unsupportedFeatures is a list of features that are not supported by the
+	// Venafi issuer.
+	var unsupportedFeatures = certificates.NewFeatureSet(
+		certificates.DurationFeature,
+		// Due to the current configuration of the test environment, it does not
+		// support signing certificates that pair with an elliptic curve private
+		// key or using the same private key multiple times.
+		certificates.ECDSAFeature,
+		certificates.ReusePrivateKeyFeature,
+	)
 
-	//(&certificates.Suite{
-	//	Name:                "Venafi ClusterIssuer",
-	//	CreateIssuerFunc:    provisioner.createClusterIssuer,
-	//	DeleteIssuerFunc:    provisioner.delete,
-	//	UnsupportedFeatures: unsupportedFeatures,
-	//}).Define()
+	provisioner := new(venafiProvisioner)
+	(&certificates.Suite{
+		Name:                "Venafi Issuer",
+		CreateIssuerFunc:    provisioner.createIssuer,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
+
+	(&certificates.Suite{
+		Name:                "Venafi ClusterIssuer",
+		CreateIssuerFunc:    provisioner.createClusterIssuer,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
 })
 
 type venafiProvisioner struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables Venafi end-to-end tests against the testing TPP server once again.

**Which issue this PR fixes**: fixes #2175 

ref #2262 

**Release note**:
```release-note
NONE
```

/area testing
/kind cleanup