### PR TITLE
Add build targets for UBI based docker images

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -63,47 +63,28 @@ git_repository(
     shallow_since = "1561646721 -0700",
 )
 
-load(
-    "@io_bazel_rules_docker//repositories:repositories.bzl",
-    container_repositories = "repositories",
-)
+load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
 
 container_repositories()
 
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
-)
-load(
-    "@io_bazel_rules_docker//go:image.bzl",
-    _go_image_repos = "repositories",
-)
+load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()
 
-## Use 'static' distroless image for all builds
-container_pull(
-    name = "static_base",
-    registry = "gcr.io",
-    repository = "distroless/static",
-    digest = "sha256:cd0679a54d2abaf3644829f5e290ad8a10688847475f570fddb9963318cf9390",
-)
-
 # Load and define targets defined in //hack/bin
-load(
-    "//hack/bin:deps.bzl",
-    install_hack_bin = "install",
-)
+load("//hack/bin:deps.bzl", install_hack_bin = "install")
 
 install_hack_bin()
 
-# Load and define targets defined in //hack/bin
-load(
-    "//test/e2e:images.bzl",
-    install_e2e_images = "install",
-)
+# Load and define targets defined in //test/e2e
+load("//test/e2e:images.bzl", install_e2e_images = "install")
 
 install_e2e_images()
+
+# Install build image targets
+load("//build:images.bzl", "define_base_images")
+
+define_base_images()
 
 load("//hack/build:repos.bzl", "go_repositories")
 

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -2,34 +2,30 @@ package(default_visibility = ["//visibility:public"])
 
 load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
 load(":container.bzl", "multi_arch_container", "multi_arch_container_push")
-load(":platforms.bzl", "SERVER_PLATFORMS", "for_platforms")
+load(":platforms.bzl", "SERVER_PLATFORMS", "UBI_PLATFORMS", "for_platforms")
 
 # This list defines the docker images that consist a release
 DOCKERIZED_BINARIES = {
     "acmesolver": {
-        "base": "@static_base//image",
         "target": "//cmd/acmesolver:acmesolver",
     },
     "cainjector": {
-        "base": "@static_base//image",
         "target": "//cmd/cainjector:cainjector",
     },
     "controller": {
-        "base": "@static_base//image",
         "target": "//cmd/controller:controller",
     },
     "webhook": {
-        "base": "@static_base//image",
         "target": "//cmd/webhook:webhook",
     },
 }
 
