### PR TITLE
Rename the CLI to kubectl cert-manager

### DIFF
--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -37,7 +37,7 @@ import (
 
 func NewCertManagerCtlCommand(in io.Reader, out, err io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "kubectl cert-manager",
+		Use:   "cert-manager",
 		Short: "cert-manager CLI tool to manage and configure cert-manager resources",
 		Long: `
 kubectl cert-manager is a CLI tool manage and configure cert-manager resources for Kubernetes`,

--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -37,7 +37,7 @@ import (
 
 func NewCertManagerCtlCommand(in io.Reader, out, err io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "cert-manager",
+		Use:   "kubectl-cert-manager",
 		Short: "cert-manager CLI tool to manage and configure cert-manager resources",
 		Long: `
 kubectl cert-manager is a CLI tool manage and configure cert-manager resources for Kubernetes`,

--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -37,10 +37,10 @@ import (
 
 func NewCertManagerCtlCommand(in io.Reader, out, err io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "cert-manager-ctl",
+		Use:   "kubectl cert-manager",
 		Short: "cert-manager CLI tool to manage and configure cert-manager resources",
 		Long: `
-cert-manager-ctl is a CLI tool manage and configure cert-manager resources for Kubernetes`,
+kubectl cert-manager is a CLI tool manage and configure cert-manager resources for Kubernetes`,
 		Run: runHelp,
 	}
 

--- a/cmd/ctl/pkg/version/version.go
+++ b/cmd/ctl/pkg/version/version.go
@@ -54,8 +54,8 @@ func NewCmdVersion(ioStreams genericclioptions.IOStreams) *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "version",
-		Short: "Print the cert-manager-ctl version",
-		Long:  "Print the cert-manager-ctl version",
+		Short: "Print the kubectl cert-manager version",
+		Long:  "Print the kubectl cert-manager version",
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Validate())
 			cmdutil.CheckErr(o.Run())

--- a/tools/cobra/main_test.go
+++ b/tools/cobra/main_test.go
@@ -49,7 +49,7 @@ func TestRun(t *testing.T) {
 		},
 		"if directory given, should write docs": {
 			input:   []string{"cobra", filepath.Join(rootDir, "foo")},
-			expDirs: []string{"foo/ca-injector", "foo/cert-manager-controller", "foo/cert-manager-ctl"},
+			expDirs: []string{"foo/ca-injector", "foo/cert-manager-controller", "foo/kubectl-cert-manager"},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Renames the CLI tool to the public name

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
