### PR TITLE
Remove AdditionalRunFuncs from base controller

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -78,7 +78,7 @@ type controller struct {
 	dns01Nameservers []string
 }
 
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -130,13 +130,13 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	var err error
 	c.dnsSolver, err = dns.NewSolver(ctx)
 	if err != nil {
-		return nil, nil, nil, err
+		return nil, nil, err
 	}
 
 	// read options from context
 	c.dns01Nameservers = ctx.ACMEOptions.DNS01Nameservers
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 // MaxChallengesPerSchedule is the maximum number of challenges that can be

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -68,7 +68,7 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -120,7 +120,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	// clock is used when setting the failureTime on an Order's status
 	c.clock = ctx.Clock
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 func (c *controller) orderGetter(namespace, name string) (interface{}, error) {

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -88,16 +88,10 @@ func (b *Builder) Complete() (Interface, error) {
 	if b.impl == nil {
 		return nil, fmt.Errorf("controller implementation must be non-nil")
 	}
-	queue, mustSync, additionalInformers, err := b.impl.Register(b.context)
+	queue, mustSync, err := b.impl.Register(b.context)
 	if err != nil {
 		return nil, fmt.Errorf("error registering controller: %v", err)
 	}
-	return &controller{
-		ctx:                 b.ctx,
-		syncHandler:         b.impl.ProcessItem,
-		mustSync:            mustSync,
-		additionalInformers: additionalInformers,
-		runDurationFuncs:    b.runDurationFuncs,
-		queue:               queue,
-	}, nil
+
+	return NewController(b.ctx, b.impl.ProcessItem, mustSync, b.runDurationFuncs, queue), nil
 }

--- a/pkg/controller/certificaterequests/controller.go
+++ b/pkg/controller/certificaterequests/controller.go
@@ -104,7 +104,7 @@ func New(issuerType string, issuer Issuer, extraInformers ...cache.SharedIndexIn
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -172,7 +172,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.log.Info("new certificate request controller registered",
 		"type", c.issuerType)
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 func (c *Controller) ProcessItem(ctx context.Context, key string) error {

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -113,7 +113,7 @@ type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, err
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *certificateRequestManager) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *certificateRequestManager) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	log := logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -167,19 +167,19 @@ func (c *certificateRequestManager) Register(ctx *controllerpkg.Context) (workqu
 	c.experimentalIssuePKCS12 = ctx.CertificateOptions.ExperimentalIssuePKCS12
 	c.experimentalPKCS12KeystorePassword = ctx.CertificateOptions.ExperimentalPKCS12KeystorePassword
 	if c.experimentalIssuePKCS12 && len(c.experimentalPKCS12KeystorePassword) == 0 {
-		return nil, nil, nil, fmt.Errorf("if experimental pkcs12 issuance is enabled, a keystore password must be provided")
+		return nil, nil, fmt.Errorf("if experimental pkcs12 issuance is enabled, a keystore password must be provided")
 	}
 	// Experimental JKS handling options
 	c.experimentalIssueJKS = ctx.CertificateOptions.ExperimentalIssueJKS
 	c.experimentalJKSPassword = ctx.CertificateOptions.ExperimentalJKSPassword
 	if c.experimentalIssueJKS && len(c.experimentalJKSPassword) == 0 {
-		return nil, nil, nil, fmt.Errorf("if experimental jks issuance is enabled, a keystore password must be provided")
+		return nil, nil, fmt.Errorf("if experimental jks issuance is enabled, a keystore password must be provided")
 	}
 
 	c.cmClient = ctx.CMClient
 	c.kubeClient = ctx.Client
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 const (

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -63,7 +63,7 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -94,7 +94,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.recorder = ctx.Recorder
 	c.clusterResourceNamespace = ctx.IssuerOptions.ClusterResourceNamespace
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 // TODO: replace with generic handleObjet function (like Navigator)

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -70,7 +70,7 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -118,7 +118,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 		ctx.DefaultIssuerGroup,
 	}
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 func (c *controller) certificateDeleted(obj interface{}) {

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -59,7 +59,7 @@ type controller struct {
 // Register registers and constructs the controller using the provided context.
 // It returns the workqueue to be used to enqueue items, a list of
 // InformerSynced functions that must be synced, or an error.
-func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, []controllerpkg.RunFunc, error) {
+func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
 	// construct a new named logger to be reused throughout the controller
 	c.log = logf.FromContext(ctx.RootContext, ControllerName)
 
@@ -89,7 +89,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.cmClient = ctx.CMClient
 	c.recorder = ctx.Recorder
 
-	return c.queue, mustSync, nil, nil
+	return c.queue, mustSync, nil
 }
 
 // TODO: replace with generic handleObjet function (like Navigator)

--- a/pkg/controller/register.go
+++ b/pkg/controller/register.go
@@ -27,11 +27,6 @@ type Interface interface {
 	// This method should block until all workers have exited cleanly, thus
 	// allowing for graceful shutdown of control loops.
 	Run(workers int, stopCh <-chan struct{}) error
-
-	// AdditionalInformers is a list of additional informer 'Run' functions
-	// that will be started when the shared informer factories 'Start' function
-	// is called.
-	AdditionalInformers() []RunFunc
 }
 
 // Constructor is a function that creates a new control loop given a

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -270,12 +270,9 @@ func (b *Builder) Stop() {
 	apiutil.Clock = clock.RealClock{}
 }
 
-func (b *Builder) Start(additional ...controller.RunFunc) {
+func (b *Builder) Start() {
 	b.KubeSharedInformerFactory.Start(b.stopCh)
 	b.SharedInformerFactory.Start(b.stopCh)
-	for _, fn := range additional {
-		go fn(b.stopCh)
-	}
 	// wait for caches to sync
 	b.Sync()
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This is no longer required as there is a `With` function on the `pkg/controller.Builder` structure that can be used to trigger additional things that should be run alongside a controller (which is used in the `acmechallenges` controller to run the challenge scheduler, and the `webhookbootstrap` controller to continuously ensure the webhook TLS assets are up to date).

Removing this option to a) simplify things a bit and b) make it easier/cleaner to start controllers during integration tests.

**Release note**:
```release-note
NONE
```

/kind cleanup