### PR TITLE
Add Vault Namespace in Vault Issuer

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1835,6 +1835,12 @@ spec:
                       the TLS connection.
                     type: string
                     format: byte
+                  namespace:
+                    description: 'Name of the vault namespace. Namespaces is a set
+                      of features within Vault Enterprise that allows Vault environments
+                      to support Secure Multi-tenancy. e.g: "ns1" More about namespaces
+                      can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                    type: string
                   path:
                     description: 'Path is the mount path of the Vault PKI backend''s
                       `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
@@ -3759,6 +3765,12 @@ spec:
                       the TLS connection.
                     type: string
                     format: byte
+                  namespace:
+                    description: 'Name of the vault namespace. Namespaces is a set
+                      of features within Vault Enterprise that allows Vault environments
+                      to support Secure Multi-tenancy. e.g: "ns1" More about namespaces
+                      can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                    type: string
                   path:
                     description: 'Path is the mount path of the Vault PKI backend''s
                       `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
@@ -5685,6 +5697,12 @@ spec:
                       the TLS connection.
                     type: string
                     format: byte
+                  namespace:
+                    description: 'Name of the vault namespace. Namespaces is a set
+                      of features within Vault Enterprise that allows Vault environments
+                      to support Secure Multi-tenancy. e.g: "ns1" More about namespaces
+                      can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                    type: string
                   path:
                     description: 'Path is the mount path of the Vault PKI backend''s
                       `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1834,6 +1834,12 @@ spec:
                       the TLS connection.
                     type: string
                     format: byte
+                  namespace:
+                    description: 'Name of the vault namespace. Namespaces is a set
+                      of features within Vault Enterprise that allows Vault environments
+                      to support Secure Multi-tenancy. e.g: "ns1" More about namespaces
+                      can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                    type: string
                   path:
                     description: 'Path is the mount path of the Vault PKI backend''s
                       `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
@@ -3757,6 +3763,12 @@ spec:
                       the TLS connection.
                     type: string
                     format: byte
