### PR TITLE
Certificate KeySize encode openapi validation

### DIFF
--- a/deploy/charts/cert-manager/crds/certificates.yaml
+++ b/deploy/charts/cert-manager/crds/certificates.yaml
@@ -150,6 +150,8 @@ spec:
                   and value must be one of (256, 384, 521) when KeyAlgorithm is set
                   to "ecdsa".
                 type: integer
+                maximum: 8192
+                minimum: 0
               organization:
                 description: Organization is the organization to be used on the Certificate
                 type: array
@@ -389,6 +391,8 @@ spec:
                   and value must be one of (256, 384, 521) when KeyAlgorithm is set
                   to "ecdsa".
                 type: integer
+                maximum: 8192
+                minimum: 0
               renewBefore:
                 description: Certificate renew before expiration duration
                 type: string

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -356,6 +356,8 @@ spec:
                   and value must be one of (256, 384, 521) when KeyAlgorithm is set
                   to "ecdsa".
                 type: integer
+                maximum: 8192
+                minimum: 0
               organization:
                 description: Organization is the organization to be used on the Certificate
                 type: array
@@ -595,6 +597,8 @@ spec:
                   and value must be one of (256, 384, 521) when KeyAlgorithm is set
                   to "ecdsa".
                 type: integer
+                maximum: 8192
+                minimum: 0
               renewBefore:
                 description: Certificate renew before expiration duration
                 type: string

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -133,6 +133,10 @@ type CertificateSpec struct {
 	// If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is
 	// empty or is set to "rsa", and value must be one of (256, 384, 521) when
 	// KeyAlgorithm is set to "ecdsa".
+	// +kubebuilder:validation:ExclusiveMaximum=false
+	// +kubebuilder:validation:Maximum=8192
+	// +kubebuilder:validation:ExclusiveMinimum=false
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	KeySize int `json:"keySize,omitempty"`
 

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -129,6 +129,10 @@ type CertificateSpec struct {
 	// If provided, value must be between 2048 and 8192 inclusive when KeyAlgorithm is
 	// empty or is set to "rsa", and value must be one of (256, 384, 521) when
 	// KeyAlgorithm is set to "ecdsa".
+	// +kubebuilder:validation:ExclusiveMaximum=false
+	// +kubebuilder:validation:Maximum=8192
+	// +kubebuilder:validation:ExclusiveMinimum=false
+	// +kubebuilder:validation:Minimum=0
 	// +optional
 	KeySize int `json:"keySize,omitempty"`
 

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -52,9 +52,6 @@ func ValidateCertificateSpec(crt *cmapi.CertificateSpec, fldPath *field.Path) fi
 	if len(crt.IPAddresses) > 0 {
 		el = append(el, validateIPAddresses(crt, fldPath)...)
 	}
-	if crt.KeySize < 0 {
-		el = append(el, field.Invalid(fldPath.Child("keySize"), crt.KeySize, "cannot be less than zero"))
-	}
 	switch crt.KeyAlgorithm {
 	case cmapi.KeyAlgorithm(""):
 	case cmapi.RSAKeyAlgorithm:
@@ -74,11 +71,6 @@ func ValidateCertificateSpec(crt *cmapi.CertificateSpec, fldPath *field.Path) fi
 	}
 	if len(crt.Usages) > 0 {
 		el = append(el, validateUsages(crt, fldPath)...)
-	}
-	switch crt.KeyEncoding {
-	case cmapi.KeyEncoding(""), cmapi.PKCS1, cmapi.PKCS8:
-	default:
-		el = append(el, field.Invalid(fldPath.Child("keyEncoding"), crt.KeyEncoding, "must be either empty or one of pkcs1 or pkcs8"))
 	}
 	return el
 }

--- a/pkg/internal/apis/certmanager/validation/certificate_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_test.go
@@ -244,19 +244,6 @@ func TestValidateCertificate(t *testing.T) {
 				},
 			},
 		},
-		"certificate with keysize less than zero": {
-			cfg: &cmapi.Certificate{
-				Spec: cmapi.CertificateSpec{
-					CommonName: "testcn",
-					SecretName: "abc",
-					IssuerRef:  validIssuerRef,
-					KeySize:    -99,
-				},
-			},
-			errs: []*field.Error{
-				field.Invalid(fldPath.Child("keySize"), -99, "cannot be less than zero"),
-			},
-		},
 		"certificate with rsa keyAlgorithm specified and invalid keysize 1024": {
 			cfg: &cmapi.Certificate{
 				Spec: cmapi.CertificateSpec{


### PR DESCRIPTION
/assign @munnerz 

Adds open API validation for maximum and minimum values for KeySize

```release-note
NONE
```
