### PR TITLE
Avoid duplicate CRDs in static manifests

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -14,13 +14,13 @@ VARIANTS = {
     "cert-manager": {
         "crd_variant": "regular",
         "values": {
-            "installCRDs": "true",
+            "installCRDs": "false",
         },
     },
     "cert-manager-legacy": {
         "crd_variant": "legacy",
         "values": {
-            "installCRDs": "true",
+            "installCRDs": "false",
         },
     },
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This should have been set to `false` as we already prepend the CRD resources using Bazel, which we have to do because `helm template` no longer has a `--kube-version` command.

**Release note**:
```release-note
Fix issuing causing CRDs to added to the static manifests twice
```

/kind bug
/assign @meyskens 