### PR TITLE
Exports cluster logs to artifacts after CI run

### DIFF
--- a/devel/ci-run-e2e.sh
+++ b/devel/ci-run-e2e.sh
@@ -22,6 +22,11 @@ set -o pipefail
 # This is inteded to be run in a CI environment and *not* for development.
 # It is not optimised for quick, iterative development.
 
+export_logs() {
+  echo "Exporting cluster logs to artifacts..."
+  "${SCRIPT_ROOT}/cluster/export-logs.sh"
+}
+
 SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 export REPO_ROOT="${SCRIPT_ROOT}/.."
 source "${SCRIPT_ROOT}/lib/lib.sh"
@@ -31,6 +36,8 @@ setup_tools
 
 echo "Ensuring a kind cluster exists..."
 "${SCRIPT_ROOT}/cluster/create.sh"
+
+trap "export_logs" ERR
 
 echo "Ensuring all e2e test dependencies are installed..."
 "${SCRIPT_ROOT}/setup-e2e-deps.sh"

--- a/devel/cluster/export-logs.sh
+++ b/devel/cluster/export-logs.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
+export REPO_ROOT="${SCRIPT_ROOT}/.."
+source "${SCRIPT_ROOT}/../lib/lib.sh"
+
+# Require helm available on PATH
+check_tool kind
+
+LOGS_DIR="${ARTIFACTS:-$REPO_ROOT/_artifacts}/cert-manager-e2e-logs"
+rm -rf $LOGS_DIR && mkdir -p $LOGS_DIR
+kind export logs $LOGS_DIR --name "${KIND_CLUSTER_NAME}"


### PR DESCRIPTION
This PR adds back exporting cert-manager logs to artifacts or CI runs but also included logs of all other components.

/assign @munnerz 
/milestone v0.14

```release-note
NONE
```
