### PR TITLE
WIP: Move some validations from webhook to OpenAPI

### DIFF
--- a/deploy/charts/cert-manager/crds/certificates.yaml
+++ b/deploy/charts/cert-manager/crds/certificates.yaml
@@ -87,6 +87,7 @@ spec:
                   avoid generating invalid CSRs. This value is ignored by TLS clients
                   when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                 type: string
+                maxLength: 64
               dnsNames:
                 description: DNSNames is a list of subject alt names to be used on
                   the Certificate.
@@ -334,6 +335,7 @@ spec:
                   avoid generating invalid CSRs. This value is ignored by TLS clients
                   when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                 type: string
+                maxLength: 64
               dnsNames:
                 description: DNSNames is a list of subject alt names to be used on
                   the Certificate.

--- a/deploy/charts/cert-manager/crds/challenges.yaml
+++ b/deploy/charts/cert-manager/crds/challenges.yaml
@@ -192,6 +192,7 @@ spec:
                               type: string
                         serviceConsumerDomain:
                           type: string
+                          minLength: 1
                     azuredns:
                       description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                         containing the configuration for Azure DNS
@@ -220,11 +221,17 @@ spec:
                               type: string
                         environment:
                           type: string
-                          enum:
-                          - AzurePublicCloud
-                          - AzureChinaCloud
-                          - AzureGermanCloud
-                          - AzureUSGovernmentCloud
+                          allOf:
+                          - enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
+                          - enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
                         hostedZoneName:
                           type: string
                         resourceGroupName:

--- a/deploy/charts/cert-manager/crds/clusterissuers.yaml
+++ b/deploy/charts/cert-manager/crds/clusterissuers.yaml
@@ -146,6 +146,7 @@ spec:
                   description: Solvers is a list of challenge solvers that will be
                     used to solve ACME challenges for the matching domains.
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     properties:
@@ -235,6 +236,7 @@ spec:
                                     type: string
                               serviceConsumerDomain:
                                 type: string
+                                minLength: 1
                           azuredns:
                             description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                               containing the configuration for Azure DNS
@@ -265,11 +267,17 @@ spec:
                                     type: string
                               environment:
                                 type: string
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
+                                allOf:
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
                               hostedZoneName:
                                 type: string
                               resourceGroupName:

--- a/deploy/charts/cert-manager/crds/issuers.yaml
+++ b/deploy/charts/cert-manager/crds/issuers.yaml
@@ -146,6 +146,7 @@ spec:
                   description: Solvers is a list of challenge solvers that will be
                     used to solve ACME challenges for the matching domains.
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     properties:
@@ -235,6 +236,7 @@ spec:
                                     type: string
                               serviceConsumerDomain:
                                 type: string
+                                minLength: 1
                           azuredns:
                             description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                               containing the configuration for Azure DNS
@@ -265,11 +267,17 @@ spec:
                                     type: string
                               environment:
                                 type: string
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
+                                allOf:
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
                               hostedZoneName:
                                 type: string
                               resourceGroupName:

--- a/deploy/manifests/00-crds.yaml
+++ b/deploy/manifests/00-crds.yaml
@@ -293,6 +293,7 @@ spec:
                   avoid generating invalid CSRs. This value is ignored by TLS clients
                   when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                 type: string
+                maxLength: 64
               dnsNames:
                 description: DNSNames is a list of subject alt names to be used on
                   the Certificate.
@@ -540,6 +541,7 @@ spec:
                   avoid generating invalid CSRs. This value is ignored by TLS clients
                   when any subject alt name is set. This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4'
                 type: string
+                maxLength: 64
               dnsNames:
                 description: DNSNames is a list of subject alt names to be used on
                   the Certificate.
@@ -947,6 +949,7 @@ spec:
                               type: string
                         serviceConsumerDomain:
                           type: string
+                          minLength: 1
                     azuredns:
                       description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                         containing the configuration for Azure DNS
@@ -975,11 +978,17 @@ spec:
                               type: string
                         environment:
                           type: string
-                          enum:
-                          - AzurePublicCloud
-                          - AzureChinaCloud
-                          - AzureGermanCloud
-                          - AzureUSGovernmentCloud
+                          allOf:
+                          - enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
+                          - enum:
+                            - AzurePublicCloud
+                            - AzureChinaCloud
+                            - AzureGermanCloud
+                            - AzureUSGovernmentCloud
                         hostedZoneName:
                           type: string
                         resourceGroupName:
@@ -2308,6 +2317,7 @@ spec:
                   description: Solvers is a list of challenge solvers that will be
                     used to solve ACME challenges for the matching domains.
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     properties:
@@ -2397,6 +2407,7 @@ spec:
                                     type: string
                               serviceConsumerDomain:
                                 type: string
+                                minLength: 1
                           azuredns:
                             description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                               containing the configuration for Azure DNS
@@ -2427,11 +2438,17 @@ spec:
                                     type: string
                               environment:
                                 type: string
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
+                                allOf:
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
                               hostedZoneName:
                                 type: string
                               resourceGroupName:
@@ -4062,6 +4079,7 @@ spec:
                   description: Solvers is a list of challenge solvers that will be
                     used to solve ACME challenges for the matching domains.
                   type: array
