### PR TITLE
Fix #2849 Add container security context to helm chart deployments

### DIFF
--- a/deploy/charts/cert-manager/.helmignore
+++ b/deploy/charts/cert-manager/.helmignore
@@ -19,3 +19,5 @@
 .project
 .idea/
 *.tmproj
+
+BUILD.bazel

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -108,6 +108,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `resources` | CPU/memory resource requests/limits | `{}` |
 | `securityContext` | Optional security context. The yaml block should adhere to the [SecurityContext spec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#securitycontext-v1-core) | `{}` |
 | `securityContext.enabled` | Deprecated (use `securityContext`) - Enable security context | `false` |
+| `containerSecurityContext` | Security context to be set on the controller component container | `{}` |
 | `nodeSelector` | Node labels for pod assignment | `{}` |
 | `affinity` | Node affinity for pod assignment | `{}` |
 | `tolerations` | Node tolerations for pod assignment | `[]` |
@@ -143,6 +144,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.image.pullPolicy` | Webhook image pull policy | `IfNotPresent` |
 | `webhook.securePort` | The port that the webhook should listen on for requests. | `10250` |
 | `webhook.securityContext` | Security context for webhook pod assignment | `{}` |
+| `webhook.containerSecurityContext` | Security context to be set on the webhook component container | `{}` |
 | `cainjector.enabled` | Toggles whether the cainjector component should be installed (required for the webhook component to work) | `true` |
 | `cainjector.replicaCount` | Number of cert-manager cainjector replicas | `1` |
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |
@@ -156,6 +158,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.image.tag` | cainjector image tag | `{{RELEASE_VERSION}}` |
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | `{}` |
+| `cainjector.containerSecurityContext` | Security context to be set on cainjector component container | `{}` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -65,6 +65,8 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          securityContext:
+            {{- toYaml .Values.cainjector.containerSecurityContext | nindent 12 }}
           resources:
 {{ toYaml .Values.cainjector.resources | indent 12 }}
     {{- with .Values.cainjector.nodeSelector }}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -65,8 +65,10 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- if .Values.cainjector.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.cainjector.containerSecurityContext | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.cainjector.resources | indent 12 }}
     {{- with .Values.cainjector.nodeSelector }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -105,8 +105,10 @@ spec:
           ports:
           - containerPort: 9402
             protocol: TCP
+          {{- if .Values.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 12 }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -105,6 +105,8 @@ spec:
           ports:
           - containerPort: 9402
             protocol: TCP
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 12 }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -79,8 +79,10 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 5
+          {{- if .Values.webhook.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.webhook.containerSecurityContext | nindent 12 }}
+          {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -79,6 +79,8 @@ spec:
               scheme: HTTP
             initialDelaySeconds: 5
             periodSeconds: 5
+          securityContext:
+            {{- toYaml .Values.webhook.containerSecurityContext | nindent 12 }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -91,7 +91,7 @@ securityContext: {}
 #   runAsUser: 1000
 #   runAsNonRoot: true
 
-# Container Security Context
+# Container Security Context to be set on the controller component container
 # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 containerSecurityContext: {}
   # capabilities:
@@ -179,7 +179,7 @@ webhook:
 
   securityContext: {}
 
-  # Container Security Context for Webhook Container
+  # Container Security Context to be set on the webhook component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext: {}
     # capabilities:
@@ -234,7 +234,7 @@ cainjector:
 
   securityContext: {}
 
-  # Container Security Context for cainjector Container
+  # Container Security Context to be set on the cainjector component container
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   containerSecurityContext: {}
     # capabilities:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -91,6 +91,16 @@ securityContext: {}
 #   runAsUser: 1000
 #   runAsNonRoot: true
 
+# Container Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+containerSecurityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+
+
 volumes: []
 
 volumeMounts: []
@@ -169,6 +179,15 @@ webhook:
 
   securityContext: {}
 
+  # Container Security Context for Webhook Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  containerSecurityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+
   # Optional additional annotations to add to the webhook Deployment
   # deploymentAnnotations: {}
 
@@ -214,6 +233,16 @@ cainjector:
     #   maxUnavailable: 1
 
   securityContext: {}
+
+  # Container Security Context for cainjector Container
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  containerSecurityContext: {}
+    # capabilities:
+    #   drop:
+    #   - ALL
+    # readOnlyRootFilesystem: true
+    # runAsNonRoot: true
+
 
   # Optional additional annotations to add to the cainjector Deployment
   # deploymentAnnotations: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds the ability to set the container securityContext for each deployment in the helm chart.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 
fixes #2849

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added the ability to set the container securityContext for each deployment in the helm chart
```
