### PR TITLE
Ctl status certificate command: Add issuer output and creation time

### DIFF
--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -136,6 +136,8 @@ func (o *Options) Run(args []string) error {
 
 	fmt.Fprintf(o.Out, fmt.Sprintf("Name: %s\nNamespace: %s\n", crt.Name, crt.Namespace))
 
+	fmt.Fprintf(o.Out, fmt.Sprintf("Created at: %s\n", crt.CreationTimestamp.Time.Format(time.RFC3339)))
+
 	// Get necessary info from Certificate
 	// Output one line about each type of Condition that is set.
 	// Certificate can have multiple Conditions of different types set, e.g. "Ready" or "Issuing"

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -180,7 +180,7 @@ func (o *Options) Run(args []string) error {
 		// ClusterIssuer
 		clusterIssuer, err := o.CMClient.CertmanagerV1alpha2().ClusterIssuers().Get(ctx, crt.Spec.IssuerRef.Name, metav1.GetOptions{})
 		if err != nil {
-			fmt.Fprintf(o.Out, "error when getting Issuer: %v\n", err)
+			fmt.Fprintf(o.Out, "error when getting ClusterIssuer: %v\n", err)
 		} else {
 			fmt.Fprintf(o.Out, issuerInfoString(crt.Spec.IssuerRef.Name, issuerKind, clusterIssuer.Status.Conditions))
 		}

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -169,7 +169,11 @@ func (o *Options) Run(args []string) error {
 		issuerKind = "Issuer"
 	}
 	// Get info on Issuer/ClusterIssuer
-	if issuerKind == "Issuer" {
+	if crt.Spec.IssuerRef.Group != "cert-manager.io" && crt.Spec.IssuerRef.Group != "" {
+		// TODO: Support Issuers/ClusterIssuers from other groups as well
+		fmt.Fprintf(o.Out, "The %s %q is not of the group cert-manager.io, this command currently does not support third party issuers.\nTo get more information about %q, try 'kubectl describe'\n",
+			issuerKind, crt.Spec.IssuerRef.Name, crt.Spec.IssuerRef.Name)
+	} else if issuerKind == "Issuer" {
 		issuer, err := o.CMClient.CertmanagerV1alpha2().Issuers(crt.Namespace).Get(ctx, crt.Spec.IssuerRef.Name, metav1.GetOptions{})
 		if err != nil {
 			fmt.Fprintf(o.Out, "error when getting Issuer: %v\n", err)

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -162,14 +162,27 @@ func (o *Options) Run(args []string) error {
 	util.DescribeEvents(crtEvents, prefixWriter, 0)
 	tabWriter.Flush()
 
-	issuerFormat := `Issuer:
-  Name: %s
-  Kind: %s`
 	issuerKind := crt.Spec.IssuerRef.Kind
 	if issuerKind == "" {
 		issuerKind = "Issuer"
 	}
-	fmt.Fprintf(o.Out, fmt.Sprintf(issuerFormat+"\n", crt.Spec.IssuerRef.Name, issuerKind))
+	// Get info on Issuer/ClusterIssuer
+	if issuerKind == "Issuer" {
+		issuer, err := o.CMClient.CertmanagerV1alpha2().Issuers(crt.Namespace).Get(ctx, crt.Spec.IssuerRef.Name, metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(o.Out, "error when getting Issuer: %v\n", err)
+		} else {
+			fmt.Fprintf(o.Out, issuerInfoString(crt.Spec.IssuerRef.Name, issuerKind, issuer.Status.Conditions))
+		}
+	} else {
+		// ClusterIssuer
+		clusterIssuer, err := o.CMClient.CertmanagerV1alpha2().ClusterIssuers().Get(ctx, crt.Spec.IssuerRef.Name, metav1.GetOptions{})
+		if err != nil {
+			fmt.Fprintf(o.Out, "error when getting Issuer: %v\n", err)
+		} else {
+			fmt.Fprintf(o.Out, issuerInfoString(crt.Spec.IssuerRef.Name, issuerKind, clusterIssuer.Status.Conditions))
+		}
+	}
 
 	fmt.Fprintf(o.Out, fmt.Sprintf("Secret Name: %s\n", crt.Spec.SecretName))
 
@@ -273,4 +286,21 @@ func crInfoString(cr *cmapi.CertificateRequest) string {
 	}
 	infos := fmt.Sprintf(crFormat, cr.Name, cr.Namespace, conditionMsg)
 	return fmt.Sprintf("CertificateRequest:%s", infos)
+}
+
+// issuerInfoString returns the information of a issuer as a string to be printed as output
+func issuerInfoString(name, kind string, conditions []cmapi.IssuerCondition) string {
+	issuerFormat := `Issuer:
+  Name: %s
+  Kind: %s
+  Conditions:
+  %s`
+	conditionMsg := ""
+	for _, con := range conditions {
+		conditionMsg += fmt.Sprintf("  %s: %s, Reason: %s, Message: %s\n", con.Type, con.Status, con.Reason, con.Message)
+	}
+	if conditionMsg == "" {
+		conditionMsg = "  No Conditions set\n"
+	}
+	return fmt.Sprintf(issuerFormat, name, kind, conditionMsg)
 }

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -94,3 +94,9 @@ func AddIssuerCondition(c v1alpha2.IssuerCondition) IssuerModifier {
 		iss.GetStatus().Conditions = append(iss.GetStatus().Conditions, c)
 	}
 }
+
+func SetIssuerNamespace(namespace string) IssuerModifier {
+	return func(iss v1alpha2.GenericIssuer) {
+		iss.GetObjectMeta().Namespace = namespace
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR adds output about the Issuer/ClusterIssuer of the Certificate resource.
Also adds the creation time of the Certificate.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add output about the Issuer/ClusterIssuer of the Certificate resource and about creation time of the Certificate.
```

/kind feature
/area ctl