### PR TITLE
Ctl command status certificate: Add challenge output

### DIFF
--- a/cmd/ctl/pkg/status/certificate/certificate_test.go
+++ b/cmd/ctl/pkg/status/certificate/certificate_test.go
@@ -354,6 +354,74 @@ MA6koCR/K23HZfML8vT6lcHvQJp9XXaHRIe9NX/M/2f6VpfO7JjKWLou5k5a
 				},
 			},
 		},
+		"Correct information extracted from Challenge resources": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Challenges: []*cmacme.Challenge{
+					{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "test-challenge1", Namespace: ns},
+						Spec: cmacme.ChallengeSpec{
+							Type:  "HTTP-01",
+							Token: "token",
+							Key:   "key",
+						},
+						Status: cmacme.ChallengeStatus{
+							Processing: false,
+							Presented:  false,
+							Reason:     "reason",
+							State:      "state",
+						},
+					},
+					{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "test-challenge2", Namespace: ns},
+						Spec: cmacme.ChallengeSpec{
+							Type:  "HTTP-01",
+							Token: "token",
+							Key:   "key",
+						},
+						Status: cmacme.ChallengeStatus{
+							Processing: false,
+							Presented:  false,
+							Reason:     "reason",
+							State:      "state",
+						},
+					},
+				},
+				ChallengeErr: nil,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				ChallengeStatusList: &ChallengeStatusList{
+					ChallengeStatuses: []*ChallengeStatus{
+						{
+							Name:       "test-challenge1",
+							Type:       "HTTP-01",
+							Token:      "token",
+							Key:        "key",
+							State:      "state",
+							Reason:     "reason",
+							Processing: false,
+							Presented:  false,
+						},
+						{
+							Name:       "test-challenge2",
+							Type:       "HTTP-01",
+							Token:      "token",
+							Key:        "key",
+							State:      "state",
+							Reason:     "reason",
+							Processing: false,
+							Presented:  false,
+						},
+					},
+				},
+			},
+		},
 		"When error, ignore rest of the info about the resource": {
 			inputData: &Data{
 				Certificate: gen.Certificate("test-crt",
@@ -370,16 +438,19 @@ MA6koCR/K23HZfML8vT6lcHvQJp9XXaHRIe9NX/M/2f6VpfO7JjKWLou5k5a
 				Order: &cmacme.Order{
 					ObjectMeta: metav1.ObjectMeta{Name: "test-order"},
 				},
-				OrderError: errors.New("dummy error"),
+				OrderError:   errors.New("dummy error"),
+				Challenges:   []*cmacme.Challenge{{ObjectMeta: metav1.ObjectMeta{Name: "test-challenge"}}},
+				ChallengeErr: errors.New("dummy error"),
 			},
 			expOutput: &CertificateStatus{
-				Name:         "test-crt",
-				Namespace:    ns,
-				CreationTime: metav1.Time{},
-				IssuerStatus: &IssuerStatus{Error: errors.New("dummy error")},
-				SecretStatus: &SecretStatus{Error: errors.New("dummy error")},
-				CRStatus:     &CRStatus{Error: errors.New("dummy error")},
-				OrderStatus:  &OrderStatus{Error: errors.New("dummy error")},
+				Name:                "test-crt",
+				Namespace:           ns,
+				CreationTime:        metav1.Time{},
+				IssuerStatus:        &IssuerStatus{Error: errors.New("dummy error")},
+				SecretStatus:        &SecretStatus{Error: errors.New("dummy error")},
+				CRStatus:            &CRStatus{Error: errors.New("dummy error")},
+				OrderStatus:         &OrderStatus{Error: errors.New("dummy error")},
+				ChallengeStatusList: &ChallengeStatusList{Error: errors.New("dummy error")},
 			},
 		},
 	}

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -41,9 +41,21 @@ func ChallengeFrom(ch *cmacme.Challenge, mods ...ChallengeModifier) *cmacme.Chal
 	return ch
 }
 
+func SetChallengeNamespace(ns string) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Namespace = ns
+	}
+}
+
 func SetChallengeType(t string) ChallengeModifier {
 	return func(ch *cmacme.Challenge) {
 		ch.Spec.Type = cmacme.ACMEChallengeType(t)
+	}
+}
+
+func SetChallengeToken(t string) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Token = t
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds info about Challenges related to a Certificate resource to the output of `status certificate` command.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Hold until previous [PR 3171](https://github.com/jetstack/cert-manager/pull/3171) is merged

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add info about Challenges related to a Certificate resource to the output of `status certificate` command.
```

/area ctl
/kind feature