### PR TITLE
Chart: Add option to run webhook in hostNetwork

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -149,6 +149,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.securePort` | The port that the webhook should listen on for requests. | `10250` |
 | `webhook.securityContext` | Security context for webhook pod assignment | `{}` |
 | `webhook.containerSecurityContext` | Security context to be set on the webhook component container | `{}` |
+| `webhook.hostNetwork` | If `true`, run the Webhook on the host network. | `false` |
 | `cainjector.enabled` | Toggles whether the cainjector component should be installed (required for the webhook component to work) | `true` |
 | `cainjector.replicaCount` | Number of cert-manager cainjector replicas | `1` |
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -47,6 +47,9 @@ spec:
       securityContext:
 {{ toYaml .Values.webhook.securityContext | indent 8 }}
       {{- end }}
+      {{- if .Values.webhook.hostNetwork.enabled }}
+      hostNetwork: true
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.webhook.image.repository }}:{{ default .Chart.AppVersion .Values.webhook.image.tag }}"

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -47,7 +47,7 @@ spec:
       securityContext:
 {{ toYaml .Values.webhook.securityContext | indent 8 }}
       {{- end }}
-      {{- if .Values.webhook.hostNetwork.enabled }}
+      {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true
       {{- end }}
       containers:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -234,7 +234,7 @@ webhook:
 
   # Specifies if the webhook should be started in hostNetwork mode.
   #
-  # Required for use in managed kubernetes clusters (such as AWS EKS) with custom
+  # Required for use in some managed kubernetes clusters (such as AWS EKS) with custom
   # CNI (such as calico), because control-plane managed by AWS cannot communicate
   # with pods' IP CIDR and admission webhooks are not working
   #

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -232,6 +232,14 @@ webhook:
   # rules or requiring NET_BIND_SERVICE capabilities to bind port numbers <1000
   securePort: 10250
 
+  hostNetwork:
+    # Specifies if the webhook should be started in hostNetwork mode.
+    #
+    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom
+    # CNI (such as calico), because control-plane managed by AWS cannot communicate
+    # with pods' IP CIDR and admission webhooks are not working
+    enabled: false
+
 cainjector:
   enabled: true
   replicaCount: 1

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -237,6 +237,10 @@ webhook:
   # Required for use in managed kubernetes clusters (such as AWS EKS) with custom
   # CNI (such as calico), because control-plane managed by AWS cannot communicate
   # with pods' IP CIDR and admission webhooks are not working
+  #
+  # Since the default port for the webhook conflicts with kubelet on the host
+  # network, `webhook.securePort` should be changed to an available port if
+  # running in hostNetwork mode.
   hostNetwork: false
 
 cainjector:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -232,13 +232,12 @@ webhook:
   # rules or requiring NET_BIND_SERVICE capabilities to bind port numbers <1000
   securePort: 10250
 
-  hostNetwork:
-    # Specifies if the webhook should be started in hostNetwork mode.
-    #
-    # Required for use in managed kubernetes clusters (such as AWS EKS) with custom
-    # CNI (such as calico), because control-plane managed by AWS cannot communicate
-    # with pods' IP CIDR and admission webhooks are not working
-    enabled: false
+  # Specifies if the webhook should be started in hostNetwork mode.
+  #
+  # Required for use in managed kubernetes clusters (such as AWS EKS) with custom
+  # CNI (such as calico), because control-plane managed by AWS cannot communicate
+  # with pods' IP CIDR and admission webhooks are not working
+  hostNetwork: false
 
 cainjector:
   enabled: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When using AWS EKS with a third party CNI (such as Weave or Calico), cert-manager cannot reach the webhook. Running the webhook on the host network solves this issue.
Used the comment from https://github.com/helm/charts/blob/master/stable/prometheus-operator/values.yaml#L1294 in the `values.yaml`.

**Which issue this PR fixes**:
Fixes some occurrences of issue https://github.com/jetstack/cert-manager/issues/2109, such as https://github.com/jetstack/cert-manager/issues/2109#issuecomment-546954893.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add `webhook.hostNetwork` option to the Helm Chart to run the webhook in hostNetwork mode
```
/kind feature