### PR TITLE
Ctl command `status certificate`: Add order output

### DIFF
--- a/cmd/ctl/pkg/status/certificate/BUILD.bazel
+++ b/cmd/ctl/pkg/status/certificate/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/ctl/pkg/status/util:go_default_library",
+        "//pkg/apis/acme/v1beta1:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/ctl:go_default_library",

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1beta1"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	"github.com/jetstack/cert-manager/pkg/ctl"
@@ -149,8 +150,7 @@ func (o *Options) Run(args []string) error {
 	req, reqErr := findMatchingCR(o.CMClient, ctx, crt)
 	if reqErr != nil {
 		reqErr = fmt.Errorf("error when finding CertificateRequest: %w\n", reqErr)
-	}
-	if req == nil {
+	} else if req == nil {
 		reqErr = errors.New("No CertificateRequest found for this Certificate\n")
 	}
 
@@ -194,6 +194,22 @@ func (o *Options) Run(args []string) error {
 		}
 		status = status.withClusterIssuer(clusterIssuer, issuerErr)
 	}
+
+	// Nothing to output about Order and Challenge if no CR, stop early
+	if req == nil {
+		fmt.Fprintf(o.Out, status.String())
+		return nil
+	}
+
+	// Get Order
+	order, orderErr := findMatchingOrder(o.CMClient, ctx, req)
+	if orderErr != nil {
+		orderErr = fmt.Errorf("error when finding Order: %w\n", orderErr)
+	} else if order == nil {
+		orderErr = errors.New("No Order found for this Certificate\n")
+	}
+
+	status.withOrder(order, orderErr)
 
 	fmt.Fprintf(o.Out, status.String())
 
@@ -251,5 +267,31 @@ func findMatchingCR(cmClient cmclient.Interface, ctx context.Context, crt *cmapi
 		return possibleMatches[0], nil
 	} else {
 		return nil, errors.New("found multiple certificate requests with expected revision and owner")
+	}
+}
+
+// findMatchingOrder tries to find an Order that is owned by req.
+// If none found returns nil
+// If one found returns the Order
+// If multiple found or error occurs when listing Orders, returns error
+func findMatchingOrder(cmClient cmclient.Interface, ctx context.Context, req *cmapi.CertificateRequest) (*cmacme.Order, error) {
+	orders, err := cmClient.AcmeV1beta1().Orders(req.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	possibleMatches := []*cmacme.Order{}
+	for _, order := range orders.Items {
+		if predicate.ResourceOwnedBy(req)(&order) {
+			possibleMatches = append(possibleMatches, order.DeepCopy())
+		}
+	}
+
+	if len(possibleMatches) < 1 {
+		return nil, nil
+	} else if len(possibleMatches) == 1 {
+		return possibleMatches[0], nil
+	} else {
+		return nil, fmt.Errorf("found multiple orders owned by CertificateRequest %s", req.Name)
 	}
 }

--- a/cmd/ctl/pkg/status/certificate/types.go
+++ b/cmd/ctl/pkg/status/certificate/types.go
@@ -74,7 +74,7 @@ type IssuerStatus struct {
 	// Conditions of Issuer/ClusterIssuer resource
 	Conditions []cmapiv1alpha2.IssuerCondition
 	// boolean indicating if Issuer/ClusterIssuer is a ACME Issuer/ClusterIssuer
-	// Defaults to false even Error is not nil
+	// Defaults to false even when Error is not nil
 	IsACME bool
 }
 

--- a/cmd/ctl/pkg/status/certificate/types.go
+++ b/cmd/ctl/pkg/status/certificate/types.go
@@ -408,7 +408,6 @@ func (crStatus *CRStatus) String() string {
 	prefixWriter := describe.NewPrefixWriter(tabWriter)
 	util.DescribeEvents(crStatus.Events, prefixWriter, 1)
 	tabWriter.Flush()
-	fmt.Println(buf.Bytes())
 	infos += buf.String()
 	buf.Reset()
 	return infos

--- a/test/integration/ctl/BUILD.bazel
+++ b/test/integration/ctl/BUILD.bazel
@@ -15,6 +15,7 @@ go_test(
         "//cmd/ctl/pkg/renew:go_default_library",
         "//cmd/ctl/pkg/status/certificate:go_default_library",
         "//pkg/api/util:go_default_library",
+        "//pkg/apis/acme/v1alpha2:go_default_library",
         "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",

--- a/test/integration/ctl/ctl_status_certificate_test.go
+++ b/test/integration/ctl/ctl_status_certificate_test.go
@@ -154,7 +154,8 @@ No CertificateRequest found for this Certificate`,
 				gen.SetCertificateRequestCSR([]byte("dummyCSR"))),
 			reqStatus: &cmapi.CertificateRequestStatus{Conditions: []cmapi.CertificateRequestCondition{reqNotReadyCond}},
 			issuer: gen.Issuer("letsencrypt-prod",
-				gen.SetIssuerNamespace(ns1)),
+				gen.SetIssuerNamespace(ns1),
+				gen.SetIssuerACME(cmacme.ACMEIssuer{})),
 			secret: gen.Secret("existing-tls-secret",
 				gen.SetSecretNamespace(ns1),
 				gen.SetSecretData(map[string][]byte{"tls.crt": tlsCrt})),
@@ -239,8 +240,7 @@ CertificateRequest:
   Namespace: testns-1
   Conditions:
     Ready: False, Reason: Pending, Message: Waiting on certificate issuance from order default/example-order: "pending"
-  Events:  <none>
-No Order found for this Certificate`,
+  Events:  <none>`,
 		},
 		"certificate issued and renewal in progress without ClusterIssuer": {
 			certificate: gen.Certificate(crt4Name,
@@ -278,8 +278,7 @@ CertificateRequest:
   Namespace: testns-1
   Conditions:
     Ready: False, Reason: Pending, Message: Waiting on certificate issuance from order default/example-order: "pending"
-  Events:  <none>
-No Order found for this Certificate`,
+  Events:  <none>`,
 		},
 	}
 

--- a/test/unit/gen/order.go
+++ b/test/unit/gen/order.go
@@ -95,3 +95,9 @@ func SetOrderNamespace(namespace string) OrderModifier {
 		order.ObjectMeta.Namespace = namespace
 	}
 }
+
+func SetOrderCsr(csr []byte) OrderModifier {
+	return func(order *cmacme.Order) {
+		order.Spec.CSR = csr
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds output about the Order resource for `status certificate` command if ACME Issuer is used.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add output about Order resource for `status certificate` command if ACME Issuer is used.
```

/kind feature
/area ctl