### PR TITLE
Remove json field tags from internal API structs

### DIFF
--- a/pkg/internal/apis/acme/types_challenge.go
+++ b/pkg/internal/apis/acme/types_challenge.go
@@ -26,60 +26,59 @@ import (
 
 // Challenge is a type to represent a Challenge request with an ACME server
 type Challenge struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ObjectMeta
 
-	Spec   ChallengeSpec   `json:"spec,omitempty"`
-	Status ChallengeStatus `json:"status,omitempty"`
+	Spec   ChallengeSpec
+	Status ChallengeStatus
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ChallengeList is a list of Challenges
 type ChallengeList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ListMeta
 
-	Items []Challenge `json:"items"`
+	Items []Challenge
 }
 
 type ChallengeSpec struct {
 	// AuthzURL is the URL to the ACME Authorization resource that this
 	// challenge is a part of.
-	AuthzURL string `json:"authzURL"`
+	AuthzURL string
 
 	// Type is the type of ACME challenge this resource represents, e.g. "dns01"
 	// or "http01"
-	Type string `json:"type"`
+	Type string
 
 	// URL is the URL of the ACME Challenge resource for this challenge.
 	// This can be used to lookup details about the status of this challenge.
-	URL string `json:"url"`
+	URL string
 
 	// DNSName is the identifier that this challenge is for, e.g. example.com.
-	DNSName string `json:"dnsName"`
+	DNSName string
 
 	// Token is the ACME challenge token for this challenge.
-	Token string `json:"token"`
+	Token string
 
 	// Key is the ACME challenge key for this challenge
-	Key string `json:"key"`
+	Key string
 
 	// Wildcard will be true if this challenge is for a wildcard identifier,
 	// for example '*.example.com'
-	// +optional
-	Wildcard bool `json:"wildcard"`
+	Wildcard bool
 
 	// Solver contains the domain solving configuration that should be used to
 	// solve this challenge resource.
-	Solver *ACMEChallengeSolver `json:"solver,omitempty"`
+	Solver *ACMEChallengeSolver
 
 	// IssuerRef references a properly configured ACME-type Issuer which should
 	// be used to create this Challenge.
 	// If the Issuer does not exist, processing will be retried.
 	// If the Issuer is not an 'ACME' Issuer, an error will be returned and the
 	// Challenge will be marked as failed.
-	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
+	IssuerRef cmmeta.ObjectReference
 }
 
 type ChallengeStatus struct {
@@ -90,8 +89,7 @@ type ChallengeStatus struct {
 	// challenge has reached a final state or timed out.
 	// If this field is set to false, the challenge controller will not take
 	// any more action.
-	// +optional
-	Processing bool `json:"processing"`
+	Processing bool
 
 	// Presented will be set to true if the challenge values for this challenge
 	// are currently 'presented'.
@@ -99,16 +97,13 @@ type ChallengeStatus struct {
 	// have been 'submitted' for the appropriate challenge mechanism (i.e. the
 	// DNS01 TXT record has been presented, or the HTTP01 configuration has been
 	// configured).
-	// +optional
-	Presented bool `json:"presented"`
+	Presented bool
 
 	// Reason contains human readable information on why the Challenge is in the
 	// current state.
-	// +optional
-	Reason string `json:"reason"`
+	Reason string
 
 	// State contains the current 'state' of the challenge.
 	// If not set, the state of the challenge is unknown.
-	// +optional
-	State State `json:"state,omitempty"`
+	State State
 }

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -26,51 +26,46 @@ import (
 // ACMEIssuer contains the specification for an ACME issuer
 type ACMEIssuer struct {
 	// Email is the email for this account
-	// +optional
-	Email string `json:"email,omitempty"`
+	Email string
 
 	// Server is the ACME server URL
-	Server string `json:"server"`
+	Server string
 
 	// If true, skip verifying the ACME server TLS certificate
-	// +optional
-	SkipTLSVerify bool `json:"skipTLSVerify,omitempty"`
+	SkipTLSVerify bool
 
 	// ExternalAcccountBinding is a reference to a CA external account of the ACME
 	// server.
-	// +optional
-	ExternalAccountBinding *ACMEExternalAccountBinding `json:"externalAccountBinding,omitempty"`
+	ExternalAccountBinding *ACMEExternalAccountBinding
 
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
-	PrivateKey cmmeta.SecretKeySelector `json:"privateKeySecretRef"`
+	PrivateKey cmmeta.SecretKeySelector
 
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
-	// +optional
-	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
+	Solvers []ACMEChallengeSolver
 }
 
 // ACMEExternalAcccountBinding is a reference to a CA external account of the ACME
 // server.
 type ACMEExternalAccountBinding struct {
 	// keyID is the ID of the CA key that the External Account is bound to.
-	KeyID string `json:"keyID"`
+	KeyID string
 
 	// keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
 	// Secret which holds the symmetric MAC key of the External Account Binding.
 	// The `key` is the index string that is paired with the key data in the
 	// Secret and should not be confused with the key data itself, or indeed with
 	// the External Account Binding keyID above.
-	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
+	Key cmmeta.SecretKeySelector
 
 	// keyAlgorithm is the MAC key algorithm that the key is used for. Valid
 	// values are "HS256", "HS384" and "HS512".
-	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+	KeyAlgorithm HMACKeyAlgorithm
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption
-// +kubebuilder:validation:Enum=HS256;HS384;HS512
 type HMACKeyAlgorithm string
 
 const (
@@ -82,13 +77,11 @@ const (
 type ACMEChallengeSolver struct {
 	// Selector selects a set of DNSNames on the Certificate resource that
 	// should be solved using this challenge solver.
-	Selector *CertificateDNSNameSelector `json:"selector,omitempty"`
+	Selector *CertificateDNSNameSelector
 
-	// +optional
-	HTTP01 *ACMEChallengeSolverHTTP01 `json:"http01,omitempty"`
+	HTTP01 *ACMEChallengeSolverHTTP01
 
-	// +optional
-	DNS01 *ACMEChallengeSolverDNS01 `json:"dns01,omitempty"`
+	DNS01 *ACMEChallengeSolverDNS01
 }
 
 // CertificateDomainSelector selects certificates using a label selector, and
@@ -98,8 +91,7 @@ type ACMEChallengeSolver struct {
 type CertificateDNSNameSelector struct {
 	// A label selector that is used to refine the set of certificate's that
 	// this challenge solver will apply to.
-	// +optional
-	MatchLabels map[string]string `json:"matchLabels,omitempty"`
+	MatchLabels map[string]string
 
 	// List of DNSNames that this solver will be used to solve.
 	// If specified and a match is found, a dnsNames selector will take
@@ -108,8 +100,7 @@ type CertificateDNSNameSelector struct {
 	// with the most matching labels in matchLabels will be selected.
 	// If neither has more matches, the solver defined earlier in the list
 	// will be selected.
-	// +optional
-	DNSNames []string `json:"dnsNames,omitempty"`
+	DNSNames []string
 
 	// List of DNSZones that this solver will be used to solve.
 	// The most specific DNS zone match specified here will take precedence
@@ -120,8 +111,7 @@ type CertificateDNSNameSelector struct {
 	// with the most matching labels in matchLabels will be selected.
 	// If neither has more matches, the solver defined earlier in the list
 	// will be selected.
-	// +optional
-	DNSZones []string `json:"dnsZones,omitempty"`
+	DNSZones []string
 }
 
 // ACMEChallengeSolverHTTP01 contains configuration detailing how to solve
@@ -134,33 +124,28 @@ type ACMEChallengeSolverHTTP01 struct {
 	// creating or modifying Ingress resources in order to route requests for
 	// '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are
 	// provisioned by cert-manager for each Challenge to be completed.
-	// +optional
-	Ingress *ACMEChallengeSolverHTTP01Ingress `json:"ingress"`
+	Ingress *ACMEChallengeSolverHTTP01Ingress
 }
 
 type ACMEChallengeSolverHTTP01Ingress struct {
 	// Optional service type for Kubernetes solver service
-	// +optional
-	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
+	ServiceType corev1.ServiceType
 
 	// The ingress class to use when creating Ingress resources to solve ACME
 	// challenges that use this challenge solver.
 	// Only one of 'class' or 'name' may be specified.
-	// +optional
-	Class *string `json:"class,omitempty"`
+	Class *string
 
 	// The name of the ingress resource that should have ACME challenge solving
 	// routes inserted into it in order to solve HTTP01 challenges.
 	// This is typically used in conjunction with ingress controllers like
 	// ingress-gce, which maintains a 1:1 mapping between external IPs and
 	// ingress resources.
-	// +optional
-	Name string `json:"name,omitempty"`
+	Name string
 
 	// Optional pod template used to configure the ACME challenge solver pods
 	// used for HTTP01 challenges
-	// +optional
-	PodTemplate *ACMEChallengeSolverHTTP01IngressPodTemplate `json:"podTemplate,omitempty"`
+	PodTemplate *ACMEChallengeSolverHTTP01IngressPodTemplate
 }
 
 type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
@@ -168,78 +153,62 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	// Only the 'labels' and 'annotations' fields may be set.
 	// If labels or annotations overlap with in-built values, the values here
 	// will override the in-built values.
-	// +optional
-	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata,omitempty"`
+	ACMEChallengeSolverHTTP01IngressPodObjectMeta
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
 	// Only the 'nodeSelector', 'affinity' and 'tolerations' fields are
 	// supported currently. All other fields will be ignored.
-	// +optional
-	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec,omitempty"`
+	Spec ACMEChallengeSolverHTTP01IngressPodSpec
 }
 
 type ACMEChallengeSolverHTTP01IngressPodObjectMeta struct {
 	// Annotations that should be added to the create ACME HTTP01 solver pods.
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]string
 
 	// Labels that should be added to the created ACME HTTP01 solver pods.
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string
 }
 
 type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// NodeSelector is a selector which must be true for the pod to fit on a node.
 	// Selector which must match a node's labels for the pod to be scheduled on that node.
 	// More info: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-	// +optional
-	NodeSelector map[string]string `json:"nodeSelector,omitempty"`
+	NodeSelector map[string]string
 
 	// If specified, the pod's scheduling constraints
-	// +optional
-	Affinity *corev1.Affinity `json:"affinity,omitempty"`
+	Affinity *corev1.Affinity
 
 	// If specified, the pod's tolerations.
-	// +optional
-	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+	Tolerations []corev1.Toleration
 }
 
 type ACMEChallengeSolverDNS01 struct {
 	// CNAMEStrategy configures how the DNS01 provider should handle CNAME
 	// records when found in DNS zones.
-	// +optional
-	CNAMEStrategy CNAMEStrategy `json:"cnameStrategy,omitempty"`
+	CNAMEStrategy CNAMEStrategy
 
-	// +optional
-	Akamai *ACMEIssuerDNS01ProviderAkamai `json:"akamai,omitempty"`
+	Akamai *ACMEIssuerDNS01ProviderAkamai
 
-	// +optional
-	CloudDNS *ACMEIssuerDNS01ProviderCloudDNS `json:"clouddns,omitempty"`
+	CloudDNS *ACMEIssuerDNS01ProviderCloudDNS
 
-	// +optional
-	Cloudflare *ACMEIssuerDNS01ProviderCloudflare `json:"cloudflare,omitempty"`
+	Cloudflare *ACMEIssuerDNS01ProviderCloudflare
 
-	// +optional
-	Route53 *ACMEIssuerDNS01ProviderRoute53 `json:"route53,omitempty"`
+	Route53 *ACMEIssuerDNS01ProviderRoute53
 
-	// +optional
-	AzureDNS *ACMEIssuerDNS01ProviderAzureDNS `json:"azuredns,omitempty"`
+	AzureDNS *ACMEIssuerDNS01ProviderAzureDNS
 
-	// +optional
-	DigitalOcean *ACMEIssuerDNS01ProviderDigitalOcean `json:"digitalocean,omitempty"`
+	DigitalOcean *ACMEIssuerDNS01ProviderDigitalOcean
 
-	// +optional
-	AcmeDNS *ACMEIssuerDNS01ProviderAcmeDNS `json:"acmedns,omitempty"`
+	AcmeDNS *ACMEIssuerDNS01ProviderAcmeDNS
 
-	// +optional
-	RFC2136 *ACMEIssuerDNS01ProviderRFC2136 `json:"rfc2136,omitempty"`
+	RFC2136 *ACMEIssuerDNS01ProviderRFC2136
 
-	// +optional
-	Webhook *ACMEIssuerDNS01ProviderWebhook `json:"webhook,omitempty"`
+	Webhook *ACMEIssuerDNS01ProviderWebhook
 }
 
 // CNAMEStrategy configures how the DNS01 provider should handle CNAME records
 // when found in DNS zones.
 // By default, the None strategy will be applied (i.e. do not follow CNAMEs).
-// +kubebuilder:validation:Enum=None;Follow
 type CNAMEStrategy string
 
 const (
@@ -258,32 +227,31 @@ const (
 // ACMEIssuerDNS01ProviderAkamai is a structure containing the DNS
 // configuration for Akamai DNS—Zone Record Management API
 type ACMEIssuerDNS01ProviderAkamai struct {
-	ServiceConsumerDomain string                   `json:"serviceConsumerDomain"`
-	ClientToken           cmmeta.SecretKeySelector `json:"clientTokenSecretRef"`
-	ClientSecret          cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
-	AccessToken           cmmeta.SecretKeySelector `json:"accessTokenSecretRef"`
+	ServiceConsumerDomain string
+	ClientToken           cmmeta.SecretKeySelector
+	ClientSecret          cmmeta.SecretKeySelector
+	AccessToken           cmmeta.SecretKeySelector
 }
 
 // ACMEIssuerDNS01ProviderCloudDNS is a structure containing the DNS
 // configuration for Google Cloud DNS
 type ACMEIssuerDNS01ProviderCloudDNS struct {
-	// +optional
-	ServiceAccount *cmmeta.SecretKeySelector `json:"serviceAccountSecretRef,omitempty"`
-	Project        string                    `json:"project"`
+	ServiceAccount *cmmeta.SecretKeySelector
+	Project        string
 }
 
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
-	Email    string                    `json:"email"`
-	APIKey   *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
-	APIToken *cmmeta.SecretKeySelector `json:"apiTokenSecretRef,omitempty"`
+	Email    string
+	APIKey   *cmmeta.SecretKeySelector
+	APIToken *cmmeta.SecretKeySelector
 }
 
 // ACMEIssuerDNS01ProviderDigitalOcean is a structure containing the DNS
 // configuration for DigitalOcean Domains
 type ACMEIssuerDNS01ProviderDigitalOcean struct {
-	Token cmmeta.SecretKeySelector `json:"tokenSecretRef"`
+	Token cmmeta.SecretKeySelector
 }
 
 // ACMEIssuerDNS01ProviderRoute53 is a structure containing the Route 53
@@ -291,48 +259,41 @@ type ACMEIssuerDNS01ProviderDigitalOcean struct {
 type ACMEIssuerDNS01ProviderRoute53 struct {
 	// The AccessKeyID is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata
 	// see: https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-	// +optional
-	AccessKeyID string `json:"accessKeyID"`
+	AccessKeyID string
 
 	// The SecretAccessKey is used for authentication. If not set we fall-back to using env vars, shared credentials file or AWS Instance metadata
 	// https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials
-	// +optional
-	SecretAccessKey cmmeta.SecretKeySelector `json:"secretAccessKeySecretRef"`
+	SecretAccessKey cmmeta.SecretKeySelector
 
 	// Role is a Role ARN which the Route53 provider will assume using either the explicit credentials AccessKeyID/SecretAccessKey
 	// or the inferred credentials from environment variables, shared credentials file or AWS Instance metadata
-	// +optional
-	Role string `json:"role"`
+	Role string
 
 	// If set, the provider will manage only this zone in Route53 and will not do an lookup using the route53:ListHostedZonesByName api call.
-	// +optional
-	HostedZoneID string `json:"hostedZoneID,omitempty"`
+	HostedZoneID string
 
 	// Always set the region when using AccessKeyID and SecretAccessKey
-	Region string `json:"region"`
+	Region string
 }
 
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
-	ClientID string `json:"clientID"`
+	ClientID string
 
-	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
+	ClientSecret cmmeta.SecretKeySelector
 
-	SubscriptionID string `json:"subscriptionID"`
+	SubscriptionID string
 
-	TenantID string `json:"tenantID"`
+	TenantID string
 
-	ResourceGroupName string `json:"resourceGroupName"`
+	ResourceGroupName string
 
-	// +optional
-	HostedZoneName string `json:"hostedZoneName,omitempty"`
+	HostedZoneName string
 
-	// +optional
-	Environment AzureDNSEnvironment `json:"environment,omitempty"`
+	Environment AzureDNSEnvironment
 }
 
-// +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
 type AzureDNSEnvironment string
 
 const (
@@ -345,9 +306,9 @@ const (
 // ACMEIssuerDNS01ProviderAcmeDNS is a structure containing the
 // configuration for ACME-DNS servers
 type ACMEIssuerDNS01ProviderAcmeDNS struct {
-	Host string `json:"host"`
+	Host string
 
-	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
+	AccountSecret cmmeta.SecretKeySelector
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the
@@ -355,24 +316,21 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The IP address of the DNS supporting RFC2136. Required.
 	// Note: FQDN is not a valid value, only IP.
-	Nameserver string `json:"nameserver"`
+	Nameserver string
 
 	// The name of the secret containing the TSIG value.
 	// If ``tsigKeyName`` is defined, this field is required.
-	// +optional
-	TSIGSecret cmmeta.SecretKeySelector `json:"tsigSecretSecretRef,omitempty"`
+	TSIGSecret cmmeta.SecretKeySelector
 
 	// The TSIG Key name configured in the DNS.
 	// If ``tsigSecretSecretRef`` is defined, this field is required.
-	// +optional
-	TSIGKeyName string `json:"tsigKeyName,omitempty"`
+	TSIGKeyName string
 
 	// The TSIG Algorithm configured in the DNS supporting RFC2136. Used only
 	// when ``tsigSecretSecretRef`` and ``tsigKeyName`` are defined.
 	// Supported values are (case-insensitive): ``HMACMD5`` (default),
 	// ``HMACSHA1``, ``HMACSHA256`` or ``HMACSHA512``.
-	// +optional
-	TSIGAlgorithm string `json:"tsigAlgorithm,omitempty"`
+	TSIGAlgorithm string
 }
 
 // ACMEIssuerDNS01ProviderWebhook specifies configuration for a webhook DNS01
@@ -382,12 +340,12 @@ type ACMEIssuerDNS01ProviderWebhook struct {
 	// resources to the webhook apiserver.
 	// This should be the same as the GroupName specified in the webhook
 	// provider implementation.
-	GroupName string `json:"groupName"`
+	GroupName string
 
 	// The name of the solver to use, as defined in the webhook provider
 	// implementation.
 	// This will typically be the name of the provider, e.g. 'cloudflare'.
-	SolverName string `json:"solverName"`
+	SolverName string
 
 	// Additional configuration that should be passed to the webhook apiserver
 	// when challenges are processed.
@@ -397,19 +355,16 @@ type ACMEIssuerDNS01ProviderWebhook struct {
 	// should use a cmmeta.SecretKeySelector to reference a Secret resource.
 	// For details on the schema of this field, consult the webhook provider
 	// implementation's documentation.
-	// +optional
-	Config *apiext.JSON `json:"config,omitempty"`
+	Config *apiext.JSON
 }
 
 type ACMEIssuerStatus struct {
 	// URI is the unique account identifier, which can also be used to retrieve
 	// account details from the CA
-	// +optional
-	URI string `json:"uri,omitempty"`
+	URI string
 
 	// LastRegisteredEmail is the email associated with the latest registered
 	// ACME account, in order to track changes made to registered account
 	// associated with the  Issuer
-	// +optional
-	LastRegisteredEmail string `json:"lastRegisteredEmail,omitempty"`
+	LastRegisteredEmail string
 }

--- a/pkg/internal/apis/acme/types_order.go
+++ b/pkg/internal/apis/acme/types_order.go
@@ -29,43 +29,42 @@ import (
 
 // Order is a type to represent an Order with an ACME server
 type Order struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ObjectMeta
 
-	Spec   OrderSpec   `json:"spec,omitempty"`
-	Status OrderStatus `json:"status,omitempty"`
+	Spec   OrderSpec
+	Status OrderStatus
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // OrderList is a list of Orders
 type OrderList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ListMeta
 
-	Items []Order `json:"items"`
+	Items []Order
 }
 
 type OrderSpec struct {
 	// Certificate signing request bytes in DER encoding.
 	// This will be used when finalizing the order.
 	// This field must be set on the order.
-	CSR []byte `json:"csr"`
+	CSR []byte
 
 	// IssuerRef references a properly configured ACME-type Issuer which should
 	// be used to create this Order.
 	// If the Issuer does not exist, processing will be retried.
 	// If the Issuer is not an 'ACME' Issuer, an error will be returned and the
 	// Order will be marked as failed.
-	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
+	IssuerRef cmmeta.ObjectReference
 
 	// CommonName is the common name as specified on the DER encoded CSR.
 	// If CommonName is not specified, the first DNSName specified will be used
 	// as the CommonName.
 	// At least one of CommonName or a DNSNames must be set.
 	// This field must match the corresponding field on the DER encoded CSR.
-	// +optional
-	CommonName string `json:"commonName,omitempty"`
+	CommonName string
 
 	// DNSNames is a list of DNS names that should be included as part of the Order
 	// validation process.
@@ -73,8 +72,7 @@ type OrderSpec struct {
 	// as the CommonName.
 	// At least one of CommonName or a DNSNames must be set.
 	// This field must match the corresponding field on the DER encoded CSR.
-	// +optional
-	DNSNames []string `json:"dnsNames,omitempty"`
+	DNSNames []string
 }
 
 type OrderStatus struct {
@@ -82,41 +80,34 @@ type OrderStatus struct {
 	// This will initially be empty when the resource is first created.
 	// The Order controller will populate this field when the Order is first processed.
 	// This field will be immutable after it is initially set.
-	// +optional
-	URL string `json:"url,omitempty"`
+	URL string
 
 	// FinalizeURL of the Order.
 	// This is used to obtain certificates for this order once it has been completed.
-	// +optional
-	FinalizeURL string `json:"finalizeURL,omitempty"`
+	FinalizeURL string
 
 	// Certificate is a copy of the PEM encoded certificate for this Order.
 	// This field will be populated after the order has been successfully
 	// finalized with the ACME server, and the order has transitioned to the
 	// 'valid' state.
-	// +optional
-	Certificate []byte `json:"certificate,omitempty"`
+	Certificate []byte
 
 	// State contains the current state of this Order resource.
 	// States 'success' and 'expired' are 'final'
-	// +optional
-	State State `json:"state,omitempty"`
+	State State
 
 	// Reason optionally provides more information about a why the order is in
 	// the current state.
-	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason string
 
 	// Authorizations contains data returned from the ACME server on what
 	// authoriations must be completed in order to validate the DNS names
 	// specified on the Order.
-	// +optional
-	Authorizations []ACMEAuthorization `json:"authorizations,omitempty"`
+	Authorizations []ACMEAuthorization
 
 	// FailureTime stores the time that this order failed.
 	// This is used to influence garbage collection and back-off.
-	// +optional
-	FailureTime *metav1.Time `json:"failureTime,omitempty"`
+	FailureTime *metav1.Time
 }
 
 // ACMEAuthorization contains data returned from the ACME server on an
@@ -124,26 +115,23 @@ type OrderStatus struct {
 // Order resource.
 type ACMEAuthorization struct {
 	// URL is the URL of the Authorization that must be completed
-	URL string `json:"url"`
+	URL string
 
 	// Identifier is the DNS name to be validated as part of this authorization
-	// +optional
-	Identifier string `json:"identifier,omitempty"`
+	Identifier string
 
 	// Wildcard will be true if this authorization is for a wildcard DNS name.
 	// If this is true, the identifier will be the *non-wildcard* version of
 	// the DNS name.
 	// For example, if '*.example.com' is the DNS name being validated, this
 	// field will be 'true' and the 'identifier' field will be 'example.com'.
-	// +optional
-	Wildcard *bool `json:"wildcard,omitempty"`
+	Wildcard *bool
 
 	// Challenges specifies the challenge types offered by the ACME server.
 	// One of these challenge types will be selected when validating the DNS
 	// name and an appropriate Challenge resource will be created to perform
 	// the ACME challenge process.
-	// +optional
-	Challenges []ACMEChallenge `json:"challenges,omitempty"`
+	Challenges []ACMEChallenge
 }
 
 // Challenge specifies a challenge offered by the ACME server for an Order.
@@ -152,14 +140,14 @@ type ACMEAuthorization struct {
 type ACMEChallenge struct {
 	// URL is the URL of this challenge. It can be used to retrieve additional
 	// metadata about the Challenge from the ACME server.
-	URL string `json:"url"`
+	URL string
 
 	// Token is the token that must be presented for this challenge.
 	// This is used to compute the 'key' that must also be presented.
-	Token string `json:"token"`
+	Token string
 
 	// Type is the type of challenge being offered, e.g. http-01, dns-01
-	Type ACMEChallengeType `json:"type"`
+	Type ACMEChallengeType
 }
 
 // ACMEChallengeType denotes a type of ACME challenge
@@ -179,7 +167,6 @@ const (
 // Full details of these values can be found here: https://tools.ietf.org/html/draft-ietf-acme-acme-15#section-7.1.6
 // Clients utilising this type must also gracefully handle unknown
 // values, as the contents of this enumeration may be added to over time.
-// +kubebuilder:validation:Enum=valid;ready;pending;processing;invalid;expired;errored
 type State string
 
 const (

--- a/pkg/internal/apis/certmanager/types.go
+++ b/pkg/internal/apis/certmanager/types.go
@@ -67,7 +67,6 @@ const (
 // KeyUsage specifies valid usage contexts for keys.
 // See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3
 //      https://tools.ietf.org/html/rfc5280#section-4.2.1.12
-// +kubebuilder:validation:Enum="signing";"digital signature";"content commitment";"key encipherment";"key agreement";"data encipherment";"cert sign";"crl sign";"encipher only";"decipher only";"any";"server auth";"client auth";"code signing";"email protection";"s/mime";"ipsec end system";"ipsec tunnel";"ipsec user";"timestamping";"ocsp signing";"microsoft sgc";"netscape sgc"
 type KeyUsage string
 
 const (

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -26,21 +26,21 @@ import (
 
 // Certificate is a type to represent a Certificate from ACME
 type Certificate struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta
+	metav1.ObjectMeta
 
-	Spec   CertificateSpec   `json:"spec,omitempty"`
-	Status CertificateStatus `json:"status,omitempty"`
+	Spec   CertificateSpec
+	Status CertificateStatus
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CertificateList is a list of Certificates
 type CertificateList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ListMeta
 
-	Items []Certificate `json:"items"`
+	Items []Certificate
 }
 
 type KeyAlgorithm string
@@ -60,8 +60,7 @@ const (
 // CertificateSpec defines the desired state of Certificate
 type CertificateSpec struct {
 	// Full X509 name specification (https://golang.org/pkg/crypto/x509/pkix/#Name).
-	// +optional
-	Subject *X509Subject `json:"subject,omitempty"`
+	Subject *X509Subject
 
 	// A valid Certificate requires at least one of a CommonName, DNSName, or
 	// URISAN to be valid.
@@ -69,32 +68,26 @@ type CertificateSpec struct {
 	// CommonName is a common name to be used on the Certificate.
 	// The CommonName should have a length of 64 characters or fewer to avoid
 	// generating invalid CSRs.
-	// +optional
-	CommonName string `json:"commonName,omitempty"`
+	CommonName string
 
 	// Certificate default Duration
-	// +optional
-	Duration *metav1.Duration `json:"duration,omitempty"`
+	Duration *metav1.Duration
 
 	// Certificate renew before expiration duration
-	// +optional
-	RenewBefore *metav1.Duration `json:"renewBefore,omitempty"`
+	RenewBefore *metav1.Duration
 
 	// DNSNames is a list of subject alt names to be used on the Certificate.
-	// +optional
-	DNSNames []string `json:"dnsNames,omitempty"`
+	DNSNames []string
 
 	// IPAddresses is a list of IP addresses to be used on the Certificate
-	// +optional
-	IPAddresses []string `json:"ipAddresses,omitempty"`
+	IPAddresses []string
 
 	// URISANs is a list of URI Subject Alternative Names to be set on this
 	// Certificate.
-	// +optional
-	URISANs []string `json:"uriSANs,omitempty"`
+	URISANs []string
 
 	// SecretName is the name of the secret resource to store this secret in
-	SecretName string `json:"secretName"`
+	SecretName string
 
 	// IssuerRef is a reference to the issuer for this certificate.
 	// If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
@@ -102,103 +95,85 @@ type CertificateSpec struct {
 	// If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the
 	// provided name will be used.
 	// The 'name' field in this stanza is required at all times.
-	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
+	IssuerRef cmmeta.ObjectReference
 
 	// IsCA will mark this Certificate as valid for signing.
 	// This implies that the 'cert sign' usage is set
-	// +optional
-	IsCA bool `json:"isCA,omitempty"`
+	IsCA bool
 
 	// Usages is the set of x509 actions that are enabled for a given key. Defaults are ('digital signature', 'key encipherment') if empty
-	// +optional
-	Usages []KeyUsage `json:"usages,omitempty"`
+	Usages []KeyUsage
 
 	// KeySize is the key bit size of the corresponding private key for this certificate.
 	// If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is
 	// empty or is set to "rsa", and value must be one of (256, 384, 521) when
 	// KeyAlgorithm is set to "ecdsa".
-	// +optional
-	KeySize int `json:"keySize,omitempty"`
+	KeySize int
 
 	// KeyAlgorithm is the private key algorithm of the corresponding private key
 	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
 	// If KeyAlgorithm is specified and KeySize is not provided,
 	// key size of 256 will be used for "ecdsa" key algorithm and
 	// key size of 2048 will be used for "rsa" key algorithm.
-	// +optional
-	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
+	KeyAlgorithm KeyAlgorithm
 
 	// KeyEncoding is the private key cryptography standards (PKCS)
 	// for this certificate's private key to be encoded in. If provided, allowed
 	// values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively.
 	// If KeyEncoding is not specified, then PKCS#1 will be used by default.
-	KeyEncoding KeyEncoding `json:"keyEncoding,omitempty"`
+	KeyEncoding KeyEncoding
 }
 
 // X509Subject Full X509 name specification
 type X509Subject struct {
 	// Organizations to be used on the Certificate.
-	// +optional
-	Organizations []string `json:"organizations,omitempty"`
+	Organizations []string
 	// Countries to be used on the Certificate.
-	// +optional
-	Countries []string `json:"countries,omitempty"`
+	Countries []string
 	// Organizational Units to be used on the Certificate.
-	// +optional
-	OrganizationalUnits []string `json:"organizationalUnits,omitempty"`
+	OrganizationalUnits []string
 	// Cities to be used on the Certificate.
-	// +optional
-	Localities []string `json:"localities,omitempty"`
+	Localities []string
 	// State/Provinces to be used on the Certificate.
-	// +optional
-	Provinces []string `json:"provinces,omitempty"`
+	Provinces []string
 	// Street addresses to be used on the Certificate.
-	// +optional
-	StreetAddresses []string `json:"streetAddresses,omitempty"`
+	StreetAddresses []string
 	// Postal codes to be used on the Certificate.
-	// +optional
-	PostalCodes []string `json:"postalCodes,omitempty"`
+	PostalCodes []string
 	// Serial number to be used on the Certificate.
-	// +optional
-	SerialNumber string `json:"serialNumber,omitempty"`
+	SerialNumber string
 }
 
 // CertificateStatus defines the observed state of Certificate
 type CertificateStatus struct {
-	// +optional
-	Conditions []CertificateCondition `json:"conditions,omitempty"`
+	Conditions []CertificateCondition
 
-	// +optional
-	LastFailureTime *metav1.Time `json:"lastFailureTime,omitempty"`
+	LastFailureTime *metav1.Time
 
 	// The expiration time of the certificate stored in the secret named
 	// by this resource in spec.secretName.
-	// +optional
-	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+	NotAfter *metav1.Time
 }
 
 // CertificateCondition contains condition information for an Certificate.
 type CertificateCondition struct {
 	// Type of the condition, currently ('Ready').
-	Type CertificateConditionType `json:"type"`
+	Type CertificateConditionType
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
-	Status cmmeta.ConditionStatus `json:"status"`
+	Status cmmeta.ConditionStatus
 
 	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
-	// +optional
-	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime *metav1.Time
 
 	// Reason is a brief machine readable explanation for the condition's last
 	// transition.
-	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason string
 
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
-	// +optional
-	Message string `json:"message,omitempty"`
+	Message string
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/internal/apis/certmanager/types_certificaterequest.go
+++ b/pkg/internal/apis/certmanager/types_certificaterequest.go
@@ -32,28 +32,27 @@ const (
 
 // CertificateRequest is a type to represent a Certificate Signing Request
 type CertificateRequest struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta
+	metav1.ObjectMeta
 
-	Spec   CertificateRequestSpec   `json:"spec,omitempty"`
-	Status CertificateRequestStatus `json:"status,omitempty"`
+	Spec   CertificateRequestSpec
+	Status CertificateRequestStatus
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CertificateRequestList is a list of Certificates
 type CertificateRequestList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ListMeta
 
-	Items []CertificateRequest `json:"items"`
+	Items []CertificateRequest
 }
 
 // CertificateRequestSpec defines the desired state of CertificateRequest
 type CertificateRequestSpec struct {
 	// Requested certificate default Duration
-	// +optional
-	Duration *metav1.Duration `json:"duration,omitempty"`
+	Duration *metav1.Duration
 
 	// IssuerRef is a reference to the issuer for this CertificateRequest.  If
 	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
@@ -62,66 +61,57 @@ type CertificateRequestSpec struct {
 	// the provided name will be used. The 'name' field in this stanza is
 	// required at all times. The group field refers to the API group of the
 	// issuer which defaults to 'cert-manager.io' if empty.
-	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
+	IssuerRef cmmeta.ObjectReference
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
-	CSRPEM []byte `json:"csr"`
+	CSRPEM []byte
 
 	// IsCA will mark the resulting certificate as valid for signing. This
 	// implies that the 'signing' usage is set
-	// +optional
-	IsCA bool `json:"isCA,omitempty"`
+	IsCA bool
 
 	// Usages is the set of x509 actions that are enabled for a given key.
 	// Defaults are ('digital signature', 'key encipherment') if empty
-	// +optional
-	Usages []KeyUsage `json:"usages,omitempty"`
+	Usages []KeyUsage
 }
 
 // CertificateStatus defines the observed state of CertificateRequest and
 // resulting signed certificate.
 type CertificateRequestStatus struct {
-	// +optional
-	Conditions []CertificateRequestCondition `json:"conditions,omitempty"`
+	Conditions []CertificateRequestCondition
 
 	// Byte slice containing a PEM encoded signed certificate resulting from the
 	// given certificate signing request.
-	// +optional
-	Certificate []byte `json:"certificate,omitempty"`
+	Certificate []byte
 
 	// Byte slice containing the PEM encoded certificate authority of the signed
 	// certificate.
-	// +optional
-	CA []byte `json:"ca,omitempty"`
+	CA []byte
 
 	// FailureTime stores the time that this CertificateRequest failed. This is
 	// used to influence garbage collection and back-off.
-	// +optional
-	FailureTime *metav1.Time `json:"failureTime,omitempty"`
+	FailureTime *metav1.Time
 }
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.
 type CertificateRequestCondition struct {
 	// Type of the condition, currently ('Ready', 'InvalidRequest').
-	Type CertificateRequestConditionType `json:"type"`
+	Type CertificateRequestConditionType
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
-	Status cmmeta.ConditionStatus `json:"status"`
+	Status cmmeta.ConditionStatus
 
 	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
-	// +optional
-	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime *metav1.Time
 
 	// Reason is a brief machine readable explanation for the condition's last
 	// transition.
-	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason string
 
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
-	// +optional
-	Message string `json:"message,omitempty"`
+	Message string
 }
 
 // CertificateRequestConditionType represents an Certificate condition value.

--- a/pkg/internal/apis/certmanager/types_issuer.go
+++ b/pkg/internal/apis/certmanager/types_issuer.go
@@ -26,64 +26,59 @@ import (
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type ClusterIssuer struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta
+	metav1.ObjectMeta
 
-	Spec   IssuerSpec   `json:"spec,omitempty"`
-	Status IssuerStatus `json:"status,omitempty"`
+	Spec   IssuerSpec
+	Status IssuerStatus
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ClusterIssuerList is a list of Issuers
 type ClusterIssuerList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ListMeta
 
-	Items []ClusterIssuer `json:"items"`
+	Items []ClusterIssuer
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 type Issuer struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta
+	metav1.ObjectMeta
 
-	Spec   IssuerSpec   `json:"spec,omitempty"`
-	Status IssuerStatus `json:"status,omitempty"`
+	Spec   IssuerSpec
+	Status IssuerStatus
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // IssuerList is a list of Issuers
 type IssuerList struct {
-	metav1.TypeMeta `json:",inline"`
-	metav1.ListMeta `json:"metadata"`
+	metav1.TypeMeta
+	metav1.ListMeta
 
-	Items []Issuer `json:"items"`
+	Items []Issuer
 }
 
 // IssuerSpec is the specification of an Issuer. This includes any
 // configuration required for the issuer.
 type IssuerSpec struct {
-	IssuerConfig `json:",inline"`
+	IssuerConfig
 }
 
 type IssuerConfig struct {
-	// +optional
-	ACME *cmacme.ACMEIssuer `json:"acme,omitempty"`
+	ACME *cmacme.ACMEIssuer
 
-	// +optional
-	CA *CAIssuer `json:"ca,omitempty"`
+	CA *CAIssuer
 
-	// +optional
-	Vault *VaultIssuer `json:"vault,omitempty"`
+	Vault *VaultIssuer
 
-	// +optional
-	SelfSigned *SelfSignedIssuer `json:"selfSigned,omitempty"`
+	SelfSigned *SelfSignedIssuer
 
-	// +optional
-	Venafi *VenafiIssuer `json:"venafi,omitempty"`
+	Venafi *VenafiIssuer
 }
 
 // VenafiIssuer describes issuer configuration details for Venafi Cloud.
@@ -92,28 +87,26 @@ type VenafiIssuer struct {
 	// All requests made to the Venafi platform will be restricted by the named
 	// zone policy.
 	// This field is required.
-	Zone string `json:"zone"`
+	Zone string
 
 	// TPP specifies Trust Protection Platform configuration settings.
 	// Only one of TPP or Cloud may be specified.
-	// +optional
-	TPP *VenafiTPP `json:"tpp,omitempty"`
+	TPP *VenafiTPP
 
 	// Cloud specifies the Venafi cloud configuration settings.
 	// Only one of TPP or Cloud may be specified.
-	// +optional
-	Cloud *VenafiCloud `json:"cloud,omitempty"`
+	Cloud *VenafiCloud
 }
 
 // VenafiTPP defines connection configuration details for a Venafi TPP instance
 type VenafiTPP struct {
 	// URL is the base URL for the Venafi TPP instance
-	URL string `json:"url"`
+	URL string
 
 	// CredentialsRef is a reference to a Secret containing the username and
 	// password for the TPP server.
 	// The secret must contain two keys, 'username' and 'password'.
-	CredentialsRef cmmeta.LocalObjectReference `json:"credentialsRef"`
+	CredentialsRef cmmeta.LocalObjectReference
 
 	// CABundle is a PEM encoded TLS certifiate to use to verify connections to
 	// the TPP instance.
@@ -121,37 +114,35 @@ type VenafiTPP struct {
 	// TPP instance must be verifiable using the provided root.
 	// If not specified, the connection will be verified using the cert-manager
 	// system root certificates.
-	// +optional
-	CABundle []byte `json:"caBundle,omitempty"`
+	CABundle []byte
 }
 
 // VenafiCloud defines connection configuration details for Venafi Cloud
 type VenafiCloud struct {
 	// URL is the base URL for Venafi Cloud
-	URL string `json:"url"`
+	URL string
 
 	// APITokenSecretRef is a secret key selector for the Venafi Cloud API token.
-	APITokenSecretRef cmmeta.SecretKeySelector `json:"apiTokenSecretRef"`
+	APITokenSecretRef cmmeta.SecretKeySelector
 }
 
 type SelfSignedIssuer struct{}
 
 type VaultIssuer struct {
 	// Vault authentication
-	Auth VaultAuth `json:"auth"`
+	Auth VaultAuth
 
 	// Server is the vault connection address
-	Server string `json:"server"`
+	Server string
 
 	// Vault URL path to the certificate role
-	Path string `json:"path"`
+	Path string
 
 	// Base64 encoded CA bundle to validate Vault server certificate. Only used
 	// if the Server URL is using HTTPS protocol. This parameter is ignored for
 	// plain HTTP protocol connection. If not set the system root certificates
 	// are used to validate the TLS connection.
-	// +optional
-	CABundle []byte `json:"caBundle,omitempty"`
+	CABundle []byte
 }
 
 // Vault authentication  can be configured:
@@ -162,26 +153,23 @@ type VaultIssuer struct {
 //   to authenticate with Vault and retrieve a token.
 type VaultAuth struct {
 	// This Secret contains the Vault token key
-	// +optional
-	TokenSecretRef *cmmeta.SecretKeySelector `json:"tokenSecretRef,omitempty"`
+	TokenSecretRef *cmmeta.SecretKeySelector
 
 	// This Secret contains a AppRole and Secret
-	// +optional
-	AppRole *VaultAppRole `json:"appRole,omitempty"`
+	AppRole *VaultAppRole
 
 	// This contains a Role and Secret with a ServiceAccount token to
 	// authenticate with vault.
-	// +optional
-	Kubernetes *VaultKubernetesAuth `json:"kubernetes,omitempty"`
+	Kubernetes *VaultKubernetesAuth
 }
 
 // Authenticate against Vault using an AppRole that is stored in a Secret.
 type VaultAppRole struct {
 	// Where the authentication path is mounted in Vault.
-	Path string `json:"path"`
+	Path string
 
-	RoleId    string                   `json:"roleId"`
-	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
+	RoleId    string
+	SecretRef cmmeta.SecretKeySelector
 }
 
 // Authenticate against Vault using a Kubernetes ServiceAccount token stored in
@@ -191,56 +179,50 @@ type VaultKubernetesAuth struct {
 	// with vault, for example if you set a value of "foo", the path used will be
 	// `/v1/auth/foo/login`. If unspecified, the default value "kubernetes" will
 	// be used.
-	// +optional
-	Path string `json:"mountPath,omitempty"`
+	Path string
 
 	// The required Secret field containing a Kubernetes ServiceAccount JWT used
 	// for authenticating with Vault. Use of 'ambient credentials' is not
 	// supported.
-	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
+	SecretRef cmmeta.SecretKeySelector
 
 	// A required field containing the Vault Role to assume. A Role binds a
 	// Kubernetes ServiceAccount with a set of Vault policies.
-	Role string `json:"role"`
+	Role string
 }
 
 type CAIssuer struct {
 	// SecretName is the name of the secret used to sign Certificates issued
 	// by this Issuer.
-	SecretName string `json:"secretName"`
+	SecretName string
 }
 
 // IssuerStatus contains status information about an Issuer
 type IssuerStatus struct {
-	// +optional
-	Conditions []IssuerCondition `json:"conditions,omitempty"`
+	Conditions []IssuerCondition
 
-	// +optional
-	ACME *cmacme.ACMEIssuerStatus `json:"acme,omitempty"`
+	ACME *cmacme.ACMEIssuerStatus
 }
 
 // IssuerCondition contains condition information for an Issuer.
 type IssuerCondition struct {
 	// Type of the condition, currently ('Ready').
-	Type IssuerConditionType `json:"type"`
+	Type IssuerConditionType
 
 	// Status of the condition, one of ('True', 'False', 'Unknown').
-	Status cmmeta.ConditionStatus `json:"status"`
+	Status cmmeta.ConditionStatus
 
 	// LastTransitionTime is the timestamp corresponding to the last status
 	// change of this condition.
-	// +optional
-	LastTransitionTime *metav1.Time `json:"lastTransitionTime,omitempty"`
+	LastTransitionTime *metav1.Time
 
 	// Reason is a brief machine readable explanation for the condition's last
 	// transition.
-	// +optional
-	Reason string `json:"reason,omitempty"`
+	Reason string
 
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
-	// +optional
-	Message string `json:"message,omitempty"`
+	Message string
 }
 
 // IssuerConditionType represents an Issuer condition value.

--- a/pkg/internal/apis/meta/types.go
+++ b/pkg/internal/apis/meta/types.go
@@ -39,24 +39,21 @@ type LocalObjectReference struct {
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	// TODO: Add other useful fields. apiVersion, kind, uid?
-	Name string `json:"name"`
+	Name string
 }
 
 // ObjectReference is a reference to an object with a given name, kind and group.
 type ObjectReference struct {
-	Name string `json:"name"`
-	// +optional
-	Kind string `json:"kind,omitempty"`
-	// +optional
-	Group string `json:"group,omitempty"`
+	Name  string
+	Kind  string
+	Group string
 }
 
 type SecretKeySelector struct {
 	// The name of the secret in the pod's namespace to select from.
-	LocalObjectReference `json:",inline"`
+	LocalObjectReference
 	// The key of the secret to select from. Must be a valid secret key.
-	// +optional
-	Key string `json:"key,omitempty"`
+	Key string
 }
 
 const (


### PR DESCRIPTION
**What this PR does / why we need it**:

These structures are never serialised or deserialised and are only used as the basis for conversion and certain types of validation.

The struct tags should be present on the internal types to reflect this, and the kubebuilder annotations are misleading as they are ignored here 😄 

**Release note**:
```release-note
NONE
```

/kind cleanup
/area api