### PR TITLE
Add cert-manager origin tag in Venafi

### DIFF
--- a/pkg/internal/venafi/sign.go
+++ b/pkg/internal/venafi/sign.go
@@ -60,7 +60,10 @@ func (v *Venafi) Sign(csrPEM []byte, duration time.Duration, customFields []inte
 
 	// Add cert-manager origin tag
 	vreq.CustomFields = []certificate.CustomField{
-		{Type: certificate.CustomFieldOrigin, Value: "Jetstack cert-manager"},
+		{
+			Type:  certificate.CustomFieldOrigin,
+			Value: "Jetstack cert-manager",
+		},
 	}
 
 	// Convert over custom fields from our struct type to venafi's

--- a/pkg/internal/venafi/sign.go
+++ b/pkg/internal/venafi/sign.go
@@ -58,9 +58,13 @@ func (v *Venafi) Sign(csrPEM []byte, duration time.Duration, customFields []inte
 	// Create a vcert Request structure
 	vreq := newVRequest(tmpl)
 
+	// Add cert-manager origin tag
+	vreq.CustomFields = []certificate.CustomField{
+		{Type: certificate.CustomFieldOrigin, Value: "Jetstack cert-manager"},
+	}
+
 	// Convert over custom fields from our struct type to venafi's
 	if len(customFields) > 0 {
-		vreq.CustomFields = []certificate.CustomField{}
 		for _, field := range customFields {
 			var fieldType certificate.CustomFieldType
 			switch field.Type {

--- a/pkg/internal/venafi/sign_test.go
+++ b/pkg/internal/venafi/sign_test.go
@@ -179,10 +179,17 @@ func TestSign(t *testing.T) {
 			customFields: []internalvanafiapi.CustomField{{Name: "test", Value: "ok"}},
 			client: internalfake.Connector{
 				RetrieveCertificateFunc: func(r *certificate.Request) (*certificate.PEMCollection, error) {
-					if len(r.CustomFields) == 0 {
+					// we set 1 field by default
+					if len(r.CustomFields) <= 1 {
 						return nil, errors.New("custom fields not set")
 					}
-					if r.CustomFields[0].Name != "test" || r.CustomFields[0].Value != "ok" {
+					foundFields := false
+					for _, fieldSet := range r.CustomFields {
+						if fieldSet.Name != "test" && fieldSet.Value != "ok" {
+							foundFields = true
+						}
+					}
+					if !foundFields {
 						return nil, errors.New("custom fields content not correct")
 					}
 					return internalfake.Connector{}.Default().RetrieveCertificate(r) // hack to return to normal


### PR DESCRIPTION
**What this PR does / why we need it**:
Add an origin tag on Venafi certificate sign requests. This allows the Venafi software to recognize that the certificates are requested by cert-manager

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Venafi issuer: add origin tag to requests
```
