### PR TITLE
chart service account improvments

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -152,7 +152,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.deploymentAnnotations` | Annotations to add to the cainjector deployment | `{}` |
 | `cainjector.extraArgs` | Optional flags for cert-manager cainjector component | `[]` |
 | `cainjector.serviceAccount.create` | If `true`, create a new service account for the cainjector component | `true` |
-| `cainjector.serviceAccount.name` | Service account to be used for the cainjector component If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `cainjector.serviceAccount.name` | Service account for the cainjector component to be used. If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `cainjector.serviceAccount.annotations` | Annotations to add to the service account for the cainjector component |  |
 | `cainjector.resources` | CPU/memory resource requests/limits for the cainjector pods | `{}` |
 | `cainjector.nodeSelector` | Node labels for cainjector pod assignment | `{}` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -134,6 +134,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
+| `webhook.serviceAccount.create` | If `true`, create a new service account for the webhook component | `true` |
+| `webhook.serviceAccount.name` | Service account for the webhook component to be used. If not set and `webhook.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `webhook.serviceAccount.annotations` | Annotations to add to the service account for the webhook component |  |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | `{}` |
 | `webhook.nodeSelector` | Node labels for webhook pod assignment | `{}` |
 | `webhook.affinity` | Node affinity for webhook pod assignment | `{}` |
@@ -148,6 +151,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |
 | `cainjector.deploymentAnnotations` | Annotations to add to the cainjector deployment | `{}` |
 | `cainjector.extraArgs` | Optional flags for cert-manager cainjector component | `[]` |
+| `cainjector.serviceAccount.create` | If `true`, create a new service account for the webhook cainjector | `true` |
+| `cainjector.serviceAccount.name` | Service account to be used for the webhook cainjector. If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `cainjector.serviceAccount.annotations` | Annotations to add to the service account for the webhook cainjector |  |
 | `cainjector.resources` | CPU/memory resource requests/limits for the cainjector pods | `{}` |
 | `cainjector.nodeSelector` | Node labels for cainjector pod assignment | `{}` |
 | `cainjector.affinity` | Node affinity for cainjector pod assignment | `{}` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -151,9 +151,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |
 | `cainjector.deploymentAnnotations` | Annotations to add to the cainjector deployment | `{}` |
 | `cainjector.extraArgs` | Optional flags for cert-manager cainjector component | `[]` |
-| `cainjector.serviceAccount.create` | If `true`, create a new service account for the webhook cainjector | `true` |
-| `cainjector.serviceAccount.name` | Service account to be used for the webhook cainjector. If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
-| `cainjector.serviceAccount.annotations` | Annotations to add to the service account for the webhook cainjector |  |
+| `cainjector.serviceAccount.create` | If `true`, create a new service account for the cainjector component | `true` |
+| `cainjector.serviceAccount.name` | Service account to be used for the cainjector component If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `cainjector.serviceAccount.annotations` | Annotations to add to the service account for the cainjector component |  |
 | `cainjector.resources` | CPU/memory resource requests/limits for the cainjector pods | `{}` |
 | `cainjector.nodeSelector` | Node labels for cainjector pod assignment | `{}` |
 | `cainjector.affinity` | Node affinity for cainjector pod assignment | `{}` |

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -76,6 +76,17 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create the name of the service account to use
+*/}}
+{{- define "webhook.serviceAccountName" -}}
+{{- if .Values.webhook.serviceAccount.create -}}
+    {{ default (include "webhook.fullname" .) .Values.webhook.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.webhook.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 cainjector templates
 */}}
 
@@ -103,4 +114,15 @@ Create chart name and version as used by the chart label.
 */}}
 {{- define "cainjector.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cainjector.serviceAccountName" -}}
+{{- if .Values.cainjector.serviceAccount.create -}}
+    {{ default (include "cainjector.fullname" .) .Values.cainjector.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.cainjector.serviceAccount.name }}
+{{- end -}}
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -40,7 +40,7 @@ spec:
 {{ toYaml .Values.cainjector.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "cainjector.fullname" . }}
+      serviceAccountName: {{ template "cainjector.serviceAccountName" . }}
       {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName | quote }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
@@ -17,7 +17,7 @@ roleRef:
   name: {{ template "cainjector.fullname" . }}-psp
 subjects:
   - kind: ServiceAccount
-    name: {{ include "cainjector.fullname" . }}
+    name: {{ template "cainjector.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -50,7 +50,7 @@ roleRef:
   kind: ClusterRole
   name: {{ template "cainjector.fullname" . }}
 subjects:
-  - name: {{ include "cainjector.fullname" . }}
+  - name: {{ template "cainjector.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
 
@@ -103,7 +103,7 @@ roleRef:
   name: {{ template "cainjector.fullname" . }}:leaderelection
 subjects:
   - kind: ServiceAccount
-    name: {{ include "cainjector.fullname" . }}
+    name: {{ template "cainjector.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 
 

--- a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -1,9 +1,14 @@
 {{- if .Values.cainjector.enabled -}}
+{{- if .Values.cainjector.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "cainjector.fullname" . }}
+  name: {{ template "cainjector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.cainjector.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.cainjector.serviceAccount.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ include "cainjector.name" . }}
     app.kubernetes.io/name: {{ include "cainjector.name" . }}
@@ -14,4 +19,5 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}
+{{- end -}}
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/psp-clusterrolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
   name: {{ template "cert-manager.fullname" . }}-psp
 subjects:
   - kind: ServiceAccount
-    name: {{ include "cert-manager.fullname" . }}
+    name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -39,7 +39,7 @@ spec:
 {{ toYaml .Values.webhook.podAnnotations | indent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: {{ include "webhook.fullname" . }}
+      serviceAccountName: {{ template "webhook.serviceAccountName" . }}
       {{- if .Values.global.priorityClassName }}
       priorityClassName: {{ .Values.global.priorityClassName | quote }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
@@ -16,6 +16,6 @@ roleRef:
   name: {{ template "webhook.fullname" . }}-psp
 subjects:
   - kind: ServiceAccount
-    name: {{ include "webhook.fullname" . }}
+    name: {{ template "webhook.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -43,7 +43,7 @@ roleRef:
 subjects:
 - apiGroup: ""
   kind: ServiceAccount
-  name: {{ include "webhook.fullname" . }}
+  name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 
 {{- end -}}

--- a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
@@ -1,8 +1,13 @@
+{{- if .Values.webhook.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "webhook.fullname" . }}
+  name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.webhook.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.webhook.serviceAccount.annotations | indent 4 }}
+  {{- end }}
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}
@@ -13,4 +18,4 @@ metadata:
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end -}}
-
+{{- end -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -196,6 +196,15 @@ webhook:
     # tag: canary
     pullPolicy: IfNotPresent
 
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    # name: ""
+    # Optional additional annotations to add to the controller's ServiceAccount
+    # annotations: {}
+
   # The port that the webhook should listen on for requests.
   # In GKE private clusters, by default kubernetes apiservers are allowed to
   # talk to the cluster nodes only on 443 and 10250. so configuring
@@ -241,3 +250,12 @@ cainjector:
     # If no value is set, the chart's appVersion will be used.
     # tag: canary
     pullPolicy: IfNotPresent
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    # name: ""
+    # Optional additional annotations to add to the controller's ServiceAccount
+    # annotations: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

The psp cluste role binding was not using the serviceAccountName template so it would have binded to the wrong service account if a name was given.

Add the ability to disable and set the name of the service accounts for the webhook and cainjector.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
* Add webhook service account customization
* Add cainjector service account customization
```
