### PR TITLE
Use ctl.Scheme in create cr ctl command

### DIFF
--- a/cmd/ctl/pkg/create/certificaterequest/BUILD.bazel
+++ b/cmd/ctl/pkg/create/certificaterequest/BUILD.bazel
@@ -8,8 +8,8 @@ go_library(
     deps = [
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/ctl:go_default_library",
         "//pkg/util/pki:go_default_library",
-        "//pkg/webhook:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -36,8 +36,8 @@ import (
 
 	cmapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"github.com/jetstack/cert-manager/pkg/ctl"
 	"github.com/jetstack/cert-manager/pkg/util/pki"
-	"github.com/jetstack/cert-manager/pkg/webhook"
 )
 
 var (
@@ -57,11 +57,9 @@ kubectl cert-manager create certificaterequest my-cr --from-certificate-file my-
 )
 
 var (
-	// Use the webhook's scheme as it already has the internal cert-manager types,
-	// and their conversion functions registered.
-	// In future we may we want to consider creating a dedicated scheme used by
-	// the ctl tool.
-	scheme = webhook.Scheme
+	// Dedicated scheme used by the ctl tool that has the internal cert-manager types,
+	// and their conversion functions registered
+	scheme = ctl.Scheme
 )
 
 // Options is a struct to support create certificaterequest command


### PR DESCRIPTION
Signed-off-by: Haoxiang Zhou <haoxiang.zhou@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Change `create cr` ctl command to use ctl.Scheme that was created recently instead of webhook.Scheme.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3029 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Use ctl.Scheme in create cr ctl command
```

/kind cleanup