+                  minItems: 1
                   items:
                     type: object
                     properties:
@@ -4151,6 +4169,7 @@ spec:
                                     type: string
                               serviceConsumerDomain:
                                 type: string
+                                minLength: 1
                           azuredns:
                             description: ACMEIssuerDNS01ProviderAzureDNS is a structure
                               containing the configuration for Azure DNS
@@ -4181,11 +4200,17 @@ spec:
                                     type: string
                               environment:
                                 type: string
-                                enum:
-                                - AzurePublicCloud
-                                - AzureChinaCloud
-                                - AzureGermanCloud
-                                - AzureUSGovernmentCloud
+                                allOf:
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
+                                - enum:
+                                  - AzurePublicCloud
+                                  - AzureChinaCloud
+                                  - AzureGermanCloud
+                                  - AzureUSGovernmentCloud
                               hostedZoneName:
                                 type: string
                               resourceGroupName:

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -45,7 +45,8 @@ kind load docker-image --name "$KIND_CLUSTER_NAME" "quay.io/jetstack/cert-manage
 
 wait
 
-# Ensure the pebble namespace exists
+controller
+#      Ensure the pebble namespace exists
 kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 
 crdsmanifest="cert-manager.crds.yaml"

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -45,7 +45,6 @@ kind load docker-image --name "$KIND_CLUSTER_NAME" "quay.io/jetstack/cert-manage
 
 wait
 
-
 # Ensure the pebble namespace exists
 kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -45,8 +45,8 @@ kind load docker-image --name "$KIND_CLUSTER_NAME" "quay.io/jetstack/cert-manage
 
 wait
 
