### PR TITLE
Fix bug of using overwritten pointer when searching for CR

### DIFF
--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -240,7 +240,7 @@ func findMatchingCR(reqs *cmapi.CertificateRequestList, crt *cmapi.Certificate) 
 	for _, req := range reqs.Items {
 		if predicate.CertificateRequestRevision(nextRevision)(&req) &&
 			predicate.ResourceOwnedBy(crt)(&req) {
-			possibleMatches = append(possibleMatches, &req)
+			possibleMatches = append(possibleMatches, req.DeepCopy())
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Haoxiang Zhou <haoxiang.zhou@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
When iterating through the list of CRs, I just took the pointer, which always gets overwritten by the next request. This is the fix.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Fix bug of status certificate command where the matching CR gets overwritten
```

/kind bug
/area ctl