### PR TITLE
Automatically prepend license boilerplate header to release manifests

### DIFF
--- a/build/licensing.bzl
+++ b/build/licensing.bzl
@@ -1,0 +1,36 @@
+# Copyright 2020 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def licensed_file(
+    name,
+    src,
+    # Default to use the 'bazel' boilerplate file.
+    # This uses '#' as a way to denote a comment.
+    # This will likely need changing depending on the type of the file being
+    # generated.
+    license_boilerplate = "//hack/boilerplate:boilerplate.bzl.txt",
+    **kwargs,
+):
+    native.genrule(
+        name = "%s.genrule" % name,
+        srcs = [src, license_boilerplate],
+        outs = [name],
+        cmd = " ".join([
+            "cat",
+            "$(location %s)" % license_boilerplate,
+            "$(location %s)" % src,
+            "> $@",
+        ]),
+        **kwargs,
+    )

--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -4,6 +4,7 @@ exports_files(["00-crds.yaml"])
 
 load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 load("//build:helm.bzl", "helm_tmpl")
+load("//build:licensing.bzl", "licensed_file")
 
 RELEASE_NAME = "cert-manager"
 
@@ -23,11 +24,11 @@ VARIANTS = {
 ) for (name, values) in VARIANTS.items()]
 
 [genrule(
-    name = "%s.crds" % name,
+    name = "%s.crds.unlicensed" % name,
     srcs = [
         "00-crds.yaml",
     ],
-    outs = ["%s.crds.yaml" % name],
+    outs = ["%s.crds.unlicensed.yaml" % name],
     cmd = " ".join([
         "$(location //hack/filter-crd)",
         "-variant=%s" % name,
@@ -39,21 +40,31 @@ VARIANTS = {
     ],
 ) for (name, values) in VARIANTS.items()]
 
+[licensed_file(
+    name = "%s.crds.yaml" % name,
+    src = "%s.crds.unlicensed" % name,
+) for (name, values) in VARIANTS.items()]
+
 [genrule(
-    name = name,
+    name = "%s.unlicensed" % name,
     srcs = [
-        "%s.crds" % name,
+        "%s.crds.unlicensed" % name,
         "01-namespace.yaml",
         "%s.manifests" % name,
     ],
-    outs = ["%s.yaml" % name],
+    outs = ["%s.unlicensed.yaml" % name],
     cmd = " ".join([
         "cat",
-        "$(location %s.crds)" % name,
+        "$(location %s.crds.unlicensed)" % name,
         "$(location 01-namespace.yaml)",
         "$(location %s.manifests)" % name,
         "> $@",
     ]),
+) for (name, values) in VARIANTS.items()]
+
+[licensed_file(
+    name = "%s.yaml" % name,
+    src = "%s.unlicensed" % name,
 ) for (name, values) in VARIANTS.items()]
 
 pkg_tar(

--- a/hack/boilerplate/BUILD.bazel
+++ b/hack/boilerplate/BUILD.bazel
@@ -1,4 +1,4 @@
-exports_files(["boilerplate.go.txt"])
+package(default_visibility = ["//visibility:public"])
 
 filegroup(
     name = "package-srcs",


### PR DESCRIPTION
**What this PR does / why we need it**:

Includes the license boilerplate header inside the release manifests we publish alongside a GitHub release.

**Which issue this PR fixes**: fixes #2645, fixes #2677

**Special notes for your reviewer**:

**Release note**:
```release-note
Include license header in manifests attached to GitHub releases
```

/area deploy
/kind cleanup
/milestone v0.14
/priority important-soon
/assign @meyskens 