-# When pushing to gcr.io, we want to use an arch, since the archless name is now used for a
+# When pushing to quay.io, we want to use an arch, since the archless name is now used for a
 # manifest list. Bazel doesn't support manifest lists (yet), so we can't do that either.
 [multi_arch_container(
     name = binary,
     architectures = SERVER_PLATFORMS["linux"],
-    base = meta["base"],
+    base = "@static_base//image",
     binary = select(for_platforms(
         for_server = meta["target"],
         only_os = "linux",
@@ -59,11 +55,52 @@ multi_arch_container_push(
     tags = ["manual"],
 )
 
+[multi_arch_container(
+    name = "%s-ubi" % binary,
+    architectures = UBI_PLATFORMS["linux"],
+    base = "@com_redhat_access_registry_ubi8_ubi_minimal-{ARCH}//image",
+    binary = select(for_platforms(
+        for_ubi = meta["target"],
+        only_os = "linux",
+    )),
+    # Since the multi_arch_container macro replaces the {ARCH} format string,
+    # we need to escape the stamping vars.
+    docker_tags = ["{{STABLE_DOCKER_REGISTRY}}/cert-manager-%s-{ARCH}:{{STABLE_DOCKER_TAG}}-ubi" % binary],
+    stamp = True,
+    symlinks = {
+        # Some cluster startup scripts expect to find the binaries in /usr/local/bin,
+        # but the debs install the binaries into /usr/bin.
+        "/usr/local/bin/" + binary: "/usr/bin/" + binary,
+    },
+    tags = ["manual"],
+    user = "1000",
+    visibility = ["//visibility:private"],
+) for binary, meta in DOCKERIZED_BINARIES.items()]
+
+# Also roll up all images into a single bundle to push with one target.
+multi_arch_container_push(
+    name = "ubi-images",
+    architectures = UBI_PLATFORMS["linux"],
+    docker_tags_images = {
+        "{{STABLE_DOCKER_REGISTRY}}/cert-manager-%s-{ARCH}:{{STABLE_DOCKER_TAG}}-ubi" % binary: "%s-internal" % binary
+        for binary in DOCKERIZED_BINARIES.keys()
+    },
+    tags = ["manual"],
+)
+
 [genrule(
     name = binary + "_docker_tag",
     srcs = [meta["target"]],
     outs = [binary + ".docker_tag"],
     cmd = "grep ^STABLE_DOCKER_TAG bazel-out/stable-status.txt | awk '{print $$2}' >$@",
+    stamp = 1,
+) for binary, meta in DOCKERIZED_BINARIES.items()]
+
+[genrule(
+    name = "%s-ubi_docker_tag" % binary,
+    srcs = [meta["target"]],
+    outs = ["%s-ubi.docker_tag" % binary],
+    cmd = "grep ^STABLE_DOCKER_TAG bazel-out/stable-status.txt | awk '{print $$2\"-ubi\"}' >$@",
     stamp = 1,
 ) for binary, meta in DOCKERIZED_BINARIES.items()]
 
@@ -80,9 +117,16 @@ grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt \
 )
 
 release_filegroup(
-    name = "docker-artifacts",
+    name = "server-artifacts",
     srcs = [":%s.tar" % binary for binary in DOCKERIZED_BINARIES.keys()] +
            [":%s.docker_tag" % binary for binary in DOCKERIZED_BINARIES.keys()],
+    tags = ["manual"],
+)
+
+release_filegroup(
+    name = "ubi-artifacts",
+    srcs = [":%s-ubi.tar" % binary for binary in DOCKERIZED_BINARIES.keys()] +
+           [":%s-ubi.docker_tag" % binary for binary in DOCKERIZED_BINARIES.keys()],
     tags = ["manual"],
 )
 

--- a/build/images.bzl
+++ b/build/images.bzl
@@ -1,0 +1,51 @@
+# Copyright 2020 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+UBI_BASE_IMAGES = {
+    # Pinned to release https://access.redhat.com/containers/#/registry.access.redhat.com/ubi8-minimal/images/8.1-407
+    # Ensure you update _all_ image digests when upgrading the UBI base image.
+    "amd64": {
+        "digest": "sha256:39df7365f1343e9a49132f96edd852ddb80e4dcdec03ef8fe1779acb5418d37e",
+    },
+    "arm64": {
+        "digest": "sha256:2166f0122117868485b429170d0848b2da566c20a61e517d44d059c360e2ed2b",
+        "variant": "v8",
+    },
+    "ppc64le": {
+        "digest": "sha256:e55721eb97b2517542b695c3ad36e9534fb8f7a8641d06b2ad87e802e36dd8d2",
+    },
+    "s390x": {
+        "digest": "sha256:d41676554f34c417c82a016c94790179fb4116063547b757ec7a65a52235c9c8",
+    },
+}
+
+def define_base_images():
+    ## Use 'static' distroless image for all builds
+    container_pull(
+        name = "static_base",
+        registry = "gcr.io",
+        repository = "distroless/static",
+        digest = "sha256:cd0679a54d2abaf3644829f5e290ad8a10688847475f570fddb9963318cf9390",
+    )
+
+    [container_pull(
+        name = "com_redhat_access_registry_ubi8_ubi_minimal-%s" % arch,
+        registry = "registry.access.redhat.com",
+        repository = "ubi8/ubi-minimal",
+        architecture = arch,
+        digest = meta["digest"],
+        cpu_variant = meta.get("variant", None),
+    ) for arch, meta in UBI_BASE_IMAGES.items()]

--- a/build/platforms.bzl
+++ b/build/platforms.bzl
@@ -22,6 +22,17 @@ SERVER_PLATFORMS = {
         "amd64",
         "arm64",
         "arm",
+        "ppc64le",
+        "s390x",
+    ],
+}
+
+UBI_PLATFORMS = {
+    "linux": [
+        "amd64",
+        "arm64",
+        "ppc64le",
+        "s390x",
     ],
 }
 
@@ -34,7 +45,7 @@ TEST_PLATFORMS = {
 # just the SERVER and TEST platforms
 def _all_platforms():
     all_platforms = {}
-    for platforms in [SERVER_PLATFORMS, TEST_PLATFORMS]:
+    for platforms in [SERVER_PLATFORMS, UBI_PLATFORMS, TEST_PLATFORMS]:
         for os, archs in platforms.items():
             all_platforms[os] = sets.union(
                 all_platforms.setdefault(os, sets.make()),
@@ -130,6 +141,7 @@ def _update_dict_for_platform_category(d, value, platforms, only_os = None):
 def for_platforms(
         for_server = None,
         for_test = None,
+        for_ubi = None,
         for_all = None,
         default = None,
         only_os = None):
@@ -138,5 +150,6 @@ def for_platforms(
         d["//conditions:default"] = default
     _update_dict_for_platform_category(d, for_server, SERVER_PLATFORMS, only_os)
     _update_dict_for_platform_category(d, for_test, TEST_PLATFORMS, only_os)
+    _update_dict_for_platform_category(d, for_ubi, UBI_PLATFORMS, only_os)
     _update_dict_for_platform_category(d, for_all, ALL_PLATFORMS, only_os)
     return d

--- a/build/release-tars/BUILD.bazel
+++ b/build/release-tars/BUILD.bazel
@@ -4,6 +4,7 @@ load(
     "//build:platforms.bzl",
     "SERVER_PLATFORMS",
     "TEST_PLATFORMS",
+    "UBI_PLATFORMS",
     "for_platforms",
     "go_platform_constraint",
 )
@@ -28,6 +29,9 @@ release_filegroup(
         ],
         for_test = [
             ":cert-manager-test-{OS}-{ARCH}.tar.gz",
+        ],
+        for_ubi = [
+            ":cert-manager-ubi-{OS}-{ARCH}.tar.gz",
         ],
     ),
     tags = [
@@ -59,9 +63,23 @@ filegroup(
 )
 
 pkg_tar(
+    name = "_ubi-images",
+    srcs = [
+        "//build:ubi-artifacts",
+    ],
+    mode = "0755",
+    package_dir = "ubi/images",
+    tags = [
+        "manual",
+        "no-cache",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+pkg_tar(
     name = "_server-images",
     srcs = [
-        "//build:docker-artifacts",
+        "//build:server-artifacts",
     ],
     mode = "0755",
     package_dir = "server/images",
@@ -91,6 +109,26 @@ pkg_tar(
         ],
     }),
 ) for arch in archs] for os, archs in SERVER_PLATFORMS.items()]
+
+[[pkg_tar(
+    name = "cert-manager-ubi-%s-%s" % (os, arch),
+    srcs = [
+        ":license-targets",
+        "//:version",
+    ],
+    extension = "tar.gz",
+    mode = "0644",
+    package_dir = "cert-manager-ubi-%s-%s" % (os, arch),
+    tags = [
+        "manual",
+        "no-cache",
+    ],
+    deps = select({
+        go_platform_constraint(os, arch): [
+            ":_ubi-images",
+        ],
+    }),
+) for arch in archs] for os, archs in UBI_PLATFORMS.items()]
 
 pkg_tar(
     name = "_test-bin",


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds UBI base image targets to the build/release targets. This will require an additional change to the github.com/cert-manager/release `cmrel` tool in order to:

1) understand the new 'ubi' variant images
2) understand the new `s390x` and `ppc64le` architectures

I've opted to keep these variants of these images within the same image repository but under a suffixed tag, e.g. `v0.14.1-ubi` or `v0.14.1-alpha.0-ubi` etc.

This PR does *not* setup end-to-end test jobs that actually use these new base images - we might want to consider creating a periodic job for this, in case anything weird with permissions etc. comes up when running in the UBI environment.

**Release note**:
```release-note
Add Red Hat Universal Base Image based image release targets
```

/kind feature
/area deploy
/priority important-soon
/milestone v0.15
