### PR TITLE
Add intermediate cert to P12 chain if ca.crt is empty

### DIFF
--- a/pkg/controller/certificates/internal/secretsmanager/BUILD.bazel
+++ b/pkg/controller/certificates/internal/secretsmanager/BUILD.bazel
@@ -39,6 +39,8 @@ go_test(
         "//pkg/util/pki:go_default_library",
         "//test/unit/gen:go_default_library",
         "@com_github_pavel_v_chernykh_keystore_go//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@com_sslmate_software_src_go_pkcs12//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/certificates/internal/secretsmanager/keystore.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore.go
@@ -65,11 +65,11 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 		if err != nil {
 			return nil, err
 		}
-		// prepend the certificate chain to the list of certificates as the PKCS12
-		// library only allows setting a single certificate.
-		if len(certs) > 1 {
-			cas = append(certs[1:], cas...)
-		}
+	}
+	// prepend the certificate chain to the list of certificates as the PKCS12
+	// library only allows setting a single certificate.
+	if len(certs) > 1 {
+		cas = append(certs[1:], cas...)
 	}
 	keystoreData, err := pkcs12.Encode(rand.Reader, key, certs[0], cas, password)
 	if err != nil {

--- a/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
@@ -18,9 +18,14 @@ package secretsmanager
 
 import (
 	"bytes"
+	"crypto"
+	"crypto/x509"
+	"fmt"
 	"testing"
 
 	jks "github.com/pavel-v-chernykh/keystore-go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"software.sslmate.com/src/go-pkcs12"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
@@ -60,6 +65,81 @@ func mustSelfSignCertificate(t *testing.T, pkBytes []byte) []byte {
 		t.Fatal(err)
 	}
 	return certBytes
+}
+
+type keyAndCert struct {
+	key     crypto.Signer
+	keyPEM  []byte
+	cert    *x509.Certificate
+	certPEM []byte
+}
+
+func mustCert(t *testing.T, commonName string, isCA bool) *keyAndCert {
+	key, err := pki.GenerateRSAPrivateKey(2048)
+	require.NoError(t, err)
+	keyPEM, err := pki.EncodePrivateKey(key, cmapi.PKCS8)
+	require.NoError(t, err)
+
+	cert, err := pki.GenerateTemplate(&cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{
+			CommonName: commonName,
+			IsCA:       isCA,
+		},
+	})
+	require.NoError(t, err)
+
+	return &keyAndCert{
+		key:    key,
+		keyPEM: keyPEM,
+		cert:   cert,
+	}
+}
+
+func (o *keyAndCert) mustSign(t *testing.T, ca *keyAndCert) {
+	require.True(t, ca.cert.IsCA, "not a CA", ca.cert)
+	var err error
+	o.certPEM, o.cert, err = pki.SignCertificate(o.cert, ca.cert, o.key.Public(), ca.key)
+	require.NoError(t, err)
+}
+
+type certChain []*keyAndCert
+
+func (o certChain) certsToPEM() (certs []byte) {
+	for _, kc := range o {
+		certs = append(certs, kc.certPEM...)
+	}
+	return
+}
+
+type leafWithChain struct {
+	all  certChain
+	leaf *keyAndCert
+	cas  certChain
+}
+
+const chainLength = 3
+
+func mustLeafWithChain(t *testing.T) leafWithChain {
+	all := make(certChain, chainLength)
+
+	var last *keyAndCert
+	for i := range all {
+		isCA := i > 0
+		commonName := fmt.Sprintf("Cert %d of %d", i+1, chainLength)
+		c := mustCert(t, commonName, isCA)
+		if last != nil {
+			last.mustSign(t, c)
+		}
+		last = c
+		all[i] = c
+	}
+	last.mustSign(t, last)
+
+	return leafWithChain{
+		all:  all,
+		leaf: all[0],
+		cas:  all[1:],
+	}
 }
 
 func TestEncodeJKSKeystore(t *testing.T) {
@@ -150,6 +230,7 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 		password               string
 		rawKey, certPEM, caPEM []byte
 		verify                 func(t *testing.T, out []byte, err error)
+		run                    func(t testing.T)
 	}{
 		"encode a JKS bundle for a PKCS1 key and certificate only": {
 			password: "password",
@@ -225,4 +306,39 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 			test.verify(t, out, err)
 		})
 	}
+	t.Run("encodePKCS12Keystore encodes non-leaf certificates to the CA certificate chain, even when the supplied CA chain is empty", func(t *testing.T) {
+		const password = "password"
+		var emptyCAChain []byte = nil
+
+		chain := mustLeafWithChain(t)
+		out, err := encodePKCS12Keystore(password, chain.leaf.keyPEM, chain.all.certsToPEM(), emptyCAChain)
+
+		pkOut, certOut, caChain, err := pkcs12.DecodeChain(out, password)
+		require.NoError(t, err)
+		assert.NotNil(t, pkOut)
+		assert.Equal(t, chain.leaf.cert.Signature, certOut.Signature, "leaf certificate signature does not match")
+		if assert.Len(t, caChain, 2, "caChain should contain 2 items: intermediate certificate and top-level certificate") {
+			assert.Equal(t, chain.cas[0].cert.Signature, caChain[0].Signature, "intermediate certificate signature does not match")
+			assert.Equal(t, chain.cas[1].cert.Signature, caChain[1].Signature, "top-level certificate signature does not match")
+		}
+	})
+	t.Run("encodePKCS12Keystore *prepends* non-leaf certificates to the supplied CA certificate chain", func(t *testing.T) {
+		const password = "password"
+		var caChainInPEM []byte = mustSelfSignCertificate(t, nil)
+		caChainIn, err := pki.DecodeX509CertificateChainBytes(caChainInPEM)
+		require.NoError(t, err)
+
+		chain := mustLeafWithChain(t)
+		out, err := encodePKCS12Keystore(password, chain.leaf.keyPEM, chain.all.certsToPEM(), caChainInPEM)
+
+		pkOut, certOut, caChainOut, err := pkcs12.DecodeChain(out, password)
+		require.NoError(t, err)
+		assert.NotNil(t, pkOut)
+		assert.Equal(t, chain.leaf.cert.Signature, certOut.Signature, "leaf certificate signature does not match")
+		if assert.Len(t, caChainOut, 3, "caChain should contain 3 items: intermediate certificate and top-level certificate and supplied CA") {
+			assert.Equal(t, chain.cas[0].cert.Signature, caChainOut[0].Signature, "intermediate certificate signature does not match")
+			assert.Equal(t, chain.cas[1].cert.Signature, caChainOut[1].Signature, "top-level certificate signature does not match")
+			assert.Equal(t, caChainIn, caChainOut[2:], "supplied certificate chain is not at the end of the chain")
+		}
+	})
 }


### PR DESCRIPTION
If ACME (or any other that has no CA.crt) issues an intermediate certificate it is dropped from our pkcs12 keystore.
This was due to the logic being inside an if statement that checked the CA.crt secret.

Fixes #3039
Supplants: https://github.com/jetstack/cert-manager/pull/3146


**Release note**:
```
Fix issue where intermediate certificates are not in the pkcs12 keystore
```
