### PR TITLE
Enable create cr ctl command to fetch certificate

### DIFF
--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -36,6 +36,7 @@ filegroup(
         "//cmd/ctl/pkg/create:all-srcs",
         "//cmd/ctl/pkg/renew:all-srcs",
         "//cmd/ctl/pkg/status:all-srcs",
+        "//cmd/ctl/pkg/util:all-srcs",
         "//cmd/ctl/pkg/version:all-srcs",
     ],
     tags = ["automanaged"],

--- a/cmd/ctl/pkg/create/certificaterequest/BUILD.bazel
+++ b/cmd/ctl/pkg/create/certificaterequest/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
         "@io_k8s_cli_runtime//pkg/resource:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",

--- a/cmd/ctl/pkg/create/certificaterequest/BUILD.bazel
+++ b/cmd/ctl/pkg/create/certificaterequest/BUILD.bazel
@@ -6,7 +6,10 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/create/certificaterequest",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/ctl/pkg/util:go_default_library",
+        "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/ctl:go_default_library",
         "//pkg/util/pki:go_default_library",

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -286,7 +286,7 @@ func (o *Options) Run(args []string) error {
 		if o.CertFileName != "" {
 			actualCertFileName = o.CertFileName
 		}
-		err = util.FetchCertificateFromCR(o.CMClient, req.Name, req.Namespace, actualCertFileName, o.IOStreams)
+		err = util.FetchCertificateFromCR(req, actualCertFileName, o.IOStreams)
 		if err != nil {
 			return fmt.Errorf("error when writing certificate to file: %w", err)
 		}

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -57,6 +57,12 @@ kubectl cert-manager create certificaterequest my-cr --namespace default --from-
 
 # Create a CertificateRequest and store private key in file 'new.key'.
 kubectl cert-manager create certificaterequest my-cr --from-certificate-file my-certificate.yaml --output-key-file new.key
+
+# Create a CertificateRequest, wait for it to be signed for up to 5 minutes (default) and store the x509 certificate in file 'new.crt'.
+kubectl cert-manager create certificaterequest my-cr --from-certificate-file my-certificate.yaml --fetch-certificate --output-cert-file new.crt
+
+# Create a CertificateRequest, wait for it to be signed for up to 20 minutes and store the x509 certificate in file 'my-cr.crt'.
+kubectl cert-manager create certificaterequest my-cr --from-certificate-file my-certificate.yaml --fetch-certificate --timeout 20m
 `))
 )
 
@@ -88,9 +94,9 @@ type Options struct {
 	// when generating the CertificateRequest resource
 	// Required
 	InputFilename string
-	// Length of time the command blocks to wait on CertificateReqeust to be ready if --fetch-certificate flag is set
+	// Length of time the command blocks to wait on CertificateRequest to be ready if --fetch-certificate flag is set
 	// If not specified, default value is 5 minutes
-	Timeout       time.Duration
+	Timeout time.Duration
 
 	genericclioptions.IOStreams
 }
@@ -124,9 +130,9 @@ func NewCmdCreateCR(ioStreams genericclioptions.IOStreams, factory cmdutil.Facto
 	cmd.Flags().StringVar(&o.CertFileName, "output-cert-file", o.CertFileName,
 		"Name of the file the certificate is to be stored in")
 	cmd.Flags().BoolVar(&o.FetchCert, "fetch-certificate", o.FetchCert,
-		"If set to true, command will wait for CertificateRequest to be ready to store x509 certificate in a file")
+		"If set to true, command will wait for CertificateRequest to be signed to store x509 certificate in a file")
 	cmd.Flags().DurationVar(&o.Timeout, "timeout", 5*time.Minute,
-		"Duration of timeout when waiting for CertificateRequest to be ready, when specifying must include unit, e.g. 10m or 1h; If not specified, default is 5 minutes")
+		"Time before timeout when waiting for CertificateRequest to be signed, must include unit, e.g. 10m or 1h")
 
 	return cmd
 }

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -127,7 +127,7 @@ func NewCmdCreateCR(ioStreams genericclioptions.IOStreams, factory cmdutil.Facto
 		"Path to a file containing a Certificate resource used as a template when generating the CertificateRequest resource")
 	cmd.Flags().StringVar(&o.KeyFilename, "output-key-file", o.KeyFilename,
 		"Name of file that the generated private key will be written to")
-	cmd.Flags().StringVar(&o.CertFileName, "output-cert-file", o.CertFileName,
+	cmd.Flags().StringVar(&o.CertFileName, "output-certificate-file", o.CertFileName,
 		"Name of the file the certificate is to be stored in")
 	cmd.Flags().BoolVar(&o.FetchCert, "fetch-certificate", o.FetchCert,
 		"If set to true, command will wait for CertificateRequest to be signed to store x509 certificate in a file")

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -275,6 +275,10 @@ func (o *Options) Run(args []string) error {
 		if err != nil {
 			return fmt.Errorf("error when waiting for CertificateRequest to be signed: %w", err)
 		}
+		if len(req.Status.Certificate) == 0 {
+			fmt.Fprintf(o.Out, "%s\n", req.Status.Certificate)
+			return errors.New("CertificateRequest in invalid state: Ready Condition is set but status.certificate is empty")
+		}
 		fmt.Fprintf(o.Out, "CertificateRequest %v in namespace %v has been signed\n", req.Name, req.Namespace)
 
 		// Fetch x509 certificate and store to file

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -263,7 +263,7 @@ func (o *Options) Run(args []string) error {
 		fmt.Fprintf(o.Out, "CertificateRequest %v in namespace %v has not been signed yet. Wait until it is signed...\n",
 			req.Name, req.Namespace)
 		err = wait.Poll(time.Second, o.Timeout, func() (done bool, err error) {
-			req, err := o.CMClient.CertmanagerV1alpha2().CertificateRequests(req.Namespace).Get(context.TODO(), req.Name, metav1.GetOptions{})
+			req, err = o.CMClient.CertmanagerV1alpha2().CertificateRequests(req.Namespace).Get(context.TODO(), req.Name, metav1.GetOptions{})
 			if err != nil {
 				return false, nil
 			}

--- a/cmd/ctl/pkg/util/BUILD.bazel
+++ b/cmd/ctl/pkg/util/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["util.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/util",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ctl/pkg/util/BUILD.bazel
+++ b/cmd/ctl/pkg/util/BUILD.bazel
@@ -9,8 +9,6 @@ go_library(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
-        "//pkg/client/clientset/versioned:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
     ],
 )

--- a/cmd/ctl/pkg/util/BUILD.bazel
+++ b/cmd/ctl/pkg/util/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
-        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
     ],
 )
 

--- a/cmd/ctl/pkg/util/util.go
+++ b/cmd/ctl/pkg/util/util.go
@@ -51,17 +51,12 @@ func FetchCertificateFromCR(cmClient cmclient.Interface,
 	}
 
 	// Store certificate to file
-	actualCertFileName := req.Name + ".crt"
-	if certFileName != "" {
-		actualCertFileName = certFileName
-	}
-
-	err = ioutil.WriteFile(actualCertFileName, req.Status.Certificate, 0600)
+	err = ioutil.WriteFile(certFileName, req.Status.Certificate, 0600)
 	if err != nil {
 		return fmt.Errorf("error when writing certificate to file: %v", err)
 	}
 
-	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %v\n", actualCertFileName)
+	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %v\n", certFileName)
 	return nil
 }
 

--- a/cmd/ctl/pkg/util/util.go
+++ b/cmd/ctl/pkg/util/util.go
@@ -32,14 +32,14 @@ import (
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 )
 
-// Fetches the x509 certificate from a CR and stores the certificate in file specified by certFilename
-// Assumes CR is ready, otherwise returns error
+// FetchCertificateFromCR fetches the x509 certificate from a CR and stores the certificate in file specified by certFilename.
+// Assumes CR is ready, otherwise returns error.
 func FetchCertificateFromCR(cmClient cmclient.Interface,
 	crName, crNamespace, certFileName string,
 	ioStreams genericclioptions.IOStreams) error {
 	req, err := cmClient.CertmanagerV1alpha2().CertificateRequests(crNamespace).Get(context.TODO(), crName, metav1.GetOptions{})
 	if err != nil {
-		return fmt.Errorf("error when querying CertificateRequest: %v", err)
+		return fmt.Errorf("error when querying CertificateRequest: %w", err)
 	}
 
 	// If CR not ready yet, error
@@ -53,14 +53,14 @@ func FetchCertificateFromCR(cmClient cmclient.Interface,
 	// Store certificate to file
 	err = ioutil.WriteFile(certFileName, req.Status.Certificate, 0600)
 	if err != nil {
-		return fmt.Errorf("error when writing certificate to file: %v", err)
+		return fmt.Errorf("error when writing certificate to file: %w", err)
 	}
 
-	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %v\n", certFileName)
+	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %s\n", certFileName)
 	return nil
 }
 
-// Waits until CertificateRequest has the Ready Condition set to true or until timeout occurs
+// PollUntilCRIsReadyOrTimeOut waits until CertificateRequest has the Ready Condition set to true or until timeout occurs.
 func PollUntilCRIsReadyOrTimeOut(client cmclient.Interface, req *cmapiv1alpha2.CertificateRequest, timeout, tick <-chan time.Time) error {
 	for {
 		select {
@@ -69,7 +69,7 @@ func PollUntilCRIsReadyOrTimeOut(client cmclient.Interface, req *cmapiv1alpha2.C
 		case <-tick:
 			req, err := client.CertmanagerV1alpha2().CertificateRequests(req.Namespace).Get(context.TODO(), req.Name, metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("error when querying current status of CertificateRequest: %v", err)
+				return fmt.Errorf("error when querying current status of CertificateRequest: %w", err)
 			}
 			if apiutil.CertificateRequestHasCondition(req, cmapiv1alpha2.CertificateRequestCondition{
 				Type:   cmapiv1alpha2.CertificateRequestConditionReady,

--- a/cmd/ctl/pkg/util/util.go
+++ b/cmd/ctl/pkg/util/util.go
@@ -21,8 +21,6 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -30,13 +28,12 @@ import (
 
 // FetchCertificateFromCR fetches the x509 certificate from a CR and stores the certificate in file specified by certFilename.
 // Assumes CR is ready, otherwise returns error.
-func FetchCertificateFromCR(req *cmapiv1alpha2.CertificateRequest, certFileName string,
-	ioStreams genericclioptions.IOStreams) error {
+func FetchCertificateFromCR(req *cmapiv1alpha2.CertificateRequest, certFileName string) error {
 	// If CR not ready yet, error
 	if !apiutil.CertificateRequestHasCondition(req, cmapiv1alpha2.CertificateRequestCondition{
 		Type:   cmapiv1alpha2.CertificateRequestConditionReady,
 		Status: cmmeta.ConditionTrue,
-	}) {
+	}) || len(req.Status.Certificate) == 0 {
 		return errors.New("CertificateRequest is not ready yet, unable to fetch certificate")
 	}
 
@@ -46,6 +43,5 @@ func FetchCertificateFromCR(req *cmapiv1alpha2.CertificateRequest, certFileName 
 		return fmt.Errorf("error when writing certificate to file: %w", err)
 	}
 
-	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %s\n", certFileName)
 	return nil
 }

--- a/cmd/ctl/pkg/util/util.go
+++ b/cmd/ctl/pkg/util/util.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+)
+
+// Fetches the x509 certificate from a CR and stores the certificate in file specified by certFilename
+// Assumes CR is ready, otherwise returns error
+func FetchCertificateFromCR(cmClient cmclient.Interface,
+	crName, crNamespace, certFileName string,
+	ioStreams genericclioptions.IOStreams) error {
+	req, err := cmClient.CertmanagerV1alpha2().CertificateRequests(crNamespace).Get(context.TODO(), crName, metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error when querying CertificateRequest: %v", err)
+	}
+
+	// If CR not ready yet, error
+	if !apiutil.CertificateRequestHasCondition(req, cmapiv1alpha2.CertificateRequestCondition{
+		Type:   cmapiv1alpha2.CertificateRequestConditionReady,
+		Status: cmmeta.ConditionTrue,
+	}) {
+		return errors.New("CertificateRequest is not ready yet, unable to fetch certificate")
+	}
+
+	// Store certificate to file
+	actualCertFileName := req.Name + ".crt"
+	if certFileName != "" {
+		actualCertFileName = certFileName
+	}
+
+	err = ioutil.WriteFile(actualCertFileName, req.Status.Certificate, 0600)
+	if err != nil {
+		return fmt.Errorf("error when writing certificate to file: %v", err)
+	}
+
+	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %v\n", actualCertFileName)
+	return nil
+}
+
+// Waits until CertificateRequest has the Ready Condition set to true or until timeout occurs
+func PollUntilCRIsReadyOrTimeOut(client cmclient.Interface, req *cmapiv1alpha2.CertificateRequest, timeout, tick <-chan time.Time) error {
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for CertificateRequest to be signed, retry later with fetch command")
+		case <-tick:
+			req, err := client.CertmanagerV1alpha2().CertificateRequests(req.Namespace).Get(context.TODO(), req.Name, metav1.GetOptions{})
+			if err != nil {
+				return fmt.Errorf("error when querying current status of CertificateRequest: %v", err)
+			}
+			if apiutil.CertificateRequestHasCondition(req, cmapiv1alpha2.CertificateRequestCondition{
+				Type:   cmapiv1alpha2.CertificateRequestConditionReady,
+				Status: cmmeta.ConditionTrue,
+			}) {
+				return nil
+			}
+		}
+	}
+}

--- a/cmd/ctl/pkg/util/util.go
+++ b/cmd/ctl/pkg/util/util.go
@@ -21,7 +21,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -58,25 +57,4 @@ func FetchCertificateFromCR(cmClient cmclient.Interface,
 
 	fmt.Fprintf(ioStreams.Out, "Certificate has been stored in file %s\n", certFileName)
 	return nil
-}
-
-// PollUntilCRIsReadyOrTimeOut waits until CertificateRequest has the Ready Condition set to true or until timeout occurs.
-func PollUntilCRIsReadyOrTimeOut(client cmclient.Interface, req *cmapiv1alpha2.CertificateRequest, timeout, tick <-chan time.Time) error {
-	for {
-		select {
-		case <-timeout:
-			return fmt.Errorf("timeout waiting for CertificateRequest to be signed, retry later with fetch command")
-		case <-tick:
-			req, err := client.CertmanagerV1alpha2().CertificateRequests(req.Namespace).Get(context.TODO(), req.Name, metav1.GetOptions{})
-			if err != nil {
-				return fmt.Errorf("error when querying current status of CertificateRequest: %w", err)
-			}
-			if apiutil.CertificateRequestHasCondition(req, cmapiv1alpha2.CertificateRequestCondition{
-				Type:   cmapiv1alpha2.CertificateRequestConditionReady,
-				Status: cmmeta.ConditionTrue,
-			}) {
-				return nil
-			}
-		}
-	}
 }

--- a/test/integration/ctl/BUILD.bazel
+++ b/test/integration/ctl/BUILD.bazel
@@ -17,6 +17,7 @@ go_test(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/integration/framework:go_default_library",
         "//test/unit/gen:go_default_library",

--- a/test/integration/ctl/BUILD.bazel
+++ b/test/integration/ctl/BUILD.bazel
@@ -17,12 +17,12 @@ go_test(
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
-        "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/integration/framework:go_default_library",
         "//test/unit/gen:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
     ],
 )

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package ctl
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -49,14 +50,15 @@ func TestCtlCreateCR(t *testing.T) {
 		t.Fatal(err)
 	}
 	var (
-		cr1Name = "testcr-1"
-		cr2Name = "testcr-2"
-		cr3Name = "testcr-3"
-		cr4Name = "testcr-4"
-		cr5Name = "testcr-5"
-		cr6Name = "testcr-6"
-		ns1     = "testns-1"
-		ns2     = "testns-2"
+		cr1Name            = "testcr-1"
+		cr2Name            = "testcr-2"
+		cr3Name            = "testcr-3"
+		cr4Name            = "testcr-4"
+		cr5Name            = "testcr-5"
+		cr6Name            = "testcr-6"
+		cr7Name            = "testcr-7"
+		ns1                = "testns-1"
+		ns2                = "testns-2"
 		exampleCertificate = []byte(`LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZUekNDQkRlZ0F3SUJBZ0lUQVBwOWhMUit2ODF2UTdpZSt6emxTMWY5MFRBTkJna3Foa2lHOXcwQkFRc0YKQURBaU1TQXdIZ1lEVlFRRERCZEdZV3RsSUV4RklFbHVkR1Z5YldWa2FXRjBaU0JZTVRBZUZ3MHlNREEyTXpBeApNelUyTkRoYUZ3MHlNREE1TWpneE16VTJORGhhTUNZeEpEQWlCZ05WQkFNVEcyaGhiM2hwWVc1bkxXZGpjQzVxClpYUnpkR0ZqYTJWeUxtNWxkRENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFOTjIKTS9zZGtPazgvenJLbXNvMEE1SmxoUjRTQU9pTVhiWGZleEpvUzZ3b3krakszNVBCOUFDUDFQcllXR0diZjNYRwo1VngvZmRBSlNmdVFmL0NoZlRsa0kwQUYxUCsxUThhQU9BUXhKdU4ySVJxT0ErNlEwUTg2Vy9oZVFXbUdOUkI4CmxMcHQvWU9IV3NreHRqRDNmN3p1QXZZUkI1czFCZ3o2K2s1REF6d1pGNnlMMEtja1JpY3dFMHh3aisrZkcyeCsKdEpQb1AwdmliM0EzU0xySFhsRW5HbFdEL3ZSbkkrNkc1dFI2ZHJWbGcrcjhSRkFiYTJDc1VpTGFiM252Q2JqUQpDNG9xZWd1NklUNzk4R0thenBXbGw2b3M0SndQdFJnQzlvYS9FeklVanlWeStuRWhHU3pwSmlNQ0NZOS96b0daCmV1TGJ0M1lSdVVIaStiemludnNDQXdFQUFhT0NBbmd3Z2dKME1BNEdBMVVkRHdFQi93UUVBd0lGb0RBZEJnTlYKSFNVRUZqQVVCZ2dyQmdFRkJRY0RBUVlJS3dZQkJRVUhBd0l3REFZRFZSMFRBUUgvQkFJd0FEQWRCZ05WSFE0RQpGZ1FVRGZKNml2NlNoRlhzLzFrUTh5bmR1NGhTUEtrd0h3WURWUjBqQkJnd0ZvQVV3TXdEUnJsWUlNeGNjbkR6CjRTN0xJS2IxYURvd2R3WUlLd1lCQlFVSEFRRUVhekJwTURJR0NDc0dBUVVGQnpBQmhpWm9kSFJ3T2k4dmIyTnoKY0M1emRHY3RhVzUwTFhneExteGxkSE5sYm1OeWVYQjBMbTl5WnpBekJnZ3JCZ0VGQlFjd0FvWW5hSFIwY0RvdgpMMk5sY25RdWMzUm5MV2x1ZEMxNE1TNXNaWFJ6Wlc1amNubHdkQzV2Y21jdk1DWUdBMVVkRVFRZk1CMkNHMmhoCmIzaHBZVzVuTFdkamNDNXFaWFJ6ZEdGamEyVnlMbTVsZERCTUJnTlZIU0FFUlRCRE1BZ0dCbWVCREFFQ0FUQTMKQmdzckJnRUVBWUxmRXdFQkFUQW9NQ1lHQ0NzR0FRVUZCd0lCRmhwb2RIUndPaTh2WTNCekxteGxkSE5sYm1OeQplWEIwTG05eVp6Q0NBUVFHQ2lzR0FRUUIxbmtDQkFJRWdmVUVnZklBOEFCMkFMRE1nK1dsK1gxcnIzd0p6Q2hKCkJJY3F4K2lMRXl4alVMZkcvU2JoYkd4M0FBQUJjd1c3QXB3QUFBUURBRWN3UlFJaEFPai9nNm9ONjNTRnBqa00Ka3FmcjRDUlVzb0dWamZqQzN4MkRFdmR0RVZzNEFpQm05OTFzTHFHUzFJYksrM1VoemZzUDUvNTVjU2FpWkVPcwpwQmdVb1plb0l3QjJBTjJaTlB5bDV5U0F5VlpvZllFMG1RaEpza24zdFduWXg3eXJQMXpCODI1a0FBQUJjd1c3CkJJb0FBQVFEQUVjd1JRSWdVbTRDbW9hdDBIdTZaMUExcFRKbTc4WTRYaHZWcmJIQ3RYUUZaa0QweHZzQ0lRQ0IKbVBSTFFZS2RObUMyMXJLRW5hUjBBRjBZbS9ENEp6NjlhWTJUbEcwM1hqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBZHZoNFJuUGVaWEliazc3b2xjaTM0K0tZRmxCSUtDbFdUTkl3dXB5NlpGM0NYSlBzSjRQQWUvMGMzTVpaCkZSbDl4SHN2LzNESXZOaU5udkJSblRjdHJFMGp1V0cxYVlrWWIzaGRJMFVNcWlqUHNmc0doZW9LQnpRVDBoREcKRDFET0hPNXB5czQvNnp3NXk2TVMrdkoyVXY3aHlWem1PdldqaFp1c0xvUUZBcmpYY0ROY0puN3N2SkdOMXRFSgpZeUxHSk42SFpMV0xSeU8zdTBHYU9HQkk4SGRmc3JzbGVKaUk4b1ROaXdjaFZuekR1UUlLZFo0M040N0R5QlgwClpjTmplbElzeGtPSlhCUHJQVWJOaGltK1dNWjlicWxpUFZLamlhRUJFQ1BIaVRFK0Y2a3dkRkpkTktJZUVtL3UKR0JTRW5Zdmp2RWRJMzh4U1JWMXZDdDgxUUE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlFcXpDQ0FwT2dBd0lCQWdJUkFJdmhLZzVaUk8wOFZHUXg4SmRoVCtVd0RRWUpLb1pJaHZjTkFRRUxCUUF3CkdqRVlNQllHQTFVRUF3d1BSbUZyWlNCTVJTQlNiMjkwSUZneE1CNFhEVEUyTURVeU16SXlNRGMxT1ZvWERUTTIKTURVeU16SXlNRGMxT1Zvd0lqRWdNQjRHQTFVRUF3d1hSbUZyWlNCTVJTQkpiblJsY20xbFpHbGhkR1VnV0RFdwpnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEdFdLeVNEbjdyV1pjNWdnanozWkIwCjhqTzR4dGkzdXpJTmZENXNRN0xqN2h6ZXRVVCt3UW9iK2lYU1praG52eCtJdmRiWEY1L3l0OGFXUHBVS25QeW0Kb0x4c1lpSTVnUUJMeE5EekllYzBPSWFmbFdxQXIyOW03SjgrTk50QXBFTjhuWkZuZjNiaGVoWlc3QXhtUzFtMApablNzZEh3MEZ3K2JnaXhQZzJNUTlrOW9lZkZlcWErN0txZGx6NWJiclVZVjJ2b2x4aERGdG5JNE1oOEJpV0NOCnhESDFIaXpxK0dLQ2NIc2luRFpXdXJDcWRlci9hZkpCblFzK1NCU0w2TVZBcEh0K2QzNXpqQkQ5MmZPMkplNTYKZGhNZnpDZ09LWGVKMzQwV2hXM1RqRDF6cUxaWGVhQ3lVTlJuZk9tV1pWOG5FaHRIT0ZiVUNVN3IvS2tqTVpPOQpBZ01CQUFHamdlTXdnZUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3CkhRWURWUjBPQkJZRUZNRE1BMGE1V0NETVhISnc4K0V1eXlDbTlXZzZNSG9HQ0NzR0FRVUZCd0VCQkc0d2JEQTAKQmdnckJnRUZCUWN3QVlZb2FIUjBjRG92TDI5amMzQXVjM1JuTFhKdmIzUXRlREV1YkdWMGMyVnVZM0o1Y0hRdQpiM0puTHpBMEJnZ3JCZ0VGQlFjd0FvWW9hSFIwY0RvdkwyTmxjblF1YzNSbkxYSnZiM1F0ZURFdWJHVjBjMlZ1ClkzSjVjSFF1YjNKbkx6QWZCZ05WSFNNRUdEQVdnQlRCSm5Ta2lrU2c1dm9nS05oY0k1cEZpQmg1NERBTkJna3EKaGtpRzl3MEJBUXNGQUFPQ0FnRUFCWVN1NElsK2ZJME1ZVTQyT1RtRWorMUhxUTVEdnlBZXlDQTZzR3VaZHdqRgpVR2VWT3YzTm5MeWZvZnVVT2pFYlk1aXJGQ0R0bnYrMGNrdWtVWk45bHo0UTJZaldHVXBXNFRUdTNpZVRzYUM5CkFGdkNTZ05ISnlXU1Z0V3ZCNVhEeHNxYXdsMUt6SHp6d3IxMzJiRjJydEd0YXpTcVZxSzlFMDdzR0hNQ2YrenAKRFFWRFZWR3RxWlBId1gzS3FVdGVmRTYyMWI4Ukk2VkNsNG9EMzBPbGY4cGp1ekc0SktCRlJGY2x6TFJqby9oNwpJa2tmalo4d0RhN2ZhT2pWWHg2bitlVVEyOWNJTUN6cjgvck5XSFM5cFlHR1FLSmlZMnhtVkM5aDEySDk5WHlmCnpXRTl2YjV6S1AzTVZHNm5lWDFoU2RvN1BFQWI5ZnFSaEhrcVZzcVV2SmxJUm12WHZWS1R3TkNQM2VDalJDQ0kKUFRBdmpWKzRuaTc4NmlYd3dGWU56OGwzUG1QTEN5UVhXR29obko4aUJtKzVuazdPMnluYVBWVzBVMlcrcHQydwpTVnV2ZERNNXpHdjJmOWx0TldVaVlaSEoxbW1POTdqU1kvNllmZE9VSDY2aVJ0UXREa0hCUmRrTkJzTWJEK0VtCjJUZ0JsZHRITlNKQmZCM3BtOUZibGdPY0owRlNXY1VEV0o3dk8wK05UWGxnclJvZlJUNnBWeXd6eFZvNmRORDAKV3pZbFRXZVVWc080MHhKcWhnVVFSRVI5WUxPTHhKME82QzhpMHhGeEFNS090U2RvZE1CM1JJd3Q3UkZRMHV5dApuNVo1TXFrWWhsTUkzSjF0UFJUcDFuRXQ5ZnlHc3BCT08wNWdpMTQ4UWFzcCszTitzdnFLb21vUWdsTm9BeFU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K`)
 
 		testdataPath = testWorkingDirectory + "/testdata/"
@@ -70,13 +72,15 @@ func TestCtlCreateCR(t *testing.T) {
 		certFilename   string
 		fetchCert      bool
 		timeout        time.Duration
+		crStatus       cmapiv1alpha2.CertificateRequestStatus
 
-		expValidateErr  bool
-		expRunErr       bool
-		expNamespace    string
-		expName         string
-		expKeyFilename  string
-		expCertFilename string
+		expValidateErr     bool
+		expRunErr          bool
+		expNamespace       string
+		expName            string
+		expKeyFilename     string
+		expCertFilename    string
+		expCertFileContent []byte
 	}{
 		"v1alpha2 Certificate given": {
 			inputFile:      testdataPath + "create_cr_cert_with_ns1.yaml",
@@ -143,19 +147,46 @@ func TestCtlCreateCR(t *testing.T) {
 			expNamespace:   ns1,
 			expKeyFilename: "",
 		},
-		"fetch flag set": {
-			inputFile:       testdataPath + "create_cr_cert_with_ns1.yaml",
-			inputArgs:       []string{cr6Name},
-			inputNamespace:  ns1,
-			keyFilename:     "",
-			fetchCert:       true,
-			timeout:         5 * time.Minute,
-			expValidateErr:  false,
-			expRunErr:       false,
-			expNamespace:    ns1,
-			expName:         cr6Name,
-			expKeyFilename:  cr6Name + ".key",
-			expCertFilename: cr6Name + ".crt",
+		"fetch flag set and CR will be ready and status.certificate set": {
+			inputFile:      testdataPath + "create_cr_cert_with_ns1.yaml",
+			inputArgs:      []string{cr6Name},
+			inputNamespace: ns1,
+			keyFilename:    "",
+			fetchCert:      true,
+			timeout:        5 * time.Minute,
+			crStatus: cmapiv1alpha2.CertificateRequestStatus{
+				Conditions: []cmapiv1alpha2.CertificateRequestCondition{
+					{Type: cmapiv1alpha2.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue},
+				},
+				Certificate: exampleCertificate,
+			},
+			expValidateErr:     false,
+			expRunErr:          false,
+			expNamespace:       ns1,
+			expName:            cr6Name,
+			expKeyFilename:     cr6Name + ".key",
+			expCertFilename:    cr6Name + ".crt",
+			expCertFileContent: exampleCertificate,
+		},
+		"fetch flag set and CR will be ready but status.certificate empty": {
+			inputFile:      testdataPath + "create_cr_cert_with_ns1.yaml",
+			inputArgs:      []string{cr7Name},
+			inputNamespace: ns1,
+			keyFilename:    "",
+			fetchCert:      true,
+			timeout:        5 * time.Minute,
+			crStatus: cmapiv1alpha2.CertificateRequestStatus{
+				Conditions: []cmapiv1alpha2.CertificateRequestCondition{
+					{Type: cmapiv1alpha2.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue},
+				},
+			},
+			expValidateErr:     false,
+			expRunErr:          true,
+			expNamespace:       ns1,
+			expName:            cr7Name,
+			expKeyFilename:     cr7Name + ".key",
+			expCertFilename:    cr7Name + ".crt",
+			expCertFileContent: exampleCertificate,
 		},
 	}
 
@@ -198,12 +229,12 @@ func TestCtlCreateCR(t *testing.T) {
 
 			// Start a goroutine that will periodically check whether the CertificateRequest has been created
 			// by the CLI command yet.
-			// TODO: Once it has been created, set the `status.certificate` and `Ready` condition so that the `--fetch` part of the
-			// command is able to proceed.
+			// Once it has been created, set the `status.certificate` and `Ready` condition so that the `--fetch-certificate`
+			// part of the command is able to proceed.
 			if test.fetchCert {
 				req := &cmapiv1alpha2.CertificateRequest{}
 				go func() {
-					err = wait.Poll(time.Second, 5 * time.Minute, func() (done bool, err error) {
+					err = wait.Poll(time.Second, 5*time.Minute, func() (done bool, err error) {
 						req, err = cmCl.CertmanagerV1alpha2().CertificateRequests(test.inputNamespace).Get(context.TODO(), test.inputArgs[0], metav1.GetOptions{})
 						if err != nil {
 							return false, nil
@@ -215,14 +246,13 @@ func TestCtlCreateCR(t *testing.T) {
 					}
 
 					// CR has been created, try update status
-					readyCond := cmapiv1alpha2.CertificateRequestCondition{Type: cmapiv1alpha2.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue}
-					req.Status.Conditions = []cmapiv1alpha2.CertificateRequestCondition{readyCond}
-					req.Status.Certificate = exampleCertificate
-					_, err = cmCl.CertmanagerV1alpha2().CertificateRequests(test.inputNamespace).UpdateStatus(context.TODO(), req, metav1.UpdateOptions{})
+					req.Status.Conditions = test.crStatus.Conditions
+					req.Status.Certificate = test.crStatus.Certificate
+					req, err = cmCl.CertmanagerV1alpha2().CertificateRequests(test.inputNamespace).UpdateStatus(context.TODO(), req, metav1.UpdateOptions{})
 					if err != nil {
 						t.Fatal(err)
 					}
-				} ()
+				}()
 			}
 
 			// Create CR
@@ -270,9 +300,13 @@ func TestCtlCreateCR(t *testing.T) {
 
 			// Check the file where the certificate is stored if applicable
 			if test.fetchCert {
-				_, err := ioutil.ReadFile(test.expCertFilename)
+				certData, err := ioutil.ReadFile(test.expCertFilename)
 				if err != nil {
 					t.Errorf("error when reading file storing private key: %v", err)
+				}
+
+				if !bytes.Equal(test.expCertFileContent, certData) {
+					t.Errorf("certificate written to file is wrong, expected: %v,\nactual: %v", test.expCertFileContent, certData)
 				}
 			}
 		})

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -24,12 +24,12 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/create/certificaterequest"
 	cmapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	"github.com/jetstack/cert-manager/pkg/util/pki"
 	"github.com/jetstack/cert-manager/test/integration/framework"
 )
@@ -57,6 +57,7 @@ func TestCtlCreateCR(t *testing.T) {
 		cr6Name = "testcr-6"
 		ns1     = "testns-1"
 		ns2     = "testns-2"
+		exampleCertificate = []byte(`LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZUekNDQkRlZ0F3SUJBZ0lUQVBwOWhMUit2ODF2UTdpZSt6emxTMWY5MFRBTkJna3Foa2lHOXcwQkFRc0YKQURBaU1TQXdIZ1lEVlFRRERCZEdZV3RsSUV4RklFbHVkR1Z5YldWa2FXRjBaU0JZTVRBZUZ3MHlNREEyTXpBeApNelUyTkRoYUZ3MHlNREE1TWpneE16VTJORGhhTUNZeEpEQWlCZ05WQkFNVEcyaGhiM2hwWVc1bkxXZGpjQzVxClpYUnpkR0ZqYTJWeUxtNWxkRENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFOTjIKTS9zZGtPazgvenJLbXNvMEE1SmxoUjRTQU9pTVhiWGZleEpvUzZ3b3krakszNVBCOUFDUDFQcllXR0diZjNYRwo1VngvZmRBSlNmdVFmL0NoZlRsa0kwQUYxUCsxUThhQU9BUXhKdU4ySVJxT0ErNlEwUTg2Vy9oZVFXbUdOUkI4CmxMcHQvWU9IV3NreHRqRDNmN3p1QXZZUkI1czFCZ3o2K2s1REF6d1pGNnlMMEtja1JpY3dFMHh3aisrZkcyeCsKdEpQb1AwdmliM0EzU0xySFhsRW5HbFdEL3ZSbkkrNkc1dFI2ZHJWbGcrcjhSRkFiYTJDc1VpTGFiM252Q2JqUQpDNG9xZWd1NklUNzk4R0thenBXbGw2b3M0SndQdFJnQzlvYS9FeklVanlWeStuRWhHU3pwSmlNQ0NZOS96b0daCmV1TGJ0M1lSdVVIaStiemludnNDQXdFQUFhT0NBbmd3Z2dKME1BNEdBMVVkRHdFQi93UUVBd0lGb0RBZEJnTlYKSFNVRUZqQVVCZ2dyQmdFRkJRY0RBUVlJS3dZQkJRVUhBd0l3REFZRFZSMFRBUUgvQkFJd0FEQWRCZ05WSFE0RQpGZ1FVRGZKNml2NlNoRlhzLzFrUTh5bmR1NGhTUEtrd0h3WURWUjBqQkJnd0ZvQVV3TXdEUnJsWUlNeGNjbkR6CjRTN0xJS2IxYURvd2R3WUlLd1lCQlFVSEFRRUVhekJwTURJR0NDc0dBUVVGQnpBQmhpWm9kSFJ3T2k4dmIyTnoKY0M1emRHY3RhVzUwTFhneExteGxkSE5sYm1OeWVYQjBMbTl5WnpBekJnZ3JCZ0VGQlFjd0FvWW5hSFIwY0RvdgpMMk5sY25RdWMzUm5MV2x1ZEMxNE1TNXNaWFJ6Wlc1amNubHdkQzV2Y21jdk1DWUdBMVVkRVFRZk1CMkNHMmhoCmIzaHBZVzVuTFdkamNDNXFaWFJ6ZEdGamEyVnlMbTVsZERCTUJnTlZIU0FFUlRCRE1BZ0dCbWVCREFFQ0FUQTMKQmdzckJnRUVBWUxmRXdFQkFUQW9NQ1lHQ0NzR0FRVUZCd0lCRmhwb2RIUndPaTh2WTNCekxteGxkSE5sYm1OeQplWEIwTG05eVp6Q0NBUVFHQ2lzR0FRUUIxbmtDQkFJRWdmVUVnZklBOEFCMkFMRE1nK1dsK1gxcnIzd0p6Q2hKCkJJY3F4K2lMRXl4alVMZkcvU2JoYkd4M0FBQUJjd1c3QXB3QUFBUURBRWN3UlFJaEFPai9nNm9ONjNTRnBqa00Ka3FmcjRDUlVzb0dWamZqQzN4MkRFdmR0RVZzNEFpQm05OTFzTHFHUzFJYksrM1VoemZzUDUvNTVjU2FpWkVPcwpwQmdVb1plb0l3QjJBTjJaTlB5bDV5U0F5VlpvZllFMG1RaEpza24zdFduWXg3eXJQMXpCODI1a0FBQUJjd1c3CkJJb0FBQVFEQUVjd1JRSWdVbTRDbW9hdDBIdTZaMUExcFRKbTc4WTRYaHZWcmJIQ3RYUUZaa0QweHZzQ0lRQ0IKbVBSTFFZS2RObUMyMXJLRW5hUjBBRjBZbS9ENEp6NjlhWTJUbEcwM1hqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBZHZoNFJuUGVaWEliazc3b2xjaTM0K0tZRmxCSUtDbFdUTkl3dXB5NlpGM0NYSlBzSjRQQWUvMGMzTVpaCkZSbDl4SHN2LzNESXZOaU5udkJSblRjdHJFMGp1V0cxYVlrWWIzaGRJMFVNcWlqUHNmc0doZW9LQnpRVDBoREcKRDFET0hPNXB5czQvNnp3NXk2TVMrdkoyVXY3aHlWem1PdldqaFp1c0xvUUZBcmpYY0ROY0puN3N2SkdOMXRFSgpZeUxHSk42SFpMV0xSeU8zdTBHYU9HQkk4SGRmc3JzbGVKaUk4b1ROaXdjaFZuekR1UUlLZFo0M040N0R5QlgwClpjTmplbElzeGtPSlhCUHJQVWJOaGltK1dNWjlicWxpUFZLamlhRUJFQ1BIaVRFK0Y2a3dkRkpkTktJZUVtL3UKR0JTRW5Zdmp2RWRJMzh4U1JWMXZDdDgxUUE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlFcXpDQ0FwT2dBd0lCQWdJUkFJdmhLZzVaUk8wOFZHUXg4SmRoVCtVd0RRWUpLb1pJaHZjTkFRRUxCUUF3CkdqRVlNQllHQTFVRUF3d1BSbUZyWlNCTVJTQlNiMjkwSUZneE1CNFhEVEUyTURVeU16SXlNRGMxT1ZvWERUTTIKTURVeU16SXlNRGMxT1Zvd0lqRWdNQjRHQTFVRUF3d1hSbUZyWlNCTVJTQkpiblJsY20xbFpHbGhkR1VnV0RFdwpnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEdFdLeVNEbjdyV1pjNWdnanozWkIwCjhqTzR4dGkzdXpJTmZENXNRN0xqN2h6ZXRVVCt3UW9iK2lYU1praG52eCtJdmRiWEY1L3l0OGFXUHBVS25QeW0Kb0x4c1lpSTVnUUJMeE5EekllYzBPSWFmbFdxQXIyOW03SjgrTk50QXBFTjhuWkZuZjNiaGVoWlc3QXhtUzFtMApablNzZEh3MEZ3K2JnaXhQZzJNUTlrOW9lZkZlcWErN0txZGx6NWJiclVZVjJ2b2x4aERGdG5JNE1oOEJpV0NOCnhESDFIaXpxK0dLQ2NIc2luRFpXdXJDcWRlci9hZkpCblFzK1NCU0w2TVZBcEh0K2QzNXpqQkQ5MmZPMkplNTYKZGhNZnpDZ09LWGVKMzQwV2hXM1RqRDF6cUxaWGVhQ3lVTlJuZk9tV1pWOG5FaHRIT0ZiVUNVN3IvS2tqTVpPOQpBZ01CQUFHamdlTXdnZUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3CkhRWURWUjBPQkJZRUZNRE1BMGE1V0NETVhISnc4K0V1eXlDbTlXZzZNSG9HQ0NzR0FRVUZCd0VCQkc0d2JEQTAKQmdnckJnRUZCUWN3QVlZb2FIUjBjRG92TDI5amMzQXVjM1JuTFhKdmIzUXRlREV1YkdWMGMyVnVZM0o1Y0hRdQpiM0puTHpBMEJnZ3JCZ0VGQlFjd0FvWW9hSFIwY0RvdkwyTmxjblF1YzNSbkxYSnZiM1F0ZURFdWJHVjBjMlZ1ClkzSjVjSFF1YjNKbkx6QWZCZ05WSFNNRUdEQVdnQlRCSm5Ta2lrU2c1dm9nS05oY0k1cEZpQmg1NERBTkJna3EKaGtpRzl3MEJBUXNGQUFPQ0FnRUFCWVN1NElsK2ZJME1ZVTQyT1RtRWorMUhxUTVEdnlBZXlDQTZzR3VaZHdqRgpVR2VWT3YzTm5MeWZvZnVVT2pFYlk1aXJGQ0R0bnYrMGNrdWtVWk45bHo0UTJZaldHVXBXNFRUdTNpZVRzYUM5CkFGdkNTZ05ISnlXU1Z0V3ZCNVhEeHNxYXdsMUt6SHp6d3IxMzJiRjJydEd0YXpTcVZxSzlFMDdzR0hNQ2YrenAKRFFWRFZWR3RxWlBId1gzS3FVdGVmRTYyMWI4Ukk2VkNsNG9EMzBPbGY4cGp1ekc0SktCRlJGY2x6TFJqby9oNwpJa2tmalo4d0RhN2ZhT2pWWHg2bitlVVEyOWNJTUN6cjgvck5XSFM5cFlHR1FLSmlZMnhtVkM5aDEySDk5WHlmCnpXRTl2YjV6S1AzTVZHNm5lWDFoU2RvN1BFQWI5ZnFSaEhrcVZzcVV2SmxJUm12WHZWS1R3TkNQM2VDalJDQ0kKUFRBdmpWKzRuaTc4NmlYd3dGWU56OGwzUG1QTEN5UVhXR29obko4aUJtKzVuazdPMnluYVBWVzBVMlcrcHQydwpTVnV2ZERNNXpHdjJmOWx0TldVaVlaSEoxbW1POTdqU1kvNllmZE9VSDY2aVJ0UXREa0hCUmRrTkJzTWJEK0VtCjJUZ0JsZHRITlNKQmZCM3BtOUZibGdPY0owRlNXY1VEV0o3dk8wK05UWGxnclJvZlJUNnBWeXd6eFZvNmRORDAKV3pZbFRXZVVWc080MHhKcWhnVVFSRVI5WUxPTHhKME82QzhpMHhGeEFNS090U2RvZE1CM1JJd3Q3UkZRMHV5dApuNVo1TXFrWWhsTUkzSjF0UFJUcDFuRXQ5ZnlHc3BCT08wNWdpMTQ4UWFzcCszTitzdnFLb21vUWdsTm9BeFU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K`)
 
 		testdataPath = testWorkingDirectory + "/testdata/"
 	)
@@ -195,10 +196,35 @@ func TestCtlCreateCR(t *testing.T) {
 				}
 			}
 
-			// Try to set Ready Condition if needed, otherwise the test just times out
+			// Start a goroutine that will periodically check whether the CertificateRequest has been created
+			// by the CLI command yet.
+			// TODO: Once it has been created, set the `status.certificate` and `Ready` condition so that the `--fetch` part of the
+			// command is able to proceed.
 			if test.fetchCert {
-				go setCRReadyCondition(t, cmCl, test.inputArgs[0], test.inputNamespace)
+				req := &cmapiv1alpha2.CertificateRequest{}
+				go func() {
+					err = wait.Poll(time.Second, 5 * time.Minute, func() (done bool, err error) {
+						req, err = cmCl.CertmanagerV1alpha2().CertificateRequests(test.inputNamespace).Get(context.TODO(), test.inputArgs[0], metav1.GetOptions{})
+						if err != nil {
+							return false, nil
+						}
+						return true, nil
+					})
+					if err != nil {
+						t.Fatal("timeout when waiting for CertificateRequest to be created")
+					}
+
+					// CR has been created, try update status
+					readyCond := cmapiv1alpha2.CertificateRequestCondition{Type: cmapiv1alpha2.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue}
+					req.Status.Conditions = []cmapiv1alpha2.CertificateRequestCondition{readyCond}
+					req.Status.Certificate = exampleCertificate
+					_, err = cmCl.CertmanagerV1alpha2().CertificateRequests(test.inputNamespace).UpdateStatus(context.TODO(), req, metav1.UpdateOptions{})
+					if err != nil {
+						t.Fatal(err)
+					}
+				} ()
 			}
+
 			// Create CR
 			err = opts.Run(test.inputArgs)
 			if err != nil {
@@ -274,32 +300,6 @@ func setupPathForTest(t *testing.T) func() {
 		}
 		if err := os.RemoveAll(tmpDir); err != nil {
 			t.Fatal(err)
-		}
-	}
-}
-
-// Retry to ensure CR has been created for up to a timeout and then
-// set the Ready Condition of CR to true
-func setCRReadyCondition(t *testing.T, cmCl versioned.Interface, crName, crNamespace string) {
-	timeout := time.After(5 * time.Minute)
-	tick := time.Tick(1 * time.Second)
-	for {
-		select {
-		case <-timeout:
-			t.Fatal("timeout waiting for CertificateRequest to be signed, retry later with fetch command")
-		case <-tick:
-			req, err := cmCl.CertmanagerV1alpha2().CertificateRequests(crNamespace).Get(context.TODO(), crName, metav1.GetOptions{})
-			if err != nil {
-				continue
-			}
-			// CR has been created, try update status
-			readyCond := cmapiv1alpha2.CertificateRequestCondition{Type: cmapiv1alpha2.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue}
-			req.Status.Conditions = []cmapiv1alpha2.CertificateRequestCondition{readyCond}
-			_, err = cmCl.CertmanagerV1alpha2().CertificateRequests(crNamespace).UpdateStatus(context.TODO(), req, metav1.UpdateOptions{})
-			if err != nil {
-				t.Fatal(err)
-			}
-			return
 		}
 	}
 }

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -68,6 +68,7 @@ func TestCtlCreateCR(t *testing.T) {
 		keyFilename    string
 		certFilename   string
 		fetchCert      bool
+		timeout        time.Duration
 
 		expValidateErr  bool
 		expRunErr       bool
@@ -147,6 +148,7 @@ func TestCtlCreateCR(t *testing.T) {
 			inputNamespace:  ns1,
 			keyFilename:     "",
 			fetchCert:       true,
+			timeout:         5 * time.Minute,
 			expValidateErr:  false,
 			expRunErr:       false,
 			expNamespace:    ns1,
@@ -173,6 +175,7 @@ func TestCtlCreateCR(t *testing.T) {
 				EnforceNamespace: test.inputNamespace != "",
 				KeyFilename:      test.keyFilename,
 				FetchCert:        test.fetchCert,
+				Timeout:          test.timeout,
 			}
 
 			opts.InputFilename = test.inputFile
@@ -203,8 +206,9 @@ func TestCtlCreateCR(t *testing.T) {
 				// to know where exactly things should fail and then check the correctness of the parts that shouldn't have failed
 				if !test.expRunErr {
 					t.Errorf("got unexpected error when trying to create CR: %v", err)
+				} else {
+					t.Logf("got an error, which was expected, details: %v", err)
 				}
-				t.Logf("got an error, which was expected, details: %v", err)
 				return
 			} else {
 				// got no error

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -174,7 +174,7 @@ func TestCtlCreateCR(t *testing.T) {
 			inputNamespace: ns1,
 			keyFilename:    "",
 			fetchCert:      true,
-			timeout:        5 * time.Minute,
+			timeout:        5 * time.Second,
 			crStatus: cmapiv1alpha2.CertificateRequestStatus{
 				Conditions: []cmapiv1alpha2.CertificateRequestCondition{
 					{Type: cmapiv1alpha2.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR enables the user to specify `--fetch-certificate` and `--output-cert-file` flags to wait for the CertificateRequest that was created to be ready and store the certificate in a file.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
kubectl cert-manager: Added flags to wait for the CertificateRequest to be ready and store the certificate in a file.
```
/kind feature
/area ctl