### PR TITLE
Export cluster logs during e2e even if test succeed

### DIFF
--- a/devel/ci-run-e2e.sh
+++ b/devel/ci-run-e2e.sh
@@ -47,3 +47,5 @@ echo "Running e2e test suite..."
 FLAKE_ATTEMPTS=2 "${SCRIPT_ROOT}/run-e2e.sh" \
   --ginkgo.skip=Venafi \
   "$@"
+
+export_logs


### PR DESCRIPTION
/assign @munnerz 

```release-note
NONE
```

This will ensure that logs are exported, regardless whether tests succeeded.
/milestone v0.14

