### PR TITLE
certificates: add SecretStore to handle different key formats

### DIFF
--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -17,6 +17,8 @@ go_library(
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/listers/certmanager/v1alpha2:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/certificates/codec:go_default_library",
+        "//pkg/controller/certificates/store:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/metrics:go_default_library",
         "//pkg/scheduler:go_default_library",
@@ -52,6 +54,7 @@ go_test(
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/certificates/codec:go_default_library",
         "//pkg/controller/test:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/pki:go_default_library",
@@ -73,7 +76,11 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/controller/certificates/codec:all-srcs",
+        "//pkg/controller/certificates/store:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/controller/certificates/codec/BUILD.bazel
+++ b/pkg/controller/certificates/codec/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "codec.go",
+        "ecdsa.go",
+        "pkcs1.go",
+        "pkcs8.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/pkg/controller/certificates/codec",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/util/errors:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/controller/certificates/codec/codec.go
+++ b/pkg/controller/certificates/codec/codec.go
@@ -1,0 +1,93 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codec
+
+import (
+	"bytes"
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// RawData contains encoded private key and certificate data.
+type RawData struct {
+	Data map[string][]byte
+}
+
+type Bundle struct {
+	PrivateKey   crypto.Signer
+	Certificates []*x509.Certificate
+	CA           []*x509.Certificate
+}
+
+type Codec interface {
+	Encoder
+	Decoder
+}
+
+type Encoder interface {
+	Encode(Bundle) (*RawData, error)
+}
+
+type Decoder interface {
+	Decode(RawData) (*Bundle, error)
+}
+
+type Format int
+
+const (
+	PKCS1Format Format = iota
+	ECDSAFormat
+	PKCS8Format
+)
+
+type Options struct {
+	Format Format
+}
+
+type Option func(opts *Options)
+
+func SetFormat(format Format) Option {
+	return func(opts *Options) {
+		opts.Format = format
+	}
+}
+
+func NewCodec(opts Options) (Codec, error) {
+	switch opts.Format {
+	case ECDSAFormat:
+		return &ECDSA{}, nil
+	case PKCS1Format:
+		return &PKCS1{}, nil
+	case PKCS8Format:
+		return &PKCS8{}, nil
+	}
+	return nil, fmt.Errorf("unrecognised format %v", opts.Format)
+}
+
+func encodeCertificatesASN1PEM(certs []*x509.Certificate) ([]byte, error) {
+	buffer := bytes.NewBuffer([]byte{})
+	for _, cert := range certs {
+		err := pem.Encode(buffer, &pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode certificate: %v", err)
+		}
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/pkg/controller/certificates/codec/ecdsa.go
+++ b/pkg/controller/certificates/codec/ecdsa.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codec
+
+import (
+	"crypto/ecdsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+type ECDSA struct{}
+
+var _ Codec = ECDSA{}
+
+func (c ECDSA) Encode(d Bundle) (*RawData, error) {
+	data := map[string][]byte{}
+	ecPK, ok := d.PrivateKey.(*ecdsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not an ECDSA key")
+	}
+	pkDER, err := x509.MarshalECPrivateKey(ecPK)
+	if err != nil {
+		return nil, err
+	}
+	pkPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "EC PRIVATE KEY",
+		Bytes: pkDER,
+	})
+	if pkPEM == nil {
+		return nil, errors.NewInvalidData("failed to encode ECDSA private key to PEM format")
+	}
+	data[corev1.TLSPrivateKeyKey] = pkPEM
+	if len(d.Certificates) > 0 {
+		certsPEM, err := encodeCertificatesASN1PEM(d.Certificates)
+		if err != nil {
+			return nil, err
+		}
+		data[corev1.TLSCertKey] = certsPEM
+	}
+
+	if len(d.CA) > 0 {
+		caPEM, err := encodeCertificatesASN1PEM(d.CA)
+		if err != nil {
+			return nil, err
+		}
+		data[cmmeta.TLSCAKey] = caPEM
+	}
+	return &RawData{Data: data}, nil
+}
+
+func (c ECDSA) Decode(e RawData) (*Bundle, error) {
+	d := &Bundle{}
+	pkPEM := e.Data[corev1.TLSPrivateKeyKey]
+	certsPEM := e.Data[corev1.TLSCertKey]
+	caPEM := e.Data[cmmeta.TLSCAKey]
+	var err error
+	if len(pkPEM) > 0 {
+		// decode the private key pem
+		block, _ := pem.Decode(pkPEM)
+		if block == nil {
+			return d, errors.NewInvalidData("failed to decode PEM block")
+		}
+		// "EC PRIVATE KEY" is the PEM marker used for ECDSA encoded data
+		if block.Type != "EC PRIVATE KEY" {
+			return d, errors.NewInvalidData("unexpected PEM block type %q - ECDSA data should specify the type as 'EC PRIVATE KEY'", block.Type)
+		}
+		pk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return d, errors.NewInvalidData("failed to decode private key: %v", err)
+		}
+		d.PrivateKey = pk
+	}
+	if len(certsPEM) > 0 {
+		d.Certificates, err = pki.DecodeX509CertificateChainBytes(certsPEM)
+		if err != nil {
+			return d, errors.NewInvalidData(err.Error())
+		}
+	}
+	if len(caPEM) > 0 {
+		d.CA, err = pki.DecodeX509CertificateChainBytes(caPEM)
+		if err != nil {
+			return d, errors.NewInvalidData(err.Error())
+		}
+	}
+	return d, nil
+}

--- a/pkg/controller/certificates/codec/pkcs1.go
+++ b/pkg/controller/certificates/codec/pkcs1.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codec
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+// PKCS1 knows how to encode and decode RSA PKCS.1 formatted private key
+// certificate data.
+type PKCS1 struct{}
+
+var _ Codec = PKCS1{}
+
+// Encode encodes the given private key into PEM-encoded PKCS.1 format.
+// The certificate be encoded into DER format and stored as a PEM,
+func (p PKCS1) Encode(d Bundle) (*RawData, error) {
+	data := map[string][]byte{}
+	rsaPK, ok := d.PrivateKey.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("private key is not an RSA key")
+	}
+	pkDER := x509.MarshalPKCS1PrivateKey(rsaPK)
+	pkPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "RSA PRIVATE KEY",
+		Bytes: pkDER,
+	})
+	if pkPEM == nil {
+		return nil, fmt.Errorf("failed to encode RSA private key to PEM format")
+	}
+	data[corev1.TLSPrivateKeyKey] = pkPEM
+
+	if len(d.Certificates) > 0 {
+		certsPEM, err := encodeCertificatesASN1PEM(d.Certificates)
+		if err != nil {
+			return nil, err
+		}
+		data[corev1.TLSCertKey] = certsPEM
+	}
+
+	if len(d.CA) > 0 {
+		caPEM, err := encodeCertificatesASN1PEM(d.CA)
+		if err != nil {
+			return nil, err
+		}
+		data[cmmeta.TLSCAKey] = caPEM
+	}
+
+	return &RawData{Data: data}, nil
+}
+
+func (p PKCS1) Decode(e RawData) (*Bundle, error) {
+	d := &Bundle{}
+	pkPEM := e.Data[corev1.TLSPrivateKeyKey]
+	certsPEM := e.Data[corev1.TLSCertKey]
+	caPEM := e.Data[cmmeta.TLSCAKey]
+	var err error
+	if len(pkPEM) > 0 {
+		// decode the private key pem
+		block, _ := pem.Decode(pkPEM)
+		if block == nil {
+			return d, errors.NewInvalidData("failed to decode PEM block")
+		}
+		// "RSA PRIVATE KEY" is the PEM marker used for PKCS1 encoded data
+		if block.Type != "RSA PRIVATE KEY" {
+			return d, errors.NewInvalidData("unexpected PEM block type %q - PKCS1 data should specify the type as 'RSA PRIVATE KEY'", block.Type)
+		}
+		pk, err := x509.ParsePKCS1PrivateKey(block.Bytes)
+		if err != nil {
+			return d, errors.NewInvalidData("failed to decode private key: %w", err)
+		}
+		d.PrivateKey = pk
+	}
+	if len(certsPEM) > 0 {
+		d.Certificates, err = pki.DecodeX509CertificateChainBytes(certsPEM)
+		if err != nil {
+			return d, errors.NewInvalidData(err.Error())
+		}
+	}
+	if len(caPEM) > 0 {
+		d.CA, err = pki.DecodeX509CertificateChainBytes(caPEM)
+		if err != nil {
+			return d, errors.NewInvalidData(err.Error())
+		}
+	}
+	return d, nil
+}

