### PR TITLE
Tidy up some remaining references to v1alpha2

### DIFF
--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest_test.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest_test.go
@@ -125,7 +125,7 @@ func TestRun(t *testing.T) {
 		// Build clients
 		"conflicting namespaces defined in flag and file": {
 			inputFileContent: `---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: testcert-1
@@ -147,7 +147,7 @@ spec:
 		},
 		"file passed in defines resource other than certificate": {
 			inputFileContent: `---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer
@@ -172,7 +172,7 @@ spec:
 		},
 		"manifest file with multiple objects throws error": {
 			inputFileContent: `---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: ca-issuer
@@ -181,7 +181,7 @@ spec:
   ca:
     secretName: ca-key-pair
 ---
-apiVersion: cert-manager.io/v1alpha2
+apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: testcert-1

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -27,7 +27,7 @@ $ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/rel
 ```
 
 > **Note**: If you're using a Kubernetes version below `v1.15` you will need to install the legacy version of the custom resource definitions.
-> This version does not have API version conversion enabled and only supports `cert-manager.io/v1alpha2` API resources.
+> This version does not have API version conversion enabled and only supports `cert-manager.io/v1` API resources.
 
 To install the chart with the release name `my-release`:
 

--- a/pkg/api/scheme.go
+++ b/pkg/api/scheme.go
@@ -29,11 +29,11 @@ import (
 
 	whapi "github.com/jetstack/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
 	cmacmev1 "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
+	cmacmev1alpha2 "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha2"
 	cmacmev1alpha3 "github.com/jetstack/cert-manager/pkg/apis/acme/v1alpha3"
 	cmacmev1beta1 "github.com/jetstack/cert-manager/pkg/apis/acme/v1beta1"
 	cmapiv1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmapiv1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmapiv1alpha3 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
 	cmapiv1beta1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -52,11 +52,11 @@ var Scheme = runtime.NewScheme()
 var Codecs = serializer.NewCodecFactory(Scheme)
 var ParameterCodec = runtime.NewParameterCodec(Scheme)
 var localSchemeBuilder = runtime.SchemeBuilder{
-	cmapi.AddToScheme,
+	cmapiv1alpha2.AddToScheme,
 	cmapiv1alpha3.AddToScheme,
 	cmapiv1beta1.AddToScheme,
 	cmapiv1.AddToScheme,
-	cmacme.AddToScheme,
+	cmacmev1alpha2.AddToScheme,
 	cmacmev1alpha3.AddToScheme,
 	cmacmev1beta1.AddToScheme,
 	cmacmev1.AddToScheme,

--- a/pkg/controller/ingress-shim/controller.go
+++ b/pkg/controller/ingress-shim/controller.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	cmv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1"
 	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
@@ -122,7 +122,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 }
 
 func (c *controller) certificateDeleted(obj interface{}) {
-	crt, ok := obj.(*cmv1alpha1.Certificate)
+	crt, ok := obj.(*cmapi.Certificate)
 	if !ok {
 		runtime.HandleError(fmt.Errorf("Object is not a certificate object %#v", obj))
 		return


### PR DESCRIPTION
Fixes some lingering references to v1alpha2 in our tests and in some of the import aliases.

Followup to https://github.com/jetstack/cert-manager/pull/3196
Part of https://github.com/jetstack/cert-manager/issues/3156


```release-note
NONE
```

/kind feature