### PR TITLE
Encode private keys to PKCS1/PKCS8 as requested by user

### DIFF
--- a/pkg/controller/expcertificates/issuing/issuing_controller.go
+++ b/pkg/controller/expcertificates/issuing/issuing_controller.go
@@ -193,7 +193,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		logf.WithResource(log, nextPrivateKeySecret).Info("Next private key secret does not contain any private key data, waiting for keymanager controller")
 		return nil
 	}
-	pk, pkData, err := utilkube.ParseTLSKeyFromSecret(nextPrivateKeySecret, corev1.TLSPrivateKeyKey)
+	pk, _, err := utilkube.ParseTLSKeyFromSecret(nextPrivateKeySecret, corev1.TLSPrivateKeyKey)
 	if err != nil {
 		// If the private key cannot be parsed here, do nothing as the key manager will handle this.
 		logf.WithResource(log, nextPrivateKeySecret).Error(err, "failed to parse next private key, waiting for keymanager controller")
@@ -277,7 +277,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	// Issue temporary certificate if needed. If a certificate was issued, then
 	// return early - we will sync again since the target Secret has been
 	// updated.
-	if issued, err := c.ensureTemporaryCertificate(ctx, crt, pkData); err != nil || issued {
+	if issued, err := c.ensureTemporaryCertificate(ctx, crt, pk); err != nil || issued {
 		return err
 	}
 

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -25,7 +25,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently when a user uses experminetal certificates controller only, the private keys are always encoded in PKCS8. This PR is to correctly handle the Spec.keyEncoding field to encode private keys to PKCS1 or PKCS8 as requested by the user.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2863

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Experimental certificate controllers encode private keys according to specification of user.
```
