### PR TITLE
expcertificates: add keymanager controller

### DIFF
--- a/cmd/controller/app/BUILD.bazel
+++ b/cmd/controller/app/BUILD.bazel
@@ -13,6 +13,8 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/controller/certificates:go_default_library",
         "//pkg/controller/clusterissuers:go_default_library",
+        "//pkg/controller/expcertificates/issuing:go_default_library",
+        "//pkg/controller/expcertificates/keymanager:go_default_library",
         "//pkg/controller/expcertificates/trigger:go_default_library",
         "//pkg/feature:go_default_library",
         "//pkg/issuer/acme/dns/util:go_default_library",

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -46,6 +46,8 @@ import (
 	"github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/controller/certificates"
 	"github.com/jetstack/cert-manager/pkg/controller/clusterissuers"
+	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/issuing"
+	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/keymanager"
 	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/trigger"
 	"github.com/jetstack/cert-manager/pkg/feature"
 	dnsutil "github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
@@ -79,6 +81,8 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) {
 
 	var experimentalCertificateControllers = []string{
 		trigger.ControllerName,
+		issuing.ControllerName,
+		keymanager.ControllerName,
 	}
 	enabledSet := sets.NewString(opts.EnabledControllers...)
 	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalCertificateControllers) {

--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -18,14 +18,15 @@ package v1alpha2
 
 // Annotation names for Secrets
 const (
-	AltNamesAnnotationKey    = "cert-manager.io/alt-names"
-	IPSANAnnotationKey       = "cert-manager.io/ip-sans"
-	URISANAnnotationKey      = "cert-manager.io/uri-sans"
-	CommonNameAnnotationKey  = "cert-manager.io/common-name"
-	IssuerNameAnnotationKey  = "cert-manager.io/issuer-name"
-	IssuerKindAnnotationKey  = "cert-manager.io/issuer-kind"
-	IssuerGroupAnnotationKey = "cert-manager.io/issuer-group"
-	CertificateNameKey       = "cert-manager.io/certificate-name"
+	AltNamesAnnotationKey          = "cert-manager.io/alt-names"
+	IPSANAnnotationKey             = "cert-manager.io/ip-sans"
+	URISANAnnotationKey            = "cert-manager.io/uri-sans"
+	CommonNameAnnotationKey        = "cert-manager.io/common-name"
+	IssuerNameAnnotationKey        = "cert-manager.io/issuer-name"
+	IssuerKindAnnotationKey        = "cert-manager.io/issuer-kind"
+	IssuerGroupAnnotationKey       = "cert-manager.io/issuer-group"
+	CertificateNameKey             = "cert-manager.io/certificate-name"
+	IsNextPrivateKeySecretLabelKey = "cert-manager.io/next-private-key"
 )
 
 // Deprecated annotation names for Secrets

--- a/pkg/controller/expcertificates/BUILD.bazel
+++ b/pkg/controller/expcertificates/BUILD.bazel
@@ -49,4 +49,8 @@ go_test(
     name = "go_default_test",
     srcs = ["util_test.go"],
     embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/util/pki:go_default_library",
+    ],
 )

--- a/pkg/controller/expcertificates/BUILD.bazel
+++ b/pkg/controller/expcertificates/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_client_go//util/workqueue:go_default_library",
     ],
 )

--- a/pkg/controller/expcertificates/BUILD.bazel
+++ b/pkg/controller/expcertificates/BUILD.bazel
@@ -39,6 +39,7 @@ filegroup(
         ":package-srcs",
         "//pkg/controller/expcertificates/internal/predicate:all-srcs",
         "//pkg/controller/expcertificates/issuing:all-srcs",
+        "//pkg/controller/expcertificates/keymanager:all-srcs",
         "//pkg/controller/expcertificates/trigger:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/controller/expcertificates/issuing/issuing_controller.go
+++ b/pkg/controller/expcertificates/issuing/issuing_controller.go
@@ -100,7 +100,13 @@ func NewController(
 	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
 		// Issuer reconciles on changes to the Secret named `spec.nextPrivateKeySecretName`
 		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
+			predicate.ResourceOwnerOf,
 			predicate.ExtractResourceName(predicate.CertificateNextPrivateKeySecretName)),
+	})
+	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+		// Issuer reconciles on changes to the Secret named `spec.secretName`
+		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
+			predicate.ExtractResourceName(predicate.CertificateSecretName)),
 	})
 
 	// build a list of InformerSynced functions that will be returned by the Register method.

