### PR TITLE
Update Helm chart & other docs with new URLs and info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ API stability.
 Notably, we may choose to make breaking changes to our API specification (i.e. the
 Issuer, ClusterIssuer and Certificate resources) in new minor releases.
 
-These will always be clearly documented in the [upgrade section of the documentation](https://docs.cert-manager.io/en/latest/admin/upgrading/index.html).
+These will always be clearly documented in the [upgrade section of the documentation](https://cert-manager.io/docs/installation/upgrading/).
 
 ## Documentation
 

--- a/deploy/charts/cert-manager/README.md
+++ b/deploy/charts/cert-manager/README.md
@@ -8,36 +8,30 @@ to renew certificates at an appropriate time before expiry.
 
 ## Prerequisites
 
-- Kubernetes 1.12+
+- Kubernetes 1.11+
 
 ## Installing the Chart
 
 Full installation instructions, including details on how to configure extra
-functionality in cert-manager can be found in the [getting started docs](https://docs.cert-manager.io/en/latest/getting-started/).
+functionality in cert-manager can be found in the [installation docs](https://cert-manager.io/docs/installation/kubernetes/).
+
+Before installing the chart, you must first install the cert-manager CustomResourceDefinition resources.
+This is performed in a separate step to allow you to easily uninstall and reinstall cert-manager without deleting your installed custom resources.
+
+```bash
+# Kubernetes 1.15+
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager.crds.yaml
+
+# Kubernetes <1.15
+$ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager-legacy.crds.yaml
+```
+
+> **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the custom resource definitions.
+> This version does not have API version conversion enabled and only supports `cert-manager.io/v1alpha2` API resources.
 
 To install the chart with the release name `my-release`:
 
 ```console
-## IMPORTANT: you MUST install the cert-manager CRDs **before** installing the
-## cert-manager Helm chart.
-$ kubectl apply --validate=false \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.14/deploy/manifests/00-crds.yaml
-
-## If you are installing on openshift :
-$ oc create \
-    -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.14/deploy/manifests/00-crds.yaml
-
-## NOTE: if you are installing the Helm chart into a namespace other than
-## 'cert-manager', you **must** replace all occurrences of 'namespace: cert-manager'
-## with 'namespace: custom-namespace-name' in the CRDs manifest.
-## The below snippet can be used to automate this, replacing
-## CUSTOM-NAMESPACE-NAME with the deployment namespace's name:
-##
-##   kubectl apply --dry-run -o yaml --validate=false \
-##      -f https://raw.githubusercontent.com/jetstack/cert-manager/release-0.14/deploy/manifests/00-crds.yaml \
-##      | sed 's/namespace\: cert-manager/namespace\: CUSTOM-NAMESPACE-NAME/g' \
-##      | kubectl apply -f -
-
 ## Add the Jetstack Helm repository
 $ helm repo add jetstack https://charts.jetstack.io
 
@@ -49,23 +43,20 @@ In order to begin issuing certificates, you will need to set up a ClusterIssuer
 or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 
 More information on the different types of issuers and how to configure them
-can be found in our documentation:
-
-https://docs.cert-manager.io/en/latest/tasks/issuers/index.html
+can be found in [our documentation](https://cert-manager.io/docs/configuration/).
 
 For information on how to configure cert-manager to automatically provision
-Certificates for Ingress resources, take a look at the `ingress-shim`
-documentation:
-
-https://docs.cert-manager.io/en/latest/tasks/issuing-certificates/ingress-shim.html
+Certificates for Ingress resources, take a look at the
+[Securing Ingresses documentation](https://cert-manager.io/docs/usage/ingress/).
 
 > **Tip**: List all releases using `helm list`
 
 ## Upgrading the Chart
 
 Special considerations may be required when upgrading the Helm chart, and these
-are documented in our full [upgrading guide](https://docs.cert-manager.io/en/latest/tasks/upgrading/index.html).
-Please check here before perform upgrades!
+are documented in our full [upgrading guide](https://cert-manager.io/docs/installation/upgrading/).
+
+**Please check here before performing upgrades!**
 
 ## Uninstalling the Chart
 
@@ -76,6 +67,17 @@ $ helm delete my-release
 ```
 
 The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+If you want to completely uninstall cert-manager from your cluster, you will also need to
+delete the previously installed CustomResourceDefinition resources:
+
+```console
+# Kubernetes 1.15+
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager.crds.yaml
+
+# Kubernetes <1.15
+$ kubectl delete -f https://github.com/jetstack/cert-manager/releases/download/v0.14.0/cert-manager-legacy.crds.yaml
+```
 
 ## Configuration
 

--- a/deploy/charts/cert-manager/templates/NOTES.txt
+++ b/deploy/charts/cert-manager/templates/NOTES.txt
@@ -6,10 +6,10 @@ or Issuer resource (for example, by creating a 'letsencrypt-staging' issuer).
 More information on the different types of issuers and how to configure them
 can be found in our documentation:
 
-https://docs.cert-manager.io/en/latest/reference/issuers.html
+https://cert-manager.io/docs/configuration/
 
 For information on how to configure cert-manager to automatically provision
 Certificates for Ingress resources, take a look at the `ingress-shim`
 documentation:
 
-https://docs.cert-manager.io/en/latest/reference/ingress-shim.html
+https://cert-manager.io/docs/usage/ingress/

--- a/deploy/manifests/README.md
+++ b/deploy/manifests/README.md
@@ -2,7 +2,7 @@
 
 This directory previously contained the Kubernetes manifests needed to deploy cert-manager.
 
-For full information on deploying cert-manager, see the [getting started guide](https://docs.cert-manager.io/en/latest/getting-started/index.html).
+For full information on deploying cert-manager, see the [getting started guide](https://cert-manager.io/docs/installation/kubernetes/).
 
 ## Where are the manifests now?
 
@@ -20,11 +20,9 @@ can do so using Bazel.
 To build the manifests, run:
 
 ```bash
-$ bazel build //deploy/manifests:cert-manager
-# Alternatively, build the openshift variant with:
-$ bazel build //deploy/manifests:cert-manager-openshift
-# Or the no-webhook variant with:
-$ bazel build //deploy/manifests:cert-manager-no-webhook
+$ bazel build //deploy/manifests:cert-manager.yaml
+# Alternatively, build the legacy variant with:
+$ bazel build //deploy/manifests:cert-manager-legacy.yaml
 ```
 
 This will generate the static deployment manifests at


### PR DESCRIPTION
**What this PR does / why we need it**:

This tidies up the Helm chart's README (which is displayed on the Helm Hub) to include proper information on the legacy manifests (in-line with the installation guide).

At the same time, I updated the URLs to point to the correct ones on the new website (there are redirects in place for these URLs anyway, but this is good to do 😄).

**Release note**:
```release-note
Update Helm chart README to properly explain legacy manifests
```

/area deploy
/milestone v0.14
/cherrypick release-0.14
/kind documentation
