### PR TITLE
Adds a duration gap for the app role Vault e2e issuer test

### DIFF
--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -227,7 +227,7 @@ func (f *Framework) Helper() *helper.Helper {
 	return f.helper
 }
 
-func (f *Framework) CertificateDurationValid(c *v1alpha2.Certificate, duration time.Duration, fuzz time.Duration) {
+func (f *Framework) CertificateDurationValid(c *v1alpha2.Certificate, duration, fuzz time.Duration) {
 	By("Verifying TLS certificate exists")
 	secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(c.Spec.SecretName, metav1.GetOptions{})
 	Expect(err).NotTo(HaveOccurred())
@@ -245,7 +245,7 @@ func (f *Framework) CertificateDurationValid(c *v1alpha2.Certificate, duration t
 	}
 }
 
-func (f *Framework) CertificateRequestDurationValid(c *v1alpha2.CertificateRequest, duration time.Duration) {
+func (f *Framework) CertificateRequestDurationValid(c *v1alpha2.CertificateRequest, duration, fuzz time.Duration) {
 	By("Verifying TLS certificate exists")
 	if len(c.Status.Certificate) == 0 {
 		Failf("No certificate data found for CertificateRequest %s", c.Name)
@@ -253,8 +253,10 @@ func (f *Framework) CertificateRequestDurationValid(c *v1alpha2.CertificateReque
 	cert, err := pki.DecodeX509CertificateBytes(c.Status.Certificate)
 	Expect(err).NotTo(HaveOccurred())
 	By("Verifying that the duration is valid")
-	if cert.NotAfter.Sub(cert.NotBefore) != duration {
-		Failf("Expected duration of %s, got %s [NotBefore: %s, NotAfter: %s]", duration, cert.NotAfter.Sub(cert.NotBefore), cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+	certDuration := cert.NotAfter.Sub(cert.NotBefore)
+	if certDuration > (duration+fuzz) || certDuration < duration {
+		Failf("Expected duration of %s, got %s (fuzz: %s) [NotBefore: %s, NotAfter: %s]", duration, certDuration,
+			fuzz, cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
 	}
 }
 

--- a/test/e2e/suite/issuers/ca/certificaterequest.go
+++ b/test/e2e/suite/issuers/ca/certificaterequest.go
@@ -149,7 +149,7 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 				Expect(err).NotTo(HaveOccurred())
 				cr, err = crClient.Get(cr.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				f.CertificateRequestDurationValid(cr, v.expectedDuration)
+				f.CertificateRequestDurationValid(cr, v.expectedDuration, 0)
 			})
 		}
 	})

--- a/test/e2e/suite/issuers/selfsigned/certificaterequest.go
+++ b/test/e2e/suite/issuers/selfsigned/certificaterequest.go
@@ -155,7 +155,7 @@ var _ = framework.CertManagerDescribe("SelfSigned CertificateRequest", func() {
 				Expect(err).NotTo(HaveOccurred())
 				cr, err := crClient.Get(certificateRequestName, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				f.CertificateRequestDurationValid(cr, v.expectedDuration)
+				f.CertificateRequestDurationValid(cr, v.expectedDuration, 0)
 			})
 		}
 	})

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -248,7 +248,8 @@ func runVaultAppRoleTests(issuerKind string) {
 			By("Verifying the Certificate is valid")
 			cr, err = crClient.Get(cr.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			f.CertificateRequestDurationValid(cr, v.expectedDuration+(30*time.Second))
+			// Vault can issue certificates with slightly skewed duration.
+			f.CertificateRequestDurationValid(cr, v.expectedDuration, 30*time.Second)
 		})
 	}
 }


### PR DESCRIPTION
fixes #2672 

This PR adds a duration fuzz to the CertificateRequest Vault AppRole e2e test. This is because Vault can sometimes issue certificates that are off by a second or so for the duration. This PR should reduce the flakes we are seeing :crossed_fingers: 

/assign @munnerz 

```release-note
NONE
```
