### PR TITLE
Add support for ACME HTTP01 Ingress Namespace

### DIFF
--- a/deploy/charts/cert-manager/crds/challenges.yaml
+++ b/deploy/charts/cert-manager/crds/challenges.yaml
@@ -437,6 +437,13 @@ spec:
                             which maintains a 1:1 mapping between external IPs and
                             ingress resources.
                           type: string
+                        namespace:
+                          description: The namespace of the ingress resource that
+                            should have ACME challenge solving routes inserted into
+                            it in order to solve HTTP01 challenges. This field requires
+                            that the issuer is of type `ClusterIssuer` as well as
+                            the `name` field also being present.
+                          type: string
                         podTemplate:
                           description: Optional pod template used to configure the
                             ACME challenge solver pods used for HTTP01 challenges

--- a/deploy/charts/cert-manager/crds/clusterissuers.yaml
+++ b/deploy/charts/cert-manager/crds/clusterissuers.yaml
@@ -501,6 +501,13 @@ spec:
                                   like ingress-gce, which maintains a 1:1 mapping
                                   between external IPs and ingress resources.
                                 type: string
+                              namespace:
+                                description: The namespace of the ingress resource
+                                  that should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  field requires that the issuer is of type `ClusterIssuer`
+                                  as well as the `name` field also being present.
+                                type: string
                               podTemplate:
                                 description: Optional pod template used to configure
                                   the ACME challenge solver pods used for HTTP01 challenges

--- a/deploy/charts/cert-manager/crds/issuers.yaml
+++ b/deploy/charts/cert-manager/crds/issuers.yaml
@@ -501,6 +501,13 @@ spec:
                                   like ingress-gce, which maintains a 1:1 mapping
                                   between external IPs and ingress resources.
                                 type: string
+                              namespace:
+                                description: The namespace of the ingress resource
+                                  that should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  field requires that the issuer is of type `ClusterIssuer`
+                                  as well as the `name` field also being present.
+                                type: string
                               podTemplate:
                                 description: Optional pod template used to configure
                                   the ACME challenge solver pods used for HTTP01 challenges

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -909,6 +909,13 @@ spec:
                             which maintains a 1:1 mapping between external IPs and
                             ingress resources.
                           type: string
+                        namespace:
+                          description: The namespace of the ingress resource that
+                            should have ACME challenge solving routes inserted into
+                            it in order to solve HTTP01 challenges. This field requires
+                            that the issuer is of type `ClusterIssuer` as well as
+                            the `name` field also being present.
+                          type: string
                         podTemplate:
                           description: Optional pod template used to configure the
                             ACME challenge solver pods used for HTTP01 challenges
@@ -2364,6 +2371,13 @@ spec:
                                   is typically used in conjunction with ingress controllers
                                   like ingress-gce, which maintains a 1:1 mapping
                                   between external IPs and ingress resources.
+                                type: string
+                              namespace:
+                                description: The namespace of the ingress resource
+                                  that should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  field requires that the issuer is of type `ClusterIssuer`
+                                  as well as the `name` field also being present.
                                 type: string
                               podTemplate:
                                 description: Optional pod template used to configure
@@ -4104,6 +4118,13 @@ spec:
                                   is typically used in conjunction with ingress controllers
                                   like ingress-gce, which maintains a 1:1 mapping
                                   between external IPs and ingress resources.
+                                type: string
+                              namespace:
+                                description: The namespace of the ingress resource
+                                  that should have ACME challenge solving routes inserted
+                                  into it in order to solve HTTP01 challenges. This
+                                  field requires that the issuer is of type `ClusterIssuer`
+                                  as well as the `name` field also being present.
                                 type: string
                               podTemplate:
                                 description: Optional pod template used to configure

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -159,6 +159,13 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	Name string `json:"name,omitempty"`
 
+	// The namespace of the ingress resource that should have ACME challenge
+	// solving routes inserted into it in order to solve HTTP01 challenges. This
+	// field requires that the issuer is of type `ClusterIssuer` as well as the
+	// `name` field also being present.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// Optional pod template used to configure the ACME challenge solver pods
 	// used for HTTP01 challenges
 	// +optional

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -159,6 +159,13 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// +optional
 	Name string `json:"name,omitempty"`
 
+	// The namespace of the ingress resource that should have ACME challenge
+	// solving routes inserted into it in order to solve HTTP01 challenges. This
+	// field requires that the issuer is of type `ClusterIssuer` as well as the
+	// `name` field also being present.
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// Optional pod template used to configure the ACME challenge solver pods
 	// used for HTTP01 challenges
 	// +optional

--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -20,8 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/jetstack/cert-manager/pkg/acme"
 	"hash/fnv"
+
+	"github.com/jetstack/cert-manager/pkg/acme"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -143,6 +143,12 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 	// ingress resources.
 	Name string
 
+	// The namespace of the ingress resource that should have ACME challenge
+	// solving routes inserted into it in order to solve HTTP01 challenges. This
+	// field requires that the issuer is of type `ClusterIssuer` as well as the
+	// `name` field also being present.
+	Namespace string `json:"namespace,omitempty"`
+
 	// Optional pod template used to configure the ACME challenge solver pods
 	// used for HTTP01 challenges
 	PodTemplate *ACMEChallengeSolverHTTP01IngressPodTemplate

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -480,6 +480,7 @@ func autoConvert_v1alpha2_ACMEChallengeSolverHTTP01Ingress_To_acme_ACMEChallenge
 	out.ServiceType = v1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
