### PR TITLE
Silence helm package output when building chart

### DIFF
--- a/build/helm.bzl
+++ b/build/helm.bzl
@@ -29,7 +29,7 @@ def helm_pkg(
         "$(location %s)" % helm_cmd,
         "package",
         "--app-version=$$version",
-        "--version=$$version",
+        "--version=$$version > /dev/null 2>&1",
         path,
     ])]
     cmds = cmds + ["mv \"%s-$$version.tgz\" $@" % chart_name]


### PR DESCRIPTION
**What this PR does / why we need it**:

Gets rid of all this unhelpful output when building the Helm package via Bazel:

```
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/.helmignore resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/.helmignore
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/Chart.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/Chart.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/README.md resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/README.md
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/NOTES.txt resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/NOTES.txt
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/_helpers.tpl resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/_helpers.tpl
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/cainjector-deployment.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/cainjector-psp.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/cainjector-psp.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/cainjector-rbac.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/deployment.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/deployment.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/psp-clusterrole.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/psp-clusterrole.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/psp-clusterrolebinding.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/psp-clusterrolebinding.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/psp.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/psp.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/rbac.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/rbac.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/service.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/service.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/serviceaccount.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/serviceaccount.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/servicemonitor.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/servicemonitor.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-deployment.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-deployment.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-psp-clusterrole.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-psp.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-psp.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-service.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-service.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
walk.go:74: found symbolic link in path: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/deploy/charts/cert-manager/values.yaml resolves to /Users/james/go/src/github.com/jetstack/cert-manager/deploy/charts/cert-manager/values.yaml
Successfully packaged chart and saved it to: /private/var/tmp/_bazel_james/7efc976e92b56f94fd5066e3c9f5d356/sandbox/darwin-sandbox/3642/execroot/com_github_jetstack_cert_manager/cert-manager-v0.14.0-alpha.1.12-7b495ae3e5f369-dirty.tgz
```


**Release note**:
```release-note
NONE
```

/kind cleanup