### PR TITLE
Ability to disable generating new ACME account key for ACME issuers

### DIFF
--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1107,6 +1110,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2114,6 +2120,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3121,6 +3130,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -69,6 +69,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -102,9 +105,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1077,6 +1077,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -1110,9 +1113,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2087,6 +2087,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -2120,9 +2123,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3097,6 +3097,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -3130,9 +3133,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -3172,6 +3172,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1121,6 +1124,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2142,6 +2148,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -69,6 +69,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -102,9 +105,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1091,6 +1091,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -1124,9 +1127,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2115,6 +2115,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -2148,9 +2151,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3139,6 +3139,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -3172,9 +3175,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1107,6 +1110,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2114,6 +2120,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3121,6 +3130,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -69,6 +69,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -102,9 +105,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1077,6 +1077,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -1110,9 +1113,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2087,6 +2087,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -2120,9 +2123,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3097,6 +3097,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -3130,9 +3133,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -3172,6 +3172,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1121,6 +1124,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2142,6 +2148,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    onlyUseExistingAccountKey:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -69,6 +69,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -102,9 +105,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1091,6 +1091,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -1124,9 +1127,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2115,6 +2115,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -2148,9 +2151,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3139,6 +3139,9 @@ spec:
                     - privateKeySecretRef
                     - server
                   properties:
