### PR TITLE
Update to latest version of https://github.com/SSLMate/go-pkcs12

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -19928,7 +19928,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ================================================================================
 = vendor/software.sslmate.com/src/go-pkcs12 licensed under: =
 
-Copyright (c) 2015, 2018 Opsmate, Inc.
+Copyright (c) 2015, 2018, 2019 Opsmate, Inc. All rights reserved.
 Copyright (c) 2009 The Go Authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -19957,6 +19957,6 @@ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-= vendor/software.sslmate.com/src/go-pkcs12/LICENSE 59ab963efbc183656060b23893ea5745
+= vendor/software.sslmate.com/src/go-pkcs12/LICENSE 259f3802525423b1a33efb1b85f64e18
 ================================================================================
 

--- a/go.mod
+++ b/go.mod
@@ -62,5 +62,5 @@ require (
 	sigs.k8s.io/controller-tools v0.2.9-0.20200414181213-645d44dca7c0
 	sigs.k8s.io/testing_frameworks v0.1.2
 	sigs.k8s.io/yaml v1.2.0
-	software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237
+	software.sslmate.com/src/go-pkcs12 v0.0.0-20200619203921-c9ed90bd32dc
 )

--- a/go.sum
+++ b/go.sum
@@ -707,4 +707,6 @@ sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
 software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237 h1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=
 software.sslmate.com/src/go-pkcs12 v0.0.0-20180114231543-2291e8f0f237/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20200619203921-c9ed90bd32dc h1:EsxyX6d5CU9zIK74f0y5OeDRFoQalEMHz1Jdvo4K16g=
+software.sslmate.com/src/go-pkcs12 v0.0.0-20200619203921-c9ed90bd32dc/go.mod h1:/xvNRWUqm0+/ZMiF4EX00vrSCMsE4/NHb+Pt3freEeQ=
 vbom.ml/util v0.0.0-20160121211510-db5cfe13f5cc/go.mod h1:so/NYdZXCz+E3ZpW0uAoCj6uzU2+8OWDFv/HxUSs7kI=

--- a/hack/build/repos.bzl
+++ b/hack/build/repos.bzl
@@ -1695,8 +1695,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "software.sslmate.com/src/go-pkcs12",
-        sum = "h1:iAEkCBPbRaflBgZ7o9gjVUuWuvWeV4sytFWg9o+Pj2k=",
-        version = "v0.0.0-20180114231543-2291e8f0f237",
+        sum = "h1:EsxyX6d5CU9zIK74f0y5OeDRFoQalEMHz1Jdvo4K16g=",
+        version = "v0.0.0-20200619203921-c9ed90bd32dc",
     )
     go_repository(
         name = "in_gopkg_alecthomas_kingpin_v2",

--- a/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
@@ -202,16 +202,19 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)
 				}
-				// The pkcs12 package does not expose a way to decode the CA
-				// data that has been written.
-				// It will return an error when attempting to decode a file
-				// with more than one 'certbag', so we just ensure the error
-				// returned is the expected error and don't inspect the keystore
-				// contents.
-				_, _, err = pkcs12.Decode(out, "password")
-				if err == nil || err.Error() != "pkcs12: expected exactly two safe bags in the PFX PDU" {
-					t.Errorf("unexpected error string, exp=%q, got=%v", "pkcs12: expected exactly two safe bags in the PFX PDU", err)
+				pk, cert, caCerts, err := pkcs12.DecodeChain(out, "password")
+				if err != nil {
+					t.Errorf("error decoding keystore: %v", err)
 					return
+				}
+				if cert == nil {
+					t.Errorf("no certificate data found in keystore")
+				}
+				if pk == nil {
+					t.Errorf("no private key data found in keystore")
+				}
+				if caCerts == nil {
+					t.Errorf("no ca data found in keystore")
 				}
 			},
 		},


### PR DESCRIPTION
This new version includes a
[pkcs12.DecodeChain](https://godoc.org/software.sslmate.com/src/go-pkcs12#DecodeChain)
which will help in testing https://github.com/jetstack/cert-manager/pull/3146

```release-note
NONE
```