### PR TITLE
Add intermediate cert to P12 chain if ca.crt is empty

### DIFF
--- a/pkg/controller/certificates/internal/secretsmanager/keystore.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore.go
@@ -65,11 +65,11 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 		if err != nil {
 			return nil, err
 		}
-		// prepend the certificate chain to the list of certificates as the PKCS12
-		// library only allows setting a single certificate.
-		if len(certs) > 1 {
-			cas = append(certs[1:], cas...)
-		}
+	}
+	// prepend the certificate chain to the list of certificates as the PKCS12
+	// library only allows setting a single certificate.
+	if len(certs) > 1 {
+		cas = append(certs[1:], cas...)
 	}
 	keystoreData, err := pkcs12.Encode(rand.Reader, key, certs[0], cas, password)
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
If ACME (or any other that has no CA.crt) issues an intermediate certificate it is dropped from our pkcs12 keystore. 
This was due to the logic being inside an if statement that checked the CA.crt secret.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes #3039

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix issue where intermediate certificates are not in the pkcs12 keystore
```
