### PR TITLE
Add a prometheus-mixin

### DIFF
--- a/deploy/prometheus-mixin/.gitignore
+++ b/deploy/prometheus-mixin/.gitignore
@@ -1,0 +1,1 @@
+manifests/

--- a/deploy/prometheus-mixin/Makefile
+++ b/deploy/prometheus-mixin/Makefile
@@ -1,0 +1,54 @@
+# Prometheus Mixin Makefile
+# Heavily copied from upstream project kubenetes-mixin
+
+JSONNET_FMT := jsonnetfmt
+PROMETHEUS_IMAGE := prom/prometheus:latest
+
+all: fmt prometheus_alerts.yaml prometheus_rules.yaml dashboards_out lint test ## Generate files, lint and test
+
+fmt: ## Format Jsonnet
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		xargs -n 1 -- $(JSONNET_FMT) -i
+
+prometheus_alerts.yaml: mixin.libsonnet lib/alerts.jsonnet alerts/*.libsonnet ## Generate Alerts YAML
+	@mkdir -p manifests
+	jsonnet -S lib/alerts.jsonnet > manifests/$@
+
+prometheus_rules.yaml: mixin.libsonnet lib/rules.jsonnet rules/*.libsonnet ## Generate Rules YAML
+	@mkdir -p manifests
+	jsonnet -S lib/rules.jsonnet > manifests/$@
+
+dashboards_out: mixin.libsonnet lib/dashboards.jsonnet dashboards/*.libsonnet ## Generate Dashboards JSON
+	jsonnet -J vendor -m manifests lib/dashboards.jsonnet
+
+lint: prometheus_alerts.yaml prometheus_rules.yaml ## Lint and check YAML
+	find . -name 'vendor' -prune -o -name '*.libsonnet' -print -o -name '*.jsonnet' -print | \
+		while read f; do \
+			$(JSONNET_FMT) "$$f" | diff -u "$$f" -; \
+		done
+	docker run \
+		-v $(PWD)/manifests:/tmp \
+		--entrypoint '/bin/promtool' \
+		$(PROMETHEUS_IMAGE) \
+		check rules /tmp/prometheus_rules.yaml; \
+	docker run \
+		-v $(PWD)/manifests:/tmp \
+		--entrypoint '/bin/promtool' \
+		$(PROMETHEUS_IMAGE) \
+		check rules /tmp/prometheus_alerts.yaml
+
+clean: ## Clean up generated files
+	rm -rf manifests/
+
+# TODO: Find out why official prom images segfaults during `test rules` if not root
+test: prometheus_alerts.yaml prometheus_rules.yaml ## Test generated files
+	docker run \
+		-v $(PWD):/tmp \
+		--user root \
+		--entrypoint '/bin/promtool' \
+		$(PROMETHEUS_IMAGE) \
+		test rules /tmp/tests.yaml
+
+.PHONY: help
+help:
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'

--- a/deploy/prometheus-mixin/README.md
+++ b/deploy/prometheus-mixin/README.md
@@ -1,0 +1,38 @@
+# cert-manager Mixin
+
+The cert-manager mixin is a collection of reusable and configurable [Prometheus](https://prometheus.io/) alerts, and a [Grafana](https://grafana.com) dashboard to help with operating cert-manager.
+
+To generate these resources, you need to have `jsonnet` (v0.16+) and `jb` installed. If you have a Go development environment setup you can use these commands:
+
+```shell
+go get github.com/google/go-jsonnet/cmd/jsonnet
+go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
+```
+
+## Config Tweaks
+
+There are some configurable options you may want to override in your usage of this mixin, as they will be specific to your deployment of cert-manager. They can be found in [config.libsonnet](config.libsonnet).
+
+## Using the mixin with kube-prometheus
+
+See the [kube-prometheus](https://github.com/coreos/kube-prometheus#kube-prometheus)
+project documentation for examples on importing mixins.
+
+## Using the mixin as raw files
+
+If you don't use the jsonnet based `kube-prometheus` project then you will need to
+generate the raw yaml files for inclusion in your Prometheus installation.
+
+Install the `jsonnet` dependencies:
+```
+$ go get github.com/google/go-jsonnet/cmd/jsonnet
+$ go get github.com/google/go-jsonnet/cmd/jsonnetfmt
+```
+
+Generate yaml:
+```
+$ make
+```
+
+To use the dashboard, it can be imported or provisioned for Grafana by grabbig the [cert-manager.json](dashboards/cert-manager.json) file as is.

--- a/deploy/prometheus-mixin/alerts/alerts.libsonnet
+++ b/deploy/prometheus-mixin/alerts/alerts.libsonnet
@@ -1,0 +1,92 @@
+{
+  prometheusAlerts+:: {
+    groups+: [{
+      name: 'cert-manager',
+      rules: [
+        {
+          alert: 'certmanager_absent',
+          expr: 'absent(up{job="%(certManagerJobLabel)s"})' % $._config,
+          'for': '10m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cert Manager has dissapeared from Prometheus service discovery',
+            impact: "New certificates will not be able to be minted, and existing ones can't be renewed until cert-manager is back.",
+            action: 'Investigate why Cert Manager has stopped running, and fix. It could also be an issue with the PodMonitor CRD.',
+          },
+        },
+        {
+          alert: 'certmanager_cert_expiry_soon',
+          expr: |||
+            avg by (exported_namespace, name) (
+              certmanager_certificate_expiration_timestamp_seconds - time()
+            ) < (21 * 24 * 3600) # 21 days in seconds
+          |||,
+          'for': '1h',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from expiry, it should have renewed over a week ago',
+            impact: 'The domain that this cert covers will be unavailable after {{ $value | humanizeDuration }}',
+            action: 'Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.',
+            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+          },
+        },
+        {
+          alert: 'certmanager_cert_not_ready',
+          expr: |||
+            max by (name, exported_namespace, condition) (
+              certmanager_certificate_ready_status{condition!="True"} == 1
+            )
+          |||,
+          'for': '10m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'The cert `{{ $labels.name }}` is not ready to serve traffic.',
+            impact: 'This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert, nginx _may_ be able to serve that instead.',
+            action: 'Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.',
+            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+          },
+        },
+        {
+          alert: 'certmanager_cert_expiry_metric_missing',
+          expr: 'absent(certmanager_certificate_expiration_timestamp_seconds)',
+          'for': '10m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'The metric used to observe cert-manager cert expiry is missing',
+            impact: 'We are blind as to whether or not we can alert on certificates expiring',
+            action: 'Assuming cert-manager is running, this is likely due to cert-manager not having permission to see certificate CRDs, a breaking change in metrics exposed, or some other misconfiguration.',
+            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+          },
+        },
+        {
+          alert: 'certmanager_hitting_rate_limits',
+          expr: |||
+            sum by (host) (
+              rate(certmanager_http_acme_client_request_count{status="429"}[5m])
+            ) > 0
+          |||,
+          'for': '5m',
+          labels: {
+            severity: 'critical',
+          },
+          annotations: {
+            message: 'Cert manager hitting LetsEncrypt rate limits',
+            impact: 'Depending on the rate limit, cert-manager may be unable to generate certificates for up to a week.',
+            action: 'Nothing we can really do in the short term. We can apply for a rate limit adjustment for the future, but it can take weeks to approve. Thoughts and prayers.',
+            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+            link_url: 'https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform',
+            link_text: 'LetsEncrypt Rate Limit Request Form',
+          },
+        },
+      ],
+    }],
+  },
+}

--- a/deploy/prometheus-mixin/alerts/alerts.libsonnet
+++ b/deploy/prometheus-mixin/alerts/alerts.libsonnet
@@ -31,7 +31,7 @@
             message: 'The cert `{{ $labels.name }}` is {{ $value | humanizeDuration }} from expiry, it should have renewed over a week ago',
             impact: 'The domain that this cert covers will be unavailable after {{ $value | humanizeDuration }}',
             action: 'Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.',
-            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+            dashboard: $._config.grafanaExternalUrl + '/d/TvuRo2iMk/cert-manager',
           },
         },
         {
@@ -49,7 +49,7 @@
             message: 'The cert `{{ $labels.name }}` is not ready to serve traffic.',
             impact: 'This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert, nginx _may_ be able to serve that instead.',
             action: 'Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.',
-            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+            dashboard: $._config.grafanaExternalUrl + '/d/TvuRo2iMk/cert-manager',
           },
         },
         {
@@ -63,7 +63,7 @@
             message: 'The metric used to observe cert-manager cert expiry is missing',
             impact: 'We are blind as to whether or not we can alert on certificates expiring',
             action: 'Assuming cert-manager is running, this is likely due to cert-manager not having permission to see certificate CRDs, a breaking change in metrics exposed, or some other misconfiguration.',
-            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+            dashboard: $._config.grafanaExternalUrl + '/d/TvuRo2iMk/cert-manager',
           },
         },
         {
@@ -81,7 +81,7 @@
             message: 'Cert manager hitting LetsEncrypt rate limits',
             impact: 'Depending on the rate limit, cert-manager may be unable to generate certificates for up to a week.',
             action: 'Nothing we can really do in the short term. We can apply for a rate limit adjustment for the future, but it can take weeks to approve. Thoughts and prayers.',
-            dashboard: 'https://' + $._config.domainPrefix + 'grafana' + $._config.domainSuffix + '/d/TvuRo2iMk/cert-manager',
+            dashboard: $._config.grafanaExternalUrl + '/d/TvuRo2iMk/cert-manager',
             link_url: 'https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform',
             link_text: 'LetsEncrypt Rate Limit Request Form',
           },

--- a/deploy/prometheus-mixin/config.libsonnet
+++ b/deploy/prometheus-mixin/config.libsonnet
@@ -2,7 +2,6 @@
 {
   _config+:: {
     certManagerJobLabel: 'cert-manager',
-    domainPrefix: 'prefix.',
-    domainSuffix: '.example.com',
+    grafanaExternalUrl: 'https://grafana.example.com',
   },
 }

--- a/deploy/prometheus-mixin/config.libsonnet
+++ b/deploy/prometheus-mixin/config.libsonnet
@@ -1,0 +1,8 @@
+// Prometheus Mixin Config
+{
+  _config+:: {
+    certManagerJobLabel: 'cert-manager',
+    domainPrefix: 'prefix.',
+    domainSuffix: '.example.com',
+  },
+}

--- a/deploy/prometheus-mixin/dashboards/cert-manager.json
+++ b/deploy/prometheus-mixin/dashboards/cert-manager.json
@@ -1,0 +1,1149 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "",
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 1,
+  "iteration": 1592254575453,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "prometheus",
+      "description": "The number of certificates in the ready state.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "True"
+            },
+            "properties": [
+              {
+                "id": "thresholds",
+                "value": {
+                  "mode": "absolute",
+                  "steps": [
+                    {
+                      "color": "green",
+                      "value": null
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "sum by (condition) (certmanager_certificate_ready_status)",
+          "interval": "",
+          "legendFormat": "{{condition}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Certificates Ready",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {},
+          "decimals": 1,
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 604800
+              },
+              {
+                "color": "green",
+                "value": 1209600
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        }
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "min(certmanager_certificate_expiration_timestamp_seconds) - time()",
+          "hide": false,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "vector(1250000)",
+          "hide": true,
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Soonest Cert Expiry",
+      "type": "stat"
+    },
+    {
+      "datasource": "$datasource",
+      "description": "Status of the certificates. Values are True, False or Unknown.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "operator": "",
+              "text": "Yes",
+              "to": "",
+              "type": 1,
+              "value": ""
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "dateTimeAsIso"
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Ready Status"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 148
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Valid Until"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 203
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 9,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Valid Until"
+          }
+        ]
+      },
+      "pluginVersion": "7.0.3",
+      "targets": [
+        {
+          "expr": "avg by (name, condition) (certmanager_certificate_ready_status == 1)",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (name, exported_namespace) (certmanager_certificate_expiration_timestamp_seconds) * 1000",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "B"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Certificates",
+      "transformations": [
+        {
+          "id": "seriesToColumns",
+          "options": {
+            "byField": "name"
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {
+              "Time": true,
+              "Value #A": true,
+              "exported_namespace": false
+            },
+            "indexByName": {
+              "Time": 5,
+              "Value #A": 4,
+              "Value #B": 3,
+              "condition": 2,
+              "exported_namespace": 1,
+              "name": 0
+            },
+            "renameByName": {
+              "Value #B": "Valid Until",
+              "condition": "Ready Status",
+              "exported_namespace": "Namespace",
+              "name": "Certificate"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "The rate of controller sync requests.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "hiddenSeries": false,
+      "id": 7,
+      "interval": "20s",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "maxDataPoints": 250,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (controller) (\n  rate(certmanager_controller_sync_call_count[$__interval])\n)",
+          "interval": "",
+          "legendFormat": "{{controller}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Controller Sync Requests/sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Rate of requests to ACME provider.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 6,
+      "interval": "20s",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "maxDataPoints": 250,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (method, path, status) (\n  rate(certmanager_http_acme_client_request_count[$__interval])\n)",
+          "interval": "",
+          "legendFormat": "{{method}} {{path}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ACME HTTP Requests/sec",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "reqps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "Average duration of requests to ACME provider. ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "hiddenSeries": false,
+      "id": 10,
+      "interval": "30s",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "hideEmpty": true,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "maxDataPoints": 250,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_sum[$__interval]))\n/\nsum by (method, path, status) (rate(certmanager_http_acme_client_request_duration_seconds_count[$__interval]))",
+          "interval": "",
+          "legendFormat": "{{method}} {{path}} {{status}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "ACME HTTP Request avg duration",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "max": "dark-yellow"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "$datasource",
+      "description": "CPU Usage and limits, as percent of a vCPU core. ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 0,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 12,
+      "interval": "1m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxDataPoints": 250,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "CPU",
+          "fill": 1,
+          "fillGradient": 5
+        },
+        {
+          "alias": "/Request.*/",
+          "color": "#FF9830",
+          "dashes": true
+        },
+        {
+          "alias": "/Limit.*/",
+          "color": "#F2495C",
+          "dashes": true
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (pod) (rate(container_cpu_usage_seconds_total{container=\"cert-manager\"}[$__interval]))",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "CPU {{pod}}",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (pod) (kube_pod_container_resource_limits_cpu_cores{container=\"cert-manager\"})",
+          "format": "time_series",
+          "hide": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Limit {{pod}}",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (pod) (kube_pod_container_resource_requests_cpu_cores{container=\"cert-manager\"})",
+          "format": "time_series",
+          "hide": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Request {{pod}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "max": "dark-yellow"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Percent of the time that the CPU is being throttled. Higher is badderer. ",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 6,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 14,
+      "interval": "1m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxDataPoints": 250,
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "$$hashKey": "object:132",
+          "alias": "/external-dns.*/",
+          "fill": 1,
+          "fillGradient": 5
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (pod) (\n  rate(container_cpu_cfs_throttled_periods_total{container=\"cert-manager\"}[$__interval])\n  /\n  rate(container_cpu_cfs_periods_total{container=\"cert-manager\"}[$__interval])\n)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "{{pod}}",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "CPU Throttling",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percentunit",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "max": "dark-yellow"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Memory utilisation and limits.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 0,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 12,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 16,
+      "interval": "1m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxDataPoints": 250,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Memory",
+          "fill": 1,
+          "fillGradient": 5
+        },
+        {
+          "alias": "Request",
+          "color": "#FF9830",
+          "dashes": true
+        },
+        {
+          "alias": "Limit",
+          "color": "#F2495C",
+          "dashes": true
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg by (pod) (container_memory_usage_bytes{container=\"cert-manager\"})",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Memory {{pod}}",
+          "refId": "A"
+        },
+        {
+          "expr": "avg by (pod) (kube_pod_container_resource_limits_memory_bytes{container=\"cert-manager\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Limit {{pod}}",
+          "refId": "B"
+        },
+        {
+          "expr": "avg by (pod) (kube_pod_container_resource_requests_memory_bytes{container=\"cert-manager\"})",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Request {{pod}}",
+          "refId": "C"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Memory",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "max": "dark-yellow"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "prometheus",
+      "description": "Network ingress/egress.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {}
+        },
+        "overrides": []
+      },
+      "fill": 1,
+      "fillGradient": 5,
+      "gridPos": {
+        "h": 8,
+        "w": 6,
+        "x": 18,
+        "y": 24
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "interval": "1m",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "transmit",
+          "transform": "negative-Y"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_receive_bytes_total{namespace=\"cert-manager\"}[$__interval])\n  )\n)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "receive",
+          "refId": "A"
+        },
+        {
+          "expr": "avg(\n  sum without (interface) (\n    rate(container_network_transmit_bytes_total{namespace=\"cert-manager\"}[$__interval])\n  )\n)",
+          "format": "time_series",
+          "hide": false,
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "transmit",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Network",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 25,
+  "style": "dark",
+  "tags": [
+    "cert-manager",
+    "infra"
+  ],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "prometheus",
+          "value": "prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Cert Manager",
+  "uid": "TvuRo2iMk",
+  "version": 1
+}

--- a/deploy/prometheus-mixin/dashboards/dashboards.libsonnet
+++ b/deploy/prometheus-mixin/dashboards/dashboards.libsonnet
@@ -1,0 +1,5 @@
+{
+  grafanaDashboards+:: {
+    'cert-manager.json': (import 'cert-manager.json'),
+  },
+}

--- a/deploy/prometheus-mixin/lib/alerts.jsonnet
+++ b/deploy/prometheus-mixin/lib/alerts.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc((import '../mixin.libsonnet').prometheusAlerts)

--- a/deploy/prometheus-mixin/lib/dashboards.jsonnet
+++ b/deploy/prometheus-mixin/lib/dashboards.jsonnet
@@ -1,0 +1,6 @@
+local dashboards = (import '../mixin.libsonnet').grafanaDashboards;
+
+{
+  [name]: dashboards[name]
+  for name in std.objectFields(dashboards)
+}

--- a/deploy/prometheus-mixin/lib/rules.jsonnet
+++ b/deploy/prometheus-mixin/lib/rules.jsonnet
@@ -1,0 +1,1 @@
+std.manifestYamlDoc((import '../mixin.libsonnet').prometheusRules)

--- a/deploy/prometheus-mixin/mixin.libsonnet
+++ b/deploy/prometheus-mixin/mixin.libsonnet
@@ -1,0 +1,9 @@
+// Prometheus Mixin
+// Follows the kubernetes-mixin project pattern here: https://github.com/kubernetes-monitoring/kubernetes-mixin
+// Mixin design doc: https://docs.google.com/document/d/1A9xvzwqnFVSOZ5fD3blKODXfsat5fg6ZhnKu9LK3lB4/edit
+
+// This file will be imported during build for all Promethei
+(import 'config.libsonnet') +
+(import 'alerts/alerts.libsonnet') +
+(import 'dashboards/dashboards.libsonnet') +
+(import 'rules/rules.libsonnet')

--- a/deploy/prometheus-mixin/rules/rules.libsonnet
+++ b/deploy/prometheus-mixin/rules/rules.libsonnet
@@ -1,0 +1,5 @@
+{
+  prometheusRules+:: {
+    groups+: [],
+  },
+}

--- a/deploy/prometheus-mixin/tests.yaml
+++ b/deploy/prometheus-mixin/tests.yaml
@@ -1,0 +1,115 @@
+---
+rule_files:
+- manifests/prometheus_alerts.yaml
+- manifests/prometheus_rules.yaml
+
+evaluation_interval: 1m
+
+tests:
+# Absent metrics
+- interval: 1m
+  input_series:
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: certmanager_absent
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        job: cert-manager
+      exp_annotations:
+        message: Cert Manager has dissapeared from Prometheus service discovery
+        impact: New certificates will not be able to be minted, and existing ones can't be renewed until cert-manager is back.
+        action: Investigate why Cert Manager has stopped running, and fix. It could also be an issue with the PodMonitor CRD.
+  - eval_time: 10m
+    alertname: certmanager_cert_expiry_metric_missing
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+      exp_annotations:
+        message: The metric used to observe cert-manager cert expiry is missing
+        impact: We are blind as to whether or not we can alert on certificates expiring
+        action: Assuming cert-manager is running, this is likely due to cert-manager not having permission to see certificate CRDs,
+          a breaking change in metrics exposed, or some other misconfiguration.
+        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+
+# Cert expiry
+- interval: 1m
+  input_series:
+  - series: certmanager_certificate_expiration_timestamp_seconds{exported_namespace="test", name="expired-ingress-cert", foo="bar"}
+    values: 1814400+0x43200  # 21d in seconds, static for 30d of samples
+  - series: certmanager_certificate_expiration_timestamp_seconds{exported_namespace="test", name="90d-ingress-cert"}
+    values: 7776000+0x43200  # 90d in seconds, static for 30d of samples
+  alert_rule_test:
+  - eval_time: 61m
+    alertname: certmanager_cert_expiry_soon
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        exported_namespace: test
+        name: expired-ingress-cert
+      exp_annotations:
+        message: The cert `expired-ingress-cert` is 20d 22h 59m 0s from expiry, it should have renewed over a week ago
+        impact: The domain that this cert covers will be unavailable after 20d 22h 59m 0s
+        action: Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.
+        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+
+# Cert not ready
+- interval: 1m
+  input_series:
+  - series: certmanager_certificate_ready_status{exported_namespace="test", name="ready", condition="True"}
+    values: 1+0x30
+  - series: certmanager_certificate_ready_status{exported_namespace="test", name="not ready", condition="False"}
+    values: 1+0x30
+  - series: certmanager_certificate_ready_status{exported_namespace="test", name="who knows", condition="Unknown"}
+    values: 1+0x30
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: certmanager_cert_not_ready
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        exported_namespace: test
+        name: not ready
+        condition: "False"
+      exp_annotations:
+        message: The cert `not ready` is not ready to serve traffic.
+        impact: This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert,
+          nginx _may_ be able to serve that instead.
+        action: Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.
+        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+    - exp_labels:
+        severity: critical
+        exported_namespace: test
+        name: who knows
+        condition: "Unknown"
+      exp_annotations:
+        message: The cert `who knows` is not ready to serve traffic.
+        impact: This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert,
+          nginx _may_ be able to serve that instead.
+        action: Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.
+        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+
+# cert-manager rate limits
+- interval: 1m
+  input_series:
+  - series: certmanager_http_acme_client_request_count{status="200", host="normal.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
+    values: 1+1x30
+  - series: certmanager_http_acme_client_request_count{status="429", host="rate-limited.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
+    values: 1+1x30
+  - series: certmanager_http_acme_client_request_count{status="429", host="one-limited-request.acme-v02.api.letsencrypt.org", path="/acme/new-order"}
+    values: 1+0x30
+  alert_rule_test:
+  - eval_time: 10m
+    alertname: certmanager_hitting_rate_limits
+    exp_alerts:
+    - exp_labels:
+        severity: critical
+        host: rate-limited.acme-v02.api.letsencrypt.org
+      exp_annotations:
+        message: Cert manager hitting LetsEncrypt rate limits
+        impact: Depending on the rate limit, cert-manager may be unable to generate certificates for up to a week.
+        action: Nothing we can really do in the short term. We can apply for a rate limit adjustment for the future,
+          but it can take weeks to approve. Thoughts and prayers.
+        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+        link_url: https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform
+        link_text: LetsEncrypt Rate Limit Request Form

--- a/deploy/prometheus-mixin/tests.yaml
+++ b/deploy/prometheus-mixin/tests.yaml
@@ -30,7 +30,7 @@ tests:
         impact: We are blind as to whether or not we can alert on certificates expiring
         action: Assuming cert-manager is running, this is likely due to cert-manager not having permission to see certificate CRDs,
           a breaking change in metrics exposed, or some other misconfiguration.
-        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+        dashboard: https://grafana.example.com/d/TvuRo2iMk/cert-manager
 
 # Cert expiry
 - interval: 1m
@@ -51,7 +51,7 @@ tests:
         message: The cert `expired-ingress-cert` is 20d 22h 59m 0s from expiry, it should have renewed over a week ago
         impact: The domain that this cert covers will be unavailable after 20d 22h 59m 0s
         action: Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.
-        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+        dashboard: https://grafana.example.com/d/TvuRo2iMk/cert-manager
 
 # Cert not ready
 - interval: 1m
@@ -76,7 +76,7 @@ tests:
         impact: This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert,
           nginx _may_ be able to serve that instead.
         action: Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.
-        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+        dashboard: https://grafana.example.com/d/TvuRo2iMk/cert-manager
     - exp_labels:
         severity: critical
         exported_namespace: test
@@ -87,7 +87,7 @@ tests:
         impact: This certificate has not been ready to serve traffic for at least 10m. If the cert is being renewed or there is another valid cert,
           nginx _may_ be able to serve that instead.
         action: Ensure cert-manager is configured correctly, no lets-encrypt rate limits are being hit. To break glass, buy a cert.
-        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+        dashboard: https://grafana.example.com/d/TvuRo2iMk/cert-manager
 
 # cert-manager rate limits
 - interval: 1m
@@ -110,6 +110,6 @@ tests:
         impact: Depending on the rate limit, cert-manager may be unable to generate certificates for up to a week.
         action: Nothing we can really do in the short term. We can apply for a rate limit adjustment for the future,
           but it can take weeks to approve. Thoughts and prayers.
-        dashboard: https://prefix.grafana.example.com/d/TvuRo2iMk/cert-manager
+        dashboard: https://grafana.example.com/d/TvuRo2iMk/cert-manager
         link_url: https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform
         link_text: LetsEncrypt Rate Limit Request Form


### PR DESCRIPTION
**What this PR does / why we need it**:
This adds a prometheus-mixin for observing and alerting on cert-manager. Having the mixin will allow new users to get up to speed with cert-manager faster, and provide some safe defaults on how to alert and view what cert-manager is doing. It can also be a common area for contribution on observing cert-manager. Intro to prometheus monitoring mixins here https://monitoring.mixins.dev/

Was suggested over in the [slack](https://kubernetes.slack.com/archives/C4NV3DWUC/p1597268503316400) that we create a PR and discuss further in here.

**Which issue this PR fixes**:
This provides some default alerts that would probably be commonly used by cert-manager users. Mainly:
- cert-manager uppness
- alerts for cert expiration
- cert-manager being rate limited by the ACME provider. 

Sample of the dashboard:
![image](https://user-images.githubusercontent.com/6227220/90211178-2057f880-de44-11ea-8d76-883ca8cb53a2.png)


**Special notes for your reviewer**:
First PR here! Apologies if I missed something from the contrib guidelines. Happy to tweak with feedback :) 

**Release note**:
