### PR TITLE
Remove empty 'annotations' blocks from resources and add missing 'metata.namespace' field

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -35,8 +35,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: "cainjector"
         helm.sh/chart: {{ include "cainjector.chart" . }}
-      annotations:
       {{- if .Values.cainjector.podAnnotations }}
+      annotations:
 {{ toYaml .Values.cainjector.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/deploy/charts/cert-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/serviceaccount.yaml
@@ -7,8 +7,8 @@ imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 metadata:
   name: {{ template "cert-manager.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  annotations:
   {{- if .Values.serviceAccount.annotations }}
+  annotations:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
   {{- end }}
   labels:

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -34,8 +34,8 @@ spec:
         app.kubernetes.io/managed-by: {{ .Release.Service }}
         app.kubernetes.io/component: "webhook"
         helm.sh/chart: {{ include "webhook.chart" . }}
-      annotations:
       {{- if .Values.webhook.podAnnotations }}
+      annotations:
 {{ toYaml .Values.webhook.podAnnotations | indent 8 }}
       {{- end }}
     spec:

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -4,6 +4,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
   name: {{ template "webhook.fullname" . }}:dynamic-serving
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}
@@ -27,6 +28,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: {{ template "webhook.fullname" . }}:dynamic-serving
+  namespace: {{ .Release.Namespace | quote }}
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -52,8 +52,9 @@ serviceAccount:
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name:
-  annotations: {}
+  # name: ""
+  # Optional additional annotations to add to the controller's ServiceAccount
+  # annotations: {}
 
 # Optional additional arguments
 extraArgs: []
@@ -91,9 +92,11 @@ volumes: []
 
 volumeMounts: []
 
-deploymentAnnotations: {}
+# Optional additional annotations to add to the controller Deployment
+# deploymentAnnotations: {}
 
-podAnnotations: {}
+# Optional additional annotations to add to the controller Pods
+# podAnnotations: {}
 
 podLabels: {}
 # Optional DNS settings, useful if you have a public and private DNS zone for
@@ -163,9 +166,11 @@ webhook:
 
   securityContext: {}
 
-  deploymentAnnotations: {}
+  # Optional additional annotations to add to the webhook Deployment
+  # deploymentAnnotations: {}
 
-  podAnnotations: {}
+  # Optional additional annotations to add to the webhook Pods
+  # podAnnotations: {}
 
   # Optional additional arguments for webhook
   extraArgs: []
@@ -207,9 +212,11 @@ cainjector:
 
   securityContext: {}
 
-  deploymentAnnotations: {}
+  # Optional additional annotations to add to the cainjector Deployment
+  # deploymentAnnotations: {}
 
-  podAnnotations: {}
+  # Optional additional annotations to add to the cainjector Pods
+  # podAnnotations: {}
 
   # Optional additional arguments for cainjector
   extraArgs: []


### PR DESCRIPTION
**What this PR does / why we need it**:

Some improvements for the Helm chart to remove `annotations` fields when none are specified, as well as correctly setting `metadata.namespace` on namespaced resources (so the 'static manifests' have to correct namespace by default).

**Release note**:
```release-note
NONE
```

/kind cleanup
/milestone v0.15
/area deploy
