### PR TITLE
Add Atomist to users

### DIFF
--- a/USERS.md
+++ b/USERS.md
@@ -8,7 +8,8 @@ The list of organizations that have publicly shared the usage of cert-manager:
 
 | Organization | Usage | Links |
 | :--- | :--- | :--- |
-| [<img src="https://raw.githubusercontent.com/cert-manager/website/master/assets/icons/jetstack.svg" alt="Jettstack text" width="100"> ](https://jetstack.io) | Securing MySQL inside Kubernetes | [blog](https://blog.jetstack.io/blog/securing-mysql-with-cert-manager/)  | 
+| [<img src="https://static.atomist.com/logo/atomist-color-lockup-horiz-small.png" alt="Atomist" width="100"> ](https://atomist.com/) | Securing ingresses | [Kubernetes, ingress-nginx, cert-manager & external-dns](https://blog.atomist.com/kubernetes-ingress-nginx-cert-manager-external-dns/) |
+| [<img src="https://raw.githubusercontent.com/cert-manager/website/master/assets/icons/jetstack.svg" alt="Jetstack text" width="100"> ](https://jetstack.io) | Securing MySQL inside Kubernetes | [blog](https://blog.jetstack.io/blog/securing-mysql-with-cert-manager/)  | 
 
 The list of individual users that have publicly shared the usage of cert-manager.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Per @meyskens [request in the Kubernetes Slack workspace](https://kubernetes.slack.com/archives/C4NV3DWUC/p1596180147499000), add Atomist as user, along with link to a blog post describing the usage.

**Special notes for your reviewer**:

It seems the intent in the user table was to have the users in alphabetical order, so I did the same for the organization table. If you prefer to have them in a different order, let me know.