+                    disableAccountKeyGeneration:
+                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will *not* request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
+                      type: boolean
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
@@ -3172,9 +3175,6 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
-                    onlyUseExistingAccountKey:
-                      description: Enables or disables generating a new ACME account key. If true, the Issuer resource will not request a new account but will expect the account key to be supplied via an existing secret. If false, the cert-manager system will generate a new ACME account key for the Issuer. Defaults to false.
-                      type: boolean
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -73,6 +73,15 @@ type ACMEIssuer struct {
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	// +optional
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
+
+	// Enables or disables generating a new ACME account key.
+	// If true, the Issuer resource will not request a new account but will expect
+	// the account key to be supplied via an existing secret.
+	// If false, the cert-manager system will generate a new ACME account key
+	// for the Issuer.
+	// Defaults to false.
+	// +optional
+	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -75,13 +75,13 @@ type ACMEIssuer struct {
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 
 	// Enables or disables generating a new ACME account key.
-	// If true, the Issuer resource will not request a new account but will expect
+	// If true, the Issuer resource will *not* request a new account but will expect
 	// the account key to be supplied via an existing secret.
 	// If false, the cert-manager system will generate a new ACME account key
 	// for the Issuer.
 	// Defaults to false.
 	// +optional
-	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
+	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -73,6 +73,15 @@ type ACMEIssuer struct {
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	// +optional
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
+
+	// Enables or disables generating a new ACME account key.
+	// If true, the Issuer resource will not request a new account but will expect
+	// the account key to be supplied via an existing secret.
+	// If false, the cert-manager system will generate a new ACME account key
+	// for the Issuer.
+	// Defaults to false.
+	// +optional
+	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -75,13 +75,13 @@ type ACMEIssuer struct {
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 
 	// Enables or disables generating a new ACME account key.
-	// If true, the Issuer resource will not request a new account but will expect
+	// If true, the Issuer resource will *not* request a new account but will expect
 	// the account key to be supplied via an existing secret.
 	// If false, the cert-manager system will generate a new ACME account key
 	// for the Issuer.
 	// Defaults to false.
 	// +optional
-	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
+	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -73,6 +73,15 @@ type ACMEIssuer struct {
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	// +optional
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
+
+	// Enables or disables generating a new ACME account key.
+	// If true, the Issuer resource will not request a new account but will expect
+	// the account key to be supplied via an existing secret.
+	// If false, the cert-manager system will generate a new ACME account key
+	// for the Issuer.
+	// Defaults to false.
+	// +optional
+	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -75,13 +75,13 @@ type ACMEIssuer struct {
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 
 	// Enables or disables generating a new ACME account key.
-	// If true, the Issuer resource will not request a new account but will expect
+	// If true, the Issuer resource will *not* request a new account but will expect
 	// the account key to be supplied via an existing secret.
 	// If false, the cert-manager system will generate a new ACME account key
 	// for the Issuer.
 	// Defaults to false.
 	// +optional
-	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
+	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -73,6 +73,15 @@ type ACMEIssuer struct {
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	// +optional
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
+
+	// Enables or disables generating a new ACME account key.
+	// If true, the Issuer resource will not request a new account but will expect
+	// the account key to be supplied via an existing secret.
+	// If false, the cert-manager system will generate a new ACME account key
+	// for the Issuer.
+	// Defaults to false.
+	// +optional
+	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -75,13 +75,13 @@ type ACMEIssuer struct {
 	Solvers []ACMEChallengeSolver `json:"solvers,omitempty"`
 
 	// Enables or disables generating a new ACME account key.
-	// If true, the Issuer resource will not request a new account but will expect
+	// If true, the Issuer resource will *not* request a new account but will expect
 	// the account key to be supplied via an existing secret.
 	// If false, the cert-manager system will generate a new ACME account key
 	// for the Issuer.
 	// Defaults to false.
 	// +optional
-	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
+	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -69,6 +69,15 @@ type ACMEIssuer struct {
 	// from an ACME server.
 	// For more information, see: https://cert-manager.io/docs/configuration/acme/
 	Solvers []ACMEChallengeSolver
+
+	// Enables or disables generating a new ACME account key.
+	// If true, the Issuer resource will not request a new account but will expect
+	// the account key to be supplied via an existing secret.
+	// If false, the cert-manager system will generate a new ACME account key
+	// for the Issuer.
+	// Defaults to false.
+	// +optional
+	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -71,13 +71,13 @@ type ACMEIssuer struct {
 	Solvers []ACMEChallengeSolver
 
 	// Enables or disables generating a new ACME account key.
-	// If true, the Issuer resource will not request a new account but will expect
+	// If true, the Issuer resource will *not* request a new account but will expect
 	// the account key to be supplied via an existing secret.
 	// If false, the cert-manager system will generate a new ACME account key
 	// for the Issuer.
 	// Defaults to false.
 	// +optional
-	OnlyUseExistingAccountKey bool `json:"onlyUseExistingAccountKey,omitempty"`
+	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -692,6 +692,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 
@@ -710,6 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 		return err
 	}
 	out.Solvers = *(*[]v1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -692,7 +692,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 
@@ -711,7 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 		return err
 	}
 	out.Solvers = *(*[]v1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -692,6 +692,7 @@ func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer,
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 
@@ -710,6 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out
 		return err
 	}
 	out.Solvers = *(*[]v1alpha2.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -692,7 +692,7 @@ func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer,
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 
@@ -711,7 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out
 		return err
 	}
 	out.Solvers = *(*[]v1alpha2.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -692,6 +692,7 @@ func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer,
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 
@@ -710,6 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out
 		return err
 	}
 	out.Solvers = *(*[]v1alpha3.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -692,7 +692,7 @@ func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer,
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 
@@ -711,7 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out
 		return err
 	}
 	out.Solvers = *(*[]v1alpha3.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -692,6 +692,7 @@ func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, o
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 
@@ -710,6 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out 
 		return err
 	}
 	out.Solvers = *(*[]v1beta1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
+	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -692,7 +692,7 @@ func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, o
 		return err
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 
@@ -711,7 +711,7 @@ func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out 
 		return err
 	}
 	out.Solvers = *(*[]v1beta1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
-	out.OnlyUseExistingAccountKey = in.OnlyUseExistingAccountKey
+	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
 	return nil
 }
 

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -86,7 +86,7 @@ func (a *Acme) Setup(ctx context.Context) error {
 	privateKeySelector := acme.PrivateKeySelector(a.issuer.GetSpec().ACME.PrivateKey)
 	pk, err := kube.SecretTLSKeyRef(ctx, a.secretsLister, ns, privateKeySelector.Name, privateKeySelector.Key)
 	switch {
-	case apierrors.IsNotFound(err):
+	case !a.issuer.GetSpec().ACME.OnlyUseExistingAccountKey && apierrors.IsNotFound(err):
 		log.V(logf.InfoLevel).Info("generating acme account private key")
 		pk, err = a.createAccountPrivateKey(privateKeySelector, ns)
 		if err != nil {
@@ -96,6 +96,11 @@ func (a *Acme) Setup(ctx context.Context) error {
 		}
 		// We clear the ACME account URI as we have generated a new private key
 		a.issuer.GetStatus().ACMEStatus().URI = ""
+
+	case a.issuer.GetSpec().ACME.OnlyUseExistingAccountKey && apierrors.IsNotFound(err):
+		wrapErr := fmt.Errorf(messageAccountVerificationFailed+"the ACME issuer config has 'onlyUseExistingAccountKey' set to true, but the secret was not found: %w", err)
+		apiutil.SetIssuerCondition(a.issuer, v1alpha2.IssuerConditionReady, cmmeta.ConditionFalse, errorAccountVerificationFailed, wrapErr.Error())
+		return wrapErr
 
 	case errors.IsInvalidData(err):
 		apiutil.SetIssuerCondition(a.issuer, v1.IssuerConditionReady, cmmeta.ConditionFalse, errorAccountVerificationFailed, fmt.Sprintf("Account private key is invalid: %v", err))

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -99,7 +99,7 @@ func (a *Acme) Setup(ctx context.Context) error {
 
 	case a.issuer.GetSpec().ACME.DisableAccountKeyGeneration && apierrors.IsNotFound(err):
 		wrapErr := fmt.Errorf(messageAccountVerificationFailed+"the ACME issuer config has 'disableAccountKeyGeneration' set to true, but the secret was not found: %w", err)
-		apiutil.SetIssuerCondition(a.issuer, v1alpha2.IssuerConditionReady, cmmeta.ConditionFalse, errorAccountVerificationFailed, wrapErr.Error())
+		apiutil.SetIssuerCondition(a.issuer, v1.IssuerConditionReady, cmmeta.ConditionFalse, errorAccountVerificationFailed, wrapErr.Error())
 		return wrapErr
 
 	case errors.IsInvalidData(err):


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently users cannot use a single ACME account ID across multiple clusters as cert-manager generates a new ACME account ID in each instance. This PR adds a new field to the ACMEIssuer API called `onlyUseExistingAccountKey` which, when set to true, disables generating a new private key on the Issuer resource. This would allow users to create a Issuer resource without creating the Secret resource, instead reusing an existing one (e.g. copied from another cluster)

Default behaviour is still the same.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2990 

**Special notes for your reviewer**:
Not sure about the correctness of the comments I wrote.
Generally not too sure about the code as it's my first API change. Did I miss something?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add boolean field `onlyUseExistingAccountKey` to `ACMEIssuer` to be able to not generate new account key and reuse existing ones.
```

/kind feature
/area api
/area acme