### PR TITLE
kustomize bases

### DIFF
--- a/deploy/BUILD.bazel
+++ b/deploy/BUILD.bazel
@@ -1,6 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
+load("//build:files.bzl", "modify_file")
 
 pkg_tar(
     name = "manifests",
@@ -28,5 +29,22 @@ filegroup(
         "//deploy/manifests:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "kustomize-base",
+    srcs = ["kustomize-base.yml"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+# legacy kustomize base in parent is a little awkward
+modify_file(
+    name = "kustomize-base-legacy",
+    src = "//deploy:kustomize-base",
+    out = "kustomize.yml",
+    prefix = "",
+    suffix = "\n  - manifests/cert-manager-legacy.yaml",
     visibility = ["//visibility:public"],
 )

--- a/deploy/kustomize-base.yml
+++ b/deploy/kustomize-base.yml
@@ -1,0 +1,1 @@
+resources:

--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -5,6 +5,7 @@ exports_files(["00-crds.yaml"])
 load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 load("//build:helm.bzl", "helm_tmpl")
 load("//build:licensing.bzl", "licensed_file")
+load("//build:files.bzl", "modify_file")
 
 RELEASE_NAME = "cert-manager"
 
@@ -81,5 +82,14 @@ filegroup(
     name = "all-srcs",
     srcs = [":package-srcs"],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+modify_file(
+    name = "kustomize-base-regular",
+    src = "//deploy:kustomize-base",
+    out = "kustomize.yaml",
+    prefix = "",
+    suffix = "\n  - cert-manager.yaml",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Add kustomize base with the already generated manifest as its only resource. This will allow users to kustomize directly from releases.

_The legacy base was placed in a parent directory._

fixes #2482 