### PR TITLE
Make Cloudflare email an optional field

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -275,8 +275,6 @@ spec:
                       description: ACMEIssuerDNS01ProviderCloudflare is a structure
                         containing the DNS configuration for Cloudflare
                       type: object
-                      required:
-                      - email
                       properties:
                         apiKeySecretRef:
                           type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -313,8 +313,6 @@ spec:
                             description: ACMEIssuerDNS01ProviderCloudflare is a structure
                               containing the DNS configuration for Cloudflare
                             type: object
-                            required:
-                            - email
                             properties:
                               apiKeySecretRef:
                                 type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -313,8 +313,6 @@ spec:
                             description: ACMEIssuerDNS01ProviderCloudflare is a structure
                               containing the DNS configuration for Cloudflare
                             type: object
-                            required:
-                            - email
                             properties:
                               apiKeySecretRef:
                                 type: object

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -303,6 +303,7 @@ type ACMEIssuerDNS01ProviderCloudDNS struct {
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
+	// +optional
 	Email    string                    `json:"email"`
 	APIKey   *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
 	APIToken *cmmeta.SecretKeySelector `json:"apiTokenSecretRef,omitempty"`

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -303,6 +303,7 @@ type ACMEIssuerDNS01ProviderCloudDNS struct {
 // ACMEIssuerDNS01ProviderCloudflare is a structure containing the DNS
 // configuration for Cloudflare
 type ACMEIssuerDNS01ProviderCloudflare struct {
+	// +optional
 	Email    string                    `json:"email"`
 	APIKey   *cmmeta.SecretKeySelector `json:"apiKeySecretRef,omitempty"`
 	APIToken *cmmeta.SecretKeySelector `json:"apiTokenSecretRef,omitempty"`

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -316,7 +316,7 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			if p.Cloudflare.APIKey == nil && p.Cloudflare.APIToken == nil {
 				el = append(el, field.Required(fldPath.Child("cloudflare"), "apiKeySecretRef or apiTokenSecretRef is required"))
 			}
-			if len(p.Cloudflare.Email) == 0 {
+			if len(p.Cloudflare.Email) == 0 && p.Cloudflare.APIKey != nil {
 				el = append(el, field.Required(fldPath.Child("cloudflare", "email"), ""))
 			}
 		}

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -48,7 +48,7 @@ func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
 // NewDNSProviderCredentials uses the supplied credentials to return a
 // DNSProvider instance configured for cloudflare.
 func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []string) (*DNSProvider, error) {
-	if email == "" || (key == "" && token == "") {
+	if (email == "" && key != "") || (key == "" && token == "") {
 		return nil, fmt.Errorf("CloudFlare credentials missing")
 	}
 	if key != "" && token != "" {
@@ -221,7 +221,9 @@ func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 		return nil, err
 	}
 
-	req.Header.Set("X-Auth-Email", c.authEmail)
+	if c.authEmail != "" {
+		req.Header.Set("X-Auth-Email", c.authEmail)
+	}
 	if c.authToken != "" {
 		req.Header.Set("Authorization", "Bearer "+c.authToken)
 	} else {


### PR DESCRIPTION
**What this PR does / why we need it**:
Cloudflare does not require an email to be sent when using token based auth. 
We should make the field optional if tokens are used.

**Which issue this PR fixes** 
fixes  #2972 
**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
DNS01: make Cloudflare email optional if a token is used
```
