### PR TITLE
cert-manager ctl renew with --wait flag

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -2318,6 +2318,41 @@ THE SOFTWARE.
 
 
 ================================================================================
+= vendor/github.com/chai2010/gettext-go licensed under: =
+
+Copyright 2013 ChaiShushan <chaishushan{AT}gmail.com>. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+= vendor/github.com/chai2010/gettext-go/LICENSE 87ce3ee0376881b02e75d3d5be2a6ba6
+================================================================================
+
+
+================================================================================
 = vendor/github.com/cloudflare/cloudflare-go licensed under: =
 
 Copyright (c) 2015-2016, Cloudflare. All rights reserved.

--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/util/cmd:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//plugin/pkg/client/auth:go_default_library",
         "@io_k8s_klog//:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
     ],

--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -14,6 +14,8 @@ go_library(
         "//pkg/util/cmd:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_klog//:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
     ],
 )
 

--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/ctl",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/ctl/pkg/renew:go_default_library",
         "//cmd/ctl/pkg/version:go_default_library",
         "//pkg/util/cmd:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
@@ -34,6 +35,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//cmd/ctl/pkg/renew:all-srcs",
         "//cmd/ctl/pkg/version:all-srcs",
     ],
     tags = ["automanaged"],

--- a/cmd/ctl/cmd.go
+++ b/cmd/ctl/cmd.go
@@ -22,6 +22,7 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/version"
 )
 
@@ -36,6 +37,7 @@ cert-manager-ctl is a CLI tool manage and configure cert-manager resources for K
 
 	ioStreams := genericclioptions.IOStreams{In: in, Out: out, ErrOut: err}
 	cmds.AddCommand(version.NewCmdVersion(ioStreams))
+	cmds.AddCommand(renew.NewCmdRenew(ioStreams))
 
 	return cmds
 }

--- a/cmd/ctl/cmd.go
+++ b/cmd/ctl/cmd.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/version"
@@ -35,9 +36,15 @@ cert-manager-ctl is a CLI tool manage and configure cert-manager resources for K
 		Run: runHelp,
 	}
 
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+	kubeConfigFlags.AddFlags(cmds.PersistentFlags())
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	matchVersionKubeConfigFlags.AddFlags(cmds.PersistentFlags())
+	factory := cmdutil.NewFactory(matchVersionKubeConfigFlags)
+
 	ioStreams := genericclioptions.IOStreams{In: in, Out: out, ErrOut: err}
 	cmds.AddCommand(version.NewCmdVersion(ioStreams))
-	cmds.AddCommand(renew.NewCmdRenew(ioStreams))
+	cmds.AddCommand(renew.NewCmdRenew(ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/cmd.go
+++ b/cmd/ctl/cmd.go
@@ -22,6 +22,8 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	// Load all auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/version"

--- a/cmd/ctl/cmd.go
+++ b/cmd/ctl/cmd.go
@@ -38,7 +38,7 @@ cert-manager-ctl is a CLI tool manage and configure cert-manager resources for K
 		Run: runHelp,
 	}
 
-	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
 	kubeConfigFlags.AddFlags(cmds.PersistentFlags())
 	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
 	matchVersionKubeConfigFlags.AddFlags(cmds.PersistentFlags())

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"os"
 
+	"k8s.io/klog"
+
 	"github.com/jetstack/cert-manager/pkg/util/cmd"
 )
 
@@ -28,8 +30,13 @@ func main() {
 	stopCh := cmd.SetupSignalHandler()
 	cmd := NewCertManagerCtlCommand(os.Stdin, os.Stdout, os.Stderr, stopCh)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)
-
 	flag.CommandLine.Parse([]string{})
+	fakefs := flag.NewFlagSet("fake", flag.ExitOnError)
+	klog.InitFlags(fakefs)
+	if err := fakefs.Parse([]string{"-logtostderr=false"}); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
 	}

--- a/cmd/ctl/pkg/renew/BUILD.bazel
+++ b/cmd/ctl/pkg/renew/BUILD.bazel
@@ -11,8 +11,10 @@ go_library(
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
     ],
 )

--- a/cmd/ctl/pkg/renew/BUILD.bazel
+++ b/cmd/ctl/pkg/renew/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+        "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
+        "@io_k8s_kubectl//pkg/util/templates:go_default_library",
     ],
 )
 

--- a/cmd/ctl/pkg/renew/BUILD.bazel
+++ b/cmd/ctl/pkg/renew/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -15,6 +15,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
         "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
         "@io_k8s_kubectl//pkg/util/templates:go_default_library",