+	out.Namespace = in.Namespace
 	out.PodTemplate = (*acme.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
 	return nil
 }
@@ -493,6 +494,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01Ingress_To_v1alpha2_ACMEChallenge
 	out.ServiceType = v1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
+	out.Namespace = in.Namespace
 	out.PodTemplate = (*v1alpha2.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
 	return nil
 }

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -480,6 +480,7 @@ func autoConvert_v1alpha3_ACMEChallengeSolverHTTP01Ingress_To_acme_ACMEChallenge
 	out.ServiceType = v1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
+	out.Namespace = in.Namespace
 	out.PodTemplate = (*acme.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
 	return nil
 }
@@ -493,6 +494,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01Ingress_To_v1alpha3_ACMEChallenge
 	out.ServiceType = v1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
+	out.Namespace = in.Namespace
 	out.PodTemplate = (*v1alpha3.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
 	return nil
 }

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -46,7 +46,7 @@ func TestEnsurePod(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createPod(s.Challenge)
+				ing, err := s.Solver.createPod(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -89,7 +89,7 @@ func TestEnsurePod(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedPod := s.Solver.buildPod(s.Challenge)
+				expectedPod := s.Solver.buildPod(s.Challenge, s.Challenge.Namespace)
 				// create a reactor that fails the test if a pod is created
 				s.Builder.FakeKubeClient().PrependReactor("create", "pods", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					pod := action.(coretesting.CreateAction).GetObject().(*v1.Pod)
@@ -142,11 +142,11 @@ func TestEnsurePod(t *testing.T) {
 			},
 			Err: true,
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createPod(s.Challenge)
+				_, err := s.Solver.createPod(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
-				_, err = s.Solver.createPod(s.Challenge)
+				_, err = s.Solver.createPod(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -169,7 +169,7 @@ func TestEnsurePod(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.ensurePod(context.TODO(), test.Challenge)
+			resp, err := test.Solver.ensurePod(context.TODO(), test.Challenge, test.Challenge.Namespace)
 			if err != nil && !test.Err {
 				t.Errorf("Expected function to not error, but got: %v", err)
 			}
@@ -196,7 +196,7 @@ func TestGetPodsForCertificate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createPod(s.Challenge)
+				ing, err := s.Solver.createPod(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -231,7 +231,7 @@ func TestGetPodsForCertificate(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				differentChallenge := s.Challenge.DeepCopy()
 				differentChallenge.Spec.DNSName = "notexample.com"
-				_, err := s.Solver.createPod(differentChallenge)
+				_, err := s.Solver.createPod(differentChallenge, differentChallenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -303,7 +303,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
+				resultingPod := s.Solver.buildDefaultPod(s.Challenge, s.Challenge.Namespace)
 				resultingPod.Labels = map[string]string{
 					"this is a":                          "label",
 					"acme.cert-manager.io/http-domain":   "44655555555",
@@ -360,7 +360,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
+				resultingPod := s.Solver.buildDefaultPod(s.Challenge, s.Challenge.Namespace)
 				s.testResources[createdPodKey] = resultingPod
 
 				s.Builder.Sync()
@@ -403,7 +403,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp := test.Solver.buildPod(test.Challenge)
+			resp := test.Solver.buildPod(test.Challenge, test.Challenge.Namespace)
 			test.Finish(t, resp, nil)
 		})
 	}

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -44,7 +44,7 @@ func TestEnsureService(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				svc, err := s.Solver.createService(s.Challenge)
+				svc, err := s.Solver.createService(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -85,7 +85,7 @@ func TestEnsureService(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				expectedService, err := buildService(s.Challenge)
+				expectedService, err := buildService(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
 				}
@@ -139,11 +139,11 @@ func TestEnsureService(t *testing.T) {
 			},
 			Err: true,
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createService(s.Challenge)
+				_, err := s.Solver.createService(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
-				_, err = s.Solver.createService(s.Challenge)
+				_, err = s.Solver.createService(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -193,7 +193,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createService(s.Challenge)
+				ing, err := s.Solver.createService(s.Challenge, s.Challenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -228,7 +228,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				differentChallenge := s.Challenge.DeepCopy()
 				differentChallenge.Spec.DNSName = "invaliddomain"
-				_, err := s.Solver.createService(differentChallenge)
+				_, err := s.Solver.createService(differentChallenge, differentChallenge.Namespace)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}

--- a/test/e2e/suite/conformance/certificates/acme/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/acme/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//extensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/intstr:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/conformance/certificates/acme/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/acme/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_api//extensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )


### PR DESCRIPTION
fixes #2579 

Adds support for setting the ingress namespace for http01 challenges on ClusterIssuers.

This also updates the conformance suite to include this change.
/kind api

```release-note
Adds support for setting the namespace for ingress resources to complete HTTP01 challenges provided a name for the target ingress is also supplied.
```
/assign
