### PR TITLE
Fix Docker architecture tag set by bazel

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -59,7 +59,7 @@ http_archive(
 git_repository(
     name = "io_bazel_rules_docker",
     remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "80ea3aae060077e5fe0cdef1a5c570d4b7622100",
+    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
     shallow_since = "1561646721 -0700",
 )
 

--- a/build/container.bzl
+++ b/build/container.bzl
@@ -61,6 +61,10 @@ def multi_arch_container(
             go_platform_constraint(os = "linux", arch = arch): base.format(ARCH = arch)
             for arch in architectures
         }),
+        architecture = select({
+            go_platform_constraint(os = "linux", arch = arch): arch
+            for arch in architectures
+        }),
         stamp = stamp,
         tags = tags,
         user = user,
@@ -82,6 +86,10 @@ def multi_arch_container(
         stamp = stamp,
         tags = tags,
         user = user,
+        architecture = select({
+            go_platform_constraint(os = "linux", arch = arch): arch
+            for arch in architectures
+        }),
         visibility = ["//visibility:public"],
     )
 

--- a/devel/addon/ingressnginx/BUILD.bazel
+++ b/devel/addon/ingressnginx/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 container_bundle(
     name = "bundle",
     images = {
-        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0": "@io_kubernetes_ingress-nginx//image",
+        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.29.0": "@io_kubernetes_ingress-nginx//image",
         "k8s.gcr.io/defaultbackend-amd64:bazel": "@io_gcr_k8s_defaultbackend//image",
     },
     tags = ["manual"],

--- a/devel/addon/ingressnginx/BUILD.bazel
+++ b/devel/addon/ingressnginx/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 container_bundle(
     name = "bundle",
     images = {
-        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1": "@io_kubernetes_ingress-nginx//image",
+        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0": "@io_kubernetes_ingress-nginx//image",
         "k8s.gcr.io/defaultbackend-amd64:bazel": "@io_gcr_k8s_defaultbackend//image",
     },
     tags = ["manual"],

--- a/devel/addon/ingressnginx/BUILD.bazel
+++ b/devel/addon/ingressnginx/BUILD.bazel
@@ -3,7 +3,7 @@ load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 container_bundle(
     name = "bundle",
     images = {
-        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.29.0": "@io_kubernetes_ingress-nginx//image",
+        "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0": "@io_kubernetes_ingress-nginx//image",
         "k8s.gcr.io/defaultbackend-amd64:bazel": "@io_gcr_k8s_defaultbackend//image",
     },
     tags = ["manual"],

--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -34,28 +34,29 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 # Require helm available on PATH
 check_tool kubectl
 check_tool helm
-require_image "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.29.0" "//devel/addon/ingressnginx:bundle"
+require_image "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0" "//devel/addon/ingressnginx:bundle"
 require_image "k8s.gcr.io/defaultbackend-amd64:bazel" "//devel/addon/ingressnginx:bundle"
 
 # Ensure the pebble namespace exists
 kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
+helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
 
 helm repo update
 
-# Upgrade or install Pebble
+# Upgrade or install nginx-ingress
 helm upgrade \
     --install \
     --wait \
-    --version 1.23.0 \
+    --version 2.4.0 \
     --namespace "${NAMESPACE}" \
-    --set controller.image.tag=0.29.0 \
+    --set controller.image.tag=0.33.0 \
     --set controller.image.pullPolicy=Never \
     --set defaultBackend.image.tag=bazel \
     --set defaultBackend.image.pullPolicy=Never \
     --set controller.service.clusterIP=10.0.0.15 \
     --set controller.service.type=ClusterIP \
     --set controller.config.no-tls-redirect-locations="" \
+    --set admissionWebhooks.enabled=false \
     "$RELEASE_NAME" \
-    stable/nginx-ingress
+    ingress-nginx/ingress-nginx

--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -34,7 +34,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 # Require helm available on PATH
 check_tool kubectl
 check_tool helm
-require_image "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.26.1" "//devel/addon/ingressnginx:bundle"
+require_image "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0" "//devel/addon/ingressnginx:bundle"
 require_image "k8s.gcr.io/defaultbackend-amd64:bazel" "//devel/addon/ingressnginx:bundle"
 
 # Ensure the pebble namespace exists
@@ -50,7 +50,7 @@ helm upgrade \
     --wait \
     --version 1.23.0 \
     --namespace "${NAMESPACE}" \
-    --set controller.image.tag=0.26.1 \
+    --set controller.image.tag=0.33.0 \
     --set controller.image.pullPolicy=Never \
     --set defaultBackend.image.tag=bazel \
     --set defaultBackend.image.pullPolicy=Never \

--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -34,7 +34,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 # Require helm available on PATH
 check_tool kubectl
 check_tool helm
-require_image "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.33.0" "//devel/addon/ingressnginx:bundle"
+require_image "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.29.0" "//devel/addon/ingressnginx:bundle"
 require_image "k8s.gcr.io/defaultbackend-amd64:bazel" "//devel/addon/ingressnginx:bundle"
 
 # Ensure the pebble namespace exists
@@ -50,7 +50,7 @@ helm upgrade \
     --wait \
     --version 1.23.0 \
     --namespace "${NAMESPACE}" \
-    --set controller.image.tag=0.33.0 \
+    --set controller.image.tag=0.29.0 \
     --set controller.image.pullPolicy=Never \
     --set defaultBackend.image.tag=bazel \
     --set defaultBackend.image.pullPolicy=Never \

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -39,7 +39,7 @@ def install():
         name = "io_kubernetes_ingress-nginx",
         registry = "quay.io",
         repository = "kubernetes-ingress-controller/nginx-ingress-controller",
-        tag = "0.29.0",
+        tag = "0.33.0",
         # For some reason, the suggested sha256 returns an error when fetched from
         # quay.io by digest.
         # digest = "sha256:f7f08fdbbeddaf3179829c662da360a3feac1ecf8c4b1305949fffd8c8f59879",

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -39,7 +39,7 @@ def install():
         name = "io_kubernetes_ingress-nginx",
         registry = "quay.io",
         repository = "kubernetes-ingress-controller/nginx-ingress-controller",
-        tag = "0.26.1",
+        tag = "0.33.0",
         # For some reason, the suggested sha256 returns an error when fetched from
         # quay.io by digest.
         # digest = "sha256:f7f08fdbbeddaf3179829c662da360a3feac1ecf8c4b1305949fffd8c8f59879",

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -39,7 +39,7 @@ def install():
         name = "io_kubernetes_ingress-nginx",
         registry = "quay.io",
         repository = "kubernetes-ingress-controller/nginx-ingress-controller",
-        tag = "0.33.0",
+        tag = "0.29.0",
         # For some reason, the suggested sha256 returns an error when fetched from
         # quay.io by digest.
         # digest = "sha256:f7f08fdbbeddaf3179829c662da360a3feac1ecf8c4b1305949fffd8c8f59879",


### PR DESCRIPTION
**What this PR does / why we need it**:
This tags the Docker images correct when building multiarch images

**Which issue this PR fixes**:
fixes #2987

**Special notes for your reviewer**:
I had to update the Bazel Docker helper to support setting this. This also deprecated v1 manifests which is why the Nginx ingress is updated also. 

Related: https://github.com/cert-manager/release/pull/17

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Tag the Docker image with the correct `architecture` attribute
```
