### PR TITLE
Move all commands into cobra

### DIFF
--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -8,8 +8,8 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/acmesolver",
     visibility = ["//visibility:private"],
     deps = [
-        "//pkg/issuer/acme/http/solver:go_default_library",
-        "//pkg/logs:go_default_library",
+        "//cmd/acmesolver/app:go_default_library",
+        "//pkg/util/cmd:go_default_library",
     ],
 )
 
@@ -29,7 +29,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//cmd/acmesolver/app:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/acmesolver/app/BUILD.bazel
+++ b/cmd/acmesolver/app/BUILD.bazel
@@ -7,6 +7,8 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/issuer/acme/http/solver:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//pkg/util:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
     ],
 )

--- a/cmd/acmesolver/app/BUILD.bazel
+++ b/cmd/acmesolver/app/BUILD.bazel
@@ -1,0 +1,26 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["app.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/acmesolver/app",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/issuer/acme/http/solver:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/acmesolver/app/app.go
+++ b/cmd/acmesolver/app/app.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
+	"github.com/spf13/cobra"
+)
+
+func NewACMESolverCommand(ctx context.Context) *cobra.Command {
+	var (
+		listenPort int
+		domain     string
+		token      string
+		key        string
+	)
+
+	cmd := &cobra.Command{
+		Use:   "acme-solver",
+		Short: "HTTP server used to solver ACME challenges.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			s := &solver.HTTP01Solver{
+				ListenPort: listenPort,
+				Domain:     domain,
+				Token:      token,
+				Key:        key,
+			}
+
+			if err := s.Listen(ctx); err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().IntVar(&listenPort, "listen-port", 8089, "the port number to listen on for connections")
+	cmd.Flags().StringVar(&domain, "domain", "", "the domain name to verify")
+	cmd.Flags().StringVar(&token, "token", "", "the challenge token to verify against")
+	cmd.Flags().StringVar(&key, "key", "", "the challenge key to respond with")
+
+	return cmd
+}

--- a/cmd/acmesolver/app/app.go
+++ b/cmd/acmesolver/app/app.go
@@ -32,7 +32,7 @@ func NewACMESolverCommand(ctx context.Context) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "acme-solver",
+		Use:   "cert-manager-acme-solver",
 		Short: "HTTP server used to solver ACME challenges.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &solver.HTTP01Solver{

