### PR TITLE
Add --experimental-issue-pkcs12 flag to enable PKCS12 bundle generation

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -17898,3 +17898,39 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 = vendor/sigs.k8s.io/yaml/LICENSE 0ceb9ff3b27d3a8cf451ca3785d73c71
 ================================================================================
 
+
+================================================================================
+= vendor/software.sslmate.com/src/go-pkcs12 licensed under: =
+
+Copyright (c) 2015, 2018 Opsmate, Inc.
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+= vendor/software.sslmate.com/src/go-pkcs12/LICENSE 59ab963efbc183656060b23893ea5745
+================================================================================
+

--- a/go.mod
+++ b/go.mod
@@ -55,4 +55,5 @@ require (
 	sigs.k8s.io/controller-runtime v0.4.0
 	sigs.k8s.io/controller-tools v0.2.5
 	sigs.k8s.io/testing_frameworks v0.1.2
+	software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
 )

--- a/go.sum
+++ b/go.sum
@@ -744,4 +744,5 @@ sigs.k8s.io/testing_frameworks v0.1.2 h1:vK0+tvjF0BZ/RYFeZ1E6BYBwHJJXhjuZ3TdsEKH
 sigs.k8s.io/testing_frameworks v0.1.2/go.mod h1:ToQrwSC3s8Xf/lADdZp3Mktcql9CG0UAmdJG9th5i0w=
 sigs.k8s.io/yaml v1.1.0 h1:4A07+ZFc2wgJwo8YNlQpr1rVlgUDlxXHhPJciaPY5gs=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237 h1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
 software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=

--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "checks.go",
         "controller.go",
+        "keystore.go",
         "sync.go",
         "util.go",
     ],
@@ -26,6 +27,7 @@ go_library(
         "//pkg/util/pki:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_kr_pretty//:go_default_library",
+        "@com_sslmate_software_src_go_pkcs12//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/certificates/keystore.go
+++ b/pkg/controller/certificates/keystore.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This file defines methods used for PKCS#12 support.
+// This is an experimental feature and the contents of this file are intended
+// to be absorbed into a more fully fledged implementing ahead of the v0.15
+// release.
+// This should hopefully not exist by the next time you come to read this :)
+
+package certificates
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+
+	"software.sslmate.com/src/go-pkcs12"
+
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+const (
+	// pkcs12SecretKey is the name of the data entry in the Secret resource
+	// used to store the p12 file.
+	pkcs12SecretKey = "keystore.p12"
+)
+
+// encodePKCS12Keystore will encode a PKCS12 keystore using the password provided.
+// The key, certificate and CA data must be provided in PKCS1 or PKCS8 PEM format.
+// If the certificate data contains multiple certificates, the first will be used
+// as the keystores 'certificate' and the remaining certificates will be prepended
+// to the list of CAs in the resulting keystore.
+func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {
+	key, err := pki.DecodePrivateKeyBytes(rawKey)
+	if err != nil {
+		return nil, err
+	}
+	certs, err := pki.DecodeX509CertificateChainBytes(certPem)
+	if err != nil {
+		return nil, err
+	}
+	var cas []*x509.Certificate
+	if len(caPem) > 0 {
+		cas, err = pki.DecodeX509CertificateChainBytes(caPem)
+		if err != nil {
+			return nil, err
+		}
+		// prepend the certificate chain to the list of certificates as the PKCS12
+		// library only allows setting a single certificate.
+		if len(certs) > 1 {
+			cas = append(certs[1:], cas...)
+		}
+	}
+	keystoreData, err := pkcs12.Encode(rand.Reader, key, certs[0], cas, password)
+	if err != nil {
+		return nil, err
+	}
+	return keystoreData, nil
+}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -132,6 +132,18 @@ type CertificateOptions struct {
 	// EnableOwnerRef controls whether the certificate is configured as an owner of
 	// secret where the effective TLS certificate is stored.
 	EnableOwnerRef bool
+
+	// ExperimentalIssuePKCS12, if true, will make the certificates controller
+	// create a `keystore.p12` in the Secret resource for each Certificate.
+	// This can only be toggled globally, and the keystore will be encrypted
+	// with the supplied ExperimentalPKCS12KeystorePassword.
+	// This flag is likely to be removed in future in favour of native PKCS12
+	// keystore bundle support.
+	ExperimentalIssuePKCS12 bool
+	// ExperimentalPKCS12KeystorePassword is the password used to encrypt and
+	// decrypt PKCS#12 bundles stored in Secret resources.
+	// This option only has any affect is ExperimentalIssuePKCS12 is true.
+	ExperimentalPKCS12KeystorePassword string
 }
 
 type SchedulerOptions struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a new experimental flag to enable generating PKCS12 bundles in 'target secrets'.

This flag will be replaced with native support for PKCS12 bundles in future, once #2402 has been implemented.

**Which issue this PR fixes**: part of #586 

**Special notes for your reviewer**:

**Release note**:

```release-note
Add `--experimental-issue-pkcs12` flag to enable PKCS12 bundle generation in generated Secret resources. This flag will be replaced with native support for PKCS12 bundles in future and is currently an experimental feature. If enabled, the `--experimental-pkcs12-keystore-password` flag must also be set to the password used to encrypt PKCS12 bundles.
```

/assign @meyskens 
/cc @JoshVanL