### PR TITLE
Add integration testing framework with a basic conversion test

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -81,6 +81,7 @@ filegroup(
         "//pkg/webhook:all-srcs",
         "//test/acme/dns:all-srcs",
         "//test/e2e:all-srcs",
+        "//test/integration:all-srcs",
         "//test/unit/gen:all-srcs",
         "//test/unit/listers:all-srcs",
     ],

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -21,10 +21,9 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/webhook",
     visibility = ["//visibility:private"],
     deps = [
-        "//pkg/logs:go_default_library",
-        "//pkg/webhook:go_default_library",
-        "//pkg/webhook/handlers:go_default_library",
-        "//pkg/webhook/server:go_default_library",
+        "//cmd/webhook/app:go_default_library",
+        "//cmd/webhook/app/options:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@io_k8s_klog//klogr:go_default_library",
     ],
@@ -47,7 +46,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//cmd/webhook/app:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/webhook/app/BUILD.bazel
+++ b/cmd/webhook/app/BUILD.bazel
@@ -1,0 +1,34 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["webhook.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/webhook/app",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/webhook/app/options:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//pkg/webhook:go_default_library",
+        "//pkg/webhook/handlers:go_default_library",
+        "//pkg/webhook/server:go_default_library",
+        "@com_github_go_logr_logr//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//cmd/webhook/app/options:all-srcs",
+        "//cmd/webhook/app/testing:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/webhook/app/options/BUILD.bazel
+++ b/cmd/webhook/app/options/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["options.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/webhook/app/options",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_spf13_pflag//:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options
+
+import (
+	"github.com/spf13/pflag"
+)
+
+type WebhookOptions struct {
+	ListenPort  int
+	HealthzPort int
+
+	TLSCertFile     string
+	TLSKeyFile      string
+	TLSCipherSuites []string
+}
+
+func (o *WebhookOptions) AddFlags(fs *pflag.FlagSet) {
+	// TODO: rename secure-port to listen-port
+	fs.IntVar(&o.ListenPort, "secure-port", 6443, "port number to listen on for secure TLS connections")
+	fs.IntVar(&o.HealthzPort, "healthz-port", 6080, "port number to listen on for insecure healthz connections")
+	fs.StringVar(&o.TLSCertFile, "tls-cert-file", "", "path to the file containing the TLS certificate to serve with")
+	fs.StringVar(&o.TLSKeyFile, "tls-private-key-file", "", "path to the file containing the TLS private key to serve with")
+	fs.StringSliceVar(&o.TLSCipherSuites, "tls-cipher-suites", defaultCipherSuites, "comma separated list of TLS 1.2 cipher suites to use (TLS 1.3 cipher suites are not configurable)")
+}
+
+var (
+	defaultCipherSuites = []string{
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+		"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305",
+		"TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
+		"TLS_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_RSA_WITH_AES_256_GCM_SHA384",
+		"TLS_RSA_WITH_AES_128_CBC_SHA",
+		"TLS_RSA_WITH_AES_256_CBC_SHA",
+	}
+)

--- a/cmd/webhook/app/testing/BUILD.bazel
+++ b/cmd/webhook/app/testing/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["testwebhook.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/webhook/app/testing",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/webhook/app:go_default_library",
+        "//cmd/webhook/app/options:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"fmt"
+	"io/ioutil"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/pflag"
+
+	"github.com/jetstack/cert-manager/cmd/webhook/app"
+	"github.com/jetstack/cert-manager/cmd/webhook/app/options"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+var log = logf.Log.WithName("webhook-server-test")
+
+type StopFunc func()
+
+type ServerOptions struct {
+	// URL is the base path/URL that the webhook server can be accessed on.
+	// This is typically of the form: https://127.0.0.1:12345.
+	URL string
+
+	// CAPEM is PEM data containing the CA used to validate connections to the
+	// webhook.
+	// If `--tls-cert-file` or `--tls-private-key-file` are explicitly provided
+	// as flags, this field will be empty.
+	CAPEM []byte
+}
+
+func StartWebhookServer(t *testing.T, args []string) (ServerOptions, StopFunc) {
+	// Allow user to override options using flags
+	opts := &options.WebhookOptions{}
+	fs := pflag.NewFlagSet("testset", pflag.ExitOnError)
+	opts.AddFlags(fs)
+	// Parse the arguments passed in into the WebhookOptions struct
+	fs.Parse(args)
+
+	var caPEM []byte
+	tempDir, err := ioutil.TempDir("", "webhook-tls-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if opts.TLSKeyFile == "" && opts.TLSCertFile == "" {
+		// Generate a CA and serving certificate
+		ca, certificatePEM, privateKeyPEM, err := generateTLSAssets()
+		if err != nil {
+			t.Fatalf("failed to generate PKI assets: %v", err)
+		}
+
+		caPEM = ca
+		if err := ioutil.WriteFile(filepath.Join(tempDir, "tls.crt"), certificatePEM, 0644); err != nil {
+			t.Fatal(err)
+		}
+		if err := ioutil.WriteFile(filepath.Join(tempDir, "tls.key"), privateKeyPEM, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		opts.TLSKeyFile = filepath.Join(tempDir, "tls.key")
+		opts.TLSCertFile = filepath.Join(tempDir, "tls.crt")
+	}
+
+	stopCh := make(chan struct{})
+	go func() {
+		if err := app.RunServer(log, *opts, stopCh); err != nil {
+			t.Fatalf("error running webhook server: %v", err)
+		}
+	}()
+
+	return ServerOptions{
+			URL:   fmt.Sprintf("https://127.0.0.1:%d", opts.ListenPort),
+			CAPEM: caPEM,
+		}, func() {
+			close(stopCh)
+			if err := os.RemoveAll(tempDir); err != nil {
+				t.Fatal(err)
+			}
+		}
+}
+
+func generateTLSAssets() (caPEM, certificatePEM, privateKeyPEM []byte, err error) {
+	caPK, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	rootCA := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(1658),
+		PublicKeyAlgorithm:    x509.RSA,
+		Subject: pkix.Name{
+			CommonName: "testing-ca",
+		},
+		NotBefore: time.Now().Add(-1 * time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+		KeyUsage:  x509.KeyUsageCertSign | x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		IsCA:      true,
+	}
+	rootCADER, err := x509.CreateCertificate(rand.Reader, rootCA, rootCA, caPK.Public(), caPK)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	rootCA, err = x509.ParseCertificate(rootCADER)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	servingCert := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(1659),
+		PublicKeyAlgorithm:    x509.RSA,
+		DNSNames:              []string{"localhost"},
+		IPAddresses:           []net.IP{{127, 0, 0, 1}},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	servingPK, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	servingDER, err := x509.CreateCertificate(rand.Reader, servingCert, rootCA, servingPK.Public(), caPK)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	servingCert, err = x509.ParseCertificate(servingDER)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+
+	// encoding PKI data to PEM
+	privateKeyPEM, err = pki.EncodePKCS8PrivateKey(servingPK)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	caPEM, err = pki.EncodeX509(rootCA)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	certificatePEM, err = pki.EncodeX509(servingCert)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	return
+}

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jetstack/cert-manager/cmd/webhook/app/options"
+	"github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/webhook"
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
+	"github.com/jetstack/cert-manager/pkg/webhook/server"
+)
+
+var validationHook handlers.ValidatingAdmissionHook = handlers.NewRegistryBackedValidator(logs.Log, webhook.Scheme, webhook.ValidationRegistry)
+var mutationHook handlers.MutatingAdmissionHook = handlers.NewSchemeBackedDefaulter(logs.Log, webhook.Scheme)
+var conversionHook handlers.ConversionHook = handlers.NewSchemeBackedConverter(logs.Log, webhook.Scheme)
+
+func RunServer(log logr.Logger, opts options.WebhookOptions, stopCh <-chan struct{}) error {
+	var source server.CertificateSource
+	if opts.TLSCertFile == "" || opts.TLSKeyFile == "" {
+		log.Info("warning: serving insecurely as tls certificate data not provided")
+	} else {
+		log.Info("enabling TLS as certificate file flags specified")
+		source = &server.FileCertificateSource{
+			CertPath: opts.TLSCertFile,
+			KeyPath:  opts.TLSKeyFile,
+			Log:      log,
+		}
+	}
+
+	srv := server.Server{
+		ListenAddr:        fmt.Sprintf(":%d", opts.ListenPort),
+		HealthzAddr:       fmt.Sprintf(":%d", opts.HealthzPort),
+		EnablePprof:       true,
+		CertificateSource: source,
+		CipherSuites:      opts.TLSCipherSuites,
+		ValidationWebhook: validationHook,
+		MutationWebhook:   mutationHook,
+		ConversionWebhook: conversionHook,
+		Log:               log,
+	}
+	if err := srv.Run(stopCh); err != nil {
+		return err
+	}
+	return nil
+}

--- a/deploy/charts/cert-manager/BUILD.bazel
+++ b/deploy/charts/cert-manager/BUILD.bazel
@@ -44,6 +44,9 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//deploy/charts/cert-manager/crds:all-srcs",
+    ],
     tags = ["automanaged"],
 )

--- a/deploy/charts/cert-manager/crds/BUILD.bazel
+++ b/deploy/charts/cert-manager/crds/BUILD.bazel
@@ -1,0 +1,13 @@
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -25,10 +25,10 @@ genrule(
 )
 
 genrule(
-    name = "fetch_etcd",
+    name = "com_coreos_etcd",
     srcs = select({
-        ":darwin": ["@etcd_v3_3_darwin//:file"],
-        ":k8": ["@etcd_v3_3_linux//:file"],
+        ":darwin": ["@com_coreos_etcd_darwin_amd64//:file"],
+        ":k8": ["@com_coreos_etcd_linux_amd64//:file"],
     }),
     outs = ["etcd"],
     cmd = "cp $(SRCS) $@",
@@ -36,10 +36,10 @@ genrule(
 )
 
 genrule(
-    name = "fetch_kube-apiserver",
+    name = "io_kubernetes_kube-apiserver",
     srcs = select({
-        ":darwin": ["@kube-apiserver_1_14_darwin//file"],
-        ":k8": ["@kube-apiserver_1_14_linux//file"],
+        ":darwin": ["@kube-apiserver_darwin_amd64//file"],
+        ":k8": ["@kube-apiserver_linux_amd64//file"],
     }),
     outs = ["kube-apiserver"],
     cmd = "cp $(SRCS) $@",
@@ -47,82 +47,10 @@ genrule(
 )
 
 genrule(
-    name = "fetch_kubectl_1_11",
-    srcs = select({
-        ":darwin": ["@kubectl_1_11_darwin//file"],
-        ":k8": ["@kubectl_1_11_linux//file"],
-    }),
-    outs = ["kubectl-1.11"],
-    cmd = "cp $(SRCS) $@",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "fetch_kubectl_1_12",
-    srcs = select({
-        ":darwin": ["@kubectl_1_12_darwin//file"],
-        ":k8": ["@kubectl_1_12_linux//file"],
-    }),
-    outs = ["kubectl-1.12"],
-    cmd = "cp $(SRCS) $@",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "fetch_kubectl_1_13",
-    srcs = select({
-        ":darwin": ["@kubectl_1_13_darwin//file"],
-        ":k8": ["@kubectl_1_13_linux//file"],
-    }),
-    outs = ["kubectl-1.13"],
-    cmd = "cp $(SRCS) $@",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "fetch_kubectl_1_14",
-    srcs = select({
-        ":darwin": ["@kubectl_1_14_darwin//file"],
-        ":k8": ["@kubectl_1_14_linux//file"],
-    }),
-    outs = ["kubectl-1.14"],
-    cmd = "cp $(SRCS) $@",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "fetch_kubectl_1_15",
-    srcs = select({
-        ":darwin": ["@kubectl_1_15_darwin//file"],
-        ":k8": ["@kubectl_1_15_linux//file"],
-    }),
-    outs = ["kubectl-1.15"],
-    cmd = "cp $(SRCS) $@",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "fetch_kubectl_1_16",
+    name = "fetch_kubectl",
     srcs = select({
         ":darwin": ["@kubectl_1_16_darwin//file"],
         ":k8": ["@kubectl_1_16_linux//file"],
-    }),
-    outs = ["kubectl-1.16"],
-    cmd = "cp $(SRCS) $@",
-    tags = ["manual"],
-    visibility = ["//visibility:public"],
-)
-
-genrule(
-    name = "fetch_kubectl",
-    srcs = select({
-        ":darwin": ["@kubectl_1_13_darwin//file"],
-        ":k8": ["@kubectl_1_13_linux//file"],
     }),
     outs = ["kubectl"],
     cmd = "cp $(SRCS) $@",

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -53,21 +53,21 @@ def install_misc():
 # Install dependencies used by the controller-runtime integration test framework
 def install_integration_test_dependencies():
     http_file(
-        name = "kube-apiserver_1_14_darwin",
+        name = "kube-apiserver_darwin_amd64",
         executable = 1,
-        sha256 = "8a7a21a5683386998ebd3a4fe9af346626ebdaf84a59094a2b2188e59e13b6d6",
-        urls = ["https://storage.googleapis.com/cert-manager-testing-assets/kube-apiserver-1.14.1_darwin_amd64"],
+        sha256 = "a874d479f183f9e4c19a5c69b44955fabd2e250b467d2d9f0641ae91a82ddbea",
+        urls = ["https://storage.googleapis.com/cert-manager-testing-assets/kube-apiserver-1.17.3_darwin_amd64"],
     )
 
     http_file(
-        name = "kube-apiserver_1_14_linux",
+        name = "kube-apiserver_linux_amd64",
         executable = 1,
-        sha256 = "1ce67dda7b125dc1adadc10ab93fe339f6ce40211ae4f1552d6de177e36a430d",
-        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.14.1/bin/linux/amd64/kube-apiserver"],
+        sha256 = "b4505b838b27b170531afbdef5e7bfaacf83da665f21b0e3269d1775b0defb7a",
+        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.17.3/bin/linux/amd64/kube-apiserver"],
     )
 
     http_archive(
-        name = "etcd_v3_3_darwin",
+        name = "com_coreos_etcd_darwin_amd64",
         sha256 = "c8f36adf4f8fb7e974f9bafe6e390a03bc33e6e465719db71d7ed3c6447ce85a",
         urls = ["https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-darwin-amd64.zip"],
         build_file_content = """
@@ -82,7 +82,7 @@ filegroup(
     )
 
     http_archive(
-        name = "etcd_v3_3_linux",
+        name = "com_coreos_etcd_linux_amd64",
         sha256 = "dc5d82df095dae0a2970e4d870b6929590689dd707ae3d33e7b86da0f7f211b6",
         urls = ["https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz"],
         build_file_content = """

--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -47,7 +47,7 @@ cd "${REPO_ROOT}"
 out="./deploy/manifests/00-crds.yaml"
 rm "$out" || true
 touch "$out"
-for file in $(find "./deploy/charts/cert-manager/crds" -type f | sort -V); do
+for file in $(find "./deploy/charts/cert-manager/crds" -name '*.yaml' -type f | sort -V); do
   # concatenate all files while removing blank (^$) lines
   < "$file" sed '/^$$/d' >> "$out"
   printf -- "---\n" >> "$out"

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -1,0 +1,17 @@
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//test/integration/conversion:all-srcs",
+        "//test/integration/framework:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/conversion/BUILD.bazel
+++ b/test/integration/conversion/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["conversion_test.go"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/certmanager/v1alpha3:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/conversion/conversion_test.go
+++ b/test/integration/conversion/conversion_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package conversion
+
+import (
+	"context"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jetstack/cert-manager/pkg/api"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/test/integration/framework"
+)
+
+func TestConversion(t *testing.T) {
+	tests := map[string]struct {
+		input  runtime.Object
+		output runtime.Object
+	}{
+		"should convert Certificates from v1alpha2 to v1alpha3": {
+			input: &v1alpha2.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1alpha2.CertificateSpec{
+					SecretName: "something",
+					IssuerRef: cmmeta.ObjectReference{
+						Name: "issuername",
+					},
+				},
+			},
+			output: &v1alpha3.Certificate{},
+		},
+		"should convert CertificateRequest from v1alpha2 to v1alpha3": {
+			input: &v1alpha2.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1alpha2.CertificateRequestSpec{
+					// validating webhook isn't currently configured in test
+					// environment so this passes validation.
+					CSRPEM: []byte("a"),
+					IssuerRef: cmmeta.ObjectReference{
+						Name: "issuername",
+					},
+				},
+			},
+			output: &v1alpha3.CertificateRequest{},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			config, stop := framework.RunControlPlane(t)
+			defer stop()
+
+			cl, err := client.New(config, client.Options{Scheme: api.Scheme})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if err := cl.Create(context.Background(), test.input); err != nil {
+				t.Fatal(err)
+			}
+			meta := test.input.(metav1.ObjectMetaAccessor)
+			if err := cl.Get(context.Background(), client.ObjectKey{Name: meta.GetObjectMeta().GetName(), Namespace: meta.GetObjectMeta().GetNamespace()}, test.output); err != nil {
+				t.Errorf("failed to fetch object in expected API version: %v", err)
+			}
+		})
+	}
+}

--- a/test/integration/framework/BUILD.bazel
+++ b/test/integration/framework/BUILD.bazel
@@ -1,0 +1,44 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "apiserver.go",
+        "paths.go",
+    ],
+    data = [
+        "//deploy/charts/cert-manager/crds:all-srcs",
+        "//hack/bin:com_coreos_etcd",
+        "//hack/bin:io_kubernetes_kube-apiserver",
+        "//hack/bin:kubectl",
+    ],
+    importpath = "github.com/jetstack/cert-manager/test/integration/framework",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/webhook/app/testing:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/install:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/serializer/json:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/serializer/versioning:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/runtime:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/envtest:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	jsonserializer "k8s.io/apimachinery/pkg/runtime/serializer/json"
+	"k8s.io/apimachinery/pkg/runtime/serializer/versioning"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	webhooktesting "github.com/jetstack/cert-manager/cmd/webhook/app/testing"
+)
+
+func init() {
+	// Set environment variables for controller-runtime's envtest package.
+	// This is done once as we cannot scope environment variables to a single
+	// invocation of RunControlPlane due to envtest's design.
+	setUpEnvTestEnv()
+}
+
+type StopFunc func()
+
+func RunControlPlane(t *testing.T) (*rest.Config, StopFunc) {
+	webhookOpts, stopWebhook := webhooktesting.StartWebhookServer(t, []string{})
+	crdsDir, err := getCRDsPath()
+	if err != nil {
+		t.Fatalf("error determining CRD directory path: %v", err)
+	}
+	crds := readCustomResourcesAtPath(t, crdsDir)
+	for _, crd := range crds {
+		t.Logf("Found CRD with name %q", crd.Name)
+	}
+	patchCRDConversion(crds, webhookOpts.URL, webhookOpts.CAPEM)
+	// environment variables
+	env := &envtest.Environment{
+		AttachControlPlaneOutput: true,
+		CRDs:                     crds,
+	}
+	config, err := env.Start()
+	if err != nil {
+		t.Fatalf("failed to start control plane: %v", err)
+	}
+	// TODO: configure Validating and Mutating webhook
+	return config, func() {
+		defer stopWebhook()
+		if err := env.Stop(); err != nil {
+			t.Logf("failed to shut down control plane, not failing test: %v", err)
+		}
+	}
+}
+
+var (
+	internalScheme = runtime.NewScheme()
+)
+
+func init() {
+	utilruntime.Must(metav1.AddMetaToScheme(internalScheme))
+	apiextensionsinstall.Install(internalScheme)
+}
+
+func patchCRDConversion(crds []*v1beta1.CustomResourceDefinition, url string, caPEM []byte) {
+	for _, crd := range crds {
+		if crd.Spec.Conversion == nil {
+			continue
+		}
+		if crd.Spec.Conversion.WebhookClientConfig == nil {
+			continue
+		}
+		if crd.Spec.Conversion.WebhookClientConfig.Service == nil {
+			continue
+		}
+		path := ""
+		if crd.Spec.Conversion.WebhookClientConfig.Service.Path != nil {
+			path = *crd.Spec.Conversion.WebhookClientConfig.Service.Path
+		}
+		url := fmt.Sprintf("%s%s", url, path)
+		crd.Spec.Conversion.WebhookClientConfig.URL = &url
+		crd.Spec.Conversion.WebhookClientConfig.CABundle = caPEM
+		crd.Spec.Conversion.WebhookClientConfig.Service = nil
+	}
+}
+
+func readCustomResourcesAtPath(t *testing.T, path string) []*v1beta1.CustomResourceDefinition {
+	serializer := jsonserializer.NewSerializerWithOptions(jsonserializer.DefaultMetaFactory, internalScheme, internalScheme, jsonserializer.SerializerOptions{
+		Yaml: true,
+	})
+	converter := runtime.UnsafeObjectConvertor(internalScheme)
+	codec := versioning.NewCodec(serializer, serializer, converter, internalScheme, internalScheme, internalScheme, runtime.InternalGroupVersioner, runtime.InternalGroupVersioner, internalScheme.Name())
+
+	var crds []*v1beta1.CustomResourceDefinition
+	if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if filepath.Ext(path) != ".yaml" {
+			return nil
+		}
+		crd, err := readCRDAtPath(codec, converter, path)
+		if err != nil {
+			return err
+		}
+		crds = append(crds, crd)
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return crds
+}
+
+func readCRDAtPath(codec runtime.Codec, converter runtime.ObjectConvertor, path string) (*v1beta1.CustomResourceDefinition, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	internalCRD := &apiextensions.CustomResourceDefinition{}
+	if _, _, err := codec.Decode(data, nil, internalCRD); err != nil {
+		return nil, err
+	}
+
+	output := &v1beta1.CustomResourceDefinition{}
+	return output, converter.Convert(internalCRD, output, nil)
+}

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -60,7 +60,7 @@ func RunControlPlane(t *testing.T) (*rest.Config, StopFunc) {
 	// environment variables
 	env := &envtest.Environment{
 		AttachControlPlaneOutput: true,
-		CRDs:                     crds,
+		CRDs:                     crdsToRuntimeObjects(crds),
 	}
 	config, err := env.Start()
 	if err != nil {
@@ -146,4 +146,14 @@ func readCRDAtPath(codec runtime.Codec, converter runtime.ObjectConvertor, path 
 
 	output := &v1beta1.CustomResourceDefinition{}
 	return output, converter.Convert(internalCRD, output, nil)
+}
+
+func crdsToRuntimeObjects(in []*v1beta1.CustomResourceDefinition) []runtime.Object {
+	out := make([]runtime.Object, len(in))
+
+	for i, crd := range in {
+		out[i] = runtime.Object(crd)
+	}
+
+	return out
 }

--- a/test/integration/framework/paths.go
+++ b/test/integration/framework/paths.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package framework
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// setEnvTestEnv configures environment variables for controller-runtime's
+// 'envtest' package.
+func setUpEnvTestEnv() {
+	maybeSetEnv("TEST_ASSET_ETCD", "etcd", "hack", "bin", "etcd")
+	maybeSetEnv("TEST_ASSET_KUBE_APISERVER", "kube-apiserver", "hack", "bin", "kube-apiserver")
+	maybeSetEnv("TEST_ASSET_KUBECTL", "kubectl", "hack", "bin", "kubectl")
+}
+
+func maybeSetEnv(key, bin string, path ...string) {
+	if os.Getenv(key) != "" {
+		return
+	}
+	p, err := getPath(bin, path...)
+	if err != nil {
+		panic(fmt.Sprintf(`Failed to find integration test dependency %q.
+Either re-run this test using "bazel test //test/integration/{name}" or set the %s environment variable.`, bin, key))
+	}
+	os.Setenv(key, p)
+}
+
+// getCRDsPath returns a path to a directory containing cert-manager CRDs.
+func getCRDsPath() (string, error) {
+	bazelPath := filepath.Join(os.Getenv("RUNFILES_DIR"), "com_github_jetstack_cert_manager", "deploy", "charts", "cert-manager", "crds")
+	d, err := os.Stat(bazelPath)
+	if err == os.ErrNotExist {
+		return filepath.Join(filepath.Dir(os.Getenv("GOMOD")), "deploy", "charts", "cert-manager", "crds"), nil
+	}
+	if err != nil {
+		return "", err
+	}
+	if m := d.Mode(); !m.IsDir() {
+		return "", fmt.Errorf("directory containing CRDs is not a directory")
+	}
+	return bazelPath, nil
+}
+
+func getPath(name string, path ...string) (string, error) {
+	bazelPath := filepath.Join(append([]string{os.Getenv("RUNFILES_DIR"), "com_github_jetstack_cert_manager"}, path...)...)
+	p, err := exec.LookPath(bazelPath)
+	if err == nil {
+		return p, nil
+	}
+
+	return exec.LookPath(name)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds an integration testing framework to make it easier for us to test functionality implemented either via our CRD resource's OpenAPI schemas or implemented as part of the webhook component.

It brings up a Kubernetes API server and an instance of etcd using controller-runtime's `envtest` package, as well as running the webhook component in-memory and configuring the CRDs to use the webhook for conversion.

In a future PR, we should also configure a Validating & Mutating webhook here too, to allow us to test functionality implemented there.

Integration tests won't be a replacement for unit tests by any means, but they provide a valuables means to test isolated but composed together bits of the system (i.e. API related things, or even certain controller behaviour).

**Release note**:
```release-note
NONE
```
