### PR TITLE
User order as variable name in gen/order.go

### DIFF
--- a/test/unit/gen/order.go
+++ b/test/unit/gen/order.go
@@ -24,74 +24,74 @@ import (
 type OrderModifier func(*cmacme.Order)
 
 func Order(name string, mods ...OrderModifier) *cmacme.Order {
-	c := &cmacme.Order{
+	order := &cmacme.Order{
 		ObjectMeta: ObjectMeta(name),
 	}
 	for _, mod := range mods {
-		mod(c)
+		mod(order)
 	}
-	return c
+	return order
 }
 
-func OrderFrom(crt *cmacme.Order, mods ...OrderModifier) *cmacme.Order {
-	crt = crt.DeepCopy()
+func OrderFrom(order *cmacme.Order, mods ...OrderModifier) *cmacme.Order {
+	order = order.DeepCopy()
 	for _, mod := range mods {
-		mod(crt)
+		mod(order)
 	}
-	return crt
+	return order
 }
 
 // SetIssuer sets the Order.spec.issuerRef field
 func SetOrderIssuer(o cmmeta.ObjectReference) OrderModifier {
-	return func(c *cmacme.Order) {
-		c.Spec.IssuerRef = o
+	return func(order *cmacme.Order) {
+		order.Spec.IssuerRef = o
 	}
 }
 
 func SetOrderDNSNames(dnsNames ...string) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.Spec.DNSNames = dnsNames
+	return func(order *cmacme.Order) {
+		order.Spec.DNSNames = dnsNames
 	}
 }
 
 func SetOrderURL(url string) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.Status.URL = url
+	return func(order *cmacme.Order) {
+		order.Status.URL = url
 	}
 }
 
 func SetOrderState(s cmacme.State) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.Status.State = s
+	return func(order *cmacme.Order) {
+		order.Status.State = s
 	}
 }
 
 func SetOrderReason(reason string) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.Status.Reason = reason
+	return func(order *cmacme.Order) {
+		order.Status.Reason = reason
 	}
 }
 
 func SetOrderStatus(s cmacme.OrderStatus) OrderModifier {
-	return func(o *cmacme.Order) {
-		o.Status = s
+	return func(order *cmacme.Order) {
+		order.Status = s
 	}
 }
 
 func SetOrderCertificate(d []byte) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.Status.Certificate = d
+	return func(order *cmacme.Order) {
+		order.Status.Certificate = d
 	}
 }
 
 func SetOrderCommonName(commonName string) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.Spec.CommonName = commonName
+	return func(order *cmacme.Order) {
+		order.Spec.CommonName = commonName
 	}
 }
 
 func SetOrderNamespace(namespace string) OrderModifier {
-	return func(crt *cmacme.Order) {
-		crt.ObjectMeta.Namespace = namespace
+	return func(order *cmacme.Order) {
+		order.ObjectMeta.Namespace = namespace
 	}
 }


### PR DESCRIPTION
Signed-off-by: Haoxiang Zhou <haoxiang.zhou@jetstack.io>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Variables of type `Order` were called `crt`, cleaning that up in a small PR.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
NONE
```

/kind cleanup