### PR TITLE
Include CRDs as part of release assets published to GitHub

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -58,7 +58,8 @@ VARIANTS = {
 
 pkg_tar(
     name = "manifests",
-    srcs = [":%s.yaml" % name for name in VARIANTS.keys()],
+    srcs = [":%s.yaml" % name for name in VARIANTS.keys()] +
+           [":%s.crds.yaml" % name for name in VARIANTS.keys()],
     extension = "tar.gz",
     mode = "0644",
     package_dir = "manifests",


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes the generated CRD manifest file as part of the artifacts published to GitHub in releases.
This can be used in favour of the `00-crds.yaml` file linked in the repository, and we should look at removing the `00-crds.yaml` file in future 😄

**Which issue this PR fixes**: fixes #2660 

**Release note**:
```release-note
Replace `00-crds.yaml` file with a manifest file published as part of the release
```