--- a/pkg/controller/certificates/codec/pkcs8.go
+++ b/pkg/controller/certificates/codec/pkcs8.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package codec
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+// PKCS8 knows how to encode and decode RSA PKCS.8 formatted private key
+// certificate data.
+type PKCS8 struct{}
+
+var _ Codec = PKCS8{}
+
+// Encode encodes the given private key into PEM-encoded PKCS.1 format.
+// The certificate be encoded into DER format and stored as a PEM,
+func (p PKCS8) Encode(d Bundle) (*RawData, error) {
+	data := map[string][]byte{}
+	pkDER, err := x509.MarshalPKCS8PrivateKey(d.PrivateKey)
+	if err != nil {
+		return nil, err
+	}
+	pkPEM := pem.EncodeToMemory(&pem.Block{
+		Type:  "PRIVATE KEY",
+		Bytes: pkDER,
+	})
+	if pkPEM == nil {
+		return nil, fmt.Errorf("failed to encode private key to PEM format")
+	}
+	data[corev1.TLSPrivateKeyKey] = pkPEM
+
+	if len(d.Certificates) > 0 {
+		certsPEM, err := encodeCertificatesASN1PEM(d.Certificates)
+		if err != nil {
+			return nil, err
+		}
+		data[corev1.TLSCertKey] = certsPEM
+	}
+
+	if len(d.CA) > 0 {
+		caPEM, err := encodeCertificatesASN1PEM(d.CA)
+		if err != nil {
+			return nil, err
+		}
+		data[cmmeta.TLSCAKey] = caPEM
+	}
+
+	return &RawData{Data: data}, nil
+}
+
+func (p PKCS8) Decode(e RawData) (*Bundle, error) {
+	d := &Bundle{}
+	pkPEM := e.Data[corev1.TLSPrivateKeyKey]
+	certsPEM := e.Data[corev1.TLSCertKey]
+	caPEM := e.Data[cmmeta.TLSCAKey]
+	var err error
+	if len(pkPEM) > 0 {
+		// decode the private key pem
+		block, _ := pem.Decode(pkPEM)
+		if block == nil {
+			return d, errors.NewInvalidData("failed to decode PEM block")
+		}
+		// "PRIVATE KEY" is the PEM marker used for PKCS8 encoded data
+		if block.Type != "PRIVATE KEY" {
+			return d, errors.NewInvalidData("unexpected PEM block type %q - PKCS8 data should specify the type as 'PRIVATE KEY'", block.Type)
+		}
+		pk, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return d, fmt.Errorf("failed to decode private key: %v", err)
+		}
+		signer, ok := pk.(crypto.Signer)
+		if !ok {
+			return d, errors.NewInvalidData("stored private key does not implement crypto.Signer")
+		}
+		d.PrivateKey = signer
+	}
+	if len(certsPEM) > 0 {
+		d.Certificates, err = pki.DecodeX509CertificateChainBytes(certsPEM)
+		if err != nil {
+			return d, errors.NewInvalidData(err.Error())
+		}
+	}
+	if len(caPEM) > 0 {
+		d.CA, err = pki.DecodeX509CertificateChainBytes(caPEM)
+		if err != nil {
+			return d, errors.NewInvalidData(err.Error())
+		}
+	}
+	return d, nil
+}

