### PR TITLE
Set Issuer kind specific to Issuer if /issuer is specified

### DIFF
--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -349,6 +349,7 @@ func (c *controller) issuerForIngress(ing *extv1beta1.Ingress) (name, kind, grou
 	issuerName, issuerNameOK := annotations[cmapi.IngressIssuerNameAnnotationKey]
 	if issuerNameOK {
 		name = issuerName
+		kind = cmapi.IssuerKind
 	}
 
 	clusterIssuerName, clusterIssuerNameOK := annotations[cmapi.IngressClusterIssuerNameAnnotationKey]


### PR DESCRIPTION
**What this PR does / why we need it**:
When the default issuer kind is overwritten to ClusterIssuer but 
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
Fixes https://github.com/jetstack/cert-manager/issues/2533

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix case where cert-manager.io/issuer doesn't set `Issuer` kind
```