@@ -33,4 +34,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["renew_test.go"],
+    embed = [":go_default_library"],
 )

--- a/cmd/ctl/pkg/renew/BUILD.bazel
+++ b/cmd/ctl/pkg/renew/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/client/clientset/versioned:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
     ],

--- a/cmd/ctl/pkg/renew/BUILD.bazel
+++ b/cmd/ctl/pkg/renew/BUILD.bazel
@@ -1,0 +1,33 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["renew.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/renew",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -20,10 +20,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
@@ -38,6 +41,14 @@ type Options struct {
 	Namespace string
 
 	LabelSelector string
+
+	All  bool
+	Wait bool
+
+	AllNamespaces bool
+
+	PollTime time.Duration
+	Timeout  time.Duration
 
 	genericclioptions.IOStreams
 }
@@ -65,6 +76,11 @@ func NewCmdRenew(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory)
 	}
 
 	cmd.Flags().StringVarP(&o.LabelSelector, "selector", "l", o.LabelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+	cmd.Flags().BoolVarP(&o.AllNamespaces, "all-namespaces", "A", o.AllNamespaces, "If present, wait for Certificates across all namespaces to become ready. Namespace in current context is ignored even if specified with --namespace.")
+	cmd.Flags().BoolVar(&o.All, "all", o.All, "Renew all Certificates in the given Namespace, or all namespaces with --all-namespaces enabled.")
+	cmd.Flags().BoolVarP(&o.Wait, "wait", "w", o.Wait, "Wait for all Certificates to become ready once being marked for renewal.")
+	cmd.Flags().DurationVar(&o.PollTime, "poll-time", time.Second*2, "Poll period between checking Certificates to become ready. Used in conjunction with --wait.")
+	cmd.Flags().DurationVar(&o.Timeout, "timeout", 0, "The length of time to wait before ending watch, zero means never. Any other values should contain a corresponding time unit (e.g. 1s, 2m, 3h).")
 
 	return cmd
 }
@@ -73,6 +89,14 @@ func NewCmdRenew(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory)
 func (o *Options) Validate(cmd *cobra.Command, args []string) error {
 	if len(o.LabelSelector) > 0 && len(args) > 0 {
 		return errors.New("cannot specify Certificate arguments as well as label selectors")
+	}
+
+	if o.All && len(args) > 0 {
+		return errors.New("cannot specify Certificate arguments as well as --all flag")
+	}
+
+	if o.All && len(o.LabelSelector) > 0 {
+		return errors.New("cannot specify label selector as well as --all flag")
 	}
 
 	return nil
@@ -101,37 +125,79 @@ func (o *Options) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) erro
 		return err
 	}
 
-	var crts []cmapi.Certificate
+	nss := []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: o.Namespace}}}
 
