### PR TITLE
Add licences to Docker images

### DIFF
--- a/build/container.bzl
+++ b/build/container.bzl
@@ -16,6 +16,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_bundle", "con
 load("@io_bazel_rules_docker//contrib:push-all.bzl", "docker_push")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load(":platforms.bzl", "go_platform_constraint")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 
 # multi_arch_container produces a private internal container_image, multiple
 # arch-specific tagged container_bundles (named NAME-ARCH), an alias
@@ -67,9 +68,17 @@ def multi_arch_container(
         **kwargs
     )
 
+    # Create a tar file containing the created license files
+    pkg_tar(
+        name = "%s.licence_tar" % name,
+        srcs = ["//:LICENSE", "//:LICENSES"],
+        package_dir = "licences",
+    )
+
     container_image(
         name = "%s.image" % name,
         base = ":%s-internal-notimestamp" % name,
+        tars = [":%s.licence_tar" % name],
         stamp = stamp,
         tags = tags,
         user = user,


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds our licence files to `/licences` in the Docker images, this is a requirement for some certifications like the RedHat Operator hub.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add license files to /licences/ in Docker images
```
