### PR TITLE
helm.bzl: correctly set 'user' attribute on all image targets

### DIFF
--- a/build/container.bzl
+++ b/build/container.bzl
@@ -51,6 +51,7 @@ def multi_arch_container(
         docker_push_tags = None,
         tags = None,
         visibility = None,
+        user = "0",
         **kwargs):
 
     go_image(
@@ -61,6 +62,7 @@ def multi_arch_container(
         }),
         stamp = stamp,
         tags = tags,
+        user = user,
         visibility = ["//visibility:private"],
         **kwargs
     )
@@ -70,6 +72,7 @@ def multi_arch_container(
         base = ":%s-internal-notimestamp" % name,
         stamp = stamp,
         tags = tags,
+        user = user,
         visibility = ["//visibility:public"],
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

As per @r0bj's comment here: https://github.com/jetstack/cert-manager/pull/2708#issuecomment-605393658 it seems like the recent changes in https://github.com/jetstack/cert-manager/pull/2708 did not correctly fix the user ID used for our release docker images.

The 'stamped' version of these images (which contains the build timestamp in it) did *not* set the `user` attribute. Because of this, it get reset back to zero in this target, meaning that in *releases* specifically, the UID is still zero.

**Which issue this PR fixes**: fixes https://github.com/jetstack/cert-manager/pull/2708#issuecomment-605393658

**Special notes for your reviewer**:

This needs cherrypicking back into v0.14 and will mean we need to release v0.14.2.

**Release note**:
```release-note
Properly fix user ID used for Docker images in release targets
```

/priority critical-urgent
/kind bug
/area deploy