-	if len(o.LabelSelector) > 0 {
-		crtsList, err := cmClient.CertmanagerV1alpha2().Certificates(o.Namespace).List(context.TODO(), metav1.ListOptions{
-			LabelSelector: o.LabelSelector,
-		})
+	// TODO: handle network context
+
+	if o.AllNamespaces {
+		kubeClient, err := kubernetes.NewForConfig(restConfig)
 		if err != nil {
 			return err
 		}
 
-		crts = crtsList.Items
+		nsList, err := kubeClient.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return err
+		}
 
-	} else {
-		for _, crtName := range args {
-			crt, err := cmClient.CertmanagerV1alpha2().Certificates(o.Namespace).Get(context.TODO(), crtName, metav1.GetOptions{})
+		nss = nsList.Items
+	}
+
+	var crts []cmapi.Certificate
+	for _, ns := range nss {
+		switch {
+		case o.All:
+			crtsList, err := cmClient.CertmanagerV1alpha2().Certificates(ns.Name).List(context.TODO(), metav1.ListOptions{})
 			if err != nil {
 				return err
 			}
 
-			crts = append(crts, *crt)
+			crts = append(crts, crtsList.Items...)
+
+		case len(o.LabelSelector) > 0:
+			crtsList, err := cmClient.CertmanagerV1alpha2().Certificates(ns.Name).List(context.TODO(), metav1.ListOptions{
+				LabelSelector: o.LabelSelector,
+			})
+			if err != nil {
+				return err
+			}
+
+			crts = append(crts, crtsList.Items...)
+
+		default:
+			for _, crtName := range args {
+				crt, err := cmClient.CertmanagerV1alpha2().Certificates(ns.Name).Get(context.TODO(), crtName, metav1.GetOptions{})
+				if err != nil {
+					return err
+				}
+
+				crts = append(crts, *crt)
+			}
 		}
 	}
 
 	if len(crts) == 0 {
-		return errors.New("No resources found")
+		if o.AllNamespaces {
+			fmt.Fprintln(o.ErrOut, "No Certificates found")
+		} else {
+			fmt.Fprintf(o.ErrOut, "No Certificates found in %s namespace.\n", o.Namespace)
+		}
+
+		return nil
 	}
 
 	for _, crt := range crts {
 		if err := o.renewCertificate(cmClient, &crt); err != nil {
 			return err
 		}
+	}
+
+	if o.Wait {
+		if err := o.waitCertificatesReady(cmClient, crts); err != nil {
+			return err
+		}
+
+		fmt.Fprintf(o.Out, "%d Certificates successfully renewed\n", len(crts))
 	}
 
 	return nil
@@ -145,4 +211,51 @@ func (o *Options) renewCertificate(cmClient *cmclient.Clientset, crt *cmapi.Cert
 	}
 	fmt.Fprintf(o.Out, "Manually triggered issuance of Certificate %s/%s\n", crt.Namespace, crt.Name)
 	return nil
+}
+
+func (o *Options) waitCertificatesReady(cmClient *cmclient.Clientset, crts []cmapi.Certificate) error {
+	// TODO: start poll time after all get requests?
+	ticker := time.NewTicker(o.PollTime)
+	defer ticker.Stop()
+
+	ctx := context.TODO()
+
+	if o.Timeout > 0 {
+		var cancel func()
+		ctx, cancel = context.WithTimeout(ctx, o.Timeout)
+		defer cancel()
+	}
+
+	for {
+		lenReady := 0
+
+		for _, crt := range crts {
+			crt, err := cmClient.CertmanagerV1alpha2().Certificates(crt.Namespace).Get(context.TODO(), crt.Name, metav1.GetOptions{})
+			if err != nil {
+				// TODO: handle certificate no longer existing?
+				return err
+			}
+
+			if cond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionIssuing); cond != nil && cond.Status == cmmeta.ConditionTrue {
+				continue
+			}
+
+			if cond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionReady); cond != nil && cond.Status == cmmeta.ConditionTrue {
+				lenReady++
+			}
+		}
+
+		if lenReady == len(crts) {
+			return nil
+		}
+
+		fmt.Fprintf(o.Out, "Currently %d Certificates out of %d are ready...\n", lenReady, len(crts))
+
+		select {
+		case <-ticker.C:
+			continue
+		case <-ctx.Done():
+			return fmt.Errorf("%d Certificates failed to become ready in time", len(crts)-lenReady)
+		}
+	}
 }

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package renew
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+)
+
+var (
+	pollInterval = time.Second
+	pollTimeout  = time.Minute
+)
+
+// Options is a struct to support version command
+type Options struct {
+	// The Namespace that the Certificate to be renewed resided in
+	Namespace string
+
+	LabelSelector string
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns initialized Options
+func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: ioStreams,
+	}
+}
+
+// NewCmdRenew returns a cobra command for renewing Certificates
+func NewCmdRenew(ioStreams genericclioptions.IOStreams) *cobra.Command {
+	o := NewOptions(ioStreams)
+
+	var factory cmdutil.Factory
+
+	cmd := &cobra.Command{
+		Use:   "renew",
+		Short: "Mark a Certificate for manual renewal",
+		Long:  "Mark a Certificate for manual renewal",
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Complete(factory, cmd, args))
+			cmdutil.CheckErr(o.Validate(cmd, args))
+			cmdutil.CheckErr(o.Run(factory, cmd, args))
+		},
+	}
+
+	cmd.Flags().StringVarP(&o.LabelSelector, "selector", "l", o.LabelSelector, "Selector (label query) to filter on, supports '=', '==', and '!='.(e.g. -l key1=value1,key2=value2)")
+
+	kubeConfigFlags := genericclioptions.NewConfigFlags(true).WithDeprecatedPasswordFlag()
+
+	kubeConfigFlags.AddFlags(cmd.PersistentFlags())
+	matchVersionKubeConfigFlags := cmdutil.NewMatchVersionFlags(kubeConfigFlags)
+	matchVersionKubeConfigFlags.AddFlags(cmd.PersistentFlags())
+
+	cmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	factory = cmdutil.NewFactory(matchVersionKubeConfigFlags)
+
+	return cmd
+}
+
+// Validate validates the provided options
+func (o *Options) Validate(cmd *cobra.Command, args []string) error {
+	if len(o.LabelSelector) > 0 && len(args) > 0 {
+		return errors.New("cannot specify Certificate arguments as well as label selectors")
+	}
+
+	return nil
+}
+
+// Complete takes the command arguments and factory and infers any remaining options.
+func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	var err error
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run executes version command
+func (o *Options) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
+	restConfig, err := f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	cmClient, err := cmclient.NewForConfig(restConfig)
+	if err != nil {
+		return err
+	}
+
+	var crts []cmapi.Certificate
+
+	if len(o.LabelSelector) > 0 {
+		crtsList, err := cmClient.CertmanagerV1alpha2().Certificates(o.Namespace).List(context.TODO(), metav1.ListOptions{
+			LabelSelector: o.LabelSelector,
+		})
+		if err != nil {
+			return err
+		}
+
+		crts = crtsList.Items
+
+	} else {
+		for _, crtName := range args {
+			crt, err := cmClient.CertmanagerV1alpha2().Certificates(o.Namespace).Get(context.TODO(), crtName, metav1.GetOptions{})
+			if err != nil {
+				return err
+			}
+
+			crts = append(crts, *crt)
+		}
+	}
+
+	if len(crts) == 0 {
+		return errors.New("No resources found")
+	}
+
+	for _, crt := range crts {
+		if err := o.renewCertificate(cmClient, &crt); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (o *Options) renewCertificate(cmClient *cmclient.Clientset, crt *cmapi.Certificate) error {
+	if cond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionReady); cond.Status != cmmeta.ConditionTrue {
+		return fmt.Errorf("Certificate %s not in ready condition: %v", crt.Name, cond)
+	}
+
+	fmt.Fprintf(o.Out, "Marking Certificate %s for renewal", crt.Name)
+
+	// TODO: Set Certificate Issuing Condition
+	// TODO: Wait for Certificate to now have Issuing condition
+
+	// TODO: be able to configure total polling interval and timeout?
+
+	// TODO: We probably want to break this out and have a "status" sub-command
+	// that does the poll behaviour for Certificates to be ready, and leave this
+	// to _only_ mark for renewal. Similar to kubectl rollout
+
+	err := wait.Poll(pollInterval, pollTimeout, func() (bool, error) {
+		fmt.Fprintf(o.Out, "Waiting for Certificate %s to renew", crt.Name)
+
+		c, err := cmClient.CertmanagerV1alpha2().Certificates(crt.Namespace).Get(context.TODO(), crt.Namespace, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if apiutil.CertificateHasCondition(c, cmapi.CertificateCondition{
+			Type:   cmapi.CertificateConditionReady,
+			Status: cmmeta.ConditionTrue,
+		}) {
+			return true, nil
+		}
+
+		return false, nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to wait for Certificate %s to become ready", crt.Name)
+	}
+
+	fmt.Fprintf(o.Out, "Certificate %s is ready", crt.Name)
+
+	return nil
+}

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -35,7 +35,7 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 )
 
-// Options is a struct to support version command
+// Options is a struct to support renew command
 type Options struct {
 	// The Namespace that the Certificate to be renewed resided in
 	Namespace string
@@ -95,10 +95,6 @@ func (o *Options) Validate(cmd *cobra.Command, args []string) error {
 		return errors.New("cannot specify Certificate arguments as well as --all flag")
 	}
 
-	if o.All && len(o.LabelSelector) > 0 {
-		return errors.New("cannot specify label selector as well as --all flag")
-	}
-
 	return nil
 }
 
@@ -113,7 +109,7 @@ func (o *Options) Complete(f cmdutil.Factory, cmd *cobra.Command, args []string)
 	return nil
 }
 
