### PR TITLE
Add script for computing SHA256 of tars of our kubectl plugin

### DIFF
--- a/hack/sha256-of-plugin-tar.sh
+++ b/hack/sha256-of-plugin-tar.sh
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+set -o errexit
+set -o nounset
+set -o pipefail
+
 version='v0.16.0-alpha.1'
 platforms='darwin-amd64 linux-amd64 linux-arm linux-arm64 windows-amd64'
 for platform in $platforms

--- a/hack/sha256-of-plugin-tar.sh
+++ b/hack/sha256-of-plugin-tar.sh
@@ -17,11 +17,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-version='v0.16.0-alpha.1'
+version="$1"
 platforms='darwin-amd64 linux-amd64 linux-arm linux-arm64 windows-amd64'
 for platform in $platforms
 do
-  curl -sSL -O $"https://github.com/jetstack/cert-manager/releases/download//${version}/kubectl-cert_manager-${platform}.tar.gz"
+  curl -sSL -O $"https://github.com/jetstack/cert-manager/releases/download/${version}/kubectl-cert_manager-${platform}.tar.gz"
   sha256sum "kubectl-cert_manager-${platform}.tar.gz"
   rm "kubectl-cert_manager-${platform}.tar.gz"
 done

--- a/hack/sha256-of-plugin-tar.sh
+++ b/hack/sha256-of-plugin-tar.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+version='v0.16.0-alpha.1'
+platforms='darwin-amd64 linux-amd64 linux-arm linux-arm64 windows-amd64'
+for platform in $platforms
+do
+  curl -sSL -O $"https://github.com/jetstack/cert-manager/releases/download//${version}/kubectl-cert_manager-${platform}.tar.gz"
+  sha256sum "kubectl-cert_manager-${platform}.tar.gz"
+  rm "kubectl-cert_manager-${platform}.tar.gz"
+done


### PR DESCRIPTION
Signed-off-by: Haoxiang Zhou <haoxiang.zhou@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This script make it easier to manually update the our plugin manifest in krew-index. It downloads the .tar files for different platforms and outputs the SHA256.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```