--- a/pkg/controller/expcertificates/keymanager/BUILD.bazel
+++ b/pkg/controller/expcertificates/keymanager/BUILD.bazel
@@ -1,0 +1,67 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["keymanager_controller.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/controller/expcertificates/keymanager",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/client/informers/externalversions:go_default_library",
+        "//pkg/client/listers/certmanager/v1alpha2:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/controller/expcertificates:go_default_library",
+        "//pkg/controller/expcertificates/internal/predicate:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@com_github_go_logr_logr//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_apimachinery//pkg/selection:go_default_library",
+        "@io_k8s_client_go//informers:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//listers/core/v1:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
+        "@io_k8s_client_go//tools/record:go_default_library",
+        "@io_k8s_client_go//util/workqueue:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["keymanager_controller_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/controller/test:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@com_github_kr_pretty//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
+    ],
+)

--- a/pkg/controller/expcertificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/expcertificates/keymanager/keymanager_controller.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymanager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes"
+	corelisters "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/workqueue"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha2"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	certificates "github.com/jetstack/cert-manager/pkg/controller/expcertificates"
+	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/internal/predicate"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+const (
+	ControllerName = "CertificateKeyManager"
+)
+
+var (
+	certificateGvk = cmapi.SchemeGroupVersion.WithKind("Certificate")
+)
+
+type controller struct {
+	certificateLister cmlisters.CertificateLister
+	secretLister      corelisters.SecretLister
+	client            cmclient.Interface
+	coreClient        kubernetes.Interface
+	recorder          record.EventRecorder
+}
+
+func NewController(
+	log logr.Logger,
+	client cmclient.Interface,
+	coreClient kubernetes.Interface,
+	factory informers.SharedInformerFactory,
+	cmFactory cminformers.SharedInformerFactory,
+	recorder record.EventRecorder,
+) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
+	// create a queue used to queue up items to be processed
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+
+	// obtain references to all the informers used by this controller
+	certificateInformer := cmFactory.Certmanager().V1alpha2().Certificates()
+	secretsInformer := factory.Core().V1().Secrets()
+
+	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
+
+	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+		// Trigger reconciles on changes to any 'owned' secret resources
+		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
+			predicate.ResourceOwnerOf,
+		),
+	})
+
+	// build a list of InformerSynced functions that will be returned by the Register method.
+	// the controller will only begin processing items once all of these informers have synced.
+	mustSync := []cache.InformerSynced{
+		secretsInformer.Informer().HasSynced,
+		certificateInformer.Informer().HasSynced,
+	}
+
+	return &controller{
+		certificateLister: certificateInformer.Lister(),
+		secretLister:      secretsInformer.Lister(),
+		client:            client,
+		coreClient:        coreClient,
+		recorder:          recorder,
+	}, queue, mustSync
+}
+
+// isNextPrivateKeyLabelSelector is a label selector used to match Secret
+// resources with the `cert-manager.io/next-private-key: "true"` label.
+var isNextPrivateKeyLabelSelector labels.Selector
+
+func init() {
+	r, err := labels.NewRequirement("cert-manager.io/next-private-key", selection.Equals, []string{"true"})
+	if err != nil {
+		panic(err)
+	}
+	isNextPrivateKeyLabelSelector = labels.NewSelector().Add(*r)
+}
+
+func (c *controller) ProcessItem(ctx context.Context, key string) error {
+	log := logf.FromContext(ctx).WithValues("key", key)
+	ctx = logf.NewContext(ctx, log)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		log.Error(err, "invalid resource key passed to ProcessItem")
+		return nil
+	}
+
+	crt, err := c.certificateLister.Certificates(namespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		log.Error(err, "certificate not found for key")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	// Discover all 'owned' secrets that have the `next-private-key` label
+	secrets, err := certificates.ListSecretsMatchingPredicates(c.secretLister.Secrets(crt.Namespace), isNextPrivateKeyLabelSelector, predicate.ResourceOwnedBy(crt))
+	if err != nil {
+		return err
+	}
+
+	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
+		Type:   cmapi.CertificateConditionIssuing,
+		Status: cmmeta.ConditionTrue,
+	}) {
+		log.V(logf.DebugLevel).Info("Cleaning up Secret resources and unsetting nextPrivateKeySecretName as issuance is no longer in progress")
+		if err := c.deleteSecretResources(ctx, secrets); err != nil {
+			return err
+		}
+		return c.setNextPrivateKeySecretName(ctx, crt, nil)
+	}
+
+	// always clean up if multiple are found
+	if len(secrets) > 1 {
+		// TODO: if nextPrivateKeySecretName is set, we should skip deleting that one Secret resource
+		log.V(logf.DebugLevel).Info("Cleaning up Secret resources as multiple nextPrivateKeySecretName candidates found")
+		return c.deleteSecretResources(ctx, secrets)
+	}
+	// if there is no existing Secret resource, create a new one
+	if len(secrets) == 0 {
+		log.V(logf.DebugLevel).Info("Creating new nextPrivateKeySecretName Secret because no existing Secret found")
+		s, err := c.createNewPrivateKeySecret(ctx, crt)
+		if err != nil {
+			return err
+		}
+		return c.setNextPrivateKeySecretName(ctx, crt, &s.Name)
+	}
+	secret := secrets[0]
+	log = logf.WithRelatedResource(log, secret)
+	ctx = logf.NewContext(ctx, log)
+
+	if crt.Status.NextPrivateKeySecretName == nil {
+		log.V(logf.DebugLevel).Info("Adopting existing private key Secret")
+		return c.setNextPrivateKeySecretName(ctx, crt, &secrets[0].Name)
+	}
+	if *crt.Status.NextPrivateKeySecretName != secrets[0].Name {
+		log.V(logf.DebugLevel).Info("Deleting existing private key secret as name does not match status.nextPrivateKeySecretName")
+		return c.deleteSecretResources(ctx, secrets)
+	}
+
+	if secret.Data == nil || len(secret.Data[corev1.TLSPrivateKeyKey]) == 0 {
+		log.V(logf.DebugLevel).Info("Deleting Secret resource as it contains no data")
+		return c.deleteSecretResources(ctx, secrets)
+	}
+	pkData := secret.Data[corev1.TLSPrivateKeyKey]
+	pk, err := pki.DecodePrivateKeyBytes(pkData)
+	if err != nil {
+		log.Error(err, "Deleting existing private key secret due to error decoding data")
+		return c.deleteSecretResources(ctx, secrets)
+	}
+
+	violations, err := certificates.PrivateKeyMatchesSpec(pk, crt.Spec)
+	if err != nil {
+		log.Error(err, "Internal error verifying if private key matches spec - please open an issue.")
+		return nil
+	}
+	if len(violations) > 0 {
+		log.V(logf.DebugLevel).Info("Regenerating private key due to change in fields", "violations", violations)
+		c.recorder.Eventf(crt, corev1.EventTypeNormal, "Deleted", "Regenerating private key due to change in fields: %v", violations)
+		return c.deleteSecretResources(ctx, secrets)
+	}
+
+	return nil
+}
+
+// deleteSecretResources will delete the given secret resources
+func (c *controller) deleteSecretResources(ctx context.Context, secrets []*corev1.Secret) error {
+	log := logf.FromContext(ctx)
+	for _, s := range secrets {
+		if err := c.coreClient.CoreV1().Secrets(s.Namespace).Delete(ctx, s.Name, metav1.DeleteOptions{}); err != nil {
+			return err
+		}
+		logf.WithRelatedResource(log, s).V(logf.DebugLevel).Info("Deleted 'next private key' Secret resource")
+	}
+	return nil
+}
+
+func (c *controller) setNextPrivateKeySecretName(ctx context.Context, crt *cmapi.Certificate, name *string) error {
+	// skip updates if there has been no change
+	if name == nil && crt.Status.NextPrivateKeySecretName == nil {
+		return nil
+	}
+	if name != nil && crt.Status.NextPrivateKeySecretName != nil {
+		if *name == *crt.Status.NextPrivateKeySecretName {
+			return nil
+		}
+	}
+	crt = crt.DeepCopy()
+	crt.Status.NextPrivateKeySecretName = name
+	_, err := c.client.CertmanagerV1alpha2().Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+	return err
+}
+
+func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.Certificate) (*corev1.Secret, error) {
+	// if the 'nextPrivateKeySecretName' field is already set, use this as the
+	// name of the Secret resource.
+	name := ""
+	if crt.Status.NextPrivateKeySecretName != nil {
+		name = *crt.Status.NextPrivateKeySecretName
+	}
+
+	pk, err := pki.GeneratePrivateKeyForCertificate(crt)
+	if err != nil {
+		return nil, err
+	}
+
+	pkData, err := pki.EncodePrivateKey(pk, cmapi.PKCS8)
+	if err != nil {
+		return nil, err
+	}
+
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       crt.Namespace,
+			Name:            name,
+			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)},
+			Labels: map[string]string{
+				"cert-manager.io/next-private-key": "true",
+			},
+		},
+		Data: map[string][]byte{
+			corev1.TLSPrivateKeyKey: pkData,
+		},
+	}
+	if s.Name == "" {
+		// TODO: handle certificate resources that have especially long names
+		s.GenerateName = crt.Name + "-"
+	}
+	s, err = c.coreClient.CoreV1().Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+	c.recorder.Event(crt, corev1.EventTypeNormal, "Generated", fmt.Sprintf("Stored new private key in temporary Secret resource %q", s.Name))
+	return s, nil
+}
+
+// controllerWrapper wraps the `controller` structure to make it implement
+// the controllerpkg.queueingController interface
+type controllerWrapper struct {
+	*controller
+}
+
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+	// construct a new named logger to be reused throughout the controller
+	log := logf.FromContext(ctx.RootContext, ControllerName)
+
+	ctrl, queue, mustSync := NewController(log,
+		ctx.CMClient,
+		ctx.Client,
+		ctx.KubeSharedInformerFactory,
+		ctx.SharedInformerFactory,
+		ctx.Recorder,
+	)
+	c.controller = ctrl
+
+	return queue, mustSync, nil
+}
+
+func init() {
+	controllerpkg.Register(ControllerName, func(ctx *controllerpkg.Context) (controllerpkg.Interface, error) {
+		return controllerpkg.NewBuilder(ctx, ControllerName).
+			For(&controllerWrapper{}).
+			Complete()
+	})
+}