-controller
-#      Ensure the pebble namespace exists
+
+# Ensure the pebble namespace exists
 kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 
 crdsmanifest="cert-manager.crds.yaml"

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -30,6 +30,7 @@ type ACMEIssuer struct {
 	Email string `json:"email,omitempty"`
 
 	// Server is the ACME server URL
+	// +kubebuilder:validation:Required
 	Server string `json:"server"`
 
 	// If true, skip verifying the ACME server TLS certificate
@@ -43,11 +44,12 @@ type ACMEIssuer struct {
 
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
+	// +kubebuilder:validation:Required
 	PrivateKey cmmeta.SecretKeySelector `json:"privateKeySecretRef"`
 
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
-	// +optional
+	// +kubebuilder:validation:MinItems=1
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 }
 
@@ -55,6 +57,7 @@ type ACMEIssuer struct {
 // server.
 type ACMEExternalAccountBinding struct {
 	// keyID is the ID of the CA key that the External Account is bound to.
+	// +kubebuilder:validation:Required
 	KeyID string `json:"keyID"`
 
 	// keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
@@ -64,10 +67,12 @@ type ACMEExternalAccountBinding struct {
 	// the External Account Binding keyID above.
 	// The secret key stored in the Secret **must** be un-padded, base64 URL
 	// encoded data.
+	// +kubebuilder:validation:Required
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
 	// keyAlgorithm is the MAC key algorithm that the key is used for. Valid
 	// values are "HS256", "HS384" and "HS512".
+	// +kubebuilder:validation:Required
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
 }
 
@@ -260,6 +265,8 @@ const (
 // ACMEIssuerDNS01ProviderAkamai is a structure containing the DNS
 // configuration for Akamai DNS—Zone Record Management API
 type ACMEIssuerDNS01ProviderAkamai struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	ServiceConsumerDomain string                   `json:"serviceConsumerDomain"`
 	ClientToken           cmmeta.SecretKeySelector `json:"clientTokenSecretRef"`
 	ClientSecret          cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
@@ -271,20 +278,28 @@ type ACMEIssuerDNS01ProviderAkamai struct {
 type ACMEIssuerDNS01ProviderCloudDNS struct {
 	// +optional
 	ServiceAccount *cmmeta.SecretKeySelector `json:"serviceAccountSecretRef,omitempty"`
-	Project        string                    `json:"project"`
+
+	// +kubebuilder:validation:Required
+	Project string `json:"project"`
 }
 
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
-	Email    string                    `json:"email"`
-	APIKey   *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
+	// +kubebuilder:validation:Required
+	Email string `json:"email"`
+
+	// +optional
+	APIKey *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
+
+	// + optional
 	APIToken *cmmeta.SecretKeySelector `json:"apiTokenSecretRef,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderDigitalOcean is a structure containing the DNS
 // configuration for DigitalOcean Domains
 type ACMEIssuerDNS01ProviderDigitalOcean struct {
+	// +kubebuilder:validation:Required
 	Token cmmeta.SecretKeySelector `json:"tokenSecretRef"`
 }
 
@@ -317,20 +332,26 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
+	// +kubebuilder:validation:Required
 	ClientID string `json:"clientID"`
 
+	// +kubebuilder:validation:Required
 	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
 
+	// +kubebuilder:validation:Required
 	SubscriptionID string `json:"subscriptionID"`
 
+	// +kubebuilder:validation:Required
 	TenantID string `json:"tenantID"`
 
+	// +kubebuilder:validation:Required
 	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional
 	HostedZoneName string `json:"hostedZoneName,omitempty"`
 
 	// +optional
+	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 }
 
@@ -347,8 +368,10 @@ const (
 // ACMEIssuerDNS01ProviderAcmeDNS is a structure containing the
 // configuration for ACME-DNS servers
 type ACMEIssuerDNS01ProviderAcmeDNS struct {
+	// +kubebuilder:validation:Required
 	Host string `json:"host"`
 
+	// +kubebuilder:validation:Required
 	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
 }
 
@@ -357,6 +380,7 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The IP address of the DNS supporting RFC2136. Required.
 	// Note: FQDN is not a valid value, only IP.
+	// +kubebuilder:validation:Required
 	Nameserver string `json:"nameserver"`
 
 	// The name of the secret containing the TSIG value.
@@ -389,6 +413,7 @@ type ACMEIssuerDNS01ProviderWebhook struct {
 	// The name of the solver to use, as defined in the webhook provider
 	// implementation.
 	// This will typically be the name of the provider, e.g. 'cloudflare'.
+	// +kubebuilder:validation:Required
 	SolverName string `json:"solverName"`
 
 	// Additional configuration that should be passed to the webhook apiserver

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -44,12 +44,10 @@ type ACMEIssuer struct {
 
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
-	// +kubebuilder:validation:Required
 	PrivateKey cmmeta.SecretKeySelector `json:"privateKeySecretRef"`
 
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
-	// +kubebuilder:validation:MinItems=1
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 }
 
@@ -57,7 +55,6 @@ type ACMEIssuer struct {
 // server.
 type ACMEExternalAccountBinding struct {
 	// keyID is the ID of the CA key that the External Account is bound to.
-	// +kubebuilder:validation:Required
 	KeyID string `json:"keyID"`
 
 	// keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
@@ -67,12 +64,10 @@ type ACMEExternalAccountBinding struct {
 	// the External Account Binding keyID above.
 	// The secret key stored in the Secret **must** be un-padded, base64 URL
 	// encoded data.
-	// +kubebuilder:validation:Required
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
 	// keyAlgorithm is the MAC key algorithm that the key is used for. Valid
 	// values are "HS256", "HS384" and "HS512".
-	// +kubebuilder:validation:Required
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
 }
 
@@ -266,7 +261,6 @@ const (
 // configuration for Akamai DNS—Zone Record Management API
 type ACMEIssuerDNS01ProviderAkamai struct {
 	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
 	ServiceConsumerDomain string                   `json:"serviceConsumerDomain"`
 	ClientToken           cmmeta.SecretKeySelector `json:"clientTokenSecretRef"`
 	ClientSecret          cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
@@ -279,14 +273,12 @@ type ACMEIssuerDNS01ProviderCloudDNS struct {
 	// +optional
 	ServiceAccount *cmmeta.SecretKeySelector `json:"serviceAccountSecretRef,omitempty"`
 
-	// +kubebuilder:validation:Required
 	Project string `json:"project"`
 }
 
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
-	// +kubebuilder:validation:Required
 	Email string `json:"email"`
 
 	// +optional
@@ -299,7 +291,6 @@ type ACMEIssuerDNS01ProviderCloudflare struct {
 // ACMEIssuerDNS01ProviderDigitalOcean is a structure containing the DNS
 // configuration for DigitalOcean Domains
 type ACMEIssuerDNS01ProviderDigitalOcean struct {
-	// +kubebuilder:validation:Required
 	Token cmmeta.SecretKeySelector `json:"tokenSecretRef"`
 }
 
@@ -332,26 +323,20 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
-	// +kubebuilder:validation:Required
 	ClientID string `json:"clientID"`
 
-	// +kubebuilder:validation:Required
 	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
 
-	// +kubebuilder:validation:Required
 	SubscriptionID string `json:"subscriptionID"`
 
-	// +kubebuilder:validation:Required
 	TenantID string `json:"tenantID"`
 
-	// +kubebuilder:validation:Required
 	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional
 	HostedZoneName string `json:"hostedZoneName,omitempty"`
 
 	// +optional
-	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 }
 

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -44,12 +44,10 @@ type ACMEIssuer struct {
 
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
-	// +kubebuilder:validation:Required
 	PrivateKey cmmeta.SecretKeySelector `json:"privateKeySecretRef"`
 
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
-	// +kubebuilder:validation:MinItems=1
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 }
 
@@ -265,8 +263,6 @@ const (
 // ACMEIssuerDNS01ProviderAkamai is a structure containing the DNS
 // configuration for Akamai DNS—Zone Record Management API
 type ACMEIssuerDNS01ProviderAkamai struct {
-	// +kubebuilder:validation:Required
-	// +kubebuilder:validation:MinLength=1
 	ServiceConsumerDomain string                   `json:"serviceConsumerDomain"`
 	ClientToken           cmmeta.SecretKeySelector `json:"clientTokenSecretRef"`
 	ClientSecret          cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
@@ -279,14 +275,12 @@ type ACMEIssuerDNS01ProviderCloudDNS struct {
 	// +optional
 	ServiceAccount *cmmeta.SecretKeySelector `json:"serviceAccountSecretRef,omitempty"`
 
-	// +kubebuilder:validation:Required
 	Project string `json:"project"`
 }
 
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
-	// +kubebuilder:validation:Required
 	Email string `json:"email"`
 
 	// +optional
@@ -299,7 +293,6 @@ type ACMEIssuerDNS01ProviderCloudflare struct {
 // ACMEIssuerDNS01ProviderDigitalOcean is a structure containing the DNS
 // configuration for DigitalOcean Domains
 type ACMEIssuerDNS01ProviderDigitalOcean struct {
-	// +kubebuilder:validation:Required
 	Token cmmeta.SecretKeySelector `json:"tokenSecretRef"`
 }
 
@@ -332,26 +325,20 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
-	// +kubebuilder:validation:Required
 	ClientID string `json:"clientID"`
 
-	// +kubebuilder:validation:Required
 	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
 
-	// +kubebuilder:validation:Required
 	SubscriptionID string `json:"subscriptionID"`
 
-	// +kubebuilder:validation:Required
 	TenantID string `json:"tenantID"`
 
-	// +kubebuilder:validation:Required
 	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional
 	HostedZoneName string `json:"hostedZoneName,omitempty"`
 
 	// +optional
-	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 }
 
@@ -413,7 +400,6 @@ type ACMEIssuerDNS01ProviderWebhook struct {
 	// The name of the solver to use, as defined in the webhook provider
 	// implementation.
 	// This will typically be the name of the provider, e.g. 'cloudflare'.
-	// +kubebuilder:validation:Required
 	SolverName string `json:"solverName"`
 
 	// Additional configuration that should be passed to the webhook apiserver

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -30,6 +30,7 @@ type ACMEIssuer struct {
 	Email string `json:"email,omitempty"`
 
 	// Server is the ACME server URL
+	// +kubebuilder:validation:Required
 	Server string `json:"server"`
 
 	// If true, skip verifying the ACME server TLS certificate
@@ -43,11 +44,12 @@ type ACMEIssuer struct {
 
 	// PrivateKey is the name of a secret containing the private key for this
 	// user account.
+	// +kubebuilder:validation:Required
 	PrivateKey cmmeta.SecretKeySelector `json:"privateKeySecretRef"`
 
 	// Solvers is a list of challenge solvers that will be used to solve
 	// ACME challenges for the matching domains.
-	// +optional
+	// +kubebuilder:validation:MinItems=1
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 }
 
@@ -55,6 +57,7 @@ type ACMEIssuer struct {
 // server.
 type ACMEExternalAccountBinding struct {
 	// keyID is the ID of the CA key that the External Account is bound to.
+	// +kubebuilder:validation:Required
 	KeyID string `json:"keyID"`
 
 	// keySecretRef is a Secret Key Selector referencing a data item in a Kubernetes
@@ -64,10 +67,12 @@ type ACMEExternalAccountBinding struct {
 	// the External Account Binding keyID above.
 	// The secret key stored in the Secret **must** be un-padded, base64 URL
 	// encoded data.
+	// +kubebuilder:validation:Required
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
 	// keyAlgorithm is the MAC key algorithm that the key is used for. Valid
 	// values are "HS256", "HS384" and "HS512".
+	// +kubebuilder:validation:Required
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
 }
 
@@ -260,6 +265,8 @@ const (
 // ACMEIssuerDNS01ProviderAkamai is a structure containing the DNS
 // configuration for Akamai DNS—Zone Record Management API
 type ACMEIssuerDNS01ProviderAkamai struct {
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:MinLength=1
 	ServiceConsumerDomain string                   `json:"serviceConsumerDomain"`
 	ClientToken           cmmeta.SecretKeySelector `json:"clientTokenSecretRef"`
 	ClientSecret          cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
@@ -271,20 +278,28 @@ type ACMEIssuerDNS01ProviderAkamai struct {
 type ACMEIssuerDNS01ProviderCloudDNS struct {
 	// +optional
 	ServiceAccount *cmmeta.SecretKeySelector `json:"serviceAccountSecretRef,omitempty"`
-	Project        string                    `json:"project"`
+
+	// +kubebuilder:validation:Required
+	Project string `json:"project"`
 }
 
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
-	Email    string                    `json:"email"`
-	APIKey   *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
+	// +kubebuilder:validation:Required
+	Email string `json:"email"`
+
+	// +optional
+	APIKey *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
+
+	// + optional
 	APIToken *cmmeta.SecretKeySelector `json:"apiTokenSecretRef,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderDigitalOcean is a structure containing the DNS
 // configuration for DigitalOcean Domains
 type ACMEIssuerDNS01ProviderDigitalOcean struct {
+	// +kubebuilder:validation:Required
 	Token cmmeta.SecretKeySelector `json:"tokenSecretRef"`
 }
 
@@ -317,20 +332,26 @@ type ACMEIssuerDNS01ProviderRoute53 struct {
 // ACMEIssuerDNS01ProviderAzureDNS is a structure containing the
 // configuration for Azure DNS
 type ACMEIssuerDNS01ProviderAzureDNS struct {
+	// +kubebuilder:validation:Required
 	ClientID string `json:"clientID"`
 
+	// +kubebuilder:validation:Required
 	ClientSecret cmmeta.SecretKeySelector `json:"clientSecretSecretRef"`
 
+	// +kubebuilder:validation:Required
 	SubscriptionID string `json:"subscriptionID"`
 
+	// +kubebuilder:validation:Required
 	TenantID string `json:"tenantID"`
 
+	// +kubebuilder:validation:Required
 	ResourceGroupName string `json:"resourceGroupName"`
 
 	// +optional
 	HostedZoneName string `json:"hostedZoneName,omitempty"`
 
 	// +optional
+	// +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 }
 
@@ -347,8 +368,10 @@ const (
 // ACMEIssuerDNS01ProviderAcmeDNS is a structure containing the
 // configuration for ACME-DNS servers
 type ACMEIssuerDNS01ProviderAcmeDNS struct {
+	// +kubebuilder:validation:Required
 	Host string `json:"host"`
 
+	// +kubebuilder:validation:Required
 	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
 }
 
@@ -357,6 +380,7 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The IP address of the DNS supporting RFC2136. Required.
 	// Note: FQDN is not a valid value, only IP.
+	// +kubebuilder:validation:Required
 	Nameserver string `json:"nameserver"`
 
 	// The name of the secret containing the TSIG value.
@@ -389,6 +413,7 @@ type ACMEIssuerDNS01ProviderWebhook struct {
 	// The name of the solver to use, as defined in the webhook provider
 	// implementation.
 	// This will typically be the name of the provider, e.g. 'cloudflare'.
+	// +kubebuilder:validation:Required
 	SolverName string `json:"solverName"`
 
 	// Additional configuration that should be passed to the webhook apiserver

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -82,6 +82,7 @@ type CertificateSpec struct {
 	// This value is ignored by TLS clients when any subject alt name is set.
 	// This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	CommonName string `json:"commonName,omitempty"`
 
 	// Organization is the organization to be used on the Certificate
@@ -115,6 +116,7 @@ type CertificateSpec struct {
 	EmailSANs []string `json:"emailSANs,omitempty"`
 
 	// SecretName is the name of the secret resource to store this secret in
+	// +kubebuilder:validation:Required
 	SecretName string `json:"secretName"`
 
 	// IssuerRef is a reference to the issuer for this certificate.

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -73,6 +73,7 @@ type CertificateRequestSpec struct {
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
+	// +kubebuilder:validation:Required
 	CSRPEM []byte `json:"csr"`
 
 	// IsCA will mark the resulting certificate as valid for signing. This

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -82,6 +82,7 @@ type CertificateSpec struct {
 	// This value is ignored by TLS clients when any subject alt name is set.
 	// This is x509 behaviour: https://tools.ietf.org/html/rfc6125#section-6.4.4
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	CommonName string `json:"commonName,omitempty"`
 
 	// Certificate default Duration
@@ -111,6 +112,7 @@ type CertificateSpec struct {
 	EmailSANs []string `json:"emailSANs,omitempty"`
 
 	// SecretName is the name of the secret resource to store this secret in
+	// +kubebuilder:validation:Required
 	SecretName string `json:"secretName"`
 
 	// IssuerRef is a reference to the issuer for this certificate.

--- a/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -73,6 +73,7 @@ type CertificateRequestSpec struct {
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// Byte slice containing the PEM encoded CertificateSigningRequest
+	// +kubebuilder:validation:Required
 	CSRPEM []byte `json:"csr"`
 
 	// IsCA will mark the resulting certificate as valid for signing. This

--- a/pkg/apis/meta/v1/types.go
+++ b/pkg/apis/meta/v1/types.go
@@ -40,11 +40,13 @@ type LocalObjectReference struct {
 	// Name of the referent.
 	// More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 	// TODO: Add other useful fields. apiVersion, kind, uid?
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 }
 
 // ObjectReference is a reference to an object with a given name, kind and group.
 type ObjectReference struct {
+	// +kubebuilder:validation:Required
 	Name string `json:"name"`
 	// +optional
 	Kind string `json:"kind,omitempty"`
@@ -54,9 +56,10 @@ type ObjectReference struct {
 
 type SecretKeySelector struct {
 	// The name of the secret in the pod's namespace to select from.
+	// +kubebuilder:validation:Required
 	LocalObjectReference `json:",inline"`
 	// The key of the secret to select from. Must be a valid secret key.
-	// +optional
+	// +kubebuilder:validation:Required
 	Key string `json:"key,omitempty"`
 }
 

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -34,19 +34,11 @@ import (
 
 func ValidateCertificateSpec(crt *cmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
-	if crt.SecretName == "" {
-		el = append(el, field.Required(fldPath.Child("secretName"), "must be specified"))
-	}
 
 	el = append(el, validateIssuerRef(crt.IssuerRef, fldPath)...)
 
 	if len(crt.CommonName) == 0 && len(crt.DNSNames) == 0 && len(crt.URISANs) == 0 && len(crt.EmailSANs) == 0 {
 		el = append(el, field.Invalid(fldPath, "", "at least one of commonName, dnsNames, uriSANs or emailSANs must be set"))
-	}
-
-	// if a common name has been specified, ensure it is no longer than 64 chars
-	if len(crt.CommonName) > 64 {
-		el = append(el, field.TooLong(fldPath.Child("commonName"), crt.CommonName, 64))
 	}
 
 	if len(crt.IPAddresses) > 0 {
@@ -90,9 +82,7 @@ func validateIssuerRef(issuerRef cmmeta.ObjectReference, fldPath *field.Path) fi
 	el := field.ErrorList{}
 
 	issuerRefPath := fldPath.Child("issuerRef")
-	if issuerRef.Name == "" {
-		el = append(el, field.Required(issuerRefPath.Child("name"), "must be specified"))
-	}
+
 	if issuerRef.Group == "" || issuerRef.Group == cmapi.SchemeGroupVersion.Group {
 		switch issuerRef.Kind {
 		case "":

--- a/pkg/internal/apis/certmanager/validation/certificate_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_test.go
@@ -106,17 +106,6 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("issuerRef", "kind"), "invalid", "must be one of Issuer or ClusterIssuer"),
 			},
 		},
-		"certificate missing secretName": {
-			cfg: &cmapi.Certificate{
-				Spec: cmapi.CertificateSpec{
-					CommonName: "testcn",
-					IssuerRef:  validIssuerRef,
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("secretName"), "must be specified"),
-			},
-		},
 		"certificate with no domains, URIs or common name": {
 			cfg: &cmapi.Certificate{
 				Spec: cmapi.CertificateSpec{
@@ -126,17 +115,6 @@ func TestValidateCertificate(t *testing.T) {
 			},
 			errs: []*field.Error{
 				field.Invalid(fldPath, "", "at least one of commonName, dnsNames, uriSANs or emailSANs must be set"),
-			},
-		},
-		"certificate with no issuerRef": {
-			cfg: &cmapi.Certificate{
-				Spec: cmapi.CertificateSpec{
-					CommonName: "testcn",
-					SecretName: "abc",
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("issuerRef", "name"), "must be specified"),
 			},
 		},
 		"valid certificate with only dnsNames": {
@@ -320,28 +298,6 @@ func TestValidateCertificate(t *testing.T) {
 			},
 			errs: []*field.Error{
 				field.Invalid(fldPath.Child("ipAddresses").Index(0), "blah", "invalid IP address"),
-			},
-		},
-		"valid certificate with commonName exactly 64 bytes": {
-			cfg: &cmapi.Certificate{
-				Spec: cmapi.CertificateSpec{
-					CommonName: "this-is-a-big-long-string-which-is-exactly-sixty-four-characters",
-					SecretName: "abc",
-					IssuerRef:  validIssuerRef,
-				},
-			},
-			errs: []*field.Error{},
-		},
-		"invalid certificate with commonName longer than 64 bytes": {
-			cfg: &cmapi.Certificate{
-				Spec: cmapi.CertificateSpec{
-					CommonName: "this-is-a-big-long-string-which-has-exactly-sixty-five-characters",
-					SecretName: "abc",
-					IssuerRef:  validIssuerRef,
-				},
-			},
-			errs: []*field.Error{
-				field.TooLong(fldPath.Child("commonName"), "this-is-a-big-long-string-which-has-exactly-sixty-five-characters", 64),
 			},
 		},
 		"valid certificate with no commonName and second dnsName longer than 64 bytes": {

--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -37,13 +37,9 @@ func ValidateCertificateRequestSpec(crSpec *cmapi.CertificateRequestSpec, fldPat
 
 	el = append(el, validateIssuerRef(crSpec.IssuerRef, fldPath)...)
 
-	if len(crSpec.CSRPEM) == 0 {
-		el = append(el, field.Required(fldPath.Child("csr"), "must be specified"))
-	} else {
-		_, err := pki.DecodeX509CertificateRequestBytes(crSpec.CSRPEM)
-		if err != nil {
-			el = append(el, field.Invalid(fldPath.Child("csr"), crSpec.CSRPEM, fmt.Sprintf("failed to decode csr: %s", err)))
-		}
+	_, err := pki.DecodeX509CertificateRequestBytes(crSpec.CSRPEM)
+	if err != nil {
+		el = append(el, field.Invalid(fldPath.Child("csr"), crSpec.CSRPEM, fmt.Sprintf("failed to decode csr: %s", err)))
 	}
 
 	return el

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -261,7 +261,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 		}
 
 		if len(p.RFC2136.TSIGSecret.Name) != 0 {
-			if len(p.RFC2136.TSIGKeyName) <= 0 {
+			if len(p.RFC2136.TSIGKeyName) == 0 {
 				el = append(el, field.Required(fldPath.Child("rfc2136", "tsigKeyName"), ""))
 			}
 		}
@@ -274,7 +274,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 	}
 
 	if numProviders > 1 {
-		el = append(el, field.Required(fldPath, "may not specify more than one provider type"))
+		el = append(el, field.Forbidden(fldPath, "may not specify more than one provider type"))
 	}
 
 	return el

--- a/pkg/internal/apis/certmanager/validation/issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/issuer_test.go
@@ -110,26 +110,6 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 		"valid acme issuer": {
 			spec: &validACMEIssuer,
 		},
-		"acme issuer with missing fields": {
-			spec: &cmacme.ACMEIssuer{},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("privateKeySecretRef", "name"), "private key secret name is a required field"),
-				field.Required(fldPath.Child("server"), "acme server URL is a required field"),
-			},
-		},
-		"acme solver without any config": {
-			spec: &cmacme.ACMEIssuer{
-				Email:      "valid-email",
-				Server:     "valid-server",
-				PrivateKey: validSecretKeyRef,
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{},
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("solvers").Index(0), "no solver type configured"),
-			},
-		},
 		"acme solver with valid dns01 config": {
 			spec: &cmacme.ACMEIssuer{
 				Email:      "valid-email",
@@ -142,27 +122,6 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 						},
 					},
 				},
-			},
-		},
-		"acme solver with empty external account binding fields": {
-			spec: &cmacme.ACMEIssuer{
-				Email:                  "valid-email",
-				Server:                 "valid-server",
-				PrivateKey:             validSecretKeyRef,
-				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{},
-				Solvers: []cmacme.ACMEChallengeSolver{
-					{
-						DNS01: &cmacme.ACMEChallengeSolverDNS01{
-							CloudDNS: &validCloudDNSProvider,
-						},
-					},
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("externalAccountBinding.keyID"), "the keyID field is required when using externalAccountBinding"),
-				field.Required(fldPath.Child("externalAccountBinding.keySecretRef.name"), "secret name is required"),
-				field.Required(fldPath.Child("externalAccountBinding.keySecretRef.key"), "secret key is required"),
-				field.Required(fldPath.Child("externalAccountBinding.keyAlgorithm"), "the keyAlgorithm field is required when using externalAccountBinding"),
 			},
 		},
 		"acme solver with missing http01 config type": {
@@ -470,73 +429,12 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 		cfg  *cmacme.ACMEChallengeSolverDNS01
 		errs []*field.Error
 	}{
-		"missing clouddns project": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
-					ServiceAccount: &validSecretKeyRef,
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("clouddns", "project"), ""),
-			},
-		},
-		"missing clouddns service account key": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
-					Project: "valid",
-					ServiceAccount: &cmmeta.SecretKeySelector{
-						LocalObjectReference: cmmeta.LocalObjectReference{Name: "something"},
-						Key:                  "",
-					},
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("clouddns", "serviceAccountSecretRef", "key"), "secret key is required"),
-			},
-		},
-		"missing clouddns service account name": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
-					Project: "valid",
-					ServiceAccount: &cmmeta.SecretKeySelector{
-						LocalObjectReference: cmmeta.LocalObjectReference{Name: ""},
-						Key:                  "something",
-					},
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("clouddns", "serviceAccountSecretRef", "name"), "secret name is required"),
-			},
-		},
+
 		"clouddns serviceAccount field not set should be allowed for ambient auth": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
 					Project: "valid",
 				},
-			},
-		},
-		"missing cloudflare api key fields": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
-					Email:  "valid",
-					APIKey: &cmmeta.SecretKeySelector{},
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("cloudflare", "apiKeySecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("cloudflare", "apiKeySecretRef", "key"), "secret key is required"),
-			},
-		},
-		"missing cloudflare api token fields": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
-					Email:    "valid",
-					APIToken: &cmmeta.SecretKeySelector{},
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("cloudflare", "apiTokenSecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("cloudflare", "apiTokenSecretRef", "key"), "secret key is required"),
 			},
 		},
 		"missing cloudflare api token or key": {
@@ -561,74 +459,6 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Forbidden(fldPath.Child("cloudflare"), "apiKeySecretRef and apiTokenSecretRef cannot both be specified"),
 			},
 		},
-		"missing cloudflare email": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{
-					APIKey: &validSecretKeyRef,
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("cloudflare", "email"), ""),
-			},
-		},
-		"missing route53 region": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("route53", "region"), ""),
-			},
-		},
-		"missing provider config": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{},
-			errs: []*field.Error{
-				field.Required(fldPath, "no DNS01 provider configured"),
-			},
-		},
-		"missing azuredns config": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "key"), "secret key is required"),
-				field.Required(fldPath.Child("azuredns", "clientID"), ""),
-				field.Required(fldPath.Child("azuredns", "subscriptionID"), ""),
-				field.Required(fldPath.Child("azuredns", "tenantID"), ""),
-				field.Required(fldPath.Child("azuredns", "resourceGroupName"), ""),
-			},
-		},
-		"invalid azuredns environment": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
-					Environment: "an env",
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("azuredns", "clientSecretSecretRef", "key"), "secret key is required"),
-				field.Required(fldPath.Child("azuredns", "clientID"), ""),
-				field.Required(fldPath.Child("azuredns", "subscriptionID"), ""),
-				field.Required(fldPath.Child("azuredns", "tenantID"), ""),
-				field.Required(fldPath.Child("azuredns", "resourceGroupName"), ""),
-				field.Invalid(fldPath.Child("azuredns", "environment"), cmacme.AzureDNSEnvironment("an env"),
-					"must be either empty or one of AzurePublicCloud, AzureChinaCloud, AzureGermanCloud or AzureUSGovernmentCloud"),
-			},
-		},
-		"missing akamai config": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("akamai", "accessToken", "name"), "secret name is required"),
-				field.Required(fldPath.Child("akamai", "accessToken", "key"), "secret key is required"),
-				field.Required(fldPath.Child("akamai", "clientSecret", "name"), "secret name is required"),
-				field.Required(fldPath.Child("akamai", "clientSecret", "key"), "secret key is required"),
-				field.Required(fldPath.Child("akamai", "clientToken", "name"), "secret name is required"),
-				field.Required(fldPath.Child("akamai", "clientToken", "key"), "secret key is required"),
-				field.Required(fldPath.Child("akamai", "serviceConsumerDomain"), ""),
-			},
-		},
 		"valid akamai config": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{
@@ -648,14 +478,7 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 			},
 			errs: []*field.Error{},
 		},
