### PR TITLE
Update references to ctl binary name

### DIFF
--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -37,12 +37,12 @@ import (
 
 func NewCertManagerCtlCommand(in io.Reader, out, err io.Writer, stopCh <-chan struct{}) *cobra.Command {
 	cmds := &cobra.Command{
-		Use:   "kubectl-cert-manager",
+		Use:   "cert-manager",
 		Short: "cert-manager CLI tool to manage and configure cert-manager resources",
 		Long: `
 kubectl cert-manager is a CLI tool manage and configure cert-manager resources for Kubernetes`,
-		Run: runHelp,
 	}
+	cmds.SetUsageTemplate(usageTemplate)
 
 	kubeConfigFlags := genericclioptions.NewConfigFlags(true)
 	kubeConfigFlags.AddFlags(cmds.PersistentFlags())
@@ -67,6 +67,27 @@ kubectl cert-manager is a CLI tool manage and configure cert-manager resources f
 	return cmds
 }
 
-func runHelp(cmd *cobra.Command, args []string) {
-	cmd.Help()
-}
+const usageTemplate = `Usage:{{if .Runnable}}
+  kubectl {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  kubectl {{.CommandPath}} [command]{{end}}{{if gt (len .Aliases) 0}}
+
+Aliases:
+  {{.NameAndAliases}}{{end}}{{if .HasExample}}
+
+Examples:
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+
+Available Commands:{{range .Commands}}{{if (or .IsAvailableCommand (eq .Name "help"))}}
+  {{rpad .Name .NamePadding }} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableLocalFlags}}
+
+Flags:
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+Global Flags:
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasHelpSubCommands}}
+
+Additional help topics:{{range .Commands}}{{if .IsAdditionalHelpTopicCommand}}
+  {{rpad .CommandPath .CommandPathPadding}} {{.Short}}{{end}}{{end}}{{end}}{{if .HasAvailableSubCommands}}
+
+Use "kubectl {{.CommandPath}} [command] --help" for more information about a command.{{end}}
+`

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -43,13 +43,13 @@ Mark cert-manager Certificate resources for manual renewal.`))
 
 	example = templates.Examples(i18n.T(`
 # Renew the Certificates named 'my-app' and 'vault' in the current context namespace.
-ctl renew my-app vault
+kubectl cert-manager renew my-app vault
 
 # Renew all Certificates in the 'kube-system' namespace.
-ctl renew --namespace kube-system --all
+kubectl cert-manager renew --namespace kube-system --all
 
 # Renew all Certificates in all namespaces, provided those Certificates have the label 'app=my-service
-ctl renew --all-namespaces -l app=my-service`))
+kubectl cert-manager renew --all-namespaces -l app=my-service`))
 )
 
 // Options is a struct to support renew command

--- a/tools/cobra/main_test.go
+++ b/tools/cobra/main_test.go
@@ -49,7 +49,7 @@ func TestRun(t *testing.T) {
 		},
 		"if directory given, should write docs": {
 			input:   []string{"cobra", filepath.Join(rootDir, "foo")},
-			expDirs: []string{"foo/ca-injector", "foo/cert-manager-controller", "foo/kubectl-cert-manager"},
+			expDirs: []string{"foo/ca-injector", "foo/cert-manager-controller", "foo/cert-manager"},
 		},
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Updates references to the command name to be consistently `kubectl cert-manager`. For the usage text, this was slightly more difficult due to the fact Cobra strips everything after the first space character in the `Use` field, so I've duplicated the default Usage template here and modified it to include `kubectl` at the start 😅 

**Which issue this PR fixes**: fixes #2886

**Release note**:
```release-note
NONE
```

/kind bug
/area ctl
/assign @JoshVanL 
/cc @meyskens 
/milestone v0.15
/priority critical-urgent