### PR TITLE
Remove AuditSink support from cainjector

### DIFF
--- a/pkg/controller/cainjector/BUILD.bazel
+++ b/pkg/controller/cainjector/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/logs:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//admissionregistration/v1beta1:go_default_library",
-        "@io_k8s_api//auditregistration/v1alpha1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",

--- a/pkg/controller/cainjector/injectors.go
+++ b/pkg/controller/cainjector/injectors.go
@@ -18,7 +18,6 @@ package cainjector
 
 import (
 	admissionreg "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/auditregistration/v1alpha1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1beta1"
@@ -137,26 +136,4 @@ func (t *crdConversionTarget) SetCA(data []byte) {
 		t.obj.Spec.Conversion.WebhookClientConfig = &apiext.WebhookClientConfig{}
 	}
 	t.obj.Spec.Conversion.WebhookClientConfig.CABundle = data
-}
-
-// auditSinkTarget knows how to set CA data for the auditSink webhook
-type auditSinkTarget struct {
-	obj v1alpha1.AuditSink
-}
-
-func (i auditSinkTarget) NewTarget() InjectTarget {
-	return &auditSinkTarget{}
-}
-
-func (i auditSinkTarget) IsAlpha() bool {
-	// TODO set this to false when auditregistration goes GA
-	return true
-}
-
-func (t *auditSinkTarget) AsObject() runtime.Object {
-	return &t.obj
-}
-
-func (t *auditSinkTarget) SetCA(data []byte) {
-	t.obj.Spec.Webhook.ClientConfig.CABundle = data
 }

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -20,7 +20,6 @@ import (
 	"io/ioutil"
 
 	admissionreg "k8s.io/api/admissionregistration/v1beta1"
-	"k8s.io/api/auditregistration/v1alpha1"
 	apiext "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -60,13 +59,7 @@ var (
 		listType:     &apiext.CustomResourceDefinitionList{},
 	}
 
-	AuditSinkSetup = injectorSetup{
-		resourceName: "auditsink",
-		injector:     auditSinkTarget{},
-		listType:     &v1alpha1.AuditSinkList{},
-	}
-
-	injectorSetups  = []injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup, CRDSetup, AuditSinkSetup}
+	injectorSetups  = []injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup, CRDSetup}
 	ControllerNames []string
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The AuditSink resource type (previously in alpha) has been removed
as per https://groups.google.com/g/kubernetes-sig-auth/c/aV_nXpa5uWU.

Remove all support for it from our cainjector so we are able to
continue to upgrade dependencies, and to avoid more users coming
to rely on this functionality ahead of it being removed from
Kubernetes.
The AuditSink resource type (previously in alpha) has been removed
as per https://groups.google.com/g/kubernetes-sig-auth/c/aV_nXpa5uWU.

Remove all support for it from our cainjector so we are able to
continue to upgrade dependencies, and to avoid more users coming
to rely on this functionality ahead of it being removed from
Kubernetes.

**Release note**:
```release-note
ACTION REQUIRED: Support for AuditSink resources in the `auditregistration.k8s.io/v1alpha1` API group has been removed
```

/kind cleanup
