### PR TITLE
chart: add image digest option

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -50,7 +50,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.cainjector.image.repository }}:{{ default .Chart.AppVersion .Values.cainjector.image.tag }}"
+          {{- with .Values.cainjector.image }}
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          {{- end }}
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:
           {{- if .Values.global.logLevel }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -73,7 +73,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.image.repository }}:{{ default .Chart.AppVersion .Values.image.tag }}"
+          {{- with .Values.image }}
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
         {{- if .Values.global.logLevel }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -52,7 +52,9 @@ spec:
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
-          image: "{{ .Values.webhook.image.repository }}:{{ default .Chart.AppVersion .Values.webhook.image.tag }}"
+          {{- with .Values.webhook.image }}
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          {{- end }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:
           {{- if .Values.global.logLevel }}
@@ -105,4 +107,3 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
-

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -40,9 +40,16 @@ featureGates: ""
 
 image:
   repository: quay.io/jetstack/cert-manager-controller
+  # You can manage a registry with
+  # registy: quay.io
+  # repository: jetstack/cert-manager-controller
+
   # Override the image tag to deploy by setting this variable.
   # If no value is set, the chart's appVersion will be used.
   # tag: canary
+
+  # Setting a digest will override any tag
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
   pullPolicy: IfNotPresent
 
 # Override the namespace used to store DNS provider credentials etc. for ClusterIssuer
@@ -217,9 +224,17 @@ webhook:
 
   image:
     repository: quay.io/jetstack/cert-manager-webhook
+    # You can manage a registry with
+    # registy: quay.io
+    # repository: jetstack/cert-manager-webhook
+
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion will be used.
     # tag: canary
+
+    # Setting a digest will override any tag
+    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+
     pullPolicy: IfNotPresent
 
   serviceAccount:
@@ -293,9 +308,17 @@ cainjector:
 
   image:
     repository: quay.io/jetstack/cert-manager-cainjector
+    # You can manage a registry with
+    # registy: quay.io
+    # repository: jetstack/cert-manager-cainjector
+
     # Override the image tag to deploy by setting this variable.
     # If no value is set, the chart's appVersion will be used.
     # tag: canary
+
+    # Setting a digest will override any tag
+    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+
     pullPolicy: IfNotPresent
 
   serviceAccount:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add digest option for images.
Also add "registry/repository" option.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*:

Impossible to use a digest reference for a docker image.
It's needed for some security purpose.

**Special notes for your reviewer**:

**Release note**:

```release-note
Helm chart: add image digest option
```