+                  namespace:
+                    description: 'Name of the vault namespace. Namespaces is a set
+                      of features within Vault Enterprise that allows Vault environments
+                      to support Secure Multi-tenancy. e.g: "ns1" More about namespaces
+                      can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                    type: string
                   path:
                     description: 'Path is the mount path of the Vault PKI backend''s
                       `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'
@@ -5682,6 +5694,12 @@ spec:
                       the TLS connection.
                     type: string
                     format: byte
+                  namespace:
+                    description: 'Name of the vault namespace. Namespaces is a set
+                      of features within Vault Enterprise that allows Vault environments
+                      to support Secure Multi-tenancy. e.g: "ns1" More about namespaces
+                      can be found here https://www.vaultproject.io/docs/enterprise/namespaces'
+                    type: string
                   path:
                     description: 'Path is the mount path of the Vault PKI backend''s
                       `sign` endpoint, e.g: "my_pki_mount/sign/my-role-name".'

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -192,6 +192,11 @@ type VaultIssuer struct {
 	// "my_pki_mount/sign/my-role-name".
 	Path string `json:"path"`
 
+	// Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+	// More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// PEM encoded CA bundle used to validate Vault server certificate. Only used
 	// if the Server URL is using HTTPS protocol. This parameter is ignored for
 	// plain HTTP protocol connection. If not set the system root certificates

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -192,6 +192,11 @@ type VaultIssuer struct {
 	// "my_pki_mount/sign/my-role-name".
 	Path string `json:"path"`
 
+	// Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+	// More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// PEM encoded CA bundle used to validate Vault server certificate. Only used
 	// if the Server URL is using HTTPS protocol. This parameter is ignored for
 	// plain HTTP protocol connection. If not set the system root certificates

--- a/pkg/apis/certmanager/v1beta1/types_issuer.go
+++ b/pkg/apis/certmanager/v1beta1/types_issuer.go
@@ -194,6 +194,11 @@ type VaultIssuer struct {
 	// "my_pki_mount/sign/my-role-name".
 	Path string `json:"path"`
 
+	// Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+	// More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+	// +optional
+	Namespace string `json:"namespace,omitempty"`
+
 	// PEM encoded CA bundle used to validate Vault server certificate. Only used
 	// if the Server URL is using HTTPS protocol. This parameter is ignored for
 	// plain HTTP protocol connection. If not set the system root certificates

--- a/pkg/internal/apis/certmanager/types_issuer.go
+++ b/pkg/internal/apis/certmanager/types_issuer.go
@@ -177,6 +177,10 @@ type VaultIssuer struct {
 	// "my_pki_mount/sign/my-role-name".
 	Path string
 
+	// Name of the vault namespace. Namespaces is a set of features within Vault Enterprise that allows Vault environments to support Secure Multi-tenancy. e.g: "ns1"
+	// More about namespaces can be found here https://www.vaultproject.io/docs/enterprise/namespaces
+	Namespace string
+
 	// PEM encoded CA bundle used to validate Vault server certificate. Only used
 	// if the Server URL is using HTTPS protocol. This parameter is ignored for
 	// plain HTTP protocol connection. If not set the system root certificates

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -1136,6 +1136,7 @@ func autoConvert_v1alpha2_VaultIssuer_To_certmanager_VaultIssuer(in *v1alpha2.Va
 	}
 	out.Server = in.Server
 	out.Path = in.Path
+	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
@@ -1151,6 +1152,7 @@ func autoConvert_certmanager_VaultIssuer_To_v1alpha2_VaultIssuer(in *certmanager
 	}
 	out.Server = in.Server
 	out.Path = in.Path
+	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -1135,6 +1135,7 @@ func autoConvert_v1alpha3_VaultIssuer_To_certmanager_VaultIssuer(in *v1alpha3.Va
 	}
 	out.Server = in.Server
 	out.Path = in.Path
+	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
@@ -1150,6 +1151,7 @@ func autoConvert_certmanager_VaultIssuer_To_v1alpha3_VaultIssuer(in *certmanager
 	}
 	out.Server = in.Server
 	out.Path = in.Path
+	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -1088,6 +1088,7 @@ func autoConvert_v1beta1_VaultIssuer_To_certmanager_VaultIssuer(in *v1beta1.Vaul
 	}
 	out.Server = in.Server
 	out.Path = in.Path
+	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }
@@ -1103,6 +1104,7 @@ func autoConvert_certmanager_VaultIssuer_To_v1beta1_VaultIssuer(in *certmanager.
 	}
 	out.Server = in.Server
 	out.Path = in.Path
+	out.Namespace = in.Namespace
 	out.CABundle = *(*[]byte)(unsafe.Pointer(&in.CABundle))
 	return nil
 }

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -104,9 +104,16 @@ func (v *Vault) Sign(csrPEM []byte, duration time.Duration) (cert []byte, ca []b
 		"exclude_cn_from_sans": "true",
 	}
 
-	url := path.Join("/v1", v.issuer.GetSpec().Vault.Path)
+	vaultIssuer := v.issuer.GetSpec().Vault
+	url := path.Join("/v1", vaultIssuer.Path)
 
 	request := v.client.NewRequest("POST", url)
+
+	if vaultIssuer.Namespace != "" {
+		vaultReqHeaders := http.Header{}
+		vaultReqHeaders.Add("X-VAULT-NAMESPACE", vaultIssuer.Namespace)
+		request.Headers = vaultReqHeaders
+	}
 
 	if err := request.SetJSONBody(parameters); err != nil {
 		return nil, nil, fmt.Errorf("failed to build vault request: %s", err)

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -156,6 +156,20 @@ func TestSign(t *testing.T) {
 			expectedCert: testCertBundle,
 			expectedCA:   testCertBundle,
 		},
+
+		"vault issuer with namespace specified": {
+			csrPEM: csrPEM,
+			issuer: gen.Issuer("vault-issuer",
+				gen.SetIssuerVault(v1alpha2.VaultIssuer{Namespace: "test"}),
+			),
+			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
+				Response: &http.Response{
+					Body: ioutil.NopCloser(bytes.NewReader(bundleData))},
+			}, nil),
+			expectedErr:  nil,
+			expectedCert: testCertBundle,
+			expectedCA:   testCertBundle,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
**Which issue this PR fixes**:
fixes #2917

**Special notes for your reviewer**:
This requires a change in the documentation, please let me know the repo where the documentations for the CRDs are kept so that I can add it there as well. 

```release-note
Added Namespace to VaultIssuer to support vault roles from a different vault namespaces
```