### PR TITLE
Ensure version x_defs are set on built ctl binary

### DIFF
--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -1,4 +1,5 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("//build:go_binary.bzl", "go_binary")
 
 go_library(
     name = "go_default_library",
@@ -14,6 +15,7 @@ go_library(
 go_binary(
     name = "ctl",
     embed = [":go_default_library"],
+    pure = "on",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Uses the correct `go_binary` (our own one that wraps the go_binary and sets x_defs correctly).

**Release note**:
```release-note
NONE
```

/kind bug
/area ctl
/priority critical-urgent
/milestone v0.15
