### PR TITLE
Remove managed by Helm labels from static manifests and CRDs

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -25,6 +25,24 @@ VARIANTS = {
     },
 }
 
+[genrule(
+    name = "%s.nohelm.crds.yaml" % name,
+    srcs = [
+        "//deploy/crds:crds.%s" % meta["crd_variant"],
+    ],
+    outs = ["%s.crds.nohelm.out" % name],
+    cmd = " ".join([
+        "$(location //hack/filter-crd)",
+        "-variant=no-helm",
+        "$(location //deploy/crds:crds.%s)" % meta["crd_variant"],
+        "> $@",
+    ]),
+    tools = [
+        "//hack/filter-crd",
+    ],
+    visibility = ["//visibility:public"],
+) for (name, meta) in VARIANTS.items()]
+
 [helm_tmpl(
     name = "%s.manifests" % name,
     helm_pkg = "//deploy/charts/cert-manager",
@@ -35,7 +53,7 @@ VARIANTS = {
 
 [licensed_file(
     name = "%s.crds.yaml" % name,
-    src = "//deploy/crds:crds.%s" % meta["crd_variant"],
+    src = ":%s.nohelm.crds.yaml" % name,
 ) for (name, meta) in VARIANTS.items()]
 
 [genrule(
@@ -55,9 +73,27 @@ VARIANTS = {
     ]),
 ) for (name, meta) in VARIANTS.items()]
 
+[genrule(
+    name = "%s.unlicensed.nohelm" % name,
+    srcs = [
+        ":%s.unlicensed" % name,
+    ],
+    outs = ["%s.unlicensed.nohelm.yaml" % name],
+    cmd = " ".join([
+        "$(location //hack/filter-crd)",
+        "-variant=no-helm",
+        "$(location :%s.unlicensed)" % name,
+        "> $@",
+    ]),
+    tools = [
+        "//hack/filter-crd",
+    ],
+    visibility = ["//visibility:public"],
+) for (name, meta) in VARIANTS.items()]
+
 [licensed_file(
     name = "%s.yaml" % name,
-    src = "%s.unlicensed" % name,
+    src = "%s.unlicensed.nohelm" % name,
 ) for (name, meta) in VARIANTS.items()]
 
 pkg_tar(

--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -195,6 +195,8 @@ func loadVariant() {
 		removeKeys = []string{
 			"metadata/labels/app.kubernetes.io/managed-by",
 			"metadata/labels/helm.sh/chart",
+			"spec/template/metadata/labels/app.kubernetes.io/managed-by",
+			"spec/template/metadata/labels/helm.sh/chart",
 		}
 	}
 }

--- a/hack/filter-crd/main.go
+++ b/hack/filter-crd/main.go
@@ -89,6 +89,7 @@ func main() {
 		}
 
 		output = append(output, string(fileOut))
+		d = map[interface{}]interface{}{} // clean out the old, otherwise the decoder will merge keys
 	}
 
 	fmt.Println(strings.Join(output, "---\n"))
@@ -190,5 +191,10 @@ func loadVariant() {
 		}
 
 		singleCRDVersion = true
+	} else if variant == "no-helm" {
+		removeKeys = []string{
+			"metadata/labels/app.kubernetes.io/managed-by",
+			"metadata/labels/helm.sh/chart",
+		}
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We always shipped "managed-by:helm" and other chart/tiller references in our static manifests, this is incorrect and can cause confusion.
This PR repurposed our `filter-crd` tool (which might be up to be renamed filter-yaml?) to remove those labels from the static CRDs and static deployment manifests.

**Which issue this PR fixes**:
fixed #2477 

**Special notes for your reviewer**:
I start to like Bazel, i'm sorry

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove Helm specific labels from static manifests
```

/kind cleanup