### PR TITLE
Mark all build/ targets as manual

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -82,6 +82,7 @@ release_filegroup(
     name = "docker-artifacts",
     srcs = [":%s.tar" % binary for binary in DOCKERIZED_BINARIES.keys()] +
            [":%s.docker_tag" % binary for binary in DOCKERIZED_BINARIES.keys()],
+    tags = ["manual"],
 )
 
 filegroup(

--- a/build/container.bzl
+++ b/build/container.bzl
@@ -85,6 +85,7 @@ def multi_arch_container(
         )
     native.alias(
         name = name,
+        tags = tags,
         actual = select({
             go_platform_constraint(os = "linux", arch = arch): "%s-%s" % (name, arch)
             for arch in architectures
@@ -93,6 +94,7 @@ def multi_arch_container(
     native.genrule(
         name = "gen_%s.tar" % name,
         outs = ["%s.tar" % name],
+        tags = tags,
         srcs = select({
             go_platform_constraint(os = "linux", arch = arch): ["%s-%s.tar" % (name, arch)]
             for arch in architectures
@@ -138,6 +140,7 @@ def multi_arch_container_push(
 
     native.alias(
         name = name,
+        tags = tags,
         actual = select({
             go_platform_constraint(os = "linux", arch = arch): "push-%s-%s" % (name, arch)
             for arch in architectures
@@ -146,6 +149,7 @@ def multi_arch_container_push(
 
     docker_push(
         name = "push-%s" % name,
+        tags = tags,
         bundle = select({
             go_platform_constraint(os = "linux", arch = arch): "push-%s-%s" % (name, arch)
             for arch in architectures

--- a/build/release-tars/BUILD.bazel
+++ b/build/release-tars/BUILD.bazel
@@ -30,6 +30,10 @@ release_filegroup(
             ":cert-manager-test-{OS}-{ARCH}.tar.gz",
         ],
     ),
+    tags = [
+        "manual",
+        "no-cache",
+    ],
 )
 
 filegroup(
@@ -115,7 +119,10 @@ pkg_tar(
 pkg_tar(
     name = "cert-manager-manifests",
     extension = "tar.gz",
-    tags = ["no-cache"],
+    tags = [
+        "manual",
+        "no-cache",
+    ],
     deps = [
         "//deploy:manifests",
     ],


### PR DESCRIPTION
**What this PR does / why we need it**:

This fixes running `bazel build //...` on macOS.

**Release note**:
```release-note
NONE
```