-		"missing rfc2136 required field": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("rfc2136", "nameserver"), ""),
-			},
-		},
+
 		"rfc2136 provider invalid nameserver": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
@@ -686,18 +509,6 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.NotSupported(fldPath.Child("rfc2136", "tsigAlgorithm"), "", supportedTSIGAlgorithms),
 			},
 		},
-		"rfc2136 provider TSIGKeyName provided but no TSIGSecret": {
-			cfg: &cmacme.ACMEChallengeSolverDNS01{
-				RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
-					Nameserver:  "127.0.0.1",
-					TSIGKeyName: "some-name",
-				},
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("rfc2136", "tsigSecretSecretRef", "name"), "secret name is required"),
-				field.Required(fldPath.Child("rfc2136", "tsigSecretSecretRef", "key"), "secret key is required"),
-			},
-		},
 		"rfc2136 provider TSIGSecret provided but no TSIGKeyName": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				RFC2136: &cmacme.ACMEIssuerDNS01ProviderRFC2136{
@@ -714,81 +525,16 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				CloudDNS: &cmacme.ACMEIssuerDNS01ProviderCloudDNS{
 					Project: "something",
 				},
-				Cloudflare: &cmacme.ACMEIssuerDNS01ProviderCloudflare{},
+				AcmeDNS: &cmacme.ACMEIssuerDNS01ProviderAcmeDNS{},
 			},
 			errs: []*field.Error{
-				field.Forbidden(fldPath.Child("cloudflare"), "may not specify more than one provider type"),
+				field.Forbidden(fldPath, "may not specify more than one provider type"),
 			},
 		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
 			errs := ValidateACMEChallengeSolverDNS01(s.cfg, fldPath)
