### PR TITLE
Fix multi version removal of x-kubernetes-preserve-unknown-field 

### DIFF
--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -178,8 +178,10 @@ func loadVariant() {
 			"spec/conversion",
 			// This field exists on the Issuer and ClusterIssuer CRD
 			"spec/validation/openAPIV3Schema/properties/spec/properties/acme/properties/solvers/items/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
+			"spec/versions/[]/schema/openAPIV3Schema/properties/spec/properties/solver/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
 			// This field exists on the Challenge CRD
 			"spec/validation/openAPIV3Schema/properties/spec/properties/solver/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
+			"spec/versions/[]/schema/openAPIV3Schema/properties/spec/properties/solver/properties/dns01/properties/webhook/properties/config/x-kubernetes-preserve-unknown-fields",
 		}
 
 		// only retain the `v1alpha2` version in the CRD


### PR DESCRIPTION
**What this PR does / why we need it**:
With adding v1beta1 the filter-crd broke causing invalid legacy CRDs. This adds the new field paths to remove in a multi version validation.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind bug
