### PR TITLE
WIP: Allow ignoring ACME challenge self check failures

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -434,6 +434,12 @@ spec:
                             the webhook provider implementation. This will typically
                             be the name of the provider, e.g. 'cloudflare'.
                           type: string
+                failurePolicy:
+                  description: Controls how the self check behaves upon failure.
+                  type: string
+                  enum:
+                  - RetryForever
+                  - Ignore
                 http01:
                   description: ACMEChallengeSolverHTTP01 contains configuration detailing
                     how to solve HTTP01 challenges within a Kubernetes cluster. Typically

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -496,6 +496,12 @@ spec:
                                   in the webhook provider implementation. This will
                                   typically be the name of the provider, e.g. 'cloudflare'.
                                 type: string
+                      failurePolicy:
+                        description: Controls how the self check behaves upon failure.
+                        type: string
+                        enum:
+                        - RetryForever
+                        - Ignore
                       http01:
                         description: ACMEChallengeSolverHTTP01 contains configuration
                           detailing how to solve HTTP01 challenges within a Kubernetes

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -496,6 +496,12 @@ spec:
                                   in the webhook provider implementation. This will
                                   typically be the name of the provider, e.g. 'cloudflare'.
                                 type: string
+                      failurePolicy:
+                        description: Controls how the self check behaves upon failure.
+                        type: string
+                        enum:
+                        - RetryForever
+                        - Ignore
                       http01:
                         description: ACMEChallengeSolverHTTP01 contains configuration
                           detailing how to solve HTTP01 challenges within a Kubernetes

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -91,6 +91,10 @@ type ACMEChallengeSolver struct {
 
 	// +optional
 	DNS01 *ACMEChallengeSolverDNS01 `json:"dns01,omitempty"`
+
+	// Controls how the self check behaves upon failure.
+	// +optional
+	FailurePolicy cmmeta.ACMESelfCheckFailurePolicy `json:"failurePolicy,omitempty"`
 }
 
 // CertificateDomainSelector selects certificates using a label selector, and

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -91,6 +91,10 @@ type ACMEChallengeSolver struct {
 
 	// +optional
 	DNS01 *ACMEChallengeSolverDNS01 `json:"dns01,omitempty"`
+
+	// Controls how the self check behaves upon failure.
+	// +optional
+	FailurePolicy cmmeta.ACMESelfCheckFailurePolicy `json:"failurePolicy,omitempty"`
 }
 
 // CertificateDomainSelector selects certificates using a label selector, and