--- a/pkg/controller/certificates/store/BUILD.bazel
+++ b/pkg/controller/certificates/store/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["secrets.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/controller/certificates/store",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller/certificates/codec:go_default_library",
+        "//pkg/util/errors:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+        "@io_k8s_client_go//listers/core/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/controller/certificates/store/secrets.go
+++ b/pkg/controller/certificates/store/secrets.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package store
+
+import (
+	"encoding/pem"
+	"reflect"
+	"strings"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	corelisters "k8s.io/client-go/listers/core/v1"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/controller/certificates/codec"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+var managedDataKeys = []string{
+	cmmeta.TLSCAKey,
+	corev1.TLSCertKey,
+	corev1.TLSPrivateKeyKey,
+}
+
+// SecretStore knows how to encode and decode bundles of PKI assets stored in
+// Kubernetes Secret resources.
+type SecretStore struct {
+	// SecretLister used to read secrets
+	Lister corelisters.SecretLister
+	// Secret client used to write secrets
+	NamespacedClient func(namespace string) typedcorev1.SecretInterface
+	// If SetOwnerReferences is true, an owner reference will be set on Secret
+	// resources when they are created.
+	// This setting does not affect existing Secret resources.
+	SetOwnerReferences bool
+	// Encoder, if provided, is the encoder used for all encode operations.
+	// If not specified, the correct encoder to use will be automatically
+	// determined. This should only be set for testing purposes.
+	Encoder codec.Encoder
+}
+
+func SecretCodecOptions(secret *corev1.Secret) codec.Options {
+	opts := codec.Options{}
+	if pkBytes, ok := secret.Data[corev1.TLSPrivateKeyKey]; ok {
+		block, _ := pem.Decode(pkBytes)
+		if block != nil {
+			switch block.Type {
+			case "PRIVATE KEY":
+				opts.Format = codec.PKCS8Format
+			case "EC PRIVATE KEY":
+				opts.Format = codec.ECDSAFormat
+			case "RSA PRIVATE KEY":
+				opts.Format = codec.PKCS1Format
+			}
+		}
+	}
+	return opts
+}
+
+func CertificateCodecOptions(crt *cmapi.Certificate) codec.Options {
+	switch crt.Spec.KeyEncoding {
+	case "", cmapi.PKCS1:
+		if crt.Spec.KeyAlgorithm == cmapi.ECDSAKeyAlgorithm {
+			return codec.Options{Format: codec.ECDSAFormat}
+		}
+		return codec.Options{Format: codec.PKCS1Format}
+	case cmapi.PKCS8:
+		return codec.Options{Format: codec.PKCS8Format}
+	}
+	return codec.Options{}
+}
+
+func (s *SecretStore) Fetch(name, namespace string) (map[string]string, *codec.Bundle, error) {
+	secret, err := s.Lister.Secrets(namespace).Get(name)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	decoder, err := codec.NewCodec(SecretCodecOptions(secret))
+	if err != nil {
+		return nil, nil, errors.NewInvalidData(err.Error())
+	}
+
+	meta := secret.Annotations
+	if meta == nil {
+		meta = make(map[string]string)
+	}
+	b, err := decoder.Decode(codec.RawData{
+		Data: secret.Data,
+	})
+	return meta, b, err
+}
+
+func (s *SecretStore) Store(name string, bundle codec.Bundle, crt *cmapi.Certificate, encoder codec.Encoder) error {
+	var err error
+	if encoder == nil {
+		if s.Encoder == nil {
+			encoder, err = codec.NewCodec(CertificateCodecOptions(crt))
+			if err != nil {
+				return err
+			}
+		} else {
+			encoder = s.Encoder
+		}
+	}
+
+	rawData, err := encoder.Encode(bundle)
+	if err != nil {
+		return err
+	}
+
+	secret, err := s.Lister.Secrets(crt.Namespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: crt.Namespace,
+			},
+			Type: corev1.SecretTypeTLS,
+		}
+		if s.SetOwnerReferences {
+			secret.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate"))}
+		}
+		setSecretValues(crt, secret, bundle, *rawData, false)
+		_, err := s.NamespacedClient(secret.Namespace).Create(secret)
+		return err
+	}
+	if err != nil {
+		return err
+	}
+
+	setSecretValues(crt, secret, bundle, *rawData, true)
+	_, err = s.NamespacedClient(secret.Namespace).Update(secret)
+	return err
+}
+
+func (s *SecretStore) EnsureMetadata(crt *cmapi.Certificate, b codec.Bundle) (bool, error) {
+	secret, err := s.Lister.Secrets(crt.Namespace).Get(crt.Spec.SecretName)
+	if err != nil {
+		return false, err
+	}
+
+	newSecret := secret.DeepCopy()
+	setSecretValues(crt, newSecret, b, codec.RawData{}, false)
+	if reflect.DeepEqual(secret, newSecret) {
+		return false, nil
+	}
+	_, err = s.NamespacedClient(secret.Namespace).Update(newSecret)
+	return err == nil, err
+}
+
+// setSecretValues will update the Secret resource 's' with the data contained
+// in the given secretData.
+// It will update labels and annotations on the Secret resource appropriately.
+// The Secret resource 's' must be non-nil, although may be a resource that does
+// not exist in the Kubernetes apiserver yet.
+// setSecretValues will NOT actually update the resource in the apiserver.
+// If updating an existing Secret resource returned by an api client 'lister',
+// make sure to DeepCopy the object first to avoid modifying data in-cache.
+// It will also update depreciated issuer name and kind annotations if they exist.
+func setSecretValues(crt *cmapi.Certificate, s *corev1.Secret, decoded codec.Bundle, encoded codec.RawData, prune bool) {
+	if s.Data == nil {
+		s.Data = make(map[string][]byte)
+	}
+	// prune existing 'managed keys' from Secret
+	if prune {
+		for _, k := range managedDataKeys {
+			delete(s.Data, k)
+		}
+	}
+	for k, v := range encoded.Data {
+		s.Data[k] = v
+	}
+
+	if s.Annotations == nil {
+		s.Annotations = make(map[string]string)
+	}
+	s.Annotations[cmapi.CertificateNameKey] = crt.Name
+	s.Annotations[cmapi.IssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
+	s.Annotations[cmapi.IssuerKindAnnotationKey] = apiutil.IssuerKind(crt.Spec.IssuerRef)
+
+	// If deprecated annotations exist with any value, then they too shall be
+	// updated
+	if _, ok := s.Annotations[cmapi.DeprecatedIssuerNameAnnotationKey]; ok {
+		s.Annotations[cmapi.DeprecatedIssuerNameAnnotationKey] = crt.Spec.IssuerRef.Name
+	}
+	if _, ok := s.Annotations[cmapi.DeprecatedIssuerKindAnnotationKey]; ok {
+		s.Annotations[cmapi.DeprecatedIssuerKindAnnotationKey] = apiutil.IssuerKind(crt.Spec.IssuerRef)
+	}
+
+	// if the certificate data is empty, clear the subject related annotations
+	if len(decoded.Certificates) == 0 {
+		delete(s.Annotations, cmapi.CommonNameAnnotationKey)
+		delete(s.Annotations, cmapi.AltNamesAnnotationKey)
+		delete(s.Annotations, cmapi.IPSANAnnotationKey)
+		delete(s.Annotations, cmapi.URISANAnnotationKey)
+	} else {
+		x509Cert := decoded.Certificates[0]
+		s.Annotations[cmapi.CommonNameAnnotationKey] = x509Cert.Subject.CommonName
+		s.Annotations[cmapi.AltNamesAnnotationKey] = strings.Join(x509Cert.DNSNames, ",")
+		s.Annotations[cmapi.IPSANAnnotationKey] = strings.Join(pki.IPAddressesToString(x509Cert.IPAddresses), ",")
+		s.Annotations[cmapi.URISANAnnotationKey] = strings.Join(pki.URLsToString(x509Cert.URIs), ",")
+	}
+}

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -268,7 +268,7 @@ func TestCertificateMatchesSpec(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			match, errs := certificateMatchesSpec(
-				test.certificate, test.cb.privateKey, test.cb.cert, test.secret)
+				test.certificate, test.cb.privateKey, test.cb.cert, test.secret.Annotations)
 
 			if match != test.expMatch {
 				t.Errorf("got unexpected match bool, exp=%t got=%t",


### PR DESCRIPTION
**What this PR does / why we need it**:

Move secret fetching/storing logic into a standalone `store` package, and move logic for encoding and decoding data stored in Secret resources into a dedicated `codec` package.

This will make it easier for us to extend the Certificates controller to support different formats, as well as providing a 'building block' for us to implement private key rotation in future too.

**Special notes for your reviewer**:

The bulk of the changes to the certificates controller is moving it to use Golang `x509.Certificate`/`crypto.Signer` types throughout instead of passing around a combination of these types + `[]byte` equivalents. All serialising and deserialising now happens transparently when `Fetch` or `Store` is called.

The `store` and `codec` packages do not currently have unit tests, although are being covered by the controller unit tests to ensure they have feature parity with the previous implementation 😄 

**Release note**:
```release-note
NONE
```
