### PR TITLE
Make directory name the correct "licenses"

### DIFF
--- a/build/container.bzl
+++ b/build/container.bzl
@@ -70,15 +70,15 @@ def multi_arch_container(
 
     # Create a tar file containing the created license files
     pkg_tar(
-        name = "%s.licence_tar" % name,
+        name = "%s.license_tar" % name,
         srcs = ["//:LICENSE", "//:LICENSES"],
-        package_dir = "licences",
+        package_dir = "licenses",
     )
 
     container_image(
         name = "%s.image" % name,
         base = ":%s-internal-notimestamp" % name,
-        tars = [":%s.licence_tar" % name],
+        tars = [":%s.license_tar" % name],
         stamp = stamp,
         tags = tags,
         user = user,


### PR DESCRIPTION
**What this PR does / why we need it**:
Licence vs. license was very confusing but the correct one for the Docker container should be licenses 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
