### PR TITLE
Make webhook-probes configurable in helm-chart

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -152,20 +152,16 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.securityContext` | Security context for webhook pod assignment | `{}` |
 | `webhook.containerSecurityContext` | Security context to be set on the webhook component container | `{}` |
 | `webhook.hostNetwork` | If `true`, run the Webhook on the host network. | `false` |
-| `webhook.livenessProbe.path` | The liveness probe path | `/healthz` |
-| `webhook.livenessProbe.port` | The livneness probe port | `6080` |
 | `webhook.livenessProbe.failureThreshold` | The livneness probe failure threshold | `3` |
 | `webhook.livenessProbe.initialDelaySeconds` | The livneness probe initial delay (in seconds) | `60` |
 | `webhook.livenessProbe.periodSeconds` | The livneness probe period (in seconds) | `10` |
 | `webhook.livenessProbe.successThreshold` | The livneness probe success threshold | `1` |
-| `webhook.livenessProbe.timeoutSeconds` | The livneness probe timeout (in seconds) | `3` |
-| `webhook.readinessProbe.path` | The readiness probe path | `/healthz` |
-| `webhook.readinessProbe.port` | The readiness probe port | `6080` |
+| `webhook.livenessProbe.timeoutSeconds` | The livneness probe timeout (in seconds) | `1` |
 | `webhook.readinessProbe.failureThreshold` | The readiness probe failure threshold | `3` |
 | `webhook.readinessProbe.initialDelaySeconds` | The readiness probe initial delay (in seconds) | `5` |
 | `webhook.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `5` |
 | `webhook.readinessProbe.successThreshold` | The readiness probe success threshold | `1` |
-| `webhook.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `3` |
+| `webhook.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `1` |
 | `cainjector.enabled` | Toggles whether the cainjector component should be installed (required for the webhook component to work) | `true` |
 | `cainjector.replicaCount` | Number of cert-manager cainjector replicas | `1` |
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -152,6 +152,20 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.securityContext` | Security context for webhook pod assignment | `{}` |
 | `webhook.containerSecurityContext` | Security context to be set on the webhook component container | `{}` |
 | `webhook.hostNetwork` | If `true`, run the Webhook on the host network. | `false` |
+| `webhook.livenessProbe.path` | The liveness probe path | `/healthz` |
+| `webhook.livenessProbe.port` | The livneness probe port | `6080` |
+| `webhook.livenessProbe.failureThreshold` | The livneness probe failure threshold | `3` |
+| `webhook.livenessProbe.initialDelaySeconds` | The livneness probe initial delay (in seconds) | `60` |
+| `webhook.livenessProbe.periodSeconds` | The livneness probe period (in seconds) | `10` |
+| `webhook.livenessProbe.successThreshold` | The livneness probe success threshold | `1` |
+| `webhook.livenessProbe.timeoutSeconds` | The livneness probe timeout (in seconds) | `3` |
+| `webhook.readinessProbe.path` | The readiness probe path | `/healthz` |
+| `webhook.readinessProbe.port` | The readiness probe port | `6080` |
+| `webhook.readinessProbe.failureThreshold` | The readiness probe failure threshold | `3` |
+| `webhook.readinessProbe.initialDelaySeconds` | The readiness probe initial delay (in seconds) | `5` |
+| `webhook.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `5` |
+| `webhook.readinessProbe.successThreshold` | The readiness probe success threshold | `1` |
+| `webhook.readinessProbe.timeoutSeconds` | The readiness probe timeout (in seconds) | `3` |
 | `cainjector.enabled` | Toggles whether the cainjector component should be installed (required for the webhook component to work) | `true` |
 | `cainjector.replicaCount` | Number of cert-manager cainjector replicas | `1` |
 | `cainjector.podAnnotations` | Annotations to add to the cainjector pods | `{}` |

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -72,8 +72,8 @@ spec:
             containerPort: {{ .Values.webhook.securePort }}
           livenessProbe:
             httpGet:
-              path: {{ .Values.webhook.livenessProbe.path | quote }}
-              port: {{ .Values.webhook.livenessProbe.port }}
+              path: /livez
+              port: 6080
               scheme: HTTP
             initialDelaySeconds: {{ .Values.webhook.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webhook.livenessProbe.periodSeconds }}
@@ -82,8 +82,8 @@ spec:
             failureThreshold: {{ .Values.webhook.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: {{ .Values.webhook.readinessProbe.path | quote }}
-              port: {{ .Values.webhook.readinessProbe.port }}
+              path: /healthz
+              port: 6080
               scheme: HTTP
             initialDelaySeconds: {{ .Values.webhook.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.webhook.readinessProbe.periodSeconds }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -72,18 +72,24 @@ spec:
             containerPort: {{ .Values.webhook.securePort }}
           livenessProbe:
             httpGet:
-              path: /livez
-              port: 6080
+              path: {{ .Values.webhook.livenessProbe.path | quote }}
+              port: {{ .Values.webhook.livenessProbe.port }}
               scheme: HTTP
-            initialDelaySeconds: 60
-            periodSeconds: 10
+            initialDelaySeconds: {{ .Values.webhook.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhook.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.webhook.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.webhook.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.webhook.livenessProbe.failureThreshold }}
           readinessProbe:
             httpGet:
-              path: /healthz
-              port: 6080
+              path: {{ .Values.webhook.readinessProbe.path | quote }}
+              port: {{ .Values.webhook.readinessProbe.port }}
               scheme: HTTP
-            initialDelaySeconds: 5
-            periodSeconds: 5
+            initialDelaySeconds: {{ .Values.webhook.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhook.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.webhook.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.webhook.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.webhook.readinessProbe.failureThreshold }}
           {{- if .Values.webhook.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.webhook.containerSecurityContext | nindent 12 }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -220,21 +220,17 @@ webhook:
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   ##
   livenessProbe:
-    path: /livez
-    port: 6080
     failureThreshold: 3
     initialDelaySeconds: 60
     periodSeconds: 10
     successThreshold: 1
-    timeoutSeconds: 3
+    timeoutSeconds: 1
   readinessProbe:
-    path: /healthz
-    port: 6080
     failureThreshold: 3
     initialDelaySeconds: 5
     periodSeconds: 5
     successThreshold: 1
-    timeoutSeconds: 3
+    timeoutSeconds: 1
 
   nodeSelector: {}
 

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -216,6 +216,26 @@ webhook:
     #   cpu: 10m
     #   memory: 32Mi
 
+  ## Liveness and readiness probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  livenessProbe:
+    path: /livez
+    port: 6080
+    failureThreshold: 3
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    successThreshold: 1
+    timeoutSeconds: 3
+  readinessProbe:
+    path: /healthz
+    port: 6080
+    failureThreshold: 3
+    initialDelaySeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 3
+
   nodeSelector: {}
 
   affinity: {}


### PR DESCRIPTION
**What this PR does / why we need it**:
- This PR makes the Probes for the Webhook-Deployment configurable in the Helm-Chart

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3184

**Special notes for your reviewer**:

**Release note**:
```release-note
Helm chart: make webhook-probes configurable 
```
