### PR TITLE
Remove webhook.enabled from Helm chart

### DIFF
--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -126,7 +126,6 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `http_proxy` | Value of the `HTTP_PROXY` environment variable in the cert-manager pod | |
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |
-| `webhook.enabled` | Toggles whether the validating webhook component should be installed | `true` |
 | `webhook.replicaCount` | Number of cert-manager webhook replicas | `1` |
 | `webhook.serviceName` | The name of the Service resource deployed for the webhook pod | `cert-manager-webhook` |
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -97,4 +96,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-{{- end -}}
+

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -31,4 +30,3 @@ webhooks:
         name: {{ .Values.webhook.serviceName }}
         namespace: {{ .Release.Namespace | quote }}
         path: /mutate
-{{- end -}}

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 {{- if .Values.global.rbac.create -}}
 ### Webhook ###
 ---
@@ -72,5 +71,4 @@ rules:
   - clusterissuers
   verbs:
   - create
-{{- end -}}
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -21,4 +20,3 @@ spec:
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/managed-by: {{ .Release.Service }}
-{{- end -}}

--- a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -13,4 +12,4 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end -}}
-{{- end -}}
+

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -1,4 +1,3 @@
-{{- if .Values.webhook.enabled -}}
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -41,4 +40,3 @@ webhooks:
         name: {{ .Values.webhook.serviceName }}
         namespace: {{ .Release.Namespace | quote }}
         path: /mutate
-{{- end -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -151,8 +151,6 @@ affinity: {}
 tolerations: []
 
 webhook:
-  enabled: true
-
   replicaCount: 1
 
   # The name of the webhook service is fixed in the values.yaml and not based


### PR DESCRIPTION
**What this PR does / why we need it**:
This removes the Webhook.enabled option from the Helm chart as we no longer ship a no-webhook version.
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
This is kind of up for debate if we want to keep it in the chart or not as we removed it from the manifest releases.
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove `webhook.enabled` variable in Helm chart as the webhook now is a required component
```
