### PR TITLE
Add tests for webhook certificate source and refactor packages

### DIFF
--- a/cmd/webhook/app/BUILD.bazel
+++ b/cmd/webhook/app/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/webhook:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
         "//pkg/webhook/server:go_default_library",
+        "//pkg/webhook/server/tls:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
     ],
 )

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -24,8 +24,11 @@ type WebhookOptions struct {
 	ListenPort  int
 	HealthzPort int
 
-	TLSCertFile     string
-	TLSKeyFile      string
+	// Path to TLS certificate and private key on disk.
+	// Both must be specified if either is.
+	TLSCertFile string
+	TLSKeyFile  string
+
 	TLSCipherSuites []string
 }
 

--- a/pkg/logs/BUILD.bazel
+++ b/pkg/logs/BUILD.bazel
@@ -26,7 +26,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/logs/testing:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/logs/testing/BUILD.bazel
+++ b/pkg/logs/testing/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["log_testing.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/logs/testing",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_go_logr_logr//:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/logs/testing/log_testing.go
+++ b/pkg/logs/testing/log_testing.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+// TestLogger is a logr.Logger that prints through a testing.T object.
+type TestLogger struct {
+	T *testing.T
+}
+
+var _ logr.Logger = TestLogger{}
+
+func (_ TestLogger) Enabled() bool {
+	return true
+}
+
+func (log TestLogger) Info(msg string, args ...interface{}) {
+	log.T.Logf("%s: %v", msg, args)
+}
+
+func (log TestLogger) Error(err error, msg string, args ...interface{}) {
+	log.T.Logf("%s: %v -- %v", msg, err, args)
+}
+
+func (log TestLogger) V(v int) logr.InfoLogger {
+	return log
+}
+
+func (log TestLogger) WithName(_ string) logr.Logger {
+	return log
+}
+
+func (log TestLogger) WithValues(_ ...interface{}) logr.Logger {
+	return log
+}

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -2,17 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = [
-        "server.go",
-        "source.go",
-        "tls_file_source.go",
-    ],
+    srcs = ["server.go"],
     importpath = "github.com/jetstack/cert-manager/pkg/webhook/server",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/logs:go_default_library",
         "//pkg/util/profiling:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
+        "//pkg/webhook/server/tls:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//admission/v1beta1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
@@ -34,7 +30,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//pkg/webhook/server/tls:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -25,8 +25,6 @@ import (
 	"net/http"
 	"time"
 
-	ciphers "k8s.io/component-base/cli/flag"
-
 	"github.com/go-logr/logr"
 	admissionv1beta1 "k8s.io/api/admission/v1beta1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -34,10 +32,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/runtime/serializer/json"
+	ciphers "k8s.io/component-base/cli/flag"
 	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/jetstack/cert-manager/pkg/util/profiling"
 	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
+	servertls "github.com/jetstack/cert-manager/pkg/webhook/server/tls"
 )
 
 var (
@@ -87,7 +87,7 @@ type Server struct {
 
 	// If specified, the server will listen with TLS using certificates
 	// provided by this CertificateSource.
-	CertificateSource CertificateSource
+	CertificateSource servertls.CertificateSource
 
 	ValidationWebhook handlers.ValidatingAdmissionHook
 	MutationWebhook   handlers.MutatingAdmissionHook

--- a/pkg/webhook/server/tls/BUILD.bazel
+++ b/pkg/webhook/server/tls/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "file_source.go",
+        "source.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/pkg/webhook/server/tls",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/logs:go_default_library",
+        "@com_github_go_logr_logr//:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["file_source_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/logs/testing:go_default_library",
+        "//pkg/util/pki:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/webhook/server/tls/file_source.go
+++ b/pkg/webhook/server/tls/file_source.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package tls
 
 import (
 	"bytes"

--- a/pkg/webhook/server/tls/file_source_test.go
+++ b/pkg/webhook/server/tls/file_source_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"io/ioutil"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	logtesting "github.com/jetstack/cert-manager/pkg/logs/testing"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+func TestFileSource_ReadsFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-temp-dir-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	serial := "serial1"
+	pkBytes, certBytes := generatePrivateKeyAndCertificate(t, serial)
+	pkFile := writeTempFile(t, dir, "pk", pkBytes)
+	certFile := writeTempFile(t, dir, "cert", certBytes)
+
+	interval := time.Millisecond * 500
+	source := FileCertificateSource{
+		CertPath:       certFile,
+		KeyPath:        pkFile,
+		UpdateInterval: interval,
+		Log:            logtesting.TestLogger{T: t},
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go source.Run(stopCh)
+
+	time.Sleep(interval * 2)
+	cert, err := source.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+	x509Crt, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("failed to decode x509 certificate: %v", err)
+	}
+	if x509Crt.Subject.SerialNumber != serial {
+		t.Errorf("certificate had unexpected serial number. exp=%s, got=%s", serial, x509Crt.Subject.SerialNumber)
+	}
+}
+
+func TestFileSource_UpdatesFile(t *testing.T) {
+	dir, err := ioutil.TempDir("", "test-temp-dir-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.RemoveAll(dir); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	serial := "serial1"
+	pkBytes, certBytes := generatePrivateKeyAndCertificate(t, serial)
+	pkFile := writeTempFile(t, dir, "pk", pkBytes)
+	certFile := writeTempFile(t, dir, "cert", certBytes)
+
+	interval := time.Millisecond * 500
+	source := FileCertificateSource{
+		CertPath:       certFile,
+		KeyPath:        pkFile,
+		UpdateInterval: interval,
+		Log:            logtesting.TestLogger{T: t},
+	}
+	stopCh := make(chan struct{})
+	defer close(stopCh)
+	go source.Run(stopCh)
+
+	time.Sleep(interval * 2)
+	cert, err := source.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+	x509Crt, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("failed to decode x509 certificate: %v", err)
+	}
+	if x509Crt.Subject.SerialNumber != serial {
+		t.Errorf("certificate had unexpected serial number. exp=%s, got=%s", serial, x509Crt.Subject.SerialNumber)
+	}
+
+	// Update the certificate data in-place
+	serial = "serial2"
+	pkBytes, certBytes = generatePrivateKeyAndCertificate(t, serial)
+	pkFile = writeTempFile(t, dir, "pk", pkBytes)
+	certFile = writeTempFile(t, dir, "cert", certBytes)
+
+	time.Sleep(interval * 2)
+	cert, err = source.GetCertificate(nil)
+	if err != nil {
+		t.Fatalf("got an unexpected error: %v", err)
+	}
+	x509Crt, err = x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		t.Fatalf("failed to decode x509 certificate: %v", err)
+	}
+	if x509Crt.Subject.SerialNumber != serial {
+		t.Errorf("certificate had unexpected serial number. exp=%s, got=%s", serial, x509Crt.Subject.SerialNumber)
+	}
+}
+
+var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []byte) {
+	pk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkBytes, err := pki.EncodePrivateKey(pk, cmapi.PKCS8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	serialNumber, err := rand.Int(rand.Reader, serialNumberLimit)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          serialNumber,
+		PublicKeyAlgorithm:    x509.RSA,
+		Subject: pkix.Name{
+			SerialNumber: serial,
+			CommonName:   "example.com",
+		},
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute * 10),
+		// see http://golang.org/pkg/crypto/x509/#KeyUsage
+		KeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	_, cert, err = pki.SignCertificate(cert, cert, pk.Public(), pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	certBytes, err := pki.EncodeX509(cert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pkBytes, certBytes
+}
+
+func writeTempFile(t *testing.T, dir, name string, data []byte) string {
+	path := filepath.Join(dir, name)
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	if _, err := f.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	return f.Name()
+}

--- a/pkg/webhook/server/tls/source.go
+++ b/pkg/webhook/server/tls/source.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package server
+package tls
 
 import "crypto/tls"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds unit tests for the file base TLS certificate source in the webhook and moves source into their own subpackage.

**Special notes for your reviewer**:

This will support the next PR which adds a 'secret based' source to improve webhook start up time.

**Release note**:
```release-note
NONE
```

/area webhook
/area testing
/kind cleanup