### PR TITLE
Design document for ACME self check failure policy

### DIFF
--- a/design/20200331.acme-self-check-failure-policy.md
+++ b/design/20200331.acme-self-check-failure-policy.md
@@ -1,0 +1,89 @@
+---
+title: Failure policy for ACME self checks
+authors:
+  - "@anton-johansson"
+reviewers:
+  - "@munnerz"
+  - "@JoshVanL"
+approvers:
+  - "@munnerz"
+  - "@JoshVanL"
+creation-date: 2020-03-31
+last-updated: 2020-03-31
+status: implementable
+---
+
+# Failure policy for ACME self checks
+
+<!-- toc -->
+- [Summary](#summary)
+- [Motivation](#motivation)
+  - [Goals](#goals)
+- [Proposal](#proposal)
+  - [API Changes](#api-changes)
+  - [Controller Behaviour](#controller-behaviour)
+<!-- /toc -->
+
+## Summary
+
+When requesting certificates from Let's Encrypt, cert-manager performs a self check to make sure that we have properly configured the ACME challenge response for the domain. This is to avoid redundant calls to Let's Encrypt and avoid getting rate limited. This is very good safety net. However, it would be a great addition to cert-manager if this check could be disabled or at least configured to allow failure.
+
+## Motivation
+
+In certain cluster setups, the ACME challenge self check performed by cert-manager isn't always possible. For example, when using MetalLB and you have local DNS records that points towards the IP address assigned by MetalLB you might run into some hairpin issues, causing the traffic to fail.
+
+There is an issue describing some of the problems: [#1292](https://github.com/jetstack/cert-manager/issues/1292)
+
+### Goals
+
+* Add support for allowing the self check to fail
+
+## Proposal
+
+We need a new policy enum to control the failure policy. It should be specified on the ACME solver level, so it works for both DNS01 and HTTP01. The two values in the initial version would be:
+* `RetryForever` - the self check must pass before the request is sent and the request is retried continuously and the `Certificate` will remain `Pending` indefinetly. This will be the default policy, to keep the existing functionality intact.
+* `Ignore` - the request will be sent even if the self check fails.
+
+### API changes
+
+To specify how ACME challenge self checks are allowed to fail, we need to slightly modify the API.
+
+```go
+package v1
+
+// Describes how the ACME challenge self check behaves when it fails.
+// +kubebuilder:validation:Enum=RetryForever;Ignore
+type ACMESelfCheckFailurePolicy string
+
+const (
+	// The default failure policy. This policy will cause the request to be
+	// sent to the certificate provider ONLY if the ACME challenge self check
+	// succeeds. The request is retried continuously and the `Certificate` will
+	// remain `Pending` indefinitely.
+	ACMESelfCheckFailurePolicyRetryForever ACMESelfCheckFailurePolicy = "RetryForever"
+
+	// This policy will cause the ACME challenge self check response to be
+	// ignored and the request will always be sent to the certificate provider.
+	ACMESelfCheckFailurePolicyIgnore ACMESelfCheckFailurePolicy = "Ignore"
+)
+```
+
+```go
+package v1alpha2
+
+type ACMEChallengeSolver struct {
+	// EXISTING FIELDS HERE
+
+	// ADDITIONAL FIELDS
+
+	// Controls how the self check behaves upon failure.
+	// +optional
+	FailurePolicy cmmeta.ACMESelfCheckFailurePolicy `json:"failurePolicy,omitempty"`
+}
+```
+
+## Controller behaviour
+
+If the self check has failed the maximum number of attempts and this policy is set to `Ignore`, perform the request the certificate provider anyway. The `acmechallenge` controller needs to be changed in order for this to happen, `sync.go` more specifically.
+
+This also needs to be covered in unit tests. A test case can easily be added to `sync_test.go`. If possible, we should also add an end-to-end test case that verifies that an ACME challenge whose self check is failing is still attempted to be accepted if the failure policy is set to `Ignore`.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds a design document for controlling failure policies for the ACME self-check.

**Which issue this PR fixes**:

The design documentation does not solve anything per se, but the functionality that the design documentation suggests is related to #1292.

**Special notes for your reviewer**:

~~This is a work in progress. The namings aren't optimal and should be improved before merge.~~

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
