### PR TITLE
Replace openshift/no-webhook manifests with legacy

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -12,7 +12,6 @@ RELEASE_NAMESPACE = "cert-manager"
 VARIANTS = {
     "cert-manager": {},
     "cert-manager-legacy": {},
-
 }
 
 [helm_tmpl(

--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -11,10 +11,8 @@ RELEASE_NAMESPACE = "cert-manager"
 
 VARIANTS = {
     "cert-manager": {},
-    "cert-manager-no-webhook": {
-        "webhook.enabled": "false",
-    },
-    "cert-manager-openshift": {},
+    "cert-manager-legacy": {},
+
 }
 
 [helm_tmpl(

--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -134,15 +134,7 @@ func checkSliceChain(s []interface{}, chain []string) []interface{} {
 					}
 
 					if value, ok := removeSliceElemForValue[strings.Join(chain, "/")]; ok && value == v.(string) {
-						newSlice := []interface{}{}
-
-						for _, sliceVal := range s {
-							if !reflect.DeepEqual(sliceVal, d) {
-								newSlice = append(newSlice, sliceVal)
-							}
-						}
-
-						s = newSlice
+						s = removeFromSlice(s, d)
 					}
 
 					if value, ok := v.(map[interface{}]interface{}); ok {
@@ -158,6 +150,19 @@ func checkSliceChain(s []interface{}, chain []string) []interface{} {
 		}
 	}
 
+	return s
+}
+
+func removeFromSlice(s []interface{}, d map[interface{}]interface{}) []interface{} {
+	newSlice := []interface{}{}
+
+	for _, sliceVal := range s {
+		if !reflect.DeepEqual(sliceVal, d) {
+			newSlice = append(newSlice, sliceVal)
+		}
+	}
+
+	s = newSlice
 	return s
 }
 

--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -29,7 +29,7 @@ import (
 
 var removeKeys = []string{}
 var removeElementForValue = map[string]string{}
-var checkValidationLocation = false
+var singleCRDVersion = false
 
 func main() {
 	loadVariant()
@@ -55,7 +55,7 @@ func main() {
 
 		checkChain(d, []string{})
 
-		if checkValidationLocation {
+		if singleCRDVersion {
 			spec, ok := d["spec"].(map[interface{}]interface{})
 			if !ok {
 				log.Fatal("Cannot read spec of CRD")
@@ -66,6 +66,9 @@ func main() {
 			}
 			if len(versions) == 0 {
 				log.Fatal("CRD versions length is 0")
+			}
+			if len(versions) > 1 {
+				log.Fatal("Multiple CRD versions found while 1 is expected")
 			}
 			versionInfo, ok := versions[0].(map[interface{}]interface{})
 			if !ok {
@@ -180,6 +183,6 @@ func loadVariant() {
 			"spec/versions/[]/name": "v1alpha3",
 		}
 
-		checkValidationLocation = true
+		singleCRDVersion = true
 	}
 }

--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -28,7 +28,7 @@ import (
 )
 
 var removeKeys = []string{}
-var removeSliceElemForValue = map[string]string{}
+var removeElementForValue = map[string]string{}
 var checkValidationLocation = false
 
 func main() {
@@ -103,11 +103,6 @@ func checkChain(d map[interface{}]interface{}, chain []string) {
 				}
 			}
 
-			// checks if keys need to be removed when a value is set
-			if value, ok := removeSliceElemForValue[strings.Join(chain, "/")]; ok && value == v.(string) {
-				// TODO
-			}
-
 			if value, ok := v.(map[interface{}]interface{}); ok {
 				checkChain(value, chain)
 			}
@@ -133,7 +128,7 @@ func checkSliceChain(s []interface{}, chain []string) []interface{} {
 						}
 					}
 
-					if value, ok := removeSliceElemForValue[strings.Join(chain, "/")]; ok && value == v.(string) {
+					if value, ok := removeElementForValue[strings.Join(chain, "/")]; ok && value == v.(string) {
 						s = removeFromSlice(s, d)
 					}
 
@@ -172,7 +167,7 @@ func loadVariant() {
 	flag.Parse()
 
 	if variant == "cert-manager-legacy" {
-		// These are the keys that the script will remove for OpenShift compatibility
+		// These are the keys that the script will remove for OpenShift 3 and older Kubernetes compatibility
 		removeKeys = []string{
 			"spec/preserveUnknownFields",
 			"spec/validation/openAPIV3Schema/type",
@@ -180,7 +175,8 @@ func loadVariant() {
 			"spec/conversion",
 		}
 
-		removeSliceElemForValue = map[string]string{
+		// this removed the whole version slice element if version name is `v1alpha3`
+		removeElementForValue = map[string]string{
 			"spec/versions/[]/name": "v1alpha3",
 		}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This releases a new manifest type "legacy" to support Kubernetes <1.15 and OpenShift 3.
This version uses the webhook but disables the conversions as they are not supported.
For this reason only the v1alpha2 API is added in these manifests.
All newer APIs are filtered by the filter-crd tool.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes #2639 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Replace openshift/no-webhook manifest variants with a "legacy" variant
```
