### PR TITLE
Updating docker-rules and allowing for Python3

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,2 @@
 # Include git version info
 build --workspace_status_command hack/build/print-workspace-status.sh
-
-# bazel including rules_docker 0.12.0 may not need the following flag
-build --host_force_python=PY2

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -56,17 +56,32 @@ http_archive(
 )
 
 ## Load rules_docker and dependencies, for working with docker images
-git_repository(
+http_archive(
     name = "io_bazel_rules_docker",
-    remote = "https://github.com/bazelbuild/rules_docker.git",
-    commit = "f1557ebc5381e2a662314e21585aa8080e9508be",
-    shallow_since = "1561646721 -0700",
+    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
+    strip_prefix = "rules_docker-0.14.4",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
 )
 
-load("@io_bazel_rules_docker//repositories:repositories.bzl", container_repositories = "repositories")
+load(
+    "@io_bazel_rules_docker//repositories:repositories.bzl",
+    container_repositories = "repositories",
+)
 
 container_repositories()
 
+load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
+
+container_deps()
+
+load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
+
+pip_deps()
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+)
 load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()


### PR DESCRIPTION
- this PR updates the docker rule version
- removed the PY2 flag from .bazelrc
- this allows the project to use a hosts python3 installation
- python3 must be installed on the host system and link /usr/bin/python is required
- on debian sudo apt-get install python3-distutil as well as possible
  other packages

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: updating the docker rules in order to run on a system with python3

**Which issue this PR fixes** 

Allows for the use of bazel and python3. python2 is no longer viable.  I can open an issue, but there is one closed that talks about this problem. Here:

https://github.com/jetstack/cert-manager/issues/1498

**Special notes for your reviewer**: 

I do not know what your testing image has installed so this may not pass CI/CD if your testing host is running python2. I am working on another operator and going to use some of this project's wonderful infrastructure. So I thought I would give back a bit. I ran the e2e and it passed locally on Debian with kind.  I am also using bazel 3.4.x.

**Release note**:
```release-note NONE
```
