### PR TITLE
Remove serverAuth default usage & remove unused DefaultKeyUsage functions

### DIFF
--- a/pkg/apis/certmanager/v1alpha2/types.go
+++ b/pkg/apis/certmanager/v1alpha2/types.go
@@ -171,5 +171,8 @@ const (
 func DefaultKeyUsages() []KeyUsage {
 	// The serverAuth EKU is required as of Mac OS Catalina: https://support.apple.com/en-us/HT210176
 	// Without this usage, certificates will _always_ flag a warning in newer Mac OS browsers.
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth}
+	// We don't explicitly add it here as it leads to strange behaviour when a user sets isCA: true
+	// (in which case, 'serverAuth' on the CA can break a lot of clients).
+	// CAs can (and often do) opt to automatically add usages.
+	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
 }

--- a/pkg/apis/certmanager/v1alpha3/types.go
+++ b/pkg/apis/certmanager/v1alpha3/types.go
@@ -164,10 +164,3 @@ const (
 	UsageMicrosoftSGC       KeyUsage = "microsoft sgc"
 	UsageNetscapeSGC        KeyUsage = "netscape sgc"
 )
-
-// DefaultKeyUsages contains the default list of key usages
-func DefaultKeyUsages() []KeyUsage {
-	// The serverAuth EKU is required as of Mac OS Catalina: https://support.apple.com/en-us/HT210176
-	// Without this usage, certificates will _always_ flag a warning in newer Mac OS browsers.
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment, UsageServerAuth}
-}

--- a/pkg/internal/apis/certmanager/types.go
+++ b/pkg/internal/apis/certmanager/types.go
@@ -97,8 +97,3 @@ const (
 	UsageMicrosoftSGC       KeyUsage = "microsoft sgc"
 	UsageNetscapeSGC        KeyUsage = "netscape sgc"
 )
-
-// DefaultKeyUsages contains the default list of key usages
-func DefaultKeyUsages() []KeyUsage {
-	return []KeyUsage{UsageDigitalSignature, UsageKeyEncipherment}
-}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -45,19 +45,17 @@ func TestBuildUsages(t *testing.T) {
 	}
 	tests := []testT{
 		{
-			name:                "default",
-			usages:              []v1alpha2.KeyUsage{},
-			expectedKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-			expectedError:       false,
+			name:             "default",
+			usages:           []v1alpha2.KeyUsage{},
+			expectedKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+			expectedError:    false,
 		},
 		{
-			name:                "isCa",
-			usages:              []v1alpha2.KeyUsage{},
-			isCa:                true,
-			expectedKeyUsage:    x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
-			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-			expectedError:       false,
+			name:             "isCa",
+			usages:           []v1alpha2.KeyUsage{},
+			isCa:             true,
+			expectedKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
+			expectedError:    false,
 		},
 		{
 			name:             "existing keyusage",


### PR DESCRIPTION
**What this PR does / why we need it**:

Removes the `serverAuth` usage by default to avoid issues when creating certificates with the `isCA` option set to true.

**Which issue this PR fixes**: fixes #2407

**Release note**:
```release-note
ACTION REQUIRED: Remove `serverAuth` key usage from set of defaults. If your configured issuer does not automatically set this usage and you do require it, you will need to manually update your Certificate & CertificateRequest resources to contain the `serverAuth` usage
```
