### PR TITLE
Fix including CRDs as part of static manifests

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -20,11 +20,21 @@ VARIANTS = {
 }
 
 [helm_tmpl(
-    name = name,
+    name = "%s.manifests" % name,
     helm_pkg = "//deploy/charts/cert-manager:package",
     release_name = RELEASE_NAME,
     release_namespace = RELEASE_NAMESPACE,
     values = values,
+) for (name, values) in VARIANTS.items()]
+
+[genrule(
+    name = name,
+    srcs = [
+        "00-crds.yaml",
+        "%s.manifests" % name,
+    ],
+    outs = ["%s.yaml" % name],
+    cmd = "cat $(location 00-crds.yaml) $(location %s.manifests) > $@" % name,
 ) for (name, values) in VARIANTS.items()]
 
 pkg_tar(


### PR DESCRIPTION
**What this PR does / why we need it**:

As part of the new release tooling changes, we forgot to include a copy of the CRDs in the generated 'static manifests'.

This updates the files we generate to include the `00-crds.yaml` file.

**Special notes for your reviewer**:

This PR currently enables the conversion webhook for CRDs even in the `no-webhook` variant, which won't work. @meyskens upcoming PR to move the CRDs into a Helm chart so we can template out these areas should fix this 😄 

**Release note**:
```release-note
NONE
```

/assign @meyskens 
