### PR TITLE
Mark filter-crd target as a tool dependency instead of src

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -31,7 +31,6 @@ VARIANTS = {
     name = "%s.crds" % name,
     srcs = [
         "00-crds.yaml",
-        "//hack/filter-crd",
     ],
     outs = ["%s.crds.yaml" % name],
     cmd = " ".join([
@@ -40,6 +39,9 @@ VARIANTS = {
         "$(location 00-crds.yaml)",
         "> $@",
     ]),
+    tools = [
+        "//hack/filter-crd",
+    ],
 ) for (name, values) in VARIANTS.items()]
 
 [genrule(


### PR DESCRIPTION
**What this PR does / why we need it**:

When building with the `--platforms` flag, it's important we correctly categorise `src` vs `tool` dependencies as it indicates to Bazel where this will be run. *tool* dependencies will be built for the *host architecture*, whereas `src` dependencies will be built for the *target architecture*.

**Which issue this PR fixes**:

Without this change, building the release-tars target for a different arch to the host results in:

```/bin/bash: bazel-out/k8-fastbuild/bin/hack/filter-crd/linux_arm_pure_stripped/filter-crd: cannot execute binary file: Exec format error```

**Release note**:
```release-note
NONE
```

/assign @meyskens 
/milestone v0.14