### PR TITLE
Add clientAuth extended key usage to Certificates by default

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -219,8 +219,8 @@ spec:
                   type: string
               usages:
                 description: Usages is the set of x509 actions that are enabled for
-                  a given key. Defaults are ('digital signature', 'key encipherment')
-                  if empty
+                  a given key. Defaults are ('digital signature', 'key encipherment',
+                  'server auth', 'client auth') if empty
                 type: array
                 items:
                   description: 'KeyUsage specifies valid usage contexts for keys.

--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -167,5 +167,7 @@ const (
 func DefaultKeyUsages() []KeyUsage {
 	// The serverAuth EKU is required as of Mac OS Catalina: https://support.apple.com/en-us/HT210176
 	// Without this usage, certificates will _always_ flag a warning in newer Mac OS browsers.
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth}
+	// The clientAuth usage is required for certificates to be used by gRPC and is more consistent
+	// with how ACME certificates are issued
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth, UsageClientAuth}
 }

--- a/pkg/apis/certmanager/v1alpha3/types.go
+++ b/pkg/apis/certmanager/v1alpha3/types.go
@@ -167,5 +167,7 @@ const (
 func DefaultKeyUsages() []KeyUsage {
 	// The serverAuth EKU is required as of Mac OS Catalina: https://support.apple.com/en-us/HT210176
 	// Without this usage, certificates will _always_ flag a warning in newer Mac OS browsers.
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth}
+	// The clientAuth usage is required for certificates to be used by gRPC and is more consistent
+	// with how ACME certificates are issued
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth, UsageClientAuth}
 }

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -48,7 +48,7 @@ func TestBuildUsages(t *testing.T) {
 			name:                "default",
 			usages:              []v1alpha2.KeyUsage{},
 			expectedKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 			expectedError:       false,
 		},
 		{
@@ -56,7 +56,7 @@ func TestBuildUsages(t *testing.T) {
 			usages:              []v1alpha2.KeyUsage{},
 			isCa:                true,
 			expectedKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
-			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
 			expectedError:       false,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This adds the client auth usage as a default. Since #2351 was merged, gRPC certificates do not work by default. Previously when there were no extended usages specified, the certificate could be used for server and client auth (requirement for gRPC). Now with the addition of "server auth" but no "client auth" it doesn't work for gRPC. A workaround for this is to specify usages specifically in the Certificate.

I'm proposing to add "client auth" as a default for certificates with this PR. Adding "client auth" will not only fix the gRPC issues but makes cert-manager certificates more consistent with external certificates since certificates issued by Let's Encrypt and Amazon ACM have the "client auth" extended usage specified with the "server auth" usage anyway.

**Which issue this PR fixes**: #2407

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add clientAuth extended key usage to Certificates by default
```
