### PR TITLE
Set a CN on ingress-shim + allow common-name annotation on ingress

### DIFF
--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -160,7 +160,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *extv1beta1.Ingr
 			return nil, nil, err
 		}
 
-		c.setCommonName(crt, ing, tls)
+		c.setCommonName(crt, ing)
 
 		// check if a Certificate for this TLS entry already exists, and if it
 		// does then skip this entry
@@ -307,7 +307,7 @@ func (c *controller) setIssuerSpecificConfig(crt *cmapi.Certificate, ing *extv1b
 	return nil
 }
 
-func (c *controller) setCommonName(crt *cmapi.Certificate, ing *extv1beta1.Ingress, tls extv1beta1.IngressTLS) {
+func (c *controller) setCommonName(crt *cmapi.Certificate, ing *extv1beta1.Ingress) {
 	// if annotation is set use that as CN
 	if ing.Annotations != nil && ing.Annotations[cmapi.CommonNameAnnotationKey] != "" {
 		crt.Spec.CommonName = ing.Annotations[cmapi.CommonNameAnnotationKey]

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -308,28 +308,10 @@ func (c *controller) setIssuerSpecificConfig(crt *cmapi.Certificate, ing *extv1b
 }
 
 func (c *controller) setCommonName(crt *cmapi.Certificate, ing *extv1beta1.Ingress, tls extv1beta1.IngressTLS) {
-	ingAnnotations := ing.Annotations
-	if ingAnnotations == nil {
-		ingAnnotations = map[string]string{}
-	}
-
 	// if annotation is set use that as CN
-	if ingAnnotations[cmapi.CommonNameAnnotationKey] != "" {
-		crt.Spec.CommonName = ingAnnotations[cmapi.CommonNameAnnotationKey]
-		return
+	if ing.Annotations != nil && ing.Annotations[cmapi.CommonNameAnnotationKey] != "" {
+		crt.Spec.CommonName = ing.Annotations[cmapi.CommonNameAnnotationKey]
 	}
-
-	// if not set pick the first DNS name that is less than 64 characters
-	// this is the length limit of the CN
-	// if none if found we leave the CN empty
-	for _, host := range tls.Hosts {
-		if len(host) < 64 {
-			crt.Spec.CommonName = host
-			return
-		}
-	}
-
-	return
 }
 
 // shouldSync returns true if this ingress should have a Certificate resource

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -186,6 +186,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *extv1beta1.Ingr
 			updateCrt := existingCrt.DeepCopy()
 
 			updateCrt.Spec = crt.Spec
+			updateCrt.Labels = crt.Labels
 			err = c.setIssuerSpecificConfig(updateCrt, ing, tls)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -185,13 +185,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *extv1beta1.Ingr
 
 			updateCrt := existingCrt.DeepCopy()
 
-			updateCrt.Spec.DNSNames = tls.Hosts
-			updateCrt.Spec.SecretName = tls.SecretName
-			updateCrt.Spec.IssuerRef.Name = issuerName
-			updateCrt.Spec.IssuerRef.Kind = issuerKind
-			updateCrt.Spec.IssuerRef.Group = issuerGroup
-			updateCrt.Spec.CommonName = ""
-			updateCrt.Labels = ing.Labels
+			updateCrt.Spec = crt.Spec
 			err = c.setIssuerSpecificConfig(updateCrt, ing, tls)
 			if err != nil {
 				return nil, nil, err

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -195,60 +195,6 @@ func TestSync(t *testing.T) {
 							"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.org",
 							"example.com",
 						},
-						CommonName: "example.com",
-						SecretName: "example-com-tls",
-						IssuerRef: cmmeta.ObjectReference{
-							Name: "issuer-name",
-							Kind: "ClusterIssuer",
-						},
-					},
-				},
-			},
-		},
-		{
-			Name:   "return a single Certificate for an ingress with all hosts over the CM length limit",
-			Issuer: acmeClusterIssuer,
-			Ingress: &extv1beta1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ingress-name",
-					Namespace: gen.DefaultTestNamespace,
-					Labels: map[string]string{
-						"my-test-label": "should be copied",
-					},
-					Annotations: map[string]string{
-						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
-					},
-					UID: types.UID("ingress-name"),
-				},
-				Spec: extv1beta1.IngressSpec{
-					TLS: []extv1beta1.IngressTLS{
-						{
-							Hosts: []string{
-								"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.com",
-								"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.org",
-							},
-							SecretName: "example-com-tls",
-						},
-					},
-				},
-			},
-			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
-			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
-			ExpectedCreate: []*cmapi.Certificate{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "example-com-tls",
-						Namespace: gen.DefaultTestNamespace,
-						Labels: map[string]string{
-							"my-test-label": "should be copied",
-						},
-						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
-					},
-					Spec: cmapi.CertificateSpec{
-						DNSNames: []string{
-							"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.com",
-							"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.org",
-						},
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -301,7 +247,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -354,7 +299,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -396,7 +340,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -439,7 +382,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -486,7 +428,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -530,7 +471,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -573,7 +513,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -618,7 +557,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com", "www.example.com"},
-						CommonName: "example.com",
 						SecretName: "example-com-tls",
 						IssuerRef: cmmeta.ObjectReference{
 							Name:  "issuer-name",
@@ -724,7 +662,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
-						CommonName: "example.com",
 						SecretName: "existing-crt",
 						IssuerRef: cmmeta.ObjectReference{
 							Name:  "issuer-name",
@@ -883,7 +820,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
-						CommonName: "example.com",
 						SecretName: "existing-crt",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -925,7 +861,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
-						CommonName: "example.com",
 						SecretName: "existing-crt",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -958,7 +893,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
-						CommonName: "example.com",
 						SecretName: "existing-crt",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",
@@ -977,7 +911,6 @@ func TestSync(t *testing.T) {
 					},
 					Spec: cmapi.CertificateSpec{
 						DNSNames:   []string{"example.com"},
-						CommonName: "example.com",
 						SecretName: "existing-crt",
 						IssuerRef: cmmeta.ObjectReference{
 							Name: "issuer-name",

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -150,61 +150,6 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
-			Name:   "return a single Certificate for an ingress with multiple hosts over the CM length limit",
-			Issuer: acmeClusterIssuer,
-			Ingress: &extv1beta1.Ingress{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "ingress-name",
-					Namespace: gen.DefaultTestNamespace,
-					Labels: map[string]string{
-						"my-test-label": "should be copied",
-					},
-					Annotations: map[string]string{
-						cmapi.IngressClusterIssuerNameAnnotationKey: "issuer-name",
-					},
-					UID: types.UID("ingress-name"),
-				},
-				Spec: extv1beta1.IngressSpec{
-					TLS: []extv1beta1.IngressTLS{
-						{
-							Hosts: []string{
-								"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.com",
-								"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.org",
-								"example.com",
-							},
-							SecretName: "example-com-tls",
-						},
-					},
-				},
-			},
-			ClusterIssuerLister: []runtime.Object{acmeClusterIssuer},
-			ExpectedEvents:      []string{`Normal CreateCertificate Successfully created Certificate "example-com-tls"`},
-			ExpectedCreate: []*cmapi.Certificate{
-				{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "example-com-tls",
-						Namespace: gen.DefaultTestNamespace,
-						Labels: map[string]string{
-							"my-test-label": "should be copied",
-						},
-						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
-					},
-					Spec: cmapi.CertificateSpec{
-						DNSNames: []string{
-							"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.com",
-							"awaytoolongdomainnameforthecommonnamefielstoballowedinsoithastopicktheotherone.example.org",
-							"example.com",
-						},
-						SecretName: "example-com-tls",
-						IssuerRef: cmmeta.ObjectReference{
-							Name: "issuer-name",
-							Kind: "ClusterIssuer",
-						},
-					},
-				},
-			},
-		},
-		{
 			Name:   "return a single HTTP01 Certificate for an ingress with a single valid TLS entry and HTTP01 annotations using edit-in-place",
 			Issuer: acmeClusterIssuer,
 			Ingress: &extv1beta1.Ingress{


### PR DESCRIPTION
**What this PR does / why we need it**:

Some issuers/consumers need a common name set. This allows ingress-shim users to set one using the CN annotation on ingress resources. ~~It also implements a defaulting for a CN which only applies on ingress-shim created resources.~~

**Which issue this PR fixes**:
Fixes https://github.com/jetstack/cert-manager/issues/2237
Fixes https://github.com/jetstack/cert-manager/issues/3087

**Special notes for your reviewer**:

Several things to have a think about:
~~1. is setting the CN by default a good idea?~~
~~1. Will there be issues by the sync controller updating older certs setting a CN?~~
~~1. The more i am writing i feel like only using the annotation might be a better idea...~~

**Release note**:
```release-note
Allow cert-manager.io/common-name annotation on ingresses
```