--- a/pkg/controller/expcertificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/expcertificates/keymanager/keymanager_controller_test.go
@@ -1,0 +1,527 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package keymanager
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/kr/pretty"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	coretesting "k8s.io/client-go/testing"
+	"k8s.io/utils/pointer"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+func mustGenerateRSA(t *testing.T, keySize int) []byte {
+	pk, err := pki.GenerateRSAPrivateKey(keySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := pki.EncodePKCS8PrivateKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func mustGenerateECDSA(t *testing.T, keySize int) []byte {
+	pk, err := pki.GenerateECPrivateKey(keySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	d, err := pki.EncodePKCS8PrivateKey(pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func relaxedSecretMatcher(l coretesting.Action, r coretesting.Action) error {
+	objL := l.(coretesting.CreateAction).GetObject().(*corev1.Secret).DeepCopy()
+	objR := r.(coretesting.CreateAction).GetObject().(*corev1.Secret).DeepCopy()
+	for k := range objL.Data {
+		objL.Data[k] = []byte("something")
+	}
+	for k := range objR.Data {
+		objR.Data[k] = []byte("something")
+	}
+	if !reflect.DeepEqual(objL, objR) {
+		return fmt.Errorf("unexpected difference between actions: %s", pretty.Diff(objL, objR))
+	}
+	return nil
+}
+
+func TestProcessItem(t *testing.T) {
+	ownedSecretWithName := func(namespace, name, owner string, data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels: map[string]string{
+				cmapi.IsNextPrivateKeySecretLabelKey: "true",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(&cmapi.Certificate{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: owner, UID: types.UID(owner)},
+				}, certificateGvk),
+			},
+		},
+			Data: data,
+		}
+	}
+	tests := map[string]struct {
+		// key that should be passed to ProcessItem.
+		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
+		// if neither is set, the key will be ""
+		key string
+
+		// Certificate to be synced for the test.
+		// if not set, the 'key' will be passed to ProcessItem instead.
+		certificate *cmapi.Certificate
+
+		secrets []runtime.Object
+
+		// Request, if set, will exist in the apiserver before the test is run.
+		requests []*cmapi.CertificateRequest
+
+		expectedActions []testpkg.Action
+
+		expectedEvents []string
+
+		// err is the expected error text returned by the controller, if any.
+		err string
+	}{
+		"do nothing if an empty 'key' is used": {},
+		"do nothing if an invalid 'key' is used": {
+			key: "abc/def/ghi",
+		},
+		"do nothing if a key references a Certificate that does not exist": {
+			key: "namespace/name",
+		},
+		"do nothing if Certificate has 'Issuing' condition set to 'false'": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionFalse,
+						},
+					},
+				},
+			},
+		},
+		"do nothing if Certificate has no 'Issuing' condition": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{},
+				},
+			},
+		},
+		"create a secret and record its name if issuing is true": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "test-notrandom"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"status",
+					"testns",
+					&cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+						Status: cmapi.CertificateStatus{
+							NextPrivateKeySecretName: pointer.StringPtr("test-notrandom"),
+							Conditions: []cmapi.CertificateCondition{
+								{
+									Type:   cmapi.CertificateConditionIssuing,
+									Status: cmmeta.ConditionTrue,
+								},
+							},
+						},
+					},
+				)),
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:       "testns",
+							GenerateName:    "test-",
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true"},
+							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
+						},
+						Data: map[string][]byte{"tls.key": nil},
+					},
+				), relaxedSecretMatcher),
+			},
+		},
+		"create a secret using the already allocated name if it is set": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "fixed-name"`},
+			expectedActions: []testpkg.Action{
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:       "testns",
+							Name:            "fixed-name",
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true"},
+							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
+						},
+						Data: map[string][]byte{"tls.key": nil},
+					},
+				), relaxedSecretMatcher),
+			},
+		},
+		// TODO: in this case we should adapt the controller behaviour to unset the nextPrivateKeySecretName to
+		//  gracefully recover
+		"error if an existing Secret exists and is named as status.nextPrivateKeySecretName but it is not owned by the Certificte": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "fixed-name"}}},
+			expectedActions: []testpkg.Action{
+				testpkg.NewCustomMatch(coretesting.NewCreateAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:       "testns",
+							Name:            "fixed-name",
+							Labels:          map[string]string{cmapi.IsNextPrivateKeySecretLabelKey: "true"},
+							OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(&cmapi.Certificate{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"}}, certificateGvk)},
+						},
+						Data: map[string][]byte{"tls.key": nil},
+					},
+				), relaxedSecretMatcher),
+			},
+			err: `secrets "fixed-name" already exists`,
+		},
+		"if multiple owned secrets exist, delete them all": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", nil),
+				ownedSecretWithName("testns", "fixed-name-2", "test", nil),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name-2",
+				)),
+			},
+		},
+		// TODO: change this behaviour to not delete the named nextPrivateKeySecretName
+		"if multiple owned secrets exist, delete them all even if one is the named Secret": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", nil),
+				ownedSecretWithName("testns", "fixed-name-2", "test", nil),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name-2",
+				)),
+			},
+		},
+		"if a named and owned secret exists but contains no data, delete it": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", nil),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
+			},
+		},
+		"if an owned secret exists but nextPrivateKeySecretName is not set, set it": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", nil),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"status",
+					"testns",
+					&cmapi.Certificate{
+						ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+						Status: cmapi.CertificateStatus{
+							NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+							Conditions: []cmapi.CertificateCondition{
+								{
+									Type:   cmapi.CertificateConditionIssuing,
+									Status: cmmeta.ConditionTrue,
+								},
+							},
+						},
+					},
+				)),
+			},
+		},
+		"if an owned secret exists but has a different name to nextPrivateKeySecretName, delete it": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name-2"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", nil),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
+			},
+		},
+		"if an owned secret exists but contains invalid private key data, delete it": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", map[string][]byte{"tls.key": []byte("invalid")}),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
+			},
+		},
+		"if an owned secret exists but contains 'non-matching' data, delete it'": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", map[string][]byte{"tls.key": mustGenerateECDSA(t, pki.ECCurve256)}),
+			},
+			expectedEvents: []string{"Normal Deleted Regenerating private key due to change in fields: [spec.keyAlgorithm]"},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
+			},
+		},
+		"if an owned secret exists and contains data valid for the spec, do nothing'": {
+			certificate: &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", UID: types.UID("test")},
+				Status: cmapi.CertificateStatus{
+					NextPrivateKeySecretName: pointer.StringPtr("fixed-name"),
+					Conditions: []cmapi.CertificateCondition{
+						{
+							Type:   cmapi.CertificateConditionIssuing,
+							Status: cmmeta.ConditionTrue,
+						},
+					},
+				},
+			},
+			secrets: []runtime.Object{
+				ownedSecretWithName("testns", "fixed-name", "test", map[string][]byte{"tls.key": mustGenerateRSA(t, 2048)}),
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create and initialise a new unit test builder
+			builder := &testpkg.Builder{
+				T:               t,
+				ExpectedEvents:  test.expectedEvents,
+				ExpectedActions: test.expectedActions,
+				StringGenerator: func(i int) string { return "notrandom" },
+			}
+			if test.certificate != nil {
+				builder.CertManagerObjects = append(builder.CertManagerObjects, test.certificate)
+			}
+			if test.secrets != nil {
+				builder.KubeObjects = append(builder.KubeObjects, test.secrets...)
+			}
+			for _, req := range test.requests {
+				builder.CertManagerObjects = append(builder.CertManagerObjects, req)
+			}
+			builder.Init()
+
+			// Register informers used by the controller using the registration wrapper
+			w := &controllerWrapper{}
+			_, _, err := w.Register(builder.Context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Start the informers and begin processing updates
+			builder.Start()
+			defer builder.Stop()
+
+			key := test.key
+			if key == "" && test.certificate != nil {
+				key, err = controllerpkg.KeyFunc(test.certificate)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Call ProcessItem
+			err = w.controller.ProcessItem(context.Background(), key)
+			switch {
+			case err != nil:
+				if test.err != err.Error() {
+					t.Errorf("error text did not match, got=%s, exp=%s", err.Error(), test.err)
+				}
+			default:
+				if test.err != "" {
+					t.Errorf("got no error but expected: %s", test.err)
+				}
+			}
+
+			if err := builder.AllEventsCalled(); err != nil {
+				builder.T.Error(err)
+			}
+			if err := builder.AllActionsExecuted(); err != nil {
+				builder.T.Error(err)
+			}
+			if err := builder.AllReactorsCalled(); err != nil {
+				builder.T.Error(err)
+			}
+		})
+	}
+}

--- a/pkg/controller/expcertificates/listers.go
+++ b/pkg/controller/expcertificates/listers.go
@@ -17,7 +17,9 @@ limitations under the License.
 package certificates
 
 import (
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	corelisters "k8s.io/client-go/listers/core/v1"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha2"
@@ -53,6 +55,25 @@ func ListCertificatesMatchingPredicates(lister cmlisters.CertificateNamespaceLis
 	}
 	funcs := predicate.Funcs(predicates)
 	out := make([]*cmapi.Certificate, 0)
+	for _, req := range reqs {
+		if funcs.Evaluate(req) {
+			out = append(out, req)
+		}
+	}
+
+	return out, nil
+}
+
+// ListSecretsMatchingPredicates will list Secret resources using
+// the provided lister, optionally applying the given predicate functions to
+// filter the Secret resources returned.
+func ListSecretsMatchingPredicates(lister corelisters.SecretNamespaceLister, selector labels.Selector, predicates ...predicate.Func) ([]*corev1.Secret, error) {
+	reqs, err := lister.List(selector)
+	if err != nil {
+		return nil, err
+	}
+	funcs := predicate.Funcs(predicates)
+	out := make([]*corev1.Secret, 0)
 	for _, req := range reqs {
 		if funcs.Evaluate(req) {
 			out = append(out, req)

--- a/pkg/controller/expcertificates/util_test.go
+++ b/pkg/controller/expcertificates/util_test.go
@@ -15,3 +15,85 @@ limitations under the License.
 */
 
 package certificates
+
+import (
+	"crypto"
+	"reflect"
+	"testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+func mustGenerateRSA(t *testing.T, keySize int) crypto.PrivateKey {
+	pk, err := pki.GenerateRSAPrivateKey(keySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pk
+}
+
+func mustGenerateECDSA(t *testing.T, keySize int) crypto.PrivateKey {
+	pk, err := pki.GenerateECPrivateKey(keySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pk
+}
+
+func TestPrivateKeyMatchesSpec(t *testing.T) {
+	tests := map[string]struct {
+		key          crypto.PrivateKey
+		expectedAlgo cmapi.KeyAlgorithm
+		expectedSize int
+		violations   []string
+		err          string
+	}{
+		"should match if keySize and algorithm are correct (RSA)": {
+			key:          mustGenerateRSA(t, 2048),
+			expectedAlgo: cmapi.RSAKeyAlgorithm,
+			expectedSize: 2048,
+		},
+		"should not match if RSA keySize is incorrect": {
+			key:          mustGenerateRSA(t, 2048),
+			expectedAlgo: cmapi.RSAKeyAlgorithm,
+			expectedSize: 4096,
+			violations:   []string{"spec.keySize"},
+		},
+		"should match if keySize and algorithm are correct (ECDSA)": {
+			key:          mustGenerateECDSA(t, pki.ECCurve256),
+			expectedAlgo: cmapi.ECDSAKeyAlgorithm,
+			expectedSize: 256,
+		},
+		"should not match if ECDSA keySize is incorrect": {
+			key:          mustGenerateECDSA(t, pki.ECCurve256),
+			expectedAlgo: cmapi.ECDSAKeyAlgorithm,
+			expectedSize: pki.ECCurve521,
+			violations:   []string{"spec.keySize"},
+		},
+		"should not match if keyAlgorithm is incorrect": {
+			key:          mustGenerateECDSA(t, pki.ECCurve256),
+			expectedAlgo: cmapi.RSAKeyAlgorithm,
+			expectedSize: 2048,
+			violations:   []string{"spec.keyAlgorithm"},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			violations, err := PrivateKeyMatchesSpec(test.key, cmapi.CertificateSpec{KeyAlgorithm: test.expectedAlgo, KeySize: test.expectedSize})
+			switch {
+			case err != nil:
+				if test.err != err.Error() {
+					t.Errorf("error text did not match, got=%s, exp=%s", err.Error(), test.err)
+				}
+			default:
+				if test.err != "" {
+					t.Errorf("got no error but expected: %s", test.err)
+				}
+			}
+			if !reflect.DeepEqual(violations, test.violations) {
+				t.Errorf("violations did not match, got=%s, exp=%s", violations, test.violations)
+			}
+		})
+	}
+}

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -58,8 +58,7 @@ func ValidateCertificateSpec(crt *cmapi.CertificateSpec, fldPath *field.Path) fi
 	}
 
 	switch crt.KeyAlgorithm {
-	case cmapi.KeyAlgorithm(""):
-	case cmapi.RSAKeyAlgorithm:
+	case "", cmapi.RSAKeyAlgorithm:
 		if crt.KeySize > 0 && (crt.KeySize < 2048 || crt.KeySize > 8192) {
 			el = append(el, field.Invalid(fldPath.Child("keySize"), crt.KeySize, "must be between 2048 & 8192 for rsa keyAlgorithm"))
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the keymanager controller which handles generating and managing 'next private keys' with the new 'experimental' certificates controller design.

**Special notes for your reviewer**:

With this PR, the controller currently *always* generates a new private key upon re-issuance, a departure from what we do today. It needs extending to default to the current behaviour with an option to enable rotation.

**Release note**:
```release-note
NONE
```