-// Run executes version command
+// Run executes renew command
 func (o *Options) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) error {
 	restConfig, err := f.ToRESTConfig()
 	if err != nil {
@@ -146,15 +142,7 @@ func (o *Options) Run(f cmdutil.Factory, cmd *cobra.Command, args []string) erro
 	var crts []cmapi.Certificate
 	for _, ns := range nss {
 		switch {
-		case o.All:
-			crtsList, err := cmClient.CertmanagerV1alpha2().Certificates(ns.Name).List(context.TODO(), metav1.ListOptions{})
-			if err != nil {
-				return err
-			}
-
-			crts = append(crts, crtsList.Items...)
-
-		case len(o.LabelSelector) > 0:
+		case o.All, len(o.LabelSelector) > 0:
 			crtsList, err := cmClient.CertmanagerV1alpha2().Certificates(ns.Name).List(context.TODO(), metav1.ListOptions{
 				LabelSelector: o.LabelSelector,
 			})

--- a/cmd/ctl/pkg/renew/renew_test.go
+++ b/cmd/ctl/pkg/renew/renew_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package renew
+
+import (
+	"testing"
+	"time"
+)
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		options *Options
+		args    []string
+		expErr  bool
+	}{
+		"If there are arguments, as well as label selector, error": {
+			options: &Options{
+				LabelSelector: "foo=bar",
+			},
+			args:   []string{"abc"},
+			expErr: true,
+		},
+		"If there are all certificates selected, as well as label selector, error": {
+			options: &Options{
+				LabelSelector: "foo=bar",
+				All:           true,
+			},
+			args:   []string{""},
+			expErr: true,
+		},
+		"If there are all certificates selected, as well as arguments, error": {
+			options: &Options{
+				All: true,
+			},
+			args:   []string{"abc"},
+			expErr: true,
+		},
+		"If waiting, and timeout is less than poll time, but not zero, error": {
+			options: &Options{
+				Timeout: time.Second,
+				Wait:    true,
+			},
+			expErr: true,
+		},
+		"If waiting, and timeout is less than poll time, but zero, don't error": {
+			options: &Options{
+				Timeout: 0,
+				Wait:    true,
+			},
+			expErr: false,
+		},
+		"If not waiting, and timeout is less than poll time, but not zero, don't error": {
+			options: &Options{
+				Timeout: time.Second,
+				Wait:    false,
+			},
+			expErr: false,
+		},
+		"If all certificates in all namespaces selected, don't error": {
+			options: &Options{
+				All:           true,
+				AllNamespaces: true,
+			},
+			expErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			err := test.options.Validate(test.args)
+
+			if test.expErr != (err != nil) {
+				t.Errorf("expected error=%t got=%v",
+					test.expErr, err)
+			}
+		})
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,7 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17OJKJXD2Cfs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5 h1:7aWHqerlJ41y6FOsEUvknqgXnGmJyJSbjhAWq5pO4F8=
 github.com/chai2010/gettext-go v0.0.0-20160711120539-c6fed771bfd5/go.mod h1:/iP1qXHoty45bqomnu2LM+VVyAEdWN+vtSHGlQgyxbw=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cloudflare/cloudflare-go v0.8.5 h1:k1iz+H2jIL8OnS+bGhNQ6GPldi7VCo2tuWmfQ4kMiDI=

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -11,6 +11,7 @@ filegroup(
         ":package-srcs",
         "//test/integration/certificates:all-srcs",
         "//test/integration/conversion:all-srcs",
+        "//test/integration/ctl:all-srcs",
         "//test/integration/framework:all-srcs",
         "//test/integration/webhook:all-srcs",
     ],

--- a/test/integration/ctl/BUILD.bazel
+++ b/test/integration/ctl/BUILD.bazel
@@ -1,0 +1,40 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["ctl_renew_test.go"],
+    deps = [
+        "//cmd/ctl/pkg/renew:go_default_library",
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/controller/expcertificates/issuing:go_default_library",
+        "//pkg/controller/expcertificates/readiness:go_default_library",
+        "//pkg/controller/expcertificates/trigger/policies:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "//test/unit/gen:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
+        "@io_k8s_client_go//util/workqueue:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/integration/ctl/ctl_renew_test.go
+++ b/test/integration/ctl/ctl_renew_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/issuing"
+	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/readiness"
+	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/trigger/policies"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+	utilpki "github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/integration/framework"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+// TestCtlRenew tests the renewal logic of the ctl CLI command against the
+// cert-manager Issuing controller.
+func TestCtlRenew(t *testing.T) {
+	config, stopFn := framework.RunControlPlane(t)
+	defer stopFn()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+	defer cancel()
+
+	// Build, instantiate and run the issuing controller.
+	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
+	controllerOptions := controllerpkg.CertificateOptions{
+		EnableOwnerRef: true,
+	}
+	recorder := framework.NewEventRecorder(t)
+
+	var (
+		crtName                  = "testcrt"
+		revision                 = 1
+		namespace                = "testns"
+		nextPrivateKeySecretName = "next-private-key-test-crt"
+		secretName               = "test-crt-tls"
+	)
+
+	// Create a new private key
+	sk, err := utilpki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	skBytes := utilpki.EncodePKCS1PrivateKey(sk)
+
+	// Store new private key in secret
+	_, err = kubeClient.CoreV1().Secrets(namespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nextPrivateKeySecretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: skBytes,
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Certificate
+	crt := gen.Certificate(crtName,
+		gen.SetCertificateNamespace(namespace),
+		gen.SetCertificateDNSNames("example.com"),
+		gen.SetCertificateKeyAlgorithm(cmapi.RSAKeyAlgorithm),
+		gen.SetCertificateKeySize(2048),
+		gen.SetCertificateSecretName(secretName),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "testissuer"}),
+	)
+
+	crt, err = cmCl.CertmanagerV1alpha2().Certificates(namespace).Create(ctx, crt, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Init and start controllers
+	ctrlIssuing, queueIssuing, mustSyncIssuing := issuing.NewController(logf.Log, kubeClient, cmCl, factory, cmFactory, recorder, clock.RealClock{}, controllerOptions)
+	ctrlReadiness, queueReadiness, mustSyncReadiness := readiness.NewController(logf.Log, cmCl, factory, cmFactory, policies.TriggerPolicyChain)
+
+	for _, ctrl := range []struct {
+		syncFunc func(ctx context.Context, key string) error
+		mustSync []cache.InformerSynced
+		queue    workqueue.RateLimitingInterface
+	}{
+		{ctrlIssuing.ProcessItem, mustSyncIssuing, queueIssuing},
+		{ctrlReadiness.ProcessItem, mustSyncReadiness, queueReadiness},
+	} {
+		c := controllerpkg.NewController(
+			context.Background(),
+			ctrl.syncFunc,
+			ctrl.mustSync,
+			nil,
+			ctrl.queue,
+		)
+
+		stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
+		defer stopController()
+	}
+
+	// Add Issuing condition to Certificate
+	apiutil.SetCertificateCondition(crt, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "", "")
+	crt.Status.NextPrivateKeySecretName = &nextPrivateKeySecretName
+	crt.Status.Revision = &revision
+	crt, err = cmCl.CertmanagerV1alpha2().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create x509 CSR from Certificate
+	csr, err := utilpki.GenerateCSR(crt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encode CSR
+	csrDER, err := utilpki.EncodeCSR(csr, sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrDER,
+	})
+
+	// Sign Certificate
+	certTemplate, err := utilpki.GenerateTemplate(crt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Sign and encode the certificate
+	certPem, _, err := utilpki.SignCertificate(certTemplate, certTemplate, sk.Public(), sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create CertificateRequest
+	req := gen.CertificateRequest(crtName,
+		gen.SetCertificateRequestNamespace(namespace),
+		gen.SetCertificateRequestCSR(csrPEM),
+		gen.SetCertificateRequestIssuer(crt.Spec.IssuerRef),
+		gen.SetCertificateRequestAnnotations(map[string]string{
+			cmapi.CertificateRequestRevisionAnnotationKey: fmt.Sprintf("%d", revision+1),
+		}),
+		gen.AddCertificateRequestOwnerReferences(*metav1.NewControllerRef(
+			crt,
+			cmapi.SchemeGroupVersion.WithKind("Certificate"),
+		)),
+	)
+	req, err = cmCl.CertmanagerV1alpha2().CertificateRequests(namespace).Create(ctx, req, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set CertificateRequest as ready
+	req.Status.CA = certPem
+	req.Status.Certificate = certPem
+	apiutil.SetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady, cmmeta.ConditionTrue, cmapi.CertificateRequestReasonIssued, "")
+	req, err = cmCl.CertmanagerV1alpha2().CertificateRequests(namespace).UpdateStatus(ctx, req, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Run ctl renew command and wait for ready
+	streams, _, _, _ := genericclioptions.NewTestIOStreams()
+	streams.Out = os.Stdout
+
+	cmd := &renew.Options{
+		Namespace:  "testns",
+		CMClient:   cmCl,
+		RestConfig: config,
+		Wait:       true,
+		Timeout:    time.Second * 10,
+		IOStreams:  streams,
+	}
+
+	if err := cmd.Run([]string{"testcrt"}); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Create a new cert-manager-ctl renew sub-command to mark a Certificate for manual renewal.

Accepts kubeconfig flags.
Accepts multiple Certificate arguments, or a label selectors.

Is based on the changes to the new extensible controller refactor.
/kind feature
/assign @munnerz 

```release-note
Adds cert-manager-ctl renew
```
