### PR TITLE
Add a user-agent on HTTP self-checks

### DIFF
--- a/pkg/issuer/acme/http/BUILD.bazel
+++ b/pkg/issuer/acme/http/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/issuer/acme/http/solver:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//extensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -35,6 +35,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
+	pkgutil "github.com/jetstack/cert-manager/pkg/util"
 )
 
 const (
@@ -175,6 +176,7 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 		Method: http.MethodGet,
 		URL:    url,
 	}
+	req.Header.Set("User-Agent", pkgutil.CertManagerUserAgent)
 	req = req.WithContext(ctx)
 
 	// ACME spec says that a verifier should try

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -172,7 +172,7 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 	log := logf.FromContext(ctx)
 	log.V(logf.DebugLevel).Info("performing HTTP01 reachability check")
 
-	req, err := http.NewRequestWithContext(ctx, url.String(), http.MethodGet, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url.String(), nil)
 	if err != nil {
 		return err
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -172,12 +172,11 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 	log := logf.FromContext(ctx)
 	log.V(logf.DebugLevel).Info("performing HTTP01 reachability check")
 
-	req := &http.Request{
-		Method: http.MethodGet,
-		URL:    url,
+	req, err := http.NewRequestWithContext(ctx, url.String(), http.MethodGet, nil)
+	if err != nil {
+		return err
 	}
 	req.Header.Set("User-Agent", pkgutil.CertManagerUserAgent)
-	req = req.WithContext(ctx)
 
 	// ACME spec says that a verifier should try
 	// on http port 80 first, but follow any redirects may be thrown its way


### PR DESCRIPTION
**What this PR does / why we need it**:
A lot of places (Kubernetes probes specifically) already use the default Go HTTP User Agent.
it would be nice for SREs to be able to more specifically pinpoint cert-manager self checks traffic inside their logs, by filtering the cert-manager user agent.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add cert-manager specific User-Agent to HTTP01 self-checks
```
