### PR TITLE
Add serviceAccountName to issuers CRDs for http01 solvers

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -569,9 +569,9 @@ spec:
                               spec:
                                 description: PodSpec defines overrides for the HTTP01
                                   challenge solver pod. Only the 'priorityClassName',
-                                  'nodeSelector', 'affinity' and 'tolerations' fields
-                                  are supported currently. All other fields will be
-                                  ignored.
+                                  'nodeSelector', 'affinity', 'serviceAccountName'
+                                  and 'tolerations' fields are supported currently.
+                                  All other fields will be ignored.
                                 type: object
                                 properties:
                                   affinity:
@@ -1378,6 +1378,9 @@ spec:
                                   priorityClassName:
                                     description: If specified, the pod's priorityClassName.
                                     type: string
+                                  serviceAccountName:
+                                    description: If specified, the pod's service account
+                                    type: string
                                   tolerations:
                                     description: If specified, the pod's tolerations.
                                     type: array
@@ -2043,9 +2046,9 @@ spec:
                               spec:
                                 description: PodSpec defines overrides for the HTTP01
                                   challenge solver pod. Only the 'priorityClassName',
-                                  'nodeSelector', 'affinity' and 'tolerations' fields
-                                  are supported currently. All other fields will be
-                                  ignored.
+                                  'nodeSelector', 'affinity', 'serviceAccountName'
+                                  and 'tolerations' fields are supported currently.
+                                  All other fields will be ignored.
                                 type: object
                                 properties:
                                   affinity:
@@ -2851,6 +2854,9 @@ spec:
                                       type: string
                                   priorityClassName:
                                     description: If specified, the pod's priorityClassName.
+                                    type: string
+                                  serviceAccountName:
+                                    description: If specified, the pod's service account
                                     type: string
                                   tolerations:
                                     description: If specified, the pod's tolerations.
@@ -3518,9 +3524,9 @@ spec:
                               spec:
                                 description: PodSpec defines overrides for the HTTP01
                                   challenge solver pod. Only the 'priorityClassName',
-                                  'nodeSelector', 'affinity' and 'tolerations' fields
-                                  are supported currently. All other fields will be
-                                  ignored.
+                                  'nodeSelector', 'affinity', 'serviceAccountName'
+                                  and 'tolerations' fields are supported currently.
+                                  All other fields will be ignored.
                                 type: object
                                 properties:
                                   affinity:
@@ -4326,6 +4332,9 @@ spec:
                                       type: string
                                   priorityClassName:
                                     description: If specified, the pod's priorityClassName.
+                                    type: string
+                                  serviceAccountName:
+                                    description: If specified, the pod's service account
                                     type: string
                                   tolerations:
                                     description: If specified, the pod's tolerations.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -650,9 +650,9 @@ spec:
                                     spec:
                                       description: PodSpec defines overrides for the
                                         HTTP01 challenge solver pod. Only the 'priorityClassName',
-                                        'nodeSelector', 'affinity' and 'tolerations'
-                                        fields are supported currently. All other
-                                        fields will be ignored.
+                                        'nodeSelector', 'affinity', 'serviceAccountName'
+                                        and 'tolerations' fields are supported currently.
+                                        All other fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -1591,6 +1591,10 @@ spec:
                                             type: string
                                         priorityClassName:
                                           description: If specified, the pod's priorityClassName.
+                                          type: string
+                                        serviceAccountName:
+                                          description: If specified, the pod's service
+                                            account
                                           type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
@@ -2584,9 +2588,9 @@ spec:
                                     spec:
                                       description: PodSpec defines overrides for the
                                         HTTP01 challenge solver pod. Only the 'priorityClassName',
-                                        'nodeSelector', 'affinity' and 'tolerations'
-                                        fields are supported currently. All other
-                                        fields will be ignored.
+                                        'nodeSelector', 'affinity', 'serviceAccountName'
+                                        and 'tolerations' fields are supported currently.
+                                        All other fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -3525,6 +3529,10 @@ spec:
                                             type: string
                                         priorityClassName:
                                           description: If specified, the pod's priorityClassName.
+                                          type: string
+                                        serviceAccountName:
+                                          description: If specified, the pod's service
+                                            account
                                           type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
@@ -4520,9 +4528,9 @@ spec:
                                     spec:
                                       description: PodSpec defines overrides for the
                                         HTTP01 challenge solver pod. Only the 'priorityClassName',
-                                        'nodeSelector', 'affinity' and 'tolerations'
-                                        fields are supported currently. All other
-                                        fields will be ignored.
+                                        'nodeSelector', 'affinity', 'serviceAccountName'
+                                        and 'tolerations' fields are supported currently.
+                                        All other fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -5461,6 +5469,10 @@ spec:
                                             type: string
                                         priorityClassName:
                                           description: If specified, the pod's priorityClassName.
+                                          type: string
+                                        serviceAccountName:
+                                          description: If specified, the pod's service
+                                            account
                                           type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -649,9 +649,9 @@ spec:
                                     spec:
                                       description: PodSpec defines overrides for the
                                         HTTP01 challenge solver pod. Only the 'priorityClassName',
-                                        'nodeSelector', 'affinity' and 'tolerations'
-                                        fields are supported currently. All other
-                                        fields will be ignored.
+                                        'nodeSelector', 'affinity', 'serviceAccountName'
+                                        and 'tolerations' fields are supported currently.
+                                        All other fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -1590,6 +1590,10 @@ spec:
                                             type: string
                                         priorityClassName:
                                           description: If specified, the pod's priorityClassName.