-			if len(errs) != len(s.errs) {
-				t.Errorf("Expected %v but got %v", s.errs, errs)
-				return
-			}
-			for i, e := range errs {
-				expectedErr := s.errs[i]
-				if !reflect.DeepEqual(e, expectedErr) {
-					t.Errorf("Expected %v but got %v", expectedErr, e)
-				}
-			}
-		})
-	}
-}
-
-func TestValidateSecretKeySelector(t *testing.T) {
-	validName := cmmeta.LocalObjectReference{Name: "name"}
-	validKey := "key"
-	// invalidName := cmmeta.LocalObjectReference{"-name-"}
-	// invalidKey := "-key-"
-	fldPath := field.NewPath("")
-	scenarios := map[string]struct {
-		isExpectedFailure bool
-		selector          *cmmeta.SecretKeySelector
-		errs              []*field.Error
-	}{
-		"valid selector": {
-			selector: &cmmeta.SecretKeySelector{
-				LocalObjectReference: validName,
-				Key:                  validKey,
-			},
-		},
-		// "invalid name": {
-		// 	isExpectedFailure: true,
-		// 	selector: &cmmeta.SecretKeySelector{
-		// 		LocalObjectReference: invalidName,
-		// 		Key:                  validKey,
-		// 	},
-		// },
-		// "invalid key": {
-		// 	isExpectedFailure: true,
-		// 	selector: &cmmeta.SecretKeySelector{
-		// 		LocalObjectReference: validName,
-		// 		Key:                  invalidKey,
-		// 	},
-		// },
-		"missing name": {
-			selector: &cmmeta.SecretKeySelector{
-				Key: validKey,
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("name"), "secret name is required"),
-			},
-		},
-		"missing key": {
-			selector: &cmmeta.SecretKeySelector{
-				LocalObjectReference: validName,
-			},
-			errs: []*field.Error{
-				field.Required(fldPath.Child("key"), "secret key is required"),
-			},
-		},
-	}
-	for n, s := range scenarios {
-		t.Run(n, func(t *testing.T) {
-			errs := ValidateSecretKeySelector(s.selector, fldPath)
 			if len(errs) != len(s.errs) {
 				t.Errorf("Expected %v but got %v", s.errs, errs)
 				return


### PR DESCRIPTION
**What this PR does / why we need it**:
This moves the validations that OpenAPI supports to the CRD defenition instead of in the webhook code.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #2571

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Move some validations to OpenAPI instead of the webhook
```
