### PR TITLE
Add support for the pod PriorityClass field in HTTP01 podTemplate

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -568,9 +568,10 @@ spec:
                                       type: string
                               spec:
                                 description: PodSpec defines overrides for the HTTP01
-                                  challenge solver pod. Only the 'nodeSelector', 'affinity'
-                                  and 'tolerations' fields are supported currently.
-                                  All other fields will be ignored.
+                                  challenge solver pod. Only the 'priorityClassName',
+                                  'nodeSelector', 'affinity' and 'tolerations' fields
+                                  are supported currently. All other fields will be
+                                  ignored.
                                 type: object
                                 properties:
                                   affinity:
@@ -1374,6 +1375,9 @@ spec:
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  priorityClassName:
+                                    description: If specified, the pod's priorityClassName.
+                                    type: string
                                   tolerations:
                                     description: If specified, the pod's tolerations.
                                     type: array
@@ -2038,9 +2042,10 @@ spec:
                                       type: string
                               spec:
                                 description: PodSpec defines overrides for the HTTP01
-                                  challenge solver pod. Only the 'nodeSelector', 'affinity'
-                                  and 'tolerations' fields are supported currently.
-                                  All other fields will be ignored.
+                                  challenge solver pod. Only the 'priorityClassName',
+                                  'nodeSelector', 'affinity' and 'tolerations' fields
+                                  are supported currently. All other fields will be
+                                  ignored.
                                 type: object
                                 properties:
                                   affinity:
@@ -2844,6 +2849,9 @@ spec:
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  priorityClassName:
+                                    description: If specified, the pod's priorityClassName.
+                                    type: string
                                   tolerations:
                                     description: If specified, the pod's tolerations.
                                     type: array
@@ -3509,9 +3517,10 @@ spec:
                                       type: string
                               spec:
                                 description: PodSpec defines overrides for the HTTP01
-                                  challenge solver pod. Only the 'nodeSelector', 'affinity'
-                                  and 'tolerations' fields are supported currently.
-                                  All other fields will be ignored.
+                                  challenge solver pod. Only the 'priorityClassName',
+                                  'nodeSelector', 'affinity' and 'tolerations' fields
+                                  are supported currently. All other fields will be
+                                  ignored.
                                 type: object
                                 properties:
                                   affinity:
@@ -4315,6 +4324,9 @@ spec:
                                     type: object
                                     additionalProperties:
                                       type: string
+                                  priorityClassName:
+                                    description: If specified, the pod's priorityClassName.
+                                    type: string
                                   tolerations:
                                     description: If specified, the pod's tolerations.
                                     type: array

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -649,9 +649,10 @@ spec:
                                             type: string
                                     spec:
                                       description: PodSpec defines overrides for the
-                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                        'affinity' and 'tolerations' fields are supported
-                                        currently. All other fields will be ignored.
+                                        HTTP01 challenge solver pod. Only the 'priorityClassName',
+                                        'nodeSelector', 'affinity' and 'tolerations'
+                                        fields are supported currently. All other
+                                        fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -1588,6 +1589,9 @@ spec:
                                           type: object
                                           additionalProperties:
                                             type: string
+                                        priorityClassName:
+                                          description: If specified, the pod's priorityClassName.
+                                          type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
                                           type: array
@@ -2573,9 +2577,10 @@ spec:
                                             type: string
                                     spec:
                                       description: PodSpec defines overrides for the
-                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                        'affinity' and 'tolerations' fields are supported
-                                        currently. All other fields will be ignored.
+                                        HTTP01 challenge solver pod. Only the 'priorityClassName',
+                                        'nodeSelector', 'affinity' and 'tolerations'
+                                        fields are supported currently. All other
+                                        fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -3512,6 +3517,9 @@ spec:
                                           type: object
                                           additionalProperties:
                                             type: string
+                                        priorityClassName:
+                                          description: If specified, the pod's priorityClassName.
+                                          type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
                                           type: array
@@ -4499,9 +4507,10 @@ spec:
                                             type: string
                                     spec:
                                       description: PodSpec defines overrides for the
-                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                        'affinity' and 'tolerations' fields are supported
-                                        currently. All other fields will be ignored.
+                                        HTTP01 challenge solver pod. Only the 'priorityClassName',
+                                        'nodeSelector', 'affinity' and 'tolerations'
+                                        fields are supported currently. All other
+                                        fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -5438,6 +5447,9 @@ spec:
                                           type: object
                                           additionalProperties:
                                             type: string
+                                        priorityClassName:
+                                          description: If specified, the pod's priorityClassName.
+                                          type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
                                           type: array

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -648,9 +648,10 @@ spec:
                                             type: string
                                     spec:
                                       description: PodSpec defines overrides for the
-                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                        'affinity' and 'tolerations' fields are supported
-                                        currently. All other fields will be ignored.
+                                        HTTP01 challenge solver pod. Only the 'priorityClassName',
+                                        'nodeSelector', 'affinity' and 'tolerations'
+                                        fields are supported currently. All other
+                                        fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -1587,6 +1588,9 @@ spec:
                                           type: object
                                           additionalProperties:
                                             type: string
