### PR TITLE
ctl: add integration test case that exercises actual object conversion

### DIFF
--- a/test/integration/ctl/ctl_convert_test.go
+++ b/test/integration/ctl/ctl_convert_test.go
@@ -29,6 +29,7 @@ const (
 	testdataResource1 = "./testdata/convert_resource1.yaml"
 	testdataResource2 = "./testdata/convert_resource2.yaml"
 	testdataResource3 = "./testdata/convert_resource3.yaml"
+	testdataResourceWithOrganizationV1alpha2 = "./testdata/convert_resource_with_organization_v1alpha2.yaml"
 
 	targetv1alpha2 = "cert-manager.io/v1alpha2"
 	targetv1alpha3 = "cert-manager.io/v1alpha3"
@@ -81,6 +82,29 @@ func TestCtlConvert(t *testing.T) {
 			input:         testdataResource3,
 			targetVersion: targetv1alpha3,
 			expErr:        true,
+		},
+		"an object in v1alpha2 that uses a field that has been renamed in v1alpha3 should be converted properly": {
+			input: testdataResourceWithOrganizationV1alpha2,
+			targetVersion: targetv1alpha3,
+			expOutput: `
+apiVersion: cert-manager.io/v1alpha3
+kind: Certificate
+metadata:
+  creationTimestamp: null
+  name: ca-issuer
+  namespace: sandbox
+spec:
+  commonName: my-csi-app
+  isCA: true
+  subject:
+    organizations:
+    - hello world
+  issuerRef:
+    group: cert-manager.io
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: ca-key-pair
+status: {}`,
 		},
 	}
 

--- a/test/integration/ctl/testdata/convert_resource_with_organization_v1alpha2.yaml
+++ b/test/integration/ctl/testdata/convert_resource_with_organization_v1alpha2.yaml
@@ -1,0 +1,15 @@
+apiVersion: cert-manager.io/v1alpha2
+kind: Certificate
+metadata:
+  name: ca-issuer
+  namespace: sandbox
+spec:
+  isCA: true
+  secretName: ca-key-pair
+  organization:
+  - "hello world"
+  commonName: my-csi-app
+  issuerRef:
+    name: selfsigned-issuer
+    kind: Issuer
+    group: cert-manager.io


### PR DESCRIPTION
**What this PR does / why we need it**:

So it turns out `kubectl cert-manager convert` does not actually work if there are real meaningful conversions to be performed (i.e. not just a 1:1 conversion).

This PR initially adds a test case to show this, and @hzhou97 and I will work to actually fix it here too so this can merge 😄 

**Release note**:
```release-note
Fix bug causing `kubectl cert-manager convert` to not work when conversions need to be performed
```

/kind bug
/priority important-soon
/area ctl
/cc @hzhou97 