### PR TITLE
webhookbootstrap: fix updating Secret resources

### DIFF
--- a/pkg/controller/webhookbootstrap/controller.go
+++ b/pkg/controller/webhookbootstrap/controller.go
@@ -408,13 +408,12 @@ func (c *controller) updateSecret(secret *corev1.Secret, pk, ca, crt []byte) err
 	secret.Data[cmmeta.TLSCAKey] = ca
 	secret.Type = corev1.SecretTypeTLS
 
-	_, err := c.kubeClient.CoreV1().Secrets(secret.Namespace).Create(secret)
-	if apierrors.IsAlreadyExists(err) {
-		// If the secret already exists then we should update it
+	var err error
+	if secret.ResourceVersion == "" {
+		_, err = c.kubeClient.CoreV1().Secrets(secret.Namespace).Create(secret)
+	} else {
 		_, err = c.kubeClient.CoreV1().Secrets(secret.Namespace).Update(secret)
-		return err
 	}
-
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/webhookbootstrap/controller_test.go
+++ b/pkg/controller/webhookbootstrap/controller_test.go
@@ -110,8 +110,9 @@ func TestProcessItem(t *testing.T) {
 
 	caSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultWebhookCAName,
-			Namespace: defaultWebhookNamespace,
+			Name:            defaultWebhookCAName,
+			Namespace:       defaultWebhookNamespace,
+			ResourceVersion: "something",
 		},
 		Type: corev1.SecretTypeTLS,
 	}
@@ -119,8 +120,9 @@ func TestProcessItem(t *testing.T) {
 
 	servingSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      defaultWebhookServingName,
-			Namespace: defaultWebhookNamespace,
+			Name:            defaultWebhookServingName,
+			Namespace:       defaultWebhookNamespace,
+			ResourceVersion: "something",
 		},
 		Type: corev1.SecretTypeTLS,
 	}
@@ -151,32 +153,14 @@ func TestProcessItem(t *testing.T) {
 					caSecret,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						caSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundleCA.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
+								Namespace:       caSecret.Namespace,
+								Name:            caSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -201,8 +185,9 @@ func TestProcessItem(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookCAName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookCAName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: []byte("garbage"),
@@ -211,32 +196,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						caSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundleCA.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
+								Namespace:       caSecret.Namespace,
+								Name:            caSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -308,32 +275,14 @@ func TestProcessItem(t *testing.T) {
 					servingSecret,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						servingSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundle.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
+								Namespace:       servingSecret.Namespace,
+								Name:            servingSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -369,8 +318,9 @@ func TestProcessItem(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookServingName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookServingName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: []byte("garbage"),
@@ -379,32 +329,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						servingSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundle.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
+								Namespace:       servingSecret.Namespace,
+								Name:            servingSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -428,8 +360,9 @@ func TestProcessItem(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookCAName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookCAName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
@@ -438,32 +371,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						caSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundleCA.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
+								Namespace:       caSecret.Namespace,
+								Name:            caSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -487,8 +402,9 @@ func TestProcessItem(t *testing.T) {
 				KubeObjects: []runtime.Object{
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookCAName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookCAName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
@@ -498,32 +414,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						caSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundleCA.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundleCA.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						caSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: caSecret.Namespace,
-								Name:      caSecret.Name,
+								Namespace:       caSecret.Namespace,
+								Name:            caSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -562,8 +460,9 @@ func TestProcessItem(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookServingName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookServingName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
@@ -572,32 +471,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						servingSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundle.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
+								Namespace:       servingSecret.Namespace,
+								Name:            servingSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -636,8 +517,9 @@ func TestProcessItem(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookServingName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookServingName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
@@ -646,32 +528,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						servingSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundle.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
+								Namespace:       servingSecret.Namespace,
+								Name:            servingSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -710,8 +574,9 @@ func TestProcessItem(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookServingName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookServingName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundleCA.certBytes,
@@ -722,32 +587,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						servingSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundle.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
+								Namespace:       servingSecret.Namespace,
+								Name:            servingSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},
@@ -783,8 +630,9 @@ func TestProcessItem(t *testing.T) {
 					},
 					&corev1.Secret{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      defaultWebhookServingName,
-							Namespace: defaultWebhookNamespace,
+							Name:            defaultWebhookServingName,
+							Namespace:       defaultWebhookNamespace,
+							ResourceVersion: "something",
 						},
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBadDNSNameBundle.certBytes,
@@ -795,32 +643,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
-						corev1.SchemeGroupVersion.WithResource("secrets"),
-						servingSecret.Namespace,
-						&corev1.Secret{
-							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
-								Annotations: map[string]string{
-									cmapi.AllowsInjectionFromSecretAnnotation: "true",
-								},
-							},
-							Data: map[string][]byte{
-								corev1.TLSCertKey:       exampleBundle.certBytes,
-								corev1.TLSPrivateKeyKey: exampleBadDNSNameBundle.privateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundleCA.certBytes,
-							},
-							Type: corev1.SecretTypeTLS,
-						},
-					)),
 					testpkg.NewAction(coretesting.NewUpdateAction(
 						corev1.SchemeGroupVersion.WithResource("secrets"),
 						servingSecret.Namespace,
 						&corev1.Secret{
 							ObjectMeta: metav1.ObjectMeta{
-								Namespace: servingSecret.Namespace,
-								Name:      servingSecret.Name,
+								Namespace:       servingSecret.Namespace,
+								Name:            servingSecret.Name,
+								ResourceVersion: "something",
 								Annotations: map[string]string{
 									cmapi.AllowsInjectionFromSecretAnnotation: "true",
 								},


### PR DESCRIPTION
**What this PR does / why we need it**:

Previously we'd always run a Create, and if this responds with `IsAlreadyExists`, we'd attempt an Update instead. This does not work in some cases, as an error "resourceVersion must not be set on Create calls" can be returned.

This changes the way we detect if something should be created to instead inspect the `resourceVersion` field, which will *always* be non-empty if an Update is to be performed.

**Release note**:
```release-note
Fix bug that could cause the `webhookbootstrap` controller to fail to Update webhook TLS resources in certain cases
```

/kind bug