+                                        priorityClassName:
+                                          description: If specified, the pod's priorityClassName.
+                                          type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
                                           type: array
@@ -2571,9 +2575,10 @@ spec:
                                             type: string
                                     spec:
                                       description: PodSpec defines overrides for the
-                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                        'affinity' and 'tolerations' fields are supported
-                                        currently. All other fields will be ignored.
+                                        HTTP01 challenge solver pod. Only the 'priorityClassName',
+                                        'nodeSelector', 'affinity' and 'tolerations'
+                                        fields are supported currently. All other
+                                        fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -3510,6 +3515,9 @@ spec:
                                           type: object
                                           additionalProperties:
                                             type: string
+                                        priorityClassName:
+                                          description: If specified, the pod's priorityClassName.
+                                          type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
                                           type: array
@@ -4496,9 +4504,10 @@ spec:
                                             type: string
                                     spec:
                                       description: PodSpec defines overrides for the
-                                        HTTP01 challenge solver pod. Only the 'nodeSelector',
-                                        'affinity' and 'tolerations' fields are supported
-                                        currently. All other fields will be ignored.
+                                        HTTP01 challenge solver pod. Only the 'priorityClassName',
+                                        'nodeSelector', 'affinity' and 'tolerations'
+                                        fields are supported currently. All other
+                                        fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -5435,6 +5444,9 @@ spec:
                                           type: object
                                           additionalProperties:
                                             type: string
+                                        priorityClassName:
+                                          description: If specified, the pod's priorityClassName.
+                                          type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
                                           type: array

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -215,8 +215,9 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata"`
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'nodeSelector', 'affinity' and 'tolerations' fields are
-	// supported currently. All other fields will be ignored.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
+	// and 'tolerations' fields are supported currently.
+	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
 }
@@ -245,6 +246,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's tolerations.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// If specified, the pod's priorityClassName.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -215,8 +215,9 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata"`
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'nodeSelector', 'affinity' and 'tolerations' fields are
-	// supported currently. All other fields will be ignored.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
+	// and 'tolerations' fields are supported currently.
+	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
 }
@@ -245,6 +246,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's tolerations.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// If specified, the pod's priorityClassName.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -215,8 +215,9 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata"`
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'nodeSelector', 'affinity' and 'tolerations' fields are
-	// supported currently. All other fields will be ignored.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
+	// and 'tolerations' fields are supported currently.
+	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
 }
@@ -245,6 +246,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's tolerations.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`
+
+	// If specified, the pod's priorityClassName.
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -197,8 +197,10 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'nodeSelector', 'affinity' and 'tolerations' fields are
-	// supported currently. All other fields will be ignored.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
+	// and 'tolerations' fields are supported currently.
+	// All other fields will be ignored.
+	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec
 }
 
@@ -221,6 +223,9 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 
 	// If specified, the pod's tolerations.
 	Tolerations []corev1.Toleration
+
+	// If specified, the pod's priorityClassName.
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -574,6 +574,7 @@ func autoConvert_v1alpha2_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMECh
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 
@@ -586,6 +587,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1alpha2_ACMECh
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -574,6 +574,7 @@ func autoConvert_v1alpha3_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMECh
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 
@@ -586,6 +587,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1alpha3_ACMECh
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -574,6 +574,7 @@ func autoConvert_v1beta1_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMECha
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 
@@ -586,6 +587,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1beta1_ACMECha
 	out.NodeSelector = *(*map[string]string)(unsafe.Pointer(&in.NodeSelector))
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
+	out.PriorityClassName = in.PriorityClassName
 	return nil
 }
 

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -245,5 +245,9 @@ func (s *Solver) mergePodObjectMetaWithPodTemplate(pod *corev1.Pod, podTempl *cm
 		pod.Spec.Affinity = podTempl.Spec.Affinity
 	}
 
+	if podTempl.Spec.PriorityClassName != "" {
+		pod.Spec.PriorityClassName = podTempl.Spec.PriorityClassName
+	}
+
 	return pod
 }

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -21,7 +21,7 @@ import (
 	"reflect"
 	"testing"
 
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	coretesting "k8s.io/client-go/testing"
@@ -285,6 +285,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 										},
 									},
 									Spec: cmacme.ACMEChallengeSolverHTTP01IngressPodSpec{
+										PriorityClassName: "high",
 										NodeSelector: map[string]string{
 											"node": "selector",
 										},
@@ -324,6 +325,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 						Effect:   "NoSchedule",
 					},
 				}
+				resultingPod.Spec.PriorityClassName = "high"
 				s.testResources[createdPodKey] = resultingPod
 
 				s.Builder.Sync()


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds support for the `priorityClassName` field for HTTP01 solvers.

**Which issue this PR fixes**:
fixes:  #3108


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add `priorityClassName` field to `podTemplate` for ACME HTTP01 issuers
```

/kind feature