### PR TITLE
Move Venafi Pickup ID annotation key to the external API package

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -127,6 +127,11 @@ const (
 	// The value is an array with objects containing the name and value keys
 	// for example: `[{"name": "custom-field", "value": "custom-value"}]`
 	VenafiCustomFieldsAnnotationKey = "venafi.cert-manager.io/custom-fields"
+
+	// VenafiPickupIDAnnotationKey is the annotation key used to record the
+	// Venafi Pickup ID of a certificate signing request that has been submitted
+	// to the Venafi API for collection later.
+	VenafiPickupIDAnnotationKey = "venafi.cert-manager.io/pickup-id"
 )
 
 // KeyUsage specifies valid usage contexts for keys.

--- a/pkg/controller/certificaterequests/venafi/venafi.go
+++ b/pkg/controller/certificaterequests/venafi/venafi.go
@@ -40,8 +40,7 @@ import (
 )
 
 const (
-	CRControllerName         = "certificaterequests-issuer-venafi"
-	VenafiPickupIDAnnotation = "venafi.cert-manager.io/pickup-id"
+	CRControllerName = "certificaterequests-issuer-venafi"
 )
 
 type Venafi struct {
@@ -109,7 +108,7 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 	}
 
 	duration := apiutil.DefaultCertDuration(cr.Spec.Duration)
-	pickupID := cr.ObjectMeta.Annotations[VenafiPickupIDAnnotation]
+	pickupID := cr.ObjectMeta.Annotations[cmapi.VenafiPickupIDAnnotationKey]
 
 	// check if the pickup ID annotation is there, if not set it up.
 	if pickupID == "" {
@@ -136,7 +135,7 @@ func (v *Venafi) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerO
 
 		v.reporter.Pending(cr, err, "IssuancePending", "Venafi certificate is requested")
 
-		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, VenafiPickupIDAnnotation, pickupID)
+		metav1.SetMetaDataAnnotation(&cr.ObjectMeta, cmapi.VenafiPickupIDAnnotationKey, pickupID)
 
 		return nil, nil
 	}

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -385,7 +385,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate is requested",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -400,7 +400,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate still in a pending state, the request will be retried: Issuance is pending. You may try retrieving the certificate later using Pickup ID: test-cert-id\n\tStatus: test-status-pending",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 				},
@@ -431,7 +431,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate is requested",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -446,7 +446,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate still in a pending state, the request will be retried: Issuance is pending. You may try retrieving the certificate later using Pickup ID: test-cert-id\n\tStatus: test-status-pending",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 				},
@@ -539,7 +539,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate is requested",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -555,7 +555,7 @@ func TestSign(t *testing.T) {
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestCertificate(certPEM),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 				},
@@ -585,7 +585,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate is requested",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -601,7 +601,7 @@ func TestSign(t *testing.T) {
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestCertificate(certPEM),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 				},
@@ -631,7 +631,7 @@ func TestSign(t *testing.T) {
 								Message:            "Venafi certificate is requested",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -647,7 +647,7 @@ func TestSign(t *testing.T) {
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestCertificate(certPEM),
-							gen.AddCertificateRequestAnnotations(map[string]string{VenafiPickupIDAnnotation: "test"}),
+							gen.AddCertificateRequestAnnotations(map[string]string{cmapi.VenafiPickupIDAnnotationKey: "test"}),
 						),
 					)),
 				},
@@ -769,7 +769,7 @@ func runTest(t *testing.T, test testT) {
 
 	if err == nil && test.fakeClient != nil && test.fakeClient.RetrieveCertificateFn != nil && !test.skipSecondSignCall {
 		// request state is ok! simulating a 2nd sync to fetch the cert
-		metav1.SetMetaDataAnnotation(&test.certificateRequest.ObjectMeta, VenafiPickupIDAnnotation, "test")
+		metav1.SetMetaDataAnnotation(&test.certificateRequest.ObjectMeta, cmapi.VenafiPickupIDAnnotationKey, "test")
 		err = controller.Sync(context.Background(), test.certificateRequest)
 	}
 


### PR DESCRIPTION
Fixes https://github.com/jetstack/cert-manager/issues/3159

**Release note**:
```release-note
NONE
```