### PR TITLE
Add a USERS.md file to list cert-manager users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -1,0 +1,17 @@
+# cert-manager users
+
+This is the list of organizations and individual users that publicly that they are using cert-manager.
+
+Please send PRs to add or remove your organizations/users! We would love to let you share your cert-manager story with the world.
+
+The list of organizations that have publicly shared the usage of cert-manager:
+
+| Organization | Usage | Links |
+| :--- | :--- | :--- |
+| [<img src="https://raw.githubusercontent.com/cert-manager/website/master/assets/icons/jetstack.svg" alt="Jettstack text" width="100"> ](https://jetstack.io) | Securing MySQL inside Kubernetes | [blog](https://blog.jetstack.io/blog/securing-mysql-with-cert-manager/)  | 
+
+The list of individual users that have publicly shared the usage of cert-manager.
+
+| user | Usage | Links |
+| :--- | :--- | :--- |
+| [Maartje Eyskens](https://github.com/meyskens) | Securing ingresses |  | 


### PR DESCRIPTION
**What this PR does / why we need it**:

We hear a lot of good cert-manager user stories but we never had a proper list for them. This file allows cert-manager users who would like to promote their use of our project to list themselves on our repo.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
