### PR TITLE
Fix 'make images'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,7 @@ images:
 	APP_VERSION=$(APP_VERSION) \
 	DOCKER_REGISTRY=$(DOCKER_REPO) \
 	bazel run \
+		--stamp \
 		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
 		//build:server-images
 

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -49,7 +49,7 @@ multi_arch_container_push(
     name = "server-images",
     architectures = SERVER_PLATFORMS["linux"],
     docker_tags_images = {
-        "{{STABLE_DOCKER_REGISTRY}}/cert-manager-%s-{ARCH}:{{STABLE_DOCKER_TAG}}" % binary: "%s-internal" % binary
+        "{{STABLE_DOCKER_REGISTRY}}/cert-manager-%s-{ARCH}:{{STABLE_DOCKER_TAG}}" % binary: "%s.image" % binary
         for binary in DOCKERIZED_BINARIES.keys()
     },
     tags = ["manual"],


### PR DESCRIPTION
**What this PR does / why we need it**:

The name of the target generated by `build/container.bzl` has changed, causing the error described in the linked issue!

**Which issue this PR fixes**: fixes #2881

**Release note**:
```release-note
NONE
```

/kind bug
