### PR TITLE
Sets ACME client context to 10s and wraps controller ctx

### DIFF
--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	timeout = time.Second * 30
+	timeout = time.Second * 10
 )
 
 func NewLogger(baseCl client.Interface) client.Interface {
@@ -44,100 +44,100 @@ var _ client.Interface = &Logger{}
 func (l *Logger) AuthorizeOrder(ctx context.Context, id []acme.AuthzID, opt ...acme.OrderOption) (*acme.Order, error) {
 	klog.Infof("Calling CreateOrder")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.AuthorizeOrder(acmectx, id, opt...)
+	return l.baseCl.AuthorizeOrder(ctx, id, opt...)
 }
 
 func (l *Logger) GetOrder(ctx context.Context, url string) (*acme.Order, error) {
 	klog.Infof("Calling GetOrder")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.GetOrder(acmectx, url)
+	return l.baseCl.GetOrder(ctx, url)
 }
 
 func (l *Logger) FetchCert(ctx context.Context, url string, bundle bool) ([][]byte, error) {
 	klog.Infof("Calling GetCertificate")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.FetchCert(acmectx, url, bundle)
+	return l.baseCl.FetchCert(ctx, url, bundle)
 }
 
 func (l *Logger) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {
 	klog.Infof("Calling WaitOrder")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.WaitOrder(acmectx, url)
+	return l.baseCl.WaitOrder(ctx, url)
 }
 
 func (l *Logger) CreateOrderCert(ctx context.Context, finalizeURL string, csr []byte, bundle bool) (der [][]byte, certURL string, err error) {
 	klog.Infof("Calling FinalizeOrder")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.CreateOrderCert(acmectx, finalizeURL, csr, bundle)
+	return l.baseCl.CreateOrderCert(ctx, finalizeURL, csr, bundle)
 }
 
 func (l *Logger) Accept(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error) {
 	klog.Infof("Calling AcceptChallenge")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.Accept(acmectx, chal)
+	return l.baseCl.Accept(ctx, chal)
 }
 
 func (l *Logger) GetChallenge(ctx context.Context, url string) (*acme.Challenge, error) {
 	klog.Infof("Calling GetChallenge")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.GetChallenge(acmectx, url)
+	return l.baseCl.GetChallenge(ctx, url)
 }
 
 func (l *Logger) GetAuthorization(ctx context.Context, url string) (*acme.Authorization, error) {
 	klog.Infof("Calling GetAuthorization")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.GetAuthorization(acmectx, url)
+	return l.baseCl.GetAuthorization(ctx, url)
 }
 
 func (l *Logger) WaitAuthorization(ctx context.Context, url string) (*acme.Authorization, error) {
 	klog.Infof("Calling WaitAuthorization")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.WaitAuthorization(acmectx, url)
+	return l.baseCl.WaitAuthorization(ctx, url)
 }
 
 func (l *Logger) Register(ctx context.Context, a *acme.Account, prompt func(tosURL string) bool) (*acme.Account, error) {
 	klog.Infof("Calling CreateAccount")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.Register(acmectx, a, prompt)
+	return l.baseCl.Register(ctx, a, prompt)
 }
 
 func (l *Logger) GetReg(ctx context.Context, url string) (*acme.Account, error) {
 	klog.Infof("Calling GetAccount")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.GetReg(acmectx, url)
+	return l.baseCl.GetReg(ctx, url)
 }
 
 func (l *Logger) HTTP01ChallengeResponse(token string) (string, error) {
@@ -152,29 +152,18 @@ func (l *Logger) DNS01ChallengeRecord(token string) (string, error) {
 
 func (l *Logger) Discover(ctx context.Context) (acme.Directory, error) {
 	klog.Infof("Calling Discover")
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
 	return l.baseCl.Discover(ctx)
 }
 
 func (l *Logger) UpdateReg(ctx context.Context, a *acme.Account) (*acme.Account, error) {
 	klog.Infof("Calling UpdateAccount")
 
-	acmectx, cancel := l.acmeContext(ctx)
+	ctx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	return l.baseCl.UpdateReg(acmectx, a)
-}
-
-func (l *Logger) acmeContext(ctx context.Context) (context.Context, context.CancelFunc) {
-	acmectx, cancel := context.WithTimeout(context.Background(), timeout)
-
-	go func() {
-		select {
-		case <-ctx.Done():
-			cancel()
-		case <-acmectx.Done():
-			return
-		}
-	}()
-
-	return acmectx, cancel
+	return l.baseCl.UpdateReg(ctx, a)
 }


### PR DESCRIPTION
/assign @munnerz 
/milestone v0.14
/area acme

Set acme client context deadline to 10 seconds as well as wraps the controller context to be more cleaner.

```release-note
NONE
```
