### PR TITLE
Do not add empty ca.crt

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -877,7 +877,7 @@ func (c *certificateRequestManager) setSecretValues(ctx context.Context, crt *cm
 
 	s.Data[corev1.TLSPrivateKeyKey] = data.pk
 	s.Data[corev1.TLSCertKey] = data.cert
-	if data.ca != nil && len(data.ca) > 0 {
+	if len(data.ca) > 0 {
 		s.Data[cmmeta.TLSCAKey] = data.ca
 	} else {
 		delete(s.Data, cmmeta.TLSCAKey)

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -877,7 +877,11 @@ func (c *certificateRequestManager) setSecretValues(ctx context.Context, crt *cm
 
 	s.Data[corev1.TLSPrivateKeyKey] = data.pk
 	s.Data[corev1.TLSCertKey] = data.cert
-	s.Data[cmmeta.TLSCAKey] = data.ca
+	if data.ca != nil && len(data.ca) > 0 {
+		s.Data[cmmeta.TLSCAKey] = data.ca
+	} else {
+		delete(s.Data, cmmeta.TLSCAKey)
+	}
 
 	if s.Annotations == nil {
 		s.Annotations = make(map[string]string)

--- a/pkg/controller/certificates/sync_test.go
+++ b/pkg/controller/certificates/sync_test.go
@@ -367,7 +367,7 @@ func TestBuildCertificateRequest(t *testing.T) {
 		}
 
 		if err == nil && test.expectedErr {
-			t.Error("expected and error but got 'nil'")
+			t.Error("expected an error but got 'nil'")
 		}
 
 		if cr == nil {
@@ -421,7 +421,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -467,7 +466,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -516,7 +514,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -565,7 +562,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -753,7 +749,6 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.certBytes,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							cmmeta.TLSCAKey:         nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -810,7 +805,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -868,7 +862,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -899,7 +892,6 @@ func TestProcessCertificate(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.generateTestCertificate(exampleBundle1.certificate, nil),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							cmmeta.TLSCAKey:         nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -963,7 +955,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1276,7 +1267,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1325,7 +1315,6 @@ func TestProcessCertificate(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       nil,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1412,7 +1401,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1470,7 +1458,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1528,7 +1515,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1559,7 +1545,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 						Data: map[string][]byte{
 							corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							cmmeta.TLSCAKey:         nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1590,7 +1575,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.certBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1652,7 +1636,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -1688,7 +1671,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 								),
 							),
 							corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-							cmmeta.TLSCAKey:         nil,
 						},
 						Type: corev1.SecretTypeTLS,
 					},
@@ -1753,7 +1735,6 @@ func TestTemporaryCertificateEnabled(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle1.localTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle1.privateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},

--- a/pkg/controller/expcertificates/internal/secretsmanager/secret.go
+++ b/pkg/controller/expcertificates/internal/secretsmanager/secret.go
@@ -192,7 +192,11 @@ func (s *SecretsManager) setValues(crt *cmapi.Certificate, secret *corev1.Secret
 
 	secret.Data[corev1.TLSPrivateKeyKey] = data.PrivateKey
 	secret.Data[corev1.TLSCertKey] = data.Certificate
-	secret.Data[cmmeta.TLSCAKey] = data.CA
+	if len(data.CA) > 0 {
+		secret.Data[cmmeta.TLSCAKey] = data.CA
+	} else {
+		delete(secret.Data, cmmeta.TLSCAKey)
+	}
 
 	if secret.Annotations == nil {
 		secret.Annotations = make(map[string]string)

--- a/pkg/controller/expcertificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/expcertificates/issuing/issuing_controller_test.go
@@ -392,7 +392,6 @@ func TestIssuingController(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle.CertificateRequestReady.Status.Certificate,
 								corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundle.CertificateRequestReady.Status.CA,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -466,7 +465,6 @@ func TestIssuingController(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle.CertificateRequestReady.Status.Certificate,
 								corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundle.CertificateRequestReady.Status.CA,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -525,7 +523,6 @@ func TestIssuingController(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle.LocalTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -596,7 +593,6 @@ func TestIssuingController(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle.LocalTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -714,7 +710,6 @@ func TestIssuingController(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle.LocalTemporaryCertificateBytes,
 								corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-								cmmeta.TLSCAKey:         nil,
 							},
 							Type: corev1.SecretTypeTLS,
 						},
@@ -828,7 +823,6 @@ func TestIssuingController(t *testing.T) {
 							Data: map[string][]byte{
 								corev1.TLSCertKey:       exampleBundle.CertificateRequestReady.Status.Certificate,
 								corev1.TLSPrivateKeyKey: exampleBundle.PrivateKeyBytes,
-								cmmeta.TLSCAKey:         exampleBundle.CertificateRequestReady.Status.CA,
 							},
 							Type: corev1.SecretTypeTLS,
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**: Currently cert-manager creates TLS secrets with three keys: tls.key, tls.crt and ca.crt.
ca.crt can be empty, and user suggested that we change the behaviour to: ca.crt either exists and contains a valid CA, or it does not exist.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #1975 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
An empty ca.crt will no longer be added into the secret resource
```
