### PR TITLE
Remove x-kubernetes-preserve-unknown-fields from Issuer and ClusterIssuer CRDs

### DIFF
--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -177,6 +177,8 @@ func loadVariant() {
 			"spec/versions/[]/schema/openAPIV3Schema/type",
 			"spec/conversion",
 			// This field exists on the Issuer and ClusterIssuer CRD
+			"spec/validation/openAPIV3Schema/properties/spec/properties/acme/properties/solvers/items/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
+			// This field exists on the Challenge CRD
 			"spec/validation/openAPIV3Schema/properties/spec/properties/solver/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
 		}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

https://github.com/jetstack/cert-manager/commit/393ee0cd47e560e674c39564dff4695bb13bf7d0 removed `x-kubernetes-preserve-unknown-fields` from Issuer and ClusterIssuer CRDs but this field is once again present in these CRDs (don't know since when though). This PR removes the `x-kubernetes-preserve-unknown-fields` field again from these CRDs.



```release-note
NONE
```