--- a/pkg/apis/meta/v1/types.go
+++ b/pkg/apis/meta/v1/types.go
@@ -63,3 +63,19 @@ type SecretKeySelector struct {
 const (
 	TLSCAKey = "ca.crt"
 )
+
+// Describes how the ACME challenge self check behaves when it fails. The default value is RetryForever.
+// +kubebuilder:validation:Enum=RetryForever;Ignore
+type ACMESelfCheckFailurePolicy string
+
+const (
+	// The default failure policy. This policy will cause the request to be
+	// sent to the certificate provider ONLY if the ACME challenge self check
+	// succeeds. The request is retried continuously and the `Certificate` will
+	// remain `Pending` indefinitely.
+	ACMESelfCheckFailurePolicyRetryForever ACMESelfCheckFailurePolicy = "RetryForever"
+
+	// This policy will cause the ACME challenge self check response to be
+	// ignored and the request will always be sent to the certificate provider.
+	ACMESelfCheckFailurePolicyIgnore ACMESelfCheckFailurePolicy = "Ignore"
+)

--- a/pkg/controller/acmechallenges/BUILD.bazel
+++ b/pkg/controller/acmechallenges/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/acme/client:go_default_library",
         "//pkg/apis/acme/v1alpha2:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/listers/acme/v1alpha2:go_default_library",
         "//pkg/client/listers/certmanager/v1alpha2:go_default_library",

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -82,6 +82,9 @@ type ACMEChallengeSolver struct {
 	HTTP01 *ACMEChallengeSolverHTTP01
 
 	DNS01 *ACMEChallengeSolverDNS01
+
+	// Controls the self check failure policy.
+	FailurePolicy cmmeta.ACMESelfCheckFailurePolicy
 }
 
 // CertificateDomainSelector selects certificates using a label selector, and

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -24,12 +24,12 @@ import (
 	unsafe "unsafe"
 
 	v1alpha2 "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
-	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	acme "github.com/jetstack/cert-manager/pkg/internal/apis/acme"
 	meta "github.com/jetstack/cert-manager/pkg/internal/apis/meta"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -418,6 +418,7 @@ func autoConvert_v1alpha2_ACMEChallengeSolver_To_acme_ACMEChallengeSolver(in *v1
 	out.Selector = (*acme.CertificateDNSNameSelector)(unsafe.Pointer(in.Selector))
 	out.HTTP01 = (*acme.ACMEChallengeSolverHTTP01)(unsafe.Pointer(in.HTTP01))
 	out.DNS01 = (*acme.ACMEChallengeSolverDNS01)(unsafe.Pointer(in.DNS01))
+	out.FailurePolicy = meta.ACMESelfCheckFailurePolicy(in.FailurePolicy)
 	return nil
 }
 
@@ -430,6 +431,7 @@ func autoConvert_acme_ACMEChallengeSolver_To_v1alpha2_ACMEChallengeSolver(in *ac
 	out.Selector = (*v1alpha2.CertificateDNSNameSelector)(unsafe.Pointer(in.Selector))
 	out.HTTP01 = (*v1alpha2.ACMEChallengeSolverHTTP01)(unsafe.Pointer(in.HTTP01))
 	out.DNS01 = (*v1alpha2.ACMEChallengeSolverDNS01)(unsafe.Pointer(in.DNS01))
+	out.FailurePolicy = v1.ACMESelfCheckFailurePolicy(in.FailurePolicy)
 	return nil
 }
 
@@ -497,7 +499,7 @@ func Convert_acme_ACMEChallengeSolverHTTP01_To_v1alpha2_ACMEChallengeSolverHTTP0
 }
 
 func autoConvert_v1alpha2_ACMEChallengeSolverHTTP01Ingress_To_acme_ACMEChallengeSolverHTTP01Ingress(in *v1alpha2.ACMEChallengeSolverHTTP01Ingress, out *acme.ACMEChallengeSolverHTTP01Ingress, s conversion.Scope) error {
-	out.ServiceType = v1.ServiceType(in.ServiceType)
+	out.ServiceType = corev1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
 	out.PodTemplate = (*acme.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
@@ -511,7 +513,7 @@ func Convert_v1alpha2_ACMEChallengeSolverHTTP01Ingress_To_acme_ACMEChallengeSolv
 }
 
 func autoConvert_acme_ACMEChallengeSolverHTTP01Ingress_To_v1alpha2_ACMEChallengeSolverHTTP01Ingress(in *acme.ACMEChallengeSolverHTTP01Ingress, out *v1alpha2.ACMEChallengeSolverHTTP01Ingress, s conversion.Scope) error {
-	out.ServiceType = v1.ServiceType(in.ServiceType)
+	out.ServiceType = corev1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
 	out.PodTemplate = (*v1alpha2.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
@@ -570,8 +572,8 @@ func Convert_acme_ACMEChallengeSolverHTTP01IngressPodObjectMeta_To_v1alpha2_ACME
 
 func autoConvert_v1alpha2_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMEChallengeSolverHTTP01IngressPodSpec(in *v1alpha2.ACMEChallengeSolverHTTP01IngressPodSpec, out *acme.ACMEChallengeSolverHTTP01IngressPodSpec, s conversion.Scope) error {
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
-	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.Affinity = (*corev1.Affinity)(unsafe.Pointer(in.Affinity))
+	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
 }
 
@@ -582,8 +584,8 @@ func Convert_v1alpha2_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMEChalle
 
 func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1alpha2_ACMEChallengeSolverHTTP01IngressPodSpec(in *acme.ACMEChallengeSolverHTTP01IngressPodSpec, out *v1alpha2.ACMEChallengeSolverHTTP01IngressPodSpec, s conversion.Scope) error {
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
-	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.Affinity = (*corev1.Affinity)(unsafe.Pointer(in.Affinity))
+	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
 }
 
@@ -834,7 +836,7 @@ func Convert_v1alpha2_ACMEIssuerDNS01ProviderCloudDNS_To_acme_ACMEIssuerDNS01Pro
 }
 
 func autoConvert_acme_ACMEIssuerDNS01ProviderCloudDNS_To_v1alpha2_ACMEIssuerDNS01ProviderCloudDNS(in *acme.ACMEIssuerDNS01ProviderCloudDNS, out *v1alpha2.ACMEIssuerDNS01ProviderCloudDNS, s conversion.Scope) error {
-	out.ServiceAccount = (*metav1.SecretKeySelector)(unsafe.Pointer(in.ServiceAccount))
+	out.ServiceAccount = (*v1.SecretKeySelector)(unsafe.Pointer(in.ServiceAccount))
 	out.Project = in.Project
 	return nil
 }
@@ -858,8 +860,8 @@ func Convert_v1alpha2_ACMEIssuerDNS01ProviderCloudflare_To_acme_ACMEIssuerDNS01P
 
 func autoConvert_acme_ACMEIssuerDNS01ProviderCloudflare_To_v1alpha2_ACMEIssuerDNS01ProviderCloudflare(in *acme.ACMEIssuerDNS01ProviderCloudflare, out *v1alpha2.ACMEIssuerDNS01ProviderCloudflare, s conversion.Scope) error {
 	out.Email = in.Email
-	out.APIKey = (*metav1.SecretKeySelector)(unsafe.Pointer(in.APIKey))
-	out.APIToken = (*metav1.SecretKeySelector)(unsafe.Pointer(in.APIToken))
+	out.APIKey = (*v1.SecretKeySelector)(unsafe.Pointer(in.APIKey))
+	out.APIToken = (*v1.SecretKeySelector)(unsafe.Pointer(in.APIToken))
 	return nil
 }
 
@@ -1265,7 +1267,7 @@ func autoConvert_v1alpha2_OrderStatus_To_acme_OrderStatus(in *v1alpha2.OrderStat
 	out.Certificate = *(*[]byte)(unsafe.Pointer(&in.Certificate))
 	out.State = acme.State(in.State)
 	out.Reason = in.Reason
-	out.FailureTime = (*apismetav1.Time)(unsafe.Pointer(in.FailureTime))
+	out.FailureTime = (*metav1.Time)(unsafe.Pointer(in.FailureTime))
 	return nil
 }
 
@@ -1281,7 +1283,7 @@ func autoConvert_acme_OrderStatus_To_v1alpha2_OrderStatus(in *acme.OrderStatus, 
 	out.State = v1alpha2.State(in.State)
 	out.Reason = in.Reason
 	out.Authorizations = *(*[]v1alpha2.ACMEAuthorization)(unsafe.Pointer(&in.Authorizations))
-	out.FailureTime = (*apismetav1.Time)(unsafe.Pointer(in.FailureTime))
+	out.FailureTime = (*metav1.Time)(unsafe.Pointer(in.FailureTime))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -24,12 +24,12 @@ import (
 	unsafe "unsafe"
 
 	v1alpha3 "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha3"
-	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	acme "github.com/jetstack/cert-manager/pkg/internal/apis/acme"
 	meta "github.com/jetstack/cert-manager/pkg/internal/apis/meta"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	conversion "k8s.io/apimachinery/pkg/conversion"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
@@ -418,6 +418,7 @@ func autoConvert_v1alpha3_ACMEChallengeSolver_To_acme_ACMEChallengeSolver(in *v1
 	out.Selector = (*acme.CertificateDNSNameSelector)(unsafe.Pointer(in.Selector))
 	out.HTTP01 = (*acme.ACMEChallengeSolverHTTP01)(unsafe.Pointer(in.HTTP01))
 	out.DNS01 = (*acme.ACMEChallengeSolverDNS01)(unsafe.Pointer(in.DNS01))
+	out.FailurePolicy = meta.ACMESelfCheckFailurePolicy(in.FailurePolicy)
 	return nil
 }
 
@@ -430,6 +431,7 @@ func autoConvert_acme_ACMEChallengeSolver_To_v1alpha3_ACMEChallengeSolver(in *ac
 	out.Selector = (*v1alpha3.CertificateDNSNameSelector)(unsafe.Pointer(in.Selector))
 	out.HTTP01 = (*v1alpha3.ACMEChallengeSolverHTTP01)(unsafe.Pointer(in.HTTP01))
 	out.DNS01 = (*v1alpha3.ACMEChallengeSolverDNS01)(unsafe.Pointer(in.DNS01))
+	out.FailurePolicy = v1.ACMESelfCheckFailurePolicy(in.FailurePolicy)
 	return nil
 }
 
@@ -497,7 +499,7 @@ func Convert_acme_ACMEChallengeSolverHTTP01_To_v1alpha3_ACMEChallengeSolverHTTP0
 }
 
 func autoConvert_v1alpha3_ACMEChallengeSolverHTTP01Ingress_To_acme_ACMEChallengeSolverHTTP01Ingress(in *v1alpha3.ACMEChallengeSolverHTTP01Ingress, out *acme.ACMEChallengeSolverHTTP01Ingress, s conversion.Scope) error {
-	out.ServiceType = v1.ServiceType(in.ServiceType)
+	out.ServiceType = corev1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
 	out.PodTemplate = (*acme.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
@@ -511,7 +513,7 @@ func Convert_v1alpha3_ACMEChallengeSolverHTTP01Ingress_To_acme_ACMEChallengeSolv
 }
 
 func autoConvert_acme_ACMEChallengeSolverHTTP01Ingress_To_v1alpha3_ACMEChallengeSolverHTTP01Ingress(in *acme.ACMEChallengeSolverHTTP01Ingress, out *v1alpha3.ACMEChallengeSolverHTTP01Ingress, s conversion.Scope) error {
-	out.ServiceType = v1.ServiceType(in.ServiceType)
+	out.ServiceType = corev1.ServiceType(in.ServiceType)
 	out.Class = (*string)(unsafe.Pointer(in.Class))
 	out.Name = in.Name
 	out.PodTemplate = (*v1alpha3.ACMEChallengeSolverHTTP01IngressPodTemplate)(unsafe.Pointer(in.PodTemplate))
@@ -570,8 +572,8 @@ func Convert_acme_ACMEChallengeSolverHTTP01IngressPodObjectMeta_To_v1alpha3_ACME
 
 func autoConvert_v1alpha3_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMEChallengeSolverHTTP01IngressPodSpec(in *v1alpha3.ACMEChallengeSolverHTTP01IngressPodSpec, out *acme.ACMEChallengeSolverHTTP01IngressPodSpec, s conversion.Scope) error {
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
-	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.Affinity = (*corev1.Affinity)(unsafe.Pointer(in.Affinity))
+	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
 }
 
@@ -582,8 +584,8 @@ func Convert_v1alpha3_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMEChalle
 
 func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1alpha3_ACMEChallengeSolverHTTP01IngressPodSpec(in *acme.ACMEChallengeSolverHTTP01IngressPodSpec, out *v1alpha3.ACMEChallengeSolverHTTP01IngressPodSpec, s conversion.Scope) error {
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
-	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
-	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.Affinity = (*corev1.Affinity)(unsafe.Pointer(in.Affinity))
+	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	return nil
 }
 
@@ -834,7 +836,7 @@ func Convert_v1alpha3_ACMEIssuerDNS01ProviderCloudDNS_To_acme_ACMEIssuerDNS01Pro
 }
 
 func autoConvert_acme_ACMEIssuerDNS01ProviderCloudDNS_To_v1alpha3_ACMEIssuerDNS01ProviderCloudDNS(in *acme.ACMEIssuerDNS01ProviderCloudDNS, out *v1alpha3.ACMEIssuerDNS01ProviderCloudDNS, s conversion.Scope) error {
-	out.ServiceAccount = (*metav1.SecretKeySelector)(unsafe.Pointer(in.ServiceAccount))
+	out.ServiceAccount = (*v1.SecretKeySelector)(unsafe.Pointer(in.ServiceAccount))
 	out.Project = in.Project
 	return nil
 }
@@ -858,8 +860,8 @@ func Convert_v1alpha3_ACMEIssuerDNS01ProviderCloudflare_To_acme_ACMEIssuerDNS01P
 
 func autoConvert_acme_ACMEIssuerDNS01ProviderCloudflare_To_v1alpha3_ACMEIssuerDNS01ProviderCloudflare(in *acme.ACMEIssuerDNS01ProviderCloudflare, out *v1alpha3.ACMEIssuerDNS01ProviderCloudflare, s conversion.Scope) error {
 	out.Email = in.Email
-	out.APIKey = (*metav1.SecretKeySelector)(unsafe.Pointer(in.APIKey))
-	out.APIToken = (*metav1.SecretKeySelector)(unsafe.Pointer(in.APIToken))
+	out.APIKey = (*v1.SecretKeySelector)(unsafe.Pointer(in.APIKey))
+	out.APIToken = (*v1.SecretKeySelector)(unsafe.Pointer(in.APIToken))
 	return nil
 }
 
@@ -1265,7 +1267,7 @@ func autoConvert_v1alpha3_OrderStatus_To_acme_OrderStatus(in *v1alpha3.OrderStat
 	out.Certificate = *(*[]byte)(unsafe.Pointer(&in.Certificate))
 	out.State = acme.State(in.State)
 	out.Reason = in.Reason
-	out.FailureTime = (*apismetav1.Time)(unsafe.Pointer(in.FailureTime))
+	out.FailureTime = (*metav1.Time)(unsafe.Pointer(in.FailureTime))
 	return nil
 }
 
@@ -1281,7 +1283,7 @@ func autoConvert_acme_OrderStatus_To_v1alpha3_OrderStatus(in *acme.OrderStatus, 
 	out.State = v1alpha3.State(in.State)
 	out.Reason = in.Reason
 	out.Authorizations = *(*[]v1alpha3.ACMEAuthorization)(unsafe.Pointer(&in.Authorizations))
-	out.FailureTime = (*apismetav1.Time)(unsafe.Pointer(in.FailureTime))
+	out.FailureTime = (*metav1.Time)(unsafe.Pointer(in.FailureTime))
 	return nil
 }
 

--- a/pkg/internal/apis/meta/types.go
+++ b/pkg/internal/apis/meta/types.go
@@ -59,3 +59,18 @@ type SecretKeySelector struct {
 const (
 	TLSCAKey = "ca.crt"
 )
+
+// Describes how the ACME challenge self check behaves when it fails.
+type ACMESelfCheckFailurePolicy string
+
+const (
+	// The default failure policy. This policy will cause the request to be
+	// sent to the certificate provider ONLY if the ACME challenge self check
+	// succeeds. The request is retried continuously and the `Certificate` will
+	// remain `Pending` indefinitely.
+	ACMESelfCheckFailurePolicyRetryForever ACMESelfCheckFailurePolicy = "RetryForever"
+
+	// This policy will cause the ACME challenge self check response to be
+	// ignored and the request will always be sent to the certificate provider.
+	ACMESelfCheckFailurePolicyIgnore ACMESelfCheckFailurePolicy = "Ignore"
+)

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -95,3 +95,9 @@ func SetChallengeProcessing(b bool) ChallengeModifier {
 		ch.Status.Processing = b
 	}
 }
+
+func SetChallengeSolver(s *cmacme.ACMEChallengeSolver) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Solver = s
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is the implementation for design document #2772. It allows us to control failure policies for the ACME self check. The default policy keeps the existing functionality by waiting indefinitely, but it can now also be configured to be ignored, leading to the request being sent to the certificate provider anyway.

**Which issue this PR fixes**:

Fixes #1292

**Special notes for your reviewer**:

My first contribution to the project, so as much feedback as possible is much appreciated!

There's a lot of redundant changes in `zz_generated.conversion.go`, but this is generated, so I'm assuming this is OK.

**Release note**:

```release-note
Allow ignoring ACME challenge self check failures
```

**To do**:
* [ ] e2e test coverage
* [ ] manual/functional tests