--- a/cmd/acmesolver/app/app.go
+++ b/cmd/acmesolver/app/app.go
@@ -32,7 +32,7 @@ func NewACMESolverCommand(ctx context.Context) *cobra.Command {
 	)
 
 	cmd := &cobra.Command{
-		Use:   "cert-manager-acme-solver",
+		Use:   "acmesolver",
 		Short: "HTTP server used to solver ACME challenges.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			s := &solver.HTTP01Solver{

--- a/cmd/acmesolver/main.go
+++ b/cmd/acmesolver/main.go
@@ -17,7 +17,6 @@ limitations under the License.
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -31,16 +30,7 @@ import (
 
 func main() {
 	stopCh := utilcmd.SetupSignalHandler()
-	ctx, cancel := context.WithCancel(context.TODO())
-	cmd := app.NewACMESolverCommand(ctx)
-
-	go func() {
-		select {
-		case <-ctx.Done():
-		case <-stopCh:
-			cancel()
-		}
-	}()
+	cmd := app.NewACMESolverCommand(stopCh)
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/cmd/acmesolver/main.go
+++ b/cmd/acmesolver/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Jetstack cert-manager contributors.
+Copyright 2020 The Jetstack cert-manager contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,38 +18,31 @@ package main
 
 import (
 	"context"
-	"flag"
-	"log"
+	"fmt"
+	"os"
 
-	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
-	"github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/cmd/acmesolver/app"
+	utilcmd "github.com/jetstack/cert-manager/pkg/util/cmd"
 )
 
 // acmesolver solves ACME http-01 challenges. This is intended to run as a pod
 // in the target kubernetes cluster in order to solve challenges for
 // cert-manager.
 
-var (
-	listenPort = flag.Int("listen-port", 8089, "the port number to listen on for connections")
-	domain     = flag.String("domain", "", "the domain name to verify")
-	token      = flag.String("token", "", "the challenge token to verify against")
-	key        = flag.String("key", "", "the challenge key to respond with")
-)
-
 func main() {
-	logs.InitLogs(nil)
-	defer logs.FlushLogs()
-	flag.Parse()
-	ctx := logs.NewContext(context.Background(), nil, "acmesolver")
+	stopCh := utilcmd.SetupSignalHandler()
+	ctx, cancel := context.WithCancel(context.TODO())
+	cmd := app.NewACMESolverCommand(ctx)
 
-	s := &solver.HTTP01Solver{
-		ListenPort: *listenPort,
-		Domain:     *domain,
-		Token:      *token,
-		Key:        *key,
-	}
+	go func() {
+		select {
+		case <-ctx.Done():
+		case <-stopCh:
+			cancel()
+		}
+	}()
 
-	if err := s.Listen(ctx); err != nil {
-		log.Fatalf("error listening for connections: %s", err.Error())
+	if err := cmd.Execute(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 	}
 }

--- a/cmd/controller/app/start.go
+++ b/cmd/controller/app/start.go
@@ -67,14 +67,14 @@ TLS certificates from various issuing sources.
 It will ensure certificates are valid and up to date periodically, and attempt
 to renew certificates at an appropriate time before expiry.`,
 
-		// TODO: Refactor this function from this package
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := o.Validate(args); err != nil {
-				logf.Log.Error(err, "error validating options")
+				return fmt.Errorf("error validating options: %s", err)
 			}
 
 			logf.Log.Info("starting controller", "version", util.AppVersion, "git-commit", util.AppGitCommit)
 			o.RunCertManagerController(stopCh)
+			return nil
 		},
 	}
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -9,11 +9,9 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//cmd/webhook/app:go_default_library",
-        "//cmd/webhook/app/options:go_default_library",
+        "//pkg/logs:go_default_library",
         "//pkg/util/cmd:go_default_library",
-        "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_klog//:go_default_library",
-        "@io_k8s_klog//klogr:go_default_library",
     ],
 )
 

--- a/cmd/webhook/app/BUILD.bazel
+++ b/cmd/webhook/app/BUILD.bazel
@@ -8,12 +8,13 @@ go_library(
     deps = [
         "//cmd/webhook/app/options:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/webhook:go_default_library",
         "//pkg/webhook/authority:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
         "//pkg/webhook/server:go_default_library",
         "//pkg/webhook/server/tls:go_default_library",
-        "@com_github_go_logr_logr//:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
     ],
 )

--- a/cmd/webhook/app/BUILD.bazel
+++ b/cmd/webhook/app/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/webhook/handlers:go_default_library",
         "//pkg/webhook/server:go_default_library",
         "//pkg/webhook/server/tls:go_default_library",
+        "@com_github_go_logr_logr//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
     ],

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -79,14 +79,14 @@ func (o *WebhookOptions) AddFlags(fs *pflag.FlagSet) {
 			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
 }
 
-func FileTLSSourceEnabled(o WebhookOptions) bool {
+func FileTLSSourceEnabled(o *WebhookOptions) bool {
 	if o.TLSCertFile != "" || o.TLSKeyFile != "" {
 		return true
 	}
 	return false
 }
 
-func DynamicTLSSourceEnabled(o WebhookOptions) bool {
+func DynamicTLSSourceEnabled(o *WebhookOptions) bool {
 	if o.DynamicServingCASecretNamespace != "" || o.DynamicServingCASecretName != "" {
 		return true
 	}

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -79,14 +79,14 @@ func (o *WebhookOptions) AddFlags(fs *pflag.FlagSet) {
 			"Possible values: "+strings.Join(tlsPossibleVersions, ", "))
 }
 
-func FileTLSSourceEnabled(o *WebhookOptions) bool {
+func FileTLSSourceEnabled(o WebhookOptions) bool {
 	if o.TLSCertFile != "" || o.TLSKeyFile != "" {
 		return true
 	}
 	return false
 }
 
-func DynamicTLSSourceEnabled(o *WebhookOptions) bool {
+func DynamicTLSSourceEnabled(o WebhookOptions) bool {
 	if o.DynamicServingCASecretNamespace != "" || o.DynamicServingCASecretName != "" {
 		return true
 	}

--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -56,7 +56,7 @@ type ServerOptions struct {
 
 func StartWebhookServer(t *testing.T, args []string) (ServerOptions, StopFunc) {
 	// Allow user to override options using flags
-	opts := options.WebhookOptions{}
+	opts := new(options.WebhookOptions)
 	fs := pflag.NewFlagSet("testset", pflag.ExitOnError)
 	opts.AddFlags(fs)
 	// Parse the arguments passed in into the WebhookOptions struct

--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -56,7 +56,7 @@ type ServerOptions struct {
 
 func StartWebhookServer(t *testing.T, args []string) (ServerOptions, StopFunc) {
 	// Allow user to override options using flags
-	opts := new(options.WebhookOptions)
+	var opts options.WebhookOptions
 	fs := pflag.NewFlagSet("testset", pflag.ExitOnError)
 	opts.AddFlags(fs)
 	// Parse the arguments passed in into the WebhookOptions struct

--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -91,7 +91,7 @@ func StartWebhookServer(t *testing.T, args []string) (ServerOptions, StopFunc) {
 	opts.HealthzPort = 0
 
 	stopCh := make(chan struct{})
-	srv, err := app.NewServer(opts, stopCh)
+	srv, err := app.NewServerWithOptions(log, opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -89,12 +89,13 @@ func StartWebhookServer(t *testing.T, args []string) (ServerOptions, StopFunc) {
 	// Listen on a random port number
 	opts.ListenPort = 0
 	opts.HealthzPort = 0
-	srv, err := app.NewServerWithOptions(log, opts)
+
+	stopCh := make(chan struct{})
+	srv, err := app.NewServer(opts, stopCh)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	stopCh := make(chan struct{})
 	go func() {
 		if err := srv.Run(stopCh); err != nil {
 			t.Fatalf("error running webhook server: %v", err)

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -18,7 +18,6 @@ package app
 
 import (
 	"context"
-	"flag"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -39,7 +38,7 @@ var validationHook handlers.ValidatingAdmissionHook = handlers.NewRegistryBacked
 var mutationHook handlers.MutatingAdmissionHook = handlers.NewSchemeBackedDefaulter(logs.Log, webhook.Scheme)
 var conversionHook handlers.ConversionHook = handlers.NewSchemeBackedConverter(logs.Log, webhook.Scheme)
 
-func NewServer(opts options.WebhookOptions, stopCh <-chan struct{}) (*server.Server, error) {
+func NewServer(opts *options.WebhookOptions, stopCh <-chan struct{}) (*server.Server, error) {
 	rootCtx := util.ContextWithStopCh(context.Background(), stopCh)
 	rootCtx = logf.NewContext(rootCtx, nil, "webhook")
 	log := logf.FromContext(rootCtx)
@@ -89,7 +88,7 @@ func NewServer(opts options.WebhookOptions, stopCh <-chan struct{}) (*server.Ser
 }
 
 func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
-	opts := options.WebhookOptions{}
+	opts := new(options.WebhookOptions)
 
 	cmd := &cobra.Command{
 		Use:   "cert-manager-webhook",
@@ -104,7 +103,7 @@ func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
 		},
 	}
 
-	cmd.Flags().AddGoFlagSet(flag.CommandLine)
+	opts.AddFlags(cmd.Flags())
 
 	return cmd
 }

--- a/cmd/webhook/app/webhook.go
+++ b/cmd/webhook/app/webhook.go
@@ -38,7 +38,7 @@ var validationHook handlers.ValidatingAdmissionHook = handlers.NewRegistryBacked
 var mutationHook handlers.MutatingAdmissionHook = handlers.NewSchemeBackedDefaulter(logs.Log, webhook.Scheme)
 var conversionHook handlers.ConversionHook = handlers.NewSchemeBackedConverter(logs.Log, webhook.Scheme)
 
-func NewServer(opts *options.WebhookOptions, stopCh <-chan struct{}) (*server.Server, error) {
+func NewServer(opts options.WebhookOptions, stopCh <-chan struct{}) (*server.Server, error) {
 	rootCtx := util.ContextWithStopCh(context.Background(), stopCh)
 	rootCtx = logf.NewContext(rootCtx, nil, "webhook")
 	log := logf.FromContext(rootCtx)
@@ -88,11 +88,11 @@ func NewServer(opts *options.WebhookOptions, stopCh <-chan struct{}) (*server.Se
 }
 
 func NewServerCommand(stopCh <-chan struct{}) *cobra.Command {
-	opts := new(options.WebhookOptions)
+	var opts options.WebhookOptions
 
 	cmd := &cobra.Command{
-		Use:   "cert-manager-webhook",
-		Short: fmt.Sprintf("Webhook for automated TLS controller for Kubernetes (%s) (%s)", util.AppVersion, util.AppGitCommit),
+		Use:   "webhook",
+		Short: fmt.Sprintf("Webhook component providing API validation, mutation and conversion functionality for cert-manager (%s) (%s)", util.AppVersion, util.AppGitCommit),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			srv, err := NewServer(opts, stopCh)
 			if err != nil {

--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -36,6 +36,6 @@ func main() {
 
 	flag.CommandLine.Parse([]string{})
 	if err := cmd.Execute(); err != nil {
-		klog.Info(err)
+		klog.Error(err)
 	}
 }

--- a/pkg/issuer/acme/http/solver/BUILD.bazel
+++ b/pkg/issuer/acme/http/solver/BUILD.bazel
@@ -8,7 +8,7 @@ go_library(
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/logs:go_default_library"],
+    deps = ["@com_github_go_logr_logr//:go_default_library"],
 )
 
 filegroup(

--- a/tools/cobra/BUILD.bazel
+++ b/tools/cobra/BUILD.bazel
@@ -6,9 +6,11 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/tools/cobra",
     visibility = ["//visibility:private"],
     deps = [
+        "//cmd/acmesolver/app:go_default_library",
         "//cmd/cainjector/app:go_default_library",
         "//cmd/controller/app:go_default_library",
         "//cmd/ctl/cmd:go_default_library",
+        "//cmd/webhook/app:go_default_library",
         "@com_github_mitchellh_go_homedir//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@com_github_spf13_cobra//doc:go_default_library",

--- a/tools/cobra/main.go
+++ b/tools/cobra/main.go
@@ -27,9 +27,11 @@ import (
 	"github.com/spf13/cobra/doc"
 	"github.com/spf13/pflag"
 
+	acmesolvercmd "github.com/jetstack/cert-manager/cmd/acmesolver/app"
 	cainjectorapp "github.com/jetstack/cert-manager/cmd/cainjector/app"
 	controllerapp "github.com/jetstack/cert-manager/cmd/controller/app"
 	ctlcmd "github.com/jetstack/cert-manager/cmd/ctl/cmd"
+	webhookcmd "github.com/jetstack/cert-manager/cmd/webhook/app"
 )
 
 func main() {
@@ -62,6 +64,8 @@ func run(args []string) error {
 		cainjectorapp.NewCommandStartInjectorController(nil, nil, nil),
 		controllerapp.NewCommandStartCertManagerController(nil),
 		ctlcmd.NewCertManagerCtlCommand(nil, nil, nil, nil),
+		webhookcmd.NewServerCommand(nil),
+		acmesolvercmd.NewACMESolverCommand(nil),
 	} {
 		dir := filepath.Join(root, c.Use)
 


### PR DESCRIPTION
This move the acmesolver and webhook commands into the cobra package for consistency and to allow documentation generation for their command line arguments.

This also fixes a small bug in the controller where it would not exit on an options validation error.

This also includes the two new cobra commands into the docs generation code.

```release-note
NONE
```
fixes #2852 