### PR TITLE
Use wildcard for apiVersions in webhook configurations

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -18,8 +18,7 @@ webhooks:
           - "cert-manager.io"
           - "acme.cert-manager.io"
         apiVersions:
-          - v1alpha2
-          - v1alpha3
+          - "*"
         operations:
           - CREATE
           - UPDATE

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -28,8 +28,7 @@ webhooks:
           - "cert-manager.io"
           - "acme.cert-manager.io"
         apiVersions:
-          - v1alpha2
-          - v1alpha3
+          - "*"
         operations:
           - CREATE
           - UPDATE


### PR DESCRIPTION
**What this PR does / why we need it**:

In #3038 we added a new API version, but forgot to add it to our webhook configuration 🙈 

Switch this to a wildcard to avoid this issue in future.

**Release note**:
```release-note
NONE
```

/kind cleanup
/area deploy
/milestone v0.16
/assign @meyskens 