### PR TITLE
Handle ACME orders with already valid authorizations upon first fetch through new 'initialState' field

### DIFF
--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -169,6 +169,24 @@ spec:
                     description: Identifier is the DNS name to be validated as part
                       of this authorization
                     type: string
+                  initialState:
+                    description: InitialState is the initial state of the ACME authorization
+                      when first fetched from the ACME server. If an Authorization
+                      is already 'valid', the Order controller will not create a Challenge
+                      resource for the authorization. This will occur when working
+                      with an ACME server that enables 'authz reuse' (such as Let's
+                      Encrypt's production endpoint). If not set and 'identifier'
+                      is set, the state is assumed to be pending and a Challenge will
+                      be created.
+                    type: string
+                    enum:
+                    - valid
+                    - ready
+                    - pending
+                    - processing
+                    - invalid
+                    - expired
+                    - errored
                   url:
                     description: URL is the URL of the Authorization that must be
                       completed

--- a/pkg/apis/acme/v1alpha2/types_order.go
+++ b/pkg/apis/acme/v1alpha2/types_order.go
@@ -143,6 +143,17 @@ type ACMEAuthorization struct {
 	// +optional
 	Wildcard *bool `json:"wildcard,omitempty"`
 
+	// InitialState is the initial state of the ACME authorization when first
+	// fetched from the ACME server.
+	// If an Authorization is already 'valid', the Order controller will not
+	// create a Challenge resource for the authorization. This will occur when
+	// working with an ACME server that enables 'authz reuse' (such as Let's
+	// Encrypt's production endpoint).
+	// If not set and 'identifier' is set, the state is assumed to be pending
+	// and a Challenge will be created.
+	// +optional
+	InitialState State `json:"initialState,omitempty"`
+
 	// Challenges specifies the challenge types offered by the ACME server.
 	// One of these challenge types will be selected when validating the DNS
 	// name and an appropriate Challenge resource will be created to perform

--- a/pkg/apis/acme/v1alpha3/types_order.go
+++ b/pkg/apis/acme/v1alpha3/types_order.go
@@ -143,6 +143,17 @@ type ACMEAuthorization struct {
 	// +optional
 	Wildcard *bool `json:"wildcard,omitempty"`
 
+	// InitialState is the initial state of the ACME authorization when first
+	// fetched from the ACME server.
+	// If an Authorization is already 'valid', the Order controller will not
+	// create a Challenge resource for the authorization. This will occur when
+	// working with an ACME server that enables 'authz reuse' (such as Let's
+	// Encrypt's production endpoint).
+	// If not set and 'identifier' is set, the state is assumed to be pending
+	// and a Challenge will be created.
+	// +optional
+	InitialState State `json:"initialState,omitempty"`
+
 	// Challenges specifies the challenge types offered by the ACME server.
 	// One of these challenge types will be selected when validating the DNS
 	// name and an appropriate Challenge resource will be created to perform

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -239,9 +239,10 @@ func (c *controller) updateOrderStatus(ctx context.Context, cl acmecl.Interface,
 	}
 	o.Status.FinalizeURL = acmeOrder.FinalizeURL
 	c.setOrderState(&o.Status, acmeOrder.Status)
-	// only set the authorizations field if the lengths mismatch.
-	// state can be rebuilt in this case on the next call to ProcessItem.
-	if len(o.Status.Authorizations) != len(acmeOrder.AuthzURLs) {
+	// once the 'authorizations' slice contains at least one item, it cannot be
+	// updated. If it does not contain any items, update it containing the list
+	// of authorizations returned on the Order.
+	if len(o.Status.Authorizations) == 0 {
 		o.Status.Authorizations = constructAuthorizations(acmeOrder)
 	}
 

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -303,6 +303,7 @@ func (c *controller) fetchMetadataForAuthorizations(ctx context.Context, o *cmac
 			return err
 		}
 
+		authz.InitialState = cmacme.State(acmeAuthz.Status)
 		authz.Identifier = acmeAuthz.Identifier.Value
 		authz.Wildcard = &acmeAuthz.Wildcard
 		authz.Challenges = make([]cmacme.ACMEChallenge, len(acmeAuthz.Challenges))

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -200,6 +200,111 @@ dGVzdA==
 				},
 			},
 		},
+		// TODO: we should improve this behaviour as this is the 'stuck order' problem described in:
+		//  https://github.com/jetstack/cert-manager/issues/2868
+		"skip creating a Challenge for an already valid authorization, and do nothing if the order is pending": {
+			order: gen.OrderFrom(testOrder, gen.SetOrderStatus(
+				cmacme.OrderStatus{
+					State:       cmacme.Pending,
+					URL:         "http://testurl.com/abcde",
+					FinalizeURL: "http://testurl.com/abcde/finalize",
+					Authorizations: []cmacme.ACMEAuthorization{
+						{
+							URL:          "http://authzurl",
+							Identifier:   "test.com",
+							InitialState: cmacme.Valid,
+							Challenges: []cmacme.ACMEChallenge{
+								{
+									URL:   "http://chalurl",
+									Token: "token",
+									Type:  cmacme.ACMEChallengeTypeHTTP01,
+								},
+							},
+						},
+					},
+				},
+			)),
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestCom, testOrderPending},
+				ExpectedActions:    []testpkg.Action{},
+				ExpectedEvents:     []string{},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeGetOrder: func(ctx context.Context, url string) (*acmeapi.Order, error) {
+					return &acmeapi.Order{
+						URI:         "http://testurl.com/abcde",
+						Status:      acmeapi.StatusPending,
+						FinalizeURL: "http://testurl.com/abcde/finalize",
+						CertURL:     "",
+					}, nil
+				},
+			},
+		},
+		"skip creating a Challenge for an already valid authorization": {
+			order: gen.OrderFrom(testOrder, gen.SetOrderStatus(
+				cmacme.OrderStatus{
+					State:       cmacme.Pending,
+					URL:         "http://testurl.com/abcde",
+					FinalizeURL: "http://testurl.com/abcde/finalize",
+					Authorizations: []cmacme.ACMEAuthorization{
+						{
+							URL:          "http://authzurl",
+							Identifier:   "test.com",
+							InitialState: cmacme.Valid,
+							Challenges: []cmacme.ACMEChallenge{
+								{
+									URL:   "http://chalurl",
+									Token: "token",
+									Type:  cmacme.ACMEChallengeTypeHTTP01,
+								},
+							},
+						},
+					},
+				},
+			)),
+			builder: &testpkg.Builder{
+				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestCom, testOrderPending},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("orders"),
+						"status",
+						testOrder.Namespace, gen.OrderFrom(testOrder, gen.SetOrderStatus(
+							cmacme.OrderStatus{
+								// The 'state' field should be updated to reflect the
+								// Order returned by FakeGetOrder
+								State:       cmacme.Valid,
+								URL:         "http://testurl.com/abcde",
+								FinalizeURL: "http://testurl.com/abcde/finalize",
+								Authorizations: []cmacme.ACMEAuthorization{
+									{
+										URL:          "http://authzurl",
+										Identifier:   "test.com",
+										InitialState: cmacme.Valid,
+										Challenges: []cmacme.ACMEChallenge{
+											{
+												URL:   "http://chalurl",
+												Token: "token",
+												Type:  cmacme.ACMEChallengeTypeHTTP01,
+											},
+										},
+									},
+								},
+							},
+						)),
+					)),
+				},
+				ExpectedEvents: []string{},
+			},
+			acmeClient: &acmecl.FakeACME{
+				FakeGetOrder: func(ctx context.Context, url string) (*acmeapi.Order, error) {
+					return &acmeapi.Order{
+						URI:         "http://testurl.com/abcde",
+						Status:      acmeapi.StatusValid,
+						FinalizeURL: "http://testurl.com/abcde/finalize",
+						CertURL:     "",
+					}, nil
+				},
+			},
+		},
 		"do nothing if the challenge for test.com is still pending": {
 			order: testOrderPending,
 			builder: &testpkg.Builder{

--- a/pkg/internal/apis/acme/types_order.go
+++ b/pkg/internal/apis/acme/types_order.go
@@ -124,6 +124,17 @@ type ACMEAuthorization struct {
 	// field will be 'true' and the 'identifier' field will be 'example.com'.
 	Wildcard *bool
 
+	// InitialState is the initial state of the ACME authorization when first
+	// fetched from the ACME server.
+	// If an Authorization is already 'valid', the Order controller will not
+	// create a Challenge resource for the authorization. This will occur when
+	// working with an ACME server that enables 'authz reuse' (such as Let's
+	// Encrypt's production endpoint).
+	// If not set and 'identifier' is set, the state is assumed to be pending
+	// and a Challenge will be created.
+	// +optional
+	InitialState State
+
 	// Challenges specifies the challenge types offered by the ACME server.
 	// One of these challenge types will be selected when validating the DNS
 	// name and an appropriate Challenge resource will be created to perform

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -368,6 +368,7 @@ func autoConvert_v1alpha2_ACMEAuthorization_To_acme_ACMEAuthorization(in *v1alph
 	out.URL = in.URL
 	out.Identifier = in.Identifier
 	out.Wildcard = (*bool)(unsafe.Pointer(in.Wildcard))
+	out.InitialState = acme.State(in.InitialState)
 	out.Challenges = *(*[]acme.ACMEChallenge)(unsafe.Pointer(&in.Challenges))
 	return nil
 }
@@ -381,6 +382,7 @@ func autoConvert_acme_ACMEAuthorization_To_v1alpha2_ACMEAuthorization(in *acme.A
 	out.URL = in.URL
 	out.Identifier = in.Identifier
 	out.Wildcard = (*bool)(unsafe.Pointer(in.Wildcard))
+	out.InitialState = v1alpha2.State(in.InitialState)
 	out.Challenges = *(*[]v1alpha2.ACMEChallenge)(unsafe.Pointer(&in.Challenges))
 	return nil
 }

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -368,6 +368,7 @@ func autoConvert_v1alpha3_ACMEAuthorization_To_acme_ACMEAuthorization(in *v1alph
 	out.URL = in.URL
 	out.Identifier = in.Identifier
 	out.Wildcard = (*bool)(unsafe.Pointer(in.Wildcard))
+	out.InitialState = acme.State(in.InitialState)
 	out.Challenges = *(*[]acme.ACMEChallenge)(unsafe.Pointer(&in.Challenges))
 	return nil
 }
@@ -381,6 +382,7 @@ func autoConvert_acme_ACMEAuthorization_To_v1alpha3_ACMEAuthorization(in *acme.A
 	out.URL = in.URL
 	out.Identifier = in.Identifier
 	out.Wildcard = (*bool)(unsafe.Pointer(in.Wildcard))
+	out.InitialState = v1alpha3.State(in.InitialState)
 	out.Challenges = *(*[]v1alpha3.ACMEChallenge)(unsafe.Pointer(&in.Challenges))
 	return nil
 }

--- a/pkg/internal/apis/acme/validation/order.go
+++ b/pkg/internal/apis/acme/validation/order.go
@@ -90,6 +90,9 @@ func ValidateOrderStatusUpdate(old, new cmacme.OrderStatus, fldPath *field.Path)
 			if old.Wildcard != nil && (new.Wildcard == nil || *old.Wildcard != *new.Wildcard) {
 				el = append(el, field.Forbidden(fldPath.Child("wildcard"), "field is immutable once set"))
 			}
+			if old.InitialState != "" && (old.InitialState != new.InitialState) {
+				el = append(el, field.Forbidden(fldPath.Child("initialState"), "field is immutable once set"))
+			}
 
 			if len(old.Challenges) > 0 {
 				fldPath := fldPath.Child("challenges")


### PR DESCRIPTION
**What this PR does / why we need it**:

If an ACME Order object contains authorizations that are already 'valid', we will still attempt to create Challenge resources for them (which would usually immediately be marked valid). [Because Let's Encrypt recently changed Boulder to not return already-valid Challenges within Authorization objects](https://github.com/jetstack/cert-manager/issues/2494#issuecomment-618503293), this would mean we'd not be able to find a valid 'solving configuration' and so we'd fail to create the Challenge resource, thus never observing that the Authorization is already valid.

This extends the `fetchMetadata` method, which fetches the initial Authorization objects from the ACME server, to record the initial state of the Authorization, thus allowing the `buildRequiredChallenges` method to skip creating those Challenge resources.

**Which issue this PR fixes**: fixes #2494

**Special notes for your reviewer**:

https://github.com/jetstack/cert-manager/issues/2494#issuecomment-622340474 describes a more permanent solution to this problem via us removing the Challenge resource altogether in favour of an Authorization resource. This will take longer to implement, so for now we can quickly fix this issue in time for v0.15 like this 😄 

**Release note**:
```release-note
Fix bug that could cause ACME Orders that contain already valid Authorizations to not be completed
```

/kind bug
/priority critical-urgent
/milestone v0.15
/area acme
/cc @JoshVanL 
/assign @meyskens