### PR TITLE
Clusterissuer in values.yaml

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -156,6 +156,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.image.tag` | cainjector image tag | `{{RELEASE_VERSION}}` |
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | `{}` |
+| `clusterIssuer` | Cluster issuer configuration | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/charts/cert-manager/templates/clusterissuer.yaml
+++ b/deploy/charts/cert-manager/templates/clusterissuer.yaml
@@ -1,0 +1,2 @@
+{{- if .Values.clusterIssuer }}
+{{ toYaml .Values.clusterIssuer }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -246,3 +246,25 @@ cainjector:
     # If no value is set, the chart's appVersion will be used.
     # tag: canary
     pullPolicy: IfNotPresent
+
+
+clusterIssuer: {}
+  # apiVersion: cert-manager.io/v1alpha2
+  # kind: ClusterIssuer
+  # metadata:
+  #   name: letsencrypt-staging
+  # spec:
+  #   acme:
+  #     # You must replace this email address with your own.
+  #     # Let's Encrypt will use this to contact you about expiring
+  #     # certificates, and issues related to your account.
+  #     email: user@example.com
+  #     server: https://acme-staging-v02.api.letsencrypt.org/directory
+  #     privateKeySecretRef:
+  #       # Secret resource that will be used to store the account's private key.
+  #       name: example-issuer-account-key
+  #     # Add a single challenge solver, HTTP01 using nginx
+  #     solvers:
+  #     - http01:
+  #         ingress:
+  #           class: nginx


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
It adds the possibility to add your clusterissuer to your values.yaml. This makes it easier to automate your cert-manager, as the configuration to start is in one configuration file

**Which issue this PR fixes**: 
fixes #2716

**Special notes for your reviewer**:
I initially limited it to 1 clusterissuer and no templating around it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add configurable ClusterIssuer to values.yaml
```

/kind feature