### PR TITLE
Fix end-to-end tests running against Kubernetes 1.14 and below

### DIFF
--- a/deploy/charts/cert-manager/BUILD.bazel
+++ b/deploy/charts/cert-manager/BUILD.bazel
@@ -28,7 +28,6 @@ filegroup(
             "Chart.yaml",
             "README.md",
             "values.yaml",
-            "crds/*.yaml",
             "templates/*.tpl",
             "templates/*.yaml",
             "templates/*.txt",

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -27,6 +27,11 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     clientConfig:
+{{- if (semverCompare "<=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
+      # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
+      # in Kubernetes 1.12 and below.
+      caBundle: ""
+{{- end }}
       service:
         name: {{ .Values.webhook.serviceName }}
         namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -37,6 +37,11 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     clientConfig:
+{{- if (semverCompare "<=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
+      # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
+      # in Kubernetes 1.12 and below.
+      caBundle: ""
+{{- end }}
       service:
         name: {{ .Values.webhook.serviceName }}
         namespace: {{ .Release.Namespace | quote }}

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -57,6 +57,9 @@ bazel build "//deploy/manifests:$crdsmanifest"
 # Install a copy of the CRDs
 kubectl apply -f "${REPO_ROOT}/bazel-bin/deploy/manifests/$crdsmanifest"
 
+# Build the Helm chart package .tgz
+bazel build //deploy/charts/cert-manager:package
+
 # Upgrade or install Pebble
 helm upgrade \
     --install \
@@ -66,4 +69,4 @@ helm upgrade \
     --set cainjector.image.tag="${APP_VERSION}" \
     --set webhook.image.tag="${APP_VERSION}" \
     "$RELEASE_NAME" \
-    "$REPO_ROOT/deploy/charts/cert-manager"
+    "$REPO_ROOT/bazel-bin/deploy/charts/cert-manager/cert-manager.tgz"

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -48,8 +48,14 @@ wait
 # Ensure the pebble namespace exists
 kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 
+crdsmanifest="cert-manager.crds.yaml"
+if [[ "$K8S_VERSION" =~ 1\.1[1-4] ]]; then
+  crdsmanifest="cert-manager-legacy.crds.yaml"
+fi
+bazel build "//deploy/manifests:$crdsmanifest"
+
 # Install a copy of the CRDs
-kubectl apply -f "${REPO_ROOT}/deploy/charts/cert-manager/crds/"
+kubectl apply -f "${REPO_ROOT}/bazel-bin/deploy/manifests/$crdsmanifest"
 
 # Upgrade or install Pebble
 helm upgrade \

--- a/devel/cluster/create.sh
+++ b/devel/cluster/create.sh
@@ -25,10 +25,6 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 # Require helm available on PATH
 check_tool kind
 
-export KIND_IMAGE_REPO="kindest/node"
-# Default Kubernetes version to use to 1.17
-export K8S_VERSION=${K8S_VERSION:-1.17}
-
 # Compute the details of the kind image to use
 export KIND_IMAGE_SHA=""
 export KIND_IMAGE_CONFIG=""

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -23,6 +23,9 @@ export REPO_ROOT="$LIB_ROOT/../.."
 
 export SKIP_BUILD_ADDON_IMAGES="${SKIP_BUILD_ADDON_IMAGES:-}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
+export KIND_IMAGE_REPO="kindest/node"
+# Default Kubernetes version to use to 1.17
+export K8S_VERSION=${K8S_VERSION:-1.17}
 
 # setup_tools will build and set up the environment to use bazel-provided
 # versions of the tools required for development

--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -176,6 +176,8 @@ func loadVariant() {
 			"spec/validation/openAPIV3Schema/type",
 			"spec/versions/[]/schema/openAPIV3Schema/type",
 			"spec/conversion",
+			// This field exists on the Issuer and ClusterIssuer CRD
+			"spec/validation/openAPIV3Schema/properties/spec/properties/solver/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
 		}
 
 		// this removed the whole version slice element if version name is `v1alpha3`


### PR DESCRIPTION
**What this PR does / why we need it**:

Our periodic end-to-end jobs have been failing against Kubernetes 1.14 and below for a little while now since we introduced the `preserveUnknownFields` flag.

This PR attempts to fix these test failures. It may need reworking to make use of the newly introduced "legacy" installation manifests, but seeing if this is sufficient for now.

**Release note**:
```release-note
NONE
```