+                                          type: string
+                                        serviceAccountName:
+                                          description: If specified, the pod's service
+                                            account
                                           type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
@@ -2582,9 +2586,9 @@ spec:
                                     spec:
                                       description: PodSpec defines overrides for the
                                         HTTP01 challenge solver pod. Only the 'priorityClassName',
-                                        'nodeSelector', 'affinity' and 'tolerations'
-                                        fields are supported currently. All other
-                                        fields will be ignored.
+                                        'nodeSelector', 'affinity', 'serviceAccountName'
+                                        and 'tolerations' fields are supported currently.
+                                        All other fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -3523,6 +3527,10 @@ spec:
                                             type: string
                                         priorityClassName:
                                           description: If specified, the pod's priorityClassName.
+                                          type: string
+                                        serviceAccountName:
+                                          description: If specified, the pod's service
+                                            account
                                           type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.
@@ -4517,9 +4525,9 @@ spec:
                                     spec:
                                       description: PodSpec defines overrides for the
                                         HTTP01 challenge solver pod. Only the 'priorityClassName',
-                                        'nodeSelector', 'affinity' and 'tolerations'
-                                        fields are supported currently. All other
-                                        fields will be ignored.
+                                        'nodeSelector', 'affinity', 'serviceAccountName'
+                                        and 'tolerations' fields are supported currently.
+                                        All other fields will be ignored.
                                       type: object
                                       properties:
                                         affinity:
@@ -5458,6 +5466,10 @@ spec:
                                             type: string
                                         priorityClassName:
                                           description: If specified, the pod's priorityClassName.
+                                          type: string
+                                        serviceAccountName:
+                                          description: If specified, the pod's service
+                                            account
                                           type: string
                                         tolerations:
                                           description: If specified, the pod's tolerations.

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -215,8 +215,8 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata"`
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
-	// and 'tolerations' fields are supported currently.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity',
+	// 'serviceAccountName' and 'tolerations' fields are supported currently.
 	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
@@ -250,6 +250,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's priorityClassName.
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// If specified, the pod's service account
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -215,8 +215,8 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata"`
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
-	// and 'tolerations' fields are supported currently.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity',
+	// 'serviceAccountName' and 'tolerations' fields are supported currently.
 	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
@@ -250,6 +250,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's priorityClassName.
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// If specified, the pod's service account
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -215,8 +215,8 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta `json:"metadata"`
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
-	// and 'tolerations' fields are supported currently.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity',
+	// 'serviceAccountName' and 'tolerations' fields are supported currently.
 	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
@@ -250,6 +250,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's priorityClassName.
 	// +optional
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// If specified, the pod's service account
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -197,8 +197,8 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 	ACMEChallengeSolverHTTP01IngressPodObjectMeta
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
-	// Only the 'priorityClassName', 'nodeSelector', 'affinity'
-	// and 'tolerations' fields are supported currently.
+	// Only the 'priorityClassName', 'nodeSelector', 'affinity',
+	// 'serviceAccountName' and 'tolerations' fields are supported currently.
 	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec
@@ -226,6 +226,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 
 	// If specified, the pod's priorityClassName.
 	PriorityClassName string `json:"priorityClassName,omitempty"`
+
+	// If specified, the pod's service account
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -575,6 +575,7 @@ func autoConvert_v1alpha2_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMECh
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
+	out.ServiceAccountName = in.ServiceAccountName
 	return nil
 }
 
@@ -588,6 +589,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1alpha2_ACMECh
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
+	out.ServiceAccountName = in.ServiceAccountName
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -575,6 +575,7 @@ func autoConvert_v1alpha3_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMECh
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
+	out.ServiceAccountName = in.ServiceAccountName
 	return nil
 }
 
@@ -588,6 +589,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1alpha3_ACMECh
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
+	out.ServiceAccountName = in.ServiceAccountName
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -575,6 +575,7 @@ func autoConvert_v1beta1_ACMEChallengeSolverHTTP01IngressPodSpec_To_acme_ACMECha
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
+	out.ServiceAccountName = in.ServiceAccountName
 	return nil
 }
 
@@ -588,6 +589,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1beta1_ACMECha
 	out.Affinity = (*v1.Affinity)(unsafe.Pointer(in.Affinity))
 	out.Tolerations = *(*[]v1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
+	out.ServiceAccountName = in.ServiceAccountName
 	return nil
 }
 

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -249,5 +249,9 @@ func (s *Solver) mergePodObjectMetaWithPodTemplate(pod *corev1.Pod, podTempl *cm
 		pod.Spec.PriorityClassName = podTempl.Spec.PriorityClassName
 	}
 
+	if podTempl.Spec.ServiceAccountName != "" {
+		pod.Spec.ServiceAccountName = podTempl.Spec.ServiceAccountName
+	}
+
 	return pod
 }

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -296,6 +296,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 												Effect:   "NoSchedule",
 											},
 										},
+										ServiceAccountName: "cert-manager",
 									},
 								},
 							},
@@ -326,6 +327,7 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 					},
 				}
 				resultingPod.Spec.PriorityClassName = "high"
+				resultingPod.Spec.ServiceAccountName = "cert-manager"
 				s.testResources[createdPodKey] = resultingPod
 
 				s.Builder.Sync()


### PR DESCRIPTION
**What this PR does / why we need it:**
This adds support for the serviceAccountName field for HTTP01 solvers.

**Which issue this PR fixes:**
fixes: #2770 

**Release note:**

```release-note
Add `serviceAccountName` field to `podTemplate` for ACME HTTP01 issuers
```

/kind feature