### PR TITLE
Add unit tests for nameserver validation

### DIFF
--- a/pkg/internal/apis/certmanager/validation/util/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/validation/util/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -19,4 +19,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["nameserver_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/internal/apis/certmanager/validation/util/nameserver_test.go
+++ b/pkg/internal/apis/certmanager/validation/util/nameserver_test.go
@@ -1,0 +1,87 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestValidNameserver(t *testing.T) {
+	tests := []struct {
+		name       string
+		nameserver string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "IPv4 with no port should should return port 53",
+			nameserver: "8.8.8.8",
+			want:       "8.8.8.8:53",
+		},
+		{
+			name:       "IPv4 with : but no port number should return port 53",
+			nameserver: "8.8.8.8:",
+			want:       "8.8.8.8:53",
+		},
+		{
+			name:       "IPv4 with port number should return the same",
+			nameserver: "8.8.8.8:5353",
+			want:       "8.8.8.8:5353",
+		},
+		{
+			name:       "IPv6 with no port should should return port 53",
+			nameserver: "[2001:db8::1]",
+			want:       "[2001:db8::1]:53",
+		},
+		{
+			name:       "IPv6 with : but no port number should return port 53",
+			nameserver: "[2001:db8::1]:",
+			want:       "[2001:db8::1]:53",
+		},
+		{
+			name:       "IPv6 with port number should return the same",
+			nameserver: "[2001:db8::1]:5353",
+			want:       "[2001:db8::1]:5353",
+		},
+		{
+			name:       "DNS name with no port should should return port 53",
+			nameserver: "nameserver.com",
+			want:       "nameserver.com:53",
+		},
+		{
+			name:       "DNS name with : but no port number should return port 53",
+			nameserver: "nameserver.com:",
+			want:       "nameserver.com:53",
+		},
+		{
+			name:       "DNS name with port number should return the same",
+			nameserver: "nameserver.com:5353",
+			want:       "nameserver.com:5353",
+		},
+		{
+			name:       "Non unenclosed IPv6 should error",
+			nameserver: "2001:db8::1:5353",
+			wantErr:    true,
+		},
+		{
+			name:       "Port only should error",
+			nameserver: ":53",
+			wantErr:    true,
+		},
+		{
+			name:       "Empty nameserver should error",
+			nameserver: "",
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ValidNameserver(tt.nameserver)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidNameserver() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ValidNameserver() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/internal/apis/certmanager/validation/util/nameserver_test.go
+++ b/pkg/internal/apis/certmanager/validation/util/nameserver_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:
While looking into a potential bug i found this validation function not to have any tests while it is quite critical. I added some basic unit tests to it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
