### PR TITLE
expcertificates: fix bug renewing certificates automatically near expiry

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -392,6 +392,16 @@ spec:
                   secret named by this resource in spec.secretName.
                 type: string
                 format: date-time
+              notBefore:
+                description: The time after which the certificate stored in the secret
+                  named by this resource in spec.secretName is valid.
+                type: string
+                format: date-time
+              renewalTime:
+                description: RenewalTime is the time at which the certificate will
+                  be next renewed. If not set, no upcoming renewal is scheduled.
+                type: string
+                format: date-time
               revision:
                 description: "The current 'revision' of the certificate as issued.
                   \n When a CertificateRequest resource is created, it will have the
@@ -738,6 +748,16 @@ spec:
               notAfter:
                 description: The expiration time of the certificate stored in the
                   secret named by this resource in spec.secretName.
+                type: string
+                format: date-time
+              notBefore:
+                description: The time after which the certificate stored in the secret
+                  named by this resource in spec.secretName is valid.
+                type: string
+                format: date-time
+              renewalTime:
+                description: RenewalTime is the time at which the certificate will
+                  be next renewed. If not set, no upcoming renewal is scheduled.
                 type: string
                 format: date-time
               revision:

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -277,10 +277,21 @@ type CertificateStatus struct {
 	// +optional
 	LastFailureTime *metav1.Time `json:"lastFailureTime,omitempty"`
 
+	// The time after which the certificate stored in the secret named
+	// by this resource in spec.secretName is valid.
+	// +optional
+	NotBefore *metav1.Time `json:"notBefore,omitempty"`
+
 	// The expiration time of the certificate stored in the secret named
 	// by this resource in spec.secretName.
 	// +optional
 	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+
+	// RenewalTime is the time at which the certificate will be next
+	// renewed.
+	// If not set, no upcoming renewal is scheduled.
+	// +optional
+	RenewalTime *metav1.Time `json:"renewalTime,omitempty"`
 
 	// The current 'revision' of the certificate as issued.
 	//

--- a/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -407,8 +407,16 @@ func (in *CertificateStatus) DeepCopyInto(out *CertificateStatus) {
 		in, out := &in.LastFailureTime, &out.LastFailureTime
 		*out = (*in).DeepCopy()
 	}
+	if in.NotBefore != nil {
+		in, out := &in.NotBefore, &out.NotBefore
+		*out = (*in).DeepCopy()
+	}
 	if in.NotAfter != nil {
 		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
+	if in.RenewalTime != nil {
+		in, out := &in.RenewalTime, &out.RenewalTime
 		*out = (*in).DeepCopy()
 	}
 	if in.Revision != nil {

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -276,10 +276,21 @@ type CertificateStatus struct {
 	// +optional
 	LastFailureTime *metav1.Time `json:"lastFailureTime,omitempty"`
 
+	// The time after which the certificate stored in the secret named
+	// by this resource in spec.secretName is valid.
+	// +optional
+	NotBefore *metav1.Time `json:"notBefore,omitempty"`
+
 	// The expiration time of the certificate stored in the secret named
 	// by this resource in spec.secretName.
 	// +optional
 	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+
+	// RenewalTime is the time at which the certificate will be next
+	// renewed.
+	// If not set, no upcoming renewal is scheduled.
+	// +optional
+	RenewalTime *metav1.Time `json:"renewalTime,omitempty"`
 
 	// The current 'revision' of the certificate as issued.
 	//

--- a/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
@@ -402,8 +402,16 @@ func (in *CertificateStatus) DeepCopyInto(out *CertificateStatus) {
 		in, out := &in.LastFailureTime, &out.LastFailureTime
 		*out = (*in).DeepCopy()
 	}
+	if in.NotBefore != nil {
+		in, out := &in.NotBefore, &out.NotBefore
+		*out = (*in).DeepCopy()
+	}
 	if in.NotAfter != nil {
 		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
+	if in.RenewalTime != nil {
+		in, out := &in.RenewalTime, &out.RenewalTime
 		*out = (*in).DeepCopy()
 	}
 	if in.Revision != nil {

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -119,13 +119,13 @@ func (c *certificateRequestManager) Register(ctx *controllerpkg.Context) (workqu
 	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: controllerpkg.HandleOwnedResourceNamespacedFunc(log, c.queue, certificateGvk, certificateGetter(c.certificateLister))})
 	secretsInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: secretResourceHandler(log, c.certificateLister, c.queue)})
 
+	// clock is used to determine whether certificates need renewal
+	c.clock = ctx.Clock
+
 	// Create a scheduled work queue that calls the ctrl.queue.Add method for
 	// each object in the queue. This is used to schedule re-checks of
 	// Certificate resources when they get near to expiry
-	c.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(c.queue.Add)
-
-	// clock is used to determine whether certificates need renewal
-	c.clock = clock.RealClock{}
+	c.scheduledWorkQueue = scheduler.NewScheduledWorkQueue(c.clock, c.queue.Add)
 
 	// recorder records events about resources to the Kubernetes api
 	c.recorder = ctx.Recorder

--- a/pkg/controller/expcertificates/readiness/readiness_controller.go
+++ b/pkg/controller/expcertificates/readiness/readiness_controller.go
@@ -217,7 +217,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.CMClient,
 		ctx.KubeSharedInformerFactory,
 		ctx.SharedInformerFactory,
-		policies.TriggerPolicyChain,
+		PolicyChain,
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/expcertificates/trigger/BUILD.bazel
+++ b/pkg/controller/expcertificates/trigger/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/controller/expcertificates/internal/predicate:go_default_library",
         "//pkg/controller/expcertificates/trigger/policies:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/scheduler:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/pkg/controller/expcertificates/trigger/policies/BUILD.bazel
+++ b/pkg/controller/expcertificates/trigger/policies/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/util/pki:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )
 

--- a/pkg/controller/expcertificates/trigger/policies/BUILD.bazel
+++ b/pkg/controller/expcertificates/trigger/policies/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/expcertificates/trigger/trigger_controller.go
+++ b/pkg/controller/expcertificates/trigger/trigger_controller.go
@@ -43,6 +43,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/internal/predicate"
 	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/trigger/policies"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/scheduler"
 )
 
 const (
@@ -67,6 +68,7 @@ type controller struct {
 	client                   cmclient.Interface
 	recorder                 record.EventRecorder
 	clock                    clock.Clock
+	scheduledWorkQueue       scheduler.ScheduledWorkQueue
 	gatherer                 *policies.Gatherer
 }
 
@@ -116,6 +118,7 @@ func NewController(
 		client:                   client,
 		recorder:                 recorder,
 		clock:                    clock,
+		scheduledWorkQueue:       scheduler.NewScheduledWorkQueue(clock, queue.Add),
 		gatherer: &policies.Gatherer{
 			CertificateRequestLister: certificateRequestInformer.Lister(),
 			SecretLister:             secretsInformer.Lister(),
@@ -148,6 +151,10 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		return nil
 	}
 
+	// ensure a resync is scheduled in the future so that we re-check
+	// Certificate resources and trigger them near expiry time
+	c.scheduleRecheckOfCertificateIfRequired(log, key, crt.Status.RenewalTime)
+
 	input, err := c.gatherer.DataForCertificate(ctx, crt)
 	if err != nil {
 		return err
@@ -155,7 +162,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 	reason, message, reissue := c.policyChain.Evaluate(input)
 	if !reissue {
-		// no reissuance required, return early
+		// no re-issuance required, return early
 		return nil
 	}
 
@@ -178,6 +185,29 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	c.recorder.Event(crt, corev1.EventTypeNormal, "Issuing", message)
 
 	return nil
+}
+
+// scheduleRecheckOfCertificateIfRequired will schedule the resource with the
+// given key to be re-queued for processing at the given time (if not nil).
+func (c *controller) scheduleRecheckOfCertificateIfRequired(log logr.Logger, key string, renewalTime *metav1.Time) {
+	if renewalTime == nil {
+		return
+	}
+
+	durationUntilRenewalTime := renewalTime.Sub(c.clock.Now())
+	// don't schedule a re-queue if the time is in the past.
+	// if it is in the past, the resource will be triggered during the
+	// current call to the ProcessItem method. If we added the item to the
+	// queue with a duration of <=0, we would otherwise continually re-queue
+	// in a tight loop whilst we wait for the caching listers to observe
+	// the 'Triggered' status condition changing to 'True'.
+	if durationUntilRenewalTime < 0 {
+		return
+	}
+
+	log.Info("scheduling renewal", "duration_until_renewal", durationUntilRenewalTime.String())
+
+	c.scheduledWorkQueue.Add(key, durationUntilRenewalTime)
 }
 
 // controllerWrapper wraps the `controller` structure to make it implement

--- a/pkg/controller/expcertificates/trigger/trigger_controller.go
+++ b/pkg/controller/expcertificates/trigger/trigger_controller.go
@@ -196,7 +196,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.SharedInformerFactory,
 		ctx.Recorder,
 		ctx.Clock,
-		policies.TriggerPolicyChain,
+		policies.NewTriggerPolicyChain(ctx.Clock),
 	)
 	c.controller = ctrl
 

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -226,9 +226,21 @@ type CertificateStatus struct {
 
 	LastFailureTime *metav1.Time
 
+	// The time after which the certificate stored in the secret named
+	// by this resource in spec.secretName is valid.
+	// +optional
+	NotBefore *metav1.Time
+
 	// The expiration time of the certificate stored in the secret named
 	// by this resource in spec.secretName.
+	// +optional
 	NotAfter *metav1.Time
+
+	// RenewalTime is the time at which the certificate will be next
+	// renewed.
+	// If not set, no upcoming renewal is scheduled.
+	// +optional
+	RenewalTime *metav1.Time
 
 	// The current 'revision' of the certificate as issued.
 	//

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -740,7 +740,9 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha2_CertificateSpec(in *cer
 func autoConvert_v1alpha2_CertificateStatus_To_certmanager_CertificateStatus(in *v1alpha2.CertificateStatus, out *certmanager.CertificateStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]certmanager.CertificateCondition)(unsafe.Pointer(&in.Conditions))
 	out.LastFailureTime = (*v1.Time)(unsafe.Pointer(in.LastFailureTime))
+	out.NotBefore = (*v1.Time)(unsafe.Pointer(in.NotBefore))
 	out.NotAfter = (*v1.Time)(unsafe.Pointer(in.NotAfter))
+	out.RenewalTime = (*v1.Time)(unsafe.Pointer(in.RenewalTime))
 	out.Revision = (*int)(unsafe.Pointer(in.Revision))
 	out.NextPrivateKeySecretName = (*string)(unsafe.Pointer(in.NextPrivateKeySecretName))
 	return nil
@@ -754,7 +756,9 @@ func Convert_v1alpha2_CertificateStatus_To_certmanager_CertificateStatus(in *v1a
 func autoConvert_certmanager_CertificateStatus_To_v1alpha2_CertificateStatus(in *certmanager.CertificateStatus, out *v1alpha2.CertificateStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]v1alpha2.CertificateCondition)(unsafe.Pointer(&in.Conditions))
 	out.LastFailureTime = (*v1.Time)(unsafe.Pointer(in.LastFailureTime))
+	out.NotBefore = (*v1.Time)(unsafe.Pointer(in.NotBefore))
 	out.NotAfter = (*v1.Time)(unsafe.Pointer(in.NotAfter))
+	out.RenewalTime = (*v1.Time)(unsafe.Pointer(in.RenewalTime))
 	out.Revision = (*int)(unsafe.Pointer(in.Revision))
 	out.NextPrivateKeySecretName = (*string)(unsafe.Pointer(in.NextPrivateKeySecretName))
 	return nil

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -713,7 +713,9 @@ func Convert_certmanager_CertificateSpec_To_v1alpha3_CertificateSpec(in *certman
 func autoConvert_v1alpha3_CertificateStatus_To_certmanager_CertificateStatus(in *v1alpha3.CertificateStatus, out *certmanager.CertificateStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]certmanager.CertificateCondition)(unsafe.Pointer(&in.Conditions))
 	out.LastFailureTime = (*v1.Time)(unsafe.Pointer(in.LastFailureTime))
+	out.NotBefore = (*v1.Time)(unsafe.Pointer(in.NotBefore))
 	out.NotAfter = (*v1.Time)(unsafe.Pointer(in.NotAfter))
+	out.RenewalTime = (*v1.Time)(unsafe.Pointer(in.RenewalTime))
 	out.Revision = (*int)(unsafe.Pointer(in.Revision))
 	out.NextPrivateKeySecretName = (*string)(unsafe.Pointer(in.NextPrivateKeySecretName))
 	return nil
@@ -727,7 +729,9 @@ func Convert_v1alpha3_CertificateStatus_To_certmanager_CertificateStatus(in *v1a
 func autoConvert_certmanager_CertificateStatus_To_v1alpha3_CertificateStatus(in *certmanager.CertificateStatus, out *v1alpha3.CertificateStatus, s conversion.Scope) error {
 	out.Conditions = *(*[]v1alpha3.CertificateCondition)(unsafe.Pointer(&in.Conditions))
 	out.LastFailureTime = (*v1.Time)(unsafe.Pointer(in.LastFailureTime))
+	out.NotBefore = (*v1.Time)(unsafe.Pointer(in.NotBefore))
 	out.NotAfter = (*v1.Time)(unsafe.Pointer(in.NotAfter))
+	out.RenewalTime = (*v1.Time)(unsafe.Pointer(in.RenewalTime))
 	out.Revision = (*int)(unsafe.Pointer(in.Revision))
 	out.NextPrivateKeySecretName = (*string)(unsafe.Pointer(in.NextPrivateKeySecretName))
 	return nil

--- a/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -402,8 +402,16 @@ func (in *CertificateStatus) DeepCopyInto(out *CertificateStatus) {
 		in, out := &in.LastFailureTime, &out.LastFailureTime
 		*out = (*in).DeepCopy()
 	}
+	if in.NotBefore != nil {
+		in, out := &in.NotBefore, &out.NotBefore
+		*out = (*in).DeepCopy()
+	}
 	if in.NotAfter != nil {
 		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
+	if in.RenewalTime != nil {
+		in, out := &in.RenewalTime, &out.RenewalTime
 		*out = (*in).DeepCopy()
 	}
 	if in.Revision != nil {

--- a/pkg/scheduler/BUILD.bazel
+++ b/pkg/scheduler/BUILD.bazel
@@ -5,12 +5,14 @@ go_library(
     srcs = ["scheduler.go"],
     importpath = "github.com/jetstack/cert-manager/pkg/scheduler",
     visibility = ["//visibility:public"],
+    deps = ["@io_k8s_utils//clock:go_default_library"],
 )
 
 go_test(
     name = "go_default_test",
     srcs = ["scheduler_test.go"],
     embed = [":go_default_library"],
+    deps = ["@io_k8s_utils//clock:go_default_library"],
 )
 
 filegroup(

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -11,6 +11,7 @@ go_test(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/certificates/metrics:go_default_library",
         "//pkg/controller/expcertificates/issuing:go_default_library",

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -25,6 +25,7 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_utils//clock:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )
 

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -28,6 +28,7 @@ import (
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/trigger"
 	"github.com/jetstack/cert-manager/pkg/controller/expcertificates/trigger/policies"
@@ -93,6 +94,112 @@ func TestTriggerController(t *testing.T) {
 		return true, nil
 	})
 	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTriggerController_RenewNearExpiry(t *testing.T) {
+	config, stopFn := framework.RunControlPlane(t)
+	defer stopFn()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+	defer cancel()
+
+	fakeClock := &fakeclock.FakeClock{}
+	// only use the 'current certificate nearing expiry' policy chain during the test
+	// as we want to test the very specific case of triggering due to a renewal being
+	// required
+	policyChain := policies.Chain{policies.CurrentCertificateNearingExpiry(fakeClock)}
+	// Build, instantiate and run the trigger controller.
+	_, factory, cmCl, cmFactory := framework.NewClients(t, config)
+	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), fakeClock, policyChain)
+	c := controllerpkg.NewController(
+		logf.NewContext(context.Background(), logf.Log, "trigger_controller_RenewNearExpiry"),
+		"trigger_test",
+		metrics.New(logf.Log),
+		ctrl.ProcessItem,
+		mustSync,
+		nil,
+		queue,
+	)
+	stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer stopController()
+
+	// Create a Certificate resource and wait for it to have the 'Issuing' condition.
+	cert, err := cmCl.CertmanagerV1alpha2().Certificates("testns").Create(ctx, &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: "testcrt", Namespace: "testns"},
+		Spec: cmapi.CertificateSpec{
+			SecretName: "example",
+			CommonName: "example.com",
+			IssuerRef:  cmmeta.ObjectReference{Name: "testissuer"}, // doesn't need to exist
+		},
+	}, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure that the Certificate does *not* get the Triggered status condition
+	// if the status.renewalTime is not set.
+	// Wait for 2s, polling every 200ms to ensure that the controller does not set
+	// the condition.
+	ensureCertificateDoesNotHaveIssuingCondition(ctx, t, cmCl, cert.Namespace, cert.Name)
+
+	t.Logf("Setting status.renewalTime in the future on Certificate resource")
+	renewalTime := metav1.NewTime(fakeClock.Now().Add(time.Second))
+	cert.Status.RenewalTime = &renewalTime
+	cert, err = cmCl.CertmanagerV1alpha2().Certificates(cert.Namespace).UpdateStatus(ctx, cert, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Ensuring Certificate does not have Issuing condition for 2s...")
+	ensureCertificateDoesNotHaveIssuingCondition(ctx, t, cmCl, cert.Namespace, cert.Name)
+
+	t.Log("Advancing the clock forward to renewal time")
+	// advance the clock to a millisecond after the renewal time, as the
+	// fakeclock implementation uses .After when checking whether to
+	// trigger timers.
+	fakeClock.SetTime(renewalTime.Time.Add(time.Millisecond))
+
+	err = wait.Poll(time.Millisecond*200, time.Second*2, func() (done bool, err error) {
+		c, err := cmCl.CertmanagerV1alpha2().Certificates(cert.Namespace).Get(ctx, cert.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if apiutil.CertificateHasCondition(c, cmapi.CertificateCondition{
+			Type:   cmapi.CertificateConditionIssuing,
+			Status: cmmeta.ConditionTrue,
+		}) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		t.Error("Failed waiting for Certificate to have Issuing condition")
+	}
+}
+
+func ensureCertificateDoesNotHaveIssuingCondition(ctx context.Context, t *testing.T, cmCl cmclient.Interface, namespace, name string) {
+	err := wait.Poll(time.Millisecond*200, time.Second*2, func() (done bool, err error) {
+		c, err := cmCl.CertmanagerV1alpha2().Certificates(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if apiutil.CertificateHasCondition(c, cmapi.CertificateCondition{
+			Type:   cmapi.CertificateConditionIssuing,
+			Status: cmmeta.ConditionTrue,
+		}) {
+			t.Logf("Certificate has unexpected 'Issuing' condition, got=%#v", apiutil.GetCertificateCondition(c, cmapi.CertificateConditionIssuing))
+			return true, nil
+		}
+		return false, nil
+	})
+	switch {
+	case err == nil:
+		t.Fatal("expected Certificate to not have the Issuing condition after test initialisation")
+	case err == wait.ErrWaitTimeout:
+		// this is the expected 'happy case'
+	default:
 		t.Fatal(err)
 	}
 }

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -23,7 +23,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/utils/clock"
+	fakeclock "k8s.io/utils/clock/testing"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -48,9 +48,10 @@ func TestTriggerController(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
 	defer cancel()
 
+	fakeClock := &fakeclock.FakeClock{}
 	// Build, instantiate and run the trigger controller.
 	_, factory, cmCl, cmFactory := framework.NewClients(t, config)
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), clock.RealClock{}, policies.TriggerPolicyChain)
+	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), fakeClock, policies.NewTriggerPolicyChain(fakeClock))
 	c := controllerpkg.NewController(
 		context.Background(),
 		"trigger_test",

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -58,7 +58,7 @@ func RunControlPlane(t *testing.T) (*rest.Config, StopFunc) {
 	patchCRDConversion(crds, webhookOpts.URL, webhookOpts.CAPEM)
 	// environment variables
 	env := &envtest.Environment{
-		AttachControlPlaneOutput: true,
+		AttachControlPlaneOutput: false,
 		CRDs:                     crdsToRuntimeObjects(crds),
 	}
 	config, err := env.Start()


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes certificate renewal near expiry when running with the new 'experimental' certificate controllers introduced in v0.15.

The 'scheduled work queue' concept has been modified to use a passed-in 'clock' which we can easily manipulate during integration tests.

I've then also added an integration test to exercise this case so we can be sure it's working.

**Which issue this PR fixes**: fixes #2978

**Special notes for your reviewer**:

This is best reviewed commit-by-commit.

I've aimed to keep things nice and separated to make it clear at each stage along the way what's going on.

I also opted to add two new fields to the Certificate resource's `status`: `status.notAfter` and `status.renewalTime`. These are computed and set/managed by the *readiness* controller. The 'trigger' controller then makes use of these status fields to decide whether to trigger a renewal or not.

**Release note**:
```release-note
experimental certificates controllers: fix automated certificate renewal
```

/kind bug
/milestone v0.16
/priority critical-urgent