### PR TITLE
Move ACME label keys to the external API package

### DIFF
--- a/pkg/apis/acme/v1/types.go
+++ b/pkg/apis/acme/v1/types.go
@@ -35,6 +35,18 @@ const (
 	// IngressEditInPlaceAnnotation is used to toggle the use of ingressClass instead
 	// of ingress on the created Certificate resource
 	IngressEditInPlaceAnnotationKey = "acme.cert-manager.io/http01-edit-in-place"
+
+	// DomainLabelKey is added to the labels of a Pod serving an ACME challenge.
+	// Its value will be the hash of the domain name that is being verified.
+	DomainLabelKey = "acme.cert-manager.io/http-domain"
+
+	// TokenLabelKey is added to the labels of a Pod serving an ACME challenge.
+	// Its value will be the hash of the challenge token that is being served by the pod.
+	TokenLabelKey = "acme.cert-manager.io/http-token"
+
+	// SolverIdentificationLabelKey is added to the labels of a Pod serving an ACME challenge.
+	// Its value will be the "true" if the Pod is an HTTP-01 solver.
+	SolverIdentificationLabelKey = "acme.cert-manager.io/http01-solver"
 )
 
 const (

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -31,7 +31,7 @@ import (
 	extv1beta1listers "k8s.io/client-go/listers/extensions/v1beta1"
 
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
-	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
@@ -44,10 +44,6 @@ const (
 	HTTP01Timeout = time.Minute * 15
 	// acmeSolverListenPort is the port acmesolver should listen on
 	acmeSolverListenPort = 8089
-
-	domainLabelKey               = "acme.cert-manager.io/http-domain"
-	tokenLabelKey                = "acme.cert-manager.io/http-token"
-	solverIdentificationLabelKey = "acme.cert-manager.io/http01-solver"
 )
 
 var (

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -451,8 +451,8 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 								IngressTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressTemplate{
 									ACMEChallengeSolverHTTP01IngressObjectMeta: cmacme.ACMEChallengeSolverHTTP01IngressObjectMeta{
 										Labels: map[string]string{
-											"this is a":                        "label",
-											"acme.cert-manager.io/http-domain": "44655555555",
+											"this is a":           "label",
+											cmacme.DomainLabelKey: "44655555555",
 										},
 										Annotations: map[string]string{
 											"nginx.ingress.kubernetes.io/whitelist-source-range":  "0.0.0.0/0,::/0",
@@ -472,10 +472,10 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 					t.Errorf("error preparing test: %v", err)
 				}
 				expectedIngress.Labels = map[string]string{
-					"this is a":                          "label",
-					"acme.cert-manager.io/http-domain":   "44655555555",
-					"acme.cert-manager.io/http-token":    "1",
-					"acme.cert-manager.io/http01-solver": "true",
+					"this is a":                         "label",
+					cmacme.DomainLabelKey:               "44655555555",
+					cmacme.TokenLabelKey:                "1",
+					cmacme.SolverIdentificationLabelKey: "true",
 				}
 				expectedIngress.Annotations = map[string]string{
 					"kubernetes.io/ingress.class":                         "nginx",

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -40,9 +40,9 @@ func podLabels(ch *cmacme.Challenge) map[string]string {
 		// this value should probably be hashed, and then the full plain text
 		// value stored as an annotation to make it easier for users to read
 		// see #425 for details: https://github.com/jetstack/cert-manager/issues/425
-		domainLabelKey:               domainHash,
-		tokenLabelKey:                tokenHash,
-		solverIdentificationLabelKey: solverIdent,
+		cmacme.DomainLabelKey:               domainHash,
+		cmacme.TokenLabelKey:                tokenHash,
+		cmacme.SolverIdentificationLabelKey: solverIdent,
 	}
 }
 

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -276,8 +276,8 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 								PodTemplate: &cmacme.ACMEChallengeSolverHTTP01IngressPodTemplate{
 									ACMEChallengeSolverHTTP01IngressPodObjectMeta: cmacme.ACMEChallengeSolverHTTP01IngressPodObjectMeta{
 										Labels: map[string]string{
-											"this is a":                        "label",
-											"acme.cert-manager.io/http-domain": "44655555555",
+											"this is a":           "label",
+											cmacme.DomainLabelKey: "44655555555",
 										},
 										Annotations: map[string]string{
 											"sidecar.istio.io/inject": "true",
@@ -307,10 +307,10 @@ func TestMergePodObjectMetaWithPodTemplate(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				resultingPod := s.Solver.buildDefaultPod(s.Challenge)
 				resultingPod.Labels = map[string]string{
-					"this is a":                          "label",
-					"acme.cert-manager.io/http-domain":   "44655555555",
-					"acme.cert-manager.io/http-token":    "1",
-					"acme.cert-manager.io/http01-solver": "true",
+					"this is a":                         "label",
+					cmacme.DomainLabelKey:               "44655555555",
+					cmacme.TokenLabelKey:                "1",
+					cmacme.SolverIdentificationLabelKey: "true",
 				}
 				resultingPod.Annotations = map[string]string{
 					"sidecar.istio.io/inject": "true",


### PR DESCRIPTION
Fixes https://github.com/jetstack/cert-manager/issues/3159

**Release note**:
```release-note
NONE
```