### PR TITLE
WIP: A script to update v1alpha2 usage to v1

### DIFF
--- a/hack/change-stored-version.ignorepatterns.txt
+++ b/hack/change-stored-version.ignorepatterns.txt
@@ -1,0 +1,7 @@
+pkg/api/scheme.go
+pkg/apis/acme/v1alpha2
+pkg/apis/certmanager/v1alpha2
+pkg/internal/apis/acme/v1alpha2
+pkg/internal/apis/certmanager/v1alpha2
+zz_generated
+pkg/client

--- a/hack/change-stored-version.patch
+++ b/hack/change-stored-version.patch
@@ -1,0 +1,112 @@
+diff --git a/pkg/controller/certificates/util_test.go b/pkg/controller/certificates/util_test.go
+index 776ad7158..3e11755fd 100644
+--- a/pkg/controller/certificates/util_test.go
++++ b/pkg/controller/certificates/util_test.go
+@@ -82,7 +82,15 @@ func TestPrivateKeyMatchesSpec(t *testing.T) {
+ 	}
+ 	for name, test := range tests {
+ 		t.Run(name, func(t *testing.T) {
+-			violations, err := PrivateKeyMatchesSpec(test.key, cmapi.CertificateSpec{KeyAlgorithm: test.expectedAlgo, KeySize: test.expectedSize})
++			violations, err := PrivateKeyMatchesSpec(
++				test.key,
++				cmapi.CertificateSpec{
++					PrivateKey: &cmapi.CertificatePrivateKey{
++						Algorithm: test.expectedAlgo,
++						Size:      test.expectedSize,
++					},
++				},
++			)
+ 			switch {
+ 			case err != nil:
+ 				if test.err != err.Error() {
+diff --git a/pkg/util/pki/generate_test.go b/pkg/util/pki/generate_test.go
+index 67535955d..8522e2a7e 100644
+--- a/pkg/util/pki/generate_test.go
++++ b/pkg/util/pki/generate_test.go
+@@ -30,16 +30,18 @@ import (
+ 	"testing"
+ 	"time"
+ 
+-	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
++	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+ )
+ 
+ func buildCertificateWithKeyParams(keyAlgo v1.PrivateKeyAlgorithm, keySize int) *v1.Certificate {
+ 	return &v1.Certificate{
+ 		Spec: v1.CertificateSpec{
+-			CommonName:   "test",
+-			DNSNames:     []string{"test.test"},
+-			KeyAlgorithm: keyAlgo,
+-			KeySize:      keySize,
++			CommonName: "test",
++			DNSNames:   []string{"test.test"},
++			PrivateKey: &v1.CertificatePrivateKey{
++				Algorithm: keyAlgo,
++				Size:      keySize,
++			},
+ 		},
+ 	}
+ }
+diff --git a/test/e2e/util/util.go b/test/e2e/util/util.go
+index 2601b8178..590be161f 100644
+--- a/test/e2e/util/util.go
++++ b/test/e2e/util/util.go
+@@ -269,12 +269,14 @@ func NewCertManagerBasicCertificate(name, secretName, issuerName string, issuerK
+ 			Name: name,
+ 		},
+ 		Spec: v1.CertificateSpec{
+-			CommonName:   cn,
+-			DNSNames:     dnsNames,
+-			Organization: []string{"test-org"},
+-			SecretName:   secretName,
+-			Duration:     duration,
+-			RenewBefore:  renewBefore,
++			CommonName: cn,
++			DNSNames:   dnsNames,
++			Subject: &v1.X509Subject{
++				Organizations: []string{"test-org"},
++			},
++			SecretName:  secretName,
++			Duration:    duration,
++			RenewBefore: renewBefore,
+ 			IssuerRef: cmmeta.ObjectReference{
+ 				Name: issuerName,
+ 				Kind: issuerKind,
+diff --git a/test/e2e/suite/conformance/certificates/suite.go b/test/e2e/suite/conformance/certificates/suite.go
+index 173298bdf..71bb04cd6 100644
+--- a/test/e2e/suite/conformance/certificates/suite.go
++++ b/test/e2e/suite/conformance/certificates/suite.go
+@@ -154,10 +154,12 @@ func (s *Suite) Define() {
+ 					Namespace: f.Namespace.Name,
+ 				},
+ 				Spec: cmapi.CertificateSpec{
+-					SecretName:   "testcert-tls",
+-					KeyAlgorithm: cmapi.ECDSAKeyAlgorithm,
+-					DNSNames:     []string{s.newDomain()},
+-					IssuerRef:    issuerRef,
++					SecretName: "testcert-tls",
++					PrivateKey: &cmapi.CertificatePrivateKey{
++						Algorithm: cmapi.ECDSAKeyAlgorithm,
++					},
++					DNSNames:  []string{s.newDomain()},
++					IssuerRef: issuerRef,
+ 				},
+ 			}
+ 			By("Creating a Certificate")
+@@ -197,10 +199,12 @@ func (s *Suite) Define() {
+ 					Namespace: f.Namespace.Name,
+ 				},
+ 				Spec: cmapi.CertificateSpec{
+-					SecretName:   "testcert-tls",
+-					KeyAlgorithm: cmapi.ECDSAKeyAlgorithm,
+-					CommonName:   "test-common-name",
+-					IssuerRef:    issuerRef,
++					SecretName: "testcert-tls",
++					PrivateKey: &cmapi.CertificatePrivateKey{
++						Algorithm: cmapi.ECDSAKeyAlgorithm,
++					},
++					CommonName: "test-common-name",
++					IssuerRef:  issuerRef,
+ 				},
+ 			}
+ 			By("Creating a Certificate")

--- a/hack/change-stored-version.sh
+++ b/hack/change-stored-version.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Copyright 2020 The Jetstack cert-manager contributors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" > /dev/null && pwd )"
+
+git reset --hard
+
+echo moving k8s v1 to corev1
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches 'v1 "k8s.io/api/core/v1"' | \
+    xargs -r sed -E -i \
+          -e 's|(\W)v1 "k8s\.io/api/core/v1"|\1corev1 "k8s.io/api/core/v1"|g' \
+          -e 's/(\W)v1\./\1corev1./g' || echo none
+
+echo CM updating versioned clientsets
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches CertmanagerV1alpha2 | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' \
+          -e 's/CertmanagerV1alpha2/CertmanagerV1/g' || echo none
+
+echo CM updating versioned listers
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches '"github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha2"' | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' || echo none
+
+echo CM updating versioned informers
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches '.V1alpha2()' | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' \
+          -e 's/\.V1alpha2()/.V1()/g' || echo none
+
+echo CM updating remaining certmanager.v1alpha2 references
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-without-match '"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"' | \
+    xargs -r fgrep --files-with-matches '"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"' | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' || echo none
+
+echo ACME updating versioned clientsets
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches AcmeV1alpha2 | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' \
+          -e 's/AcmeV1alpha2/AcmeV1/g' || echo none
+
+echo ACME updating versioned listers
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches '"github.com/jetstack/cert-manager/pkg/client/listers/acme/v1alpha2"' | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' || echo none
+
+echo ACME updating remaining acme
+find cmd pkg test -type f -name '*.go' | \
+    fgrep -v --file "${REPO_ROOT}/hack/change-stored-version.ignorepatterns.txt" | \
+    xargs -r fgrep --files-with-matches '"github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"' | \
+    xargs -r sed -i \
+          -e 's/v1alpha2/v1/g' || echo none found
+
+echo Updating field names
+
+sed -i -E \
+    -e 's/URISANs(\W)/URIs\1/g' \
+    -e 's/EmailSANs(\W)/EmailAddresses\1/g' \
+    pkg/util/pki/csr.go \
+    test/unit/gen/certificate.go \
+    pkg/controller/certificates/util.go \
+    test/e2e/framework/helper/certificates.go \
+    test/e2e/suite/conformance/certificates/suite.go
+
+
+sed -i \
+    -e 's/pec.Organization/pec.Subject.Organizations/g' \
+    pkg/util/pki/csr.go \
+    test/unit/gen/certificate.go \
+    pkg/controller/certificates/util.go
+
+sed -i -E \
+    -e 's/(\W)CSRPEM/\1Request/g' \
+    pkg/util/pki/csr.go \
+    pkg/controller/certificates/util.go \
+    cmd/ctl/pkg/create/certificaterequest/certificaterequest.go \
+    test/unit/gen/certificaterequest.go \
+    pkg/controller/certificaterequests/vault/vault.go \
+    pkg/controller/certificaterequests/venafi/venafi.go \
+    pkg/controller/certificaterequests/acme/acme.go \
+    pkg/controller/certificates/requestmanager/requestmanager_controller.go \
+    pkg/controller/certificates/trigger/policies/policies_test.go \
+    pkg/controller/certificates/internal/test/test.go \
+    pkg/controller/certificates/requestmanager/requestmanager_controller_test.go \
+    pkg/controller/certificates/issuing/issuing_controller.go \
+    pkg/controller/certificates/requestmanager/util_test.go \
+    test/e2e/framework/helper/certificaterequests.go \
+    test/e2e/util/util.go
+
+sed -i -E \
+    -e 's/(\W)CSR(\W)?/\1Request\2/g' \
+    pkg/controller/certificaterequests/acme/acme.go \
+    test/unit/gen/order.go \
+    pkg/controller/acmeorders/sync.go
+
+sed -i \
+    -e 's/pec\.KeyAlgorithm/pec.PrivateKey.Algorithm/g' \
+    -e 's/pec\.KeySize/pec.PrivateKey.Size/g' \
+    -e 's/pec\.KeyEncoding/pec.PrivateKey.Encoding/g' \
+    pkg/util/pki/csr.go \
+    pkg/util/pki/generate.go \
+    pkg/controller/certificates/util.go \
+    test/unit/gen/certificate.go \
+    cmd/ctl/pkg/create/certificaterequest/certificaterequest.go \
+    pkg/controller/certificates/internal/test/test.go \
+    pkg/controller/certificates/issuing/issuing_controller.go \
+    pkg/controller/certificates/requestmanager/util_test.go \
+    pkg/controller/certificates/issuing/temporary.go \
+    pkg/util/pki/parse_test.go \
+    test/e2e/framework/helper/certificates.go \
+    test/e2e/suite/issuers/selfsigned/certificate.go \
+    test/e2e/suite/issuers/ca/certificate.go
+
+
+sed -i -E \
+    -e 's/(v1|cmapi)\.KeyEncoding/\1.PrivateKeyEncoding/g' \
+    -e 's/(v1|cmapi)\.KeyAlgorithm/\1.PrivateKeyAlgorithm/g' \
+    pkg/util/pki/generate.go \
+    pkg/util/pki/generate_test.go \
+    pkg/util/pki/parse_test.go \
+    pkg/util/pki/csr.go \
+    pkg/util/pki/csr_test.go \
+    test/unit/gen/certificate.go \
+    pkg/controller/certificates/util_test.go \
+    pkg/controller/certificates/internal/secretsmanager/keystore_test.go \
+    test/e2e/framework/helper/certificates.go \
+    test/e2e/framework/helper/certificaterequests.go
+
+sed -i \
+    -e 's/\AuthzURL/AuthorizationURL/g' \
+    pkg/controller/acmechallenges/sync.go \
+    pkg/controller/acmeorders/util.go
+
+${REPO_ROOT}/hack/update-gofmt.sh
+patch -p1 < ${REPO_ROOT}/hack/change-stored-version.patch
+
+echo "CHANGES:"
+git status | tee changes.txt | wc -l
+tail changes.txt
+echo "ERRORS:"
+if ! go vet ./cmd/... ./pkg/... ./test/...  >errors.txt 2>&1; then
+    tail errors.txt
+    wc -l < errors.txt
+fi
+date


### PR DESCRIPTION
This is the script used in https://github.com/jetstack/cert-manager/pull/3196 to partially automate the conversion of internal controllers to use v1 API.

Part of https://github.com/jetstack/cert-manager/issues/3156

```release-note
None
```