### PR TITLE
Add support for alternate certs with PrefferedChain in ACME

### DIFF
--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1107,6 +1110,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2114,6 +2120,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3121,6 +3130,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -103,8 +103,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1111,8 +1112,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2121,8 +2123,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3131,8 +3134,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -103,8 +103,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1125,8 +1126,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2149,8 +2151,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3173,8 +3176,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1121,6 +1124,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2142,6 +2148,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3163,6 +3172,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1107,6 +1110,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2114,6 +2120,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3121,6 +3130,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -103,8 +103,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1111,8 +1112,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2121,8 +2123,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3131,8 +3134,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -103,8 +103,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1125,8 +1126,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2149,8 +2151,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3173,8 +3176,9 @@ spec:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
                     preferredChain:
-                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA. This value picks the first certificate bundle in the ACME alternative chains that has a certificate with this value as its issuer''s CN'
                       type: string
+                      maxLength: 64
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -102,6 +102,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -1121,6 +1124,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -2142,6 +2148,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object
@@ -3163,6 +3172,9 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                    preferredChain:
+                      description: 'PreferredChain is the chain to use if the ACME server outputs multiple. PreferredChain is no guarantee that this one gets delivered by the ACME endpoint. For example, for Let''s Encrypt''s DST crosssign you would use: "DST Root CA X3" or "ISRG Root X1" for the newer Let''s Encrypt root CA.'
+                      type: string
                     privateKeySecretRef:
                       description: PrivateKey is the name of a Kubernetes Secret resource that will be used to store the automatically generated ACME account private key. Optionally, a `key` may be specified to select a specific entry within the named Secret resource. If `key` is not specified, a default of `tls.key` will be used.
                       type: object

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,8 @@ module github.com/jetstack/cert-manager
 go 1.12
 
 replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.4
-
+// this if a fork to add EAB and alternative chains in ACME
+// to be replaced after https://github.com/golang/crypto/pull/109 merges
 replace golang.org/x/crypto => github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jetstack/cert-manager
 go 1.12
 
 replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.4
+
 // this if a fork to add EAB and alternative chains in ACME
 // to be replaced after https://github.com/golang/crypto/pull/109 merges
 replace golang.org/x/crypto => github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.12
 
 replace github.com/prometheus/client_golang => github.com/prometheus/client_golang v0.9.4
 
-replace golang.org/x/crypto => github.com/munnerz/crypto v0.0.0-20191203200931-e1844778daa5
+replace golang.org/x/crypto => github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0
 
 require (
 	github.com/Azure/azure-sdk-for-go v32.5.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -357,6 +357,8 @@ github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
+github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0 h1:09XQpCKCNW3zrjz4zvD/cYU3hqUEWW+bZrBwK8NwFW0=
+github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0/go.mod h1:ihkquczjM7M0cZsn7H1TJ3ACXW1rCuAMKX9lZEWNU3U=
 github.com/miekg/dns v1.1.29 h1:xHBEhR+t5RzcFJjBLJlax2daXOrTYtr9z4WdKEfWFzg=
 github.com/miekg/dns v1.1.29/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
@@ -378,8 +380,6 @@ github.com/modern-go/reflect2 v1.0.1 h1:9f412s+6RmYXLWZSEzVVgPGK7C2PphHj5RJrvfx9
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/munnerz/crd-schema-fuzz v1.0.0 h1:8erI9yzEnOGw9K5O+a8zZdoo8N/OwrFi7c7SjBtkHAs=
 github.com/munnerz/crd-schema-fuzz v1.0.0/go.mod h1:4z/rcm37JxUkSsExFcLL6ZIT1SgDRdLiu7qq1evdVS0=
-github.com/munnerz/crypto v0.0.0-20191203200931-e1844778daa5 h1:hzR/iusv78rQSxebvSpz0olAoNmGbJrE42oeKFQ+Ni8=
-github.com/munnerz/crypto v0.0.0-20191203200931-e1844778daa5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq1c1nUAm88MOHcQC9l5mIlSMApZMrHA=
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=

--- a/hack/build/repos.bzl
+++ b/hack/build/repos.bzl
@@ -1967,9 +1967,9 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/crypto",
-        replace = "github.com/munnerz/crypto",
-        sum = "h1:hzR/iusv78rQSxebvSpz0olAoNmGbJrE42oeKFQ+Ni8=",
-        version = "v0.0.0-20191203200931-e1844778daa5",
+        replace = "github.com/meyskens/crypto",
+        sum = "h1:09XQpCKCNW3zrjz4zvD/cYU3hqUEWW+bZrBwK8NwFW0=",
+        version = "v0.0.0-20200821143559-6ca9aec645f0",
     )
     go_repository(
         name = "org_golang_x_exp",

--- a/pkg/acme/client/fake.go
+++ b/pkg/acme/client/fake.go
@@ -31,6 +31,7 @@ type FakeACME struct {
 	FakeAuthorizeOrder          func(ctx context.Context, id []acme.AuthzID, opt ...acme.OrderOption) (*acme.Order, error)
 	FakeGetOrder                func(ctx context.Context, url string) (*acme.Order, error)
 	FakeFetchCert               func(ctx context.Context, url string, bundle bool) ([][]byte, error)
+	FakeFetchCertAlternatives   func(ctx context.Context, url string, bundle bool) ([][][]byte, error)
 	FakeWaitOrder               func(ctx context.Context, url string) (*acme.Order, error)
 	FakeCreateOrderCert         func(ctx context.Context, finalizeURL string, csr []byte, bundle bool) (der [][]byte, certURL string, err error)
 	FakeAccept                  func(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error)
@@ -66,6 +67,14 @@ func (f *FakeACME) FetchCert(ctx context.Context, url string, bundle bool) ([][]
 		return f.FakeFetchCert(ctx, url, bundle)
 	}
 	return nil, fmt.Errorf("FetchCert not implemented")
+}
+
+func (f *FakeACME) FetchCertAlternatives(ctx context.Context, url string, bundle bool) ([][][]byte, error) {
+	//TODO: make actual fake
+	if f.FakeFetchCertAlternatives != nil {
+		return f.FakeFetchCertAlternatives(ctx, url, bundle)
+	}
+	return nil, fmt.Errorf("FetchCertAlternatives not implemented")
 }
 
 func (f *FakeACME) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {

--- a/pkg/acme/client/interfaces.go
+++ b/pkg/acme/client/interfaces.go
@@ -26,6 +26,7 @@ type Interface interface {
 	AuthorizeOrder(ctx context.Context, id []acme.AuthzID, opt ...acme.OrderOption) (*acme.Order, error)
 	GetOrder(ctx context.Context, url string) (*acme.Order, error)
 	FetchCert(ctx context.Context, url string, bundle bool) ([][]byte, error)
+	FetchCertAlternatives(ctx context.Context, url string, bundle bool) ([][][]byte, error)
 	WaitOrder(ctx context.Context, url string) (*acme.Order, error)
 	CreateOrderCert(ctx context.Context, finalizeURL string, csr []byte, bundle bool) (der [][]byte, certURL string, err error)
 	Accept(ctx context.Context, chal *acme.Challenge) (*acme.Challenge, error)

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -73,7 +73,7 @@ func (l *Logger) FetchCert(ctx context.Context, url string, bundle bool) ([][]by
 	return l.baseCl.FetchCert(ctx, url, bundle)
 }
 
-func (l *Logger) FetchCertAlternatives(ctx context.Context, url string, bundle bool) ([][]byte, error) {
+func (l *Logger) FetchCertAlternatives(ctx context.Context, url string, bundle bool) ([][][]byte, error) {
 	l.log.V(logf.TraceLevel).Info("Calling FetchCertAlternatives")
 
 	ctx, cancel := context.WithTimeout(ctx, timeout)

--- a/pkg/acme/client/middleware/logger.go
+++ b/pkg/acme/client/middleware/logger.go
@@ -73,6 +73,15 @@ func (l *Logger) FetchCert(ctx context.Context, url string, bundle bool) ([][]by
 	return l.baseCl.FetchCert(ctx, url, bundle)
 }
 
+func (l *Logger) FetchCertAlternatives(ctx context.Context, url string, bundle bool) ([][]byte, error) {
+	l.log.V(logf.TraceLevel).Info("Calling FetchCertAlternatives")
+
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return l.baseCl.FetchCertAlternatives(ctx, url, bundle)
+}
+
 func (l *Logger) WaitOrder(ctx context.Context, url string) (*acme.Order, error) {
 	l.log.V(logf.TraceLevel).Info("Calling WaitOrder")
 

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -47,7 +47,10 @@ type ACMEIssuer struct {
 	// endpoint.
 	// For example, for Let's Encrypt's DST crosssign you would use:
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// This value picks the first certificate bundle in the ACME alternative
+	// chains that has a certificate with this value as its issuer's CN
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	PreferredChain string `json:"preferredChain"`
 
 	// Enables or disables validation of the ACME server TLS certificate.

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -42,6 +42,14 @@ type ACMEIssuer struct {
 	// Only ACME v2 endpoints (i.e. RFC 8555) are supported.
 	Server string `json:"server"`
 
+	// PreferredChain is the chain to use if the ACME server outputs multiple.
+	// PreferredChain is no guarantee that this one gets delivered by the ACME
+	// endpoint.
+	// For example, for Let's Encrypt's DST crosssign you would use:
+	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// +optional
+	PreferredChain string `json:"preferredChain"`
+
 	// Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have their TLS certificate
 	// validated (i.e. insecure connections will be allowed).

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -47,7 +47,10 @@ type ACMEIssuer struct {
 	// endpoint.
 	// For example, for Let's Encrypt's DST crosssign you would use:
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// This value picks the first certificate bundle in the ACME alternative
+	// chains that has a certificate with this value as its issuer's CN
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	PreferredChain string `json:"preferredChain"`
 
 	// Enables or disables validation of the ACME server TLS certificate.

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -42,6 +42,14 @@ type ACMEIssuer struct {
 	// Only ACME v2 endpoints (i.e. RFC 8555) are supported.
 	Server string `json:"server"`
 
+	// PreferredChain is the chain to use if the ACME server outputs multiple.
+	// PreferredChain is no guarantee that this one gets delivered by the ACME
+	// endpoint.
+	// For example, for Let's Encrypt's DST crosssign you would use:
+	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// +optional
+	PreferredChain string `json:"preferredChain"`
+
 	// Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have their TLS certificate
 	// validated (i.e. insecure connections will be allowed).

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -47,7 +47,10 @@ type ACMEIssuer struct {
 	// endpoint.
 	// For example, for Let's Encrypt's DST crosssign you would use:
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// This value picks the first certificate bundle in the ACME alternative
+	// chains that has a certificate with this value as its issuer's CN
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	PreferredChain string `json:"preferredChain"`
 
 	// Enables or disables validation of the ACME server TLS certificate.

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -42,6 +42,14 @@ type ACMEIssuer struct {
 	// Only ACME v2 endpoints (i.e. RFC 8555) are supported.
 	Server string `json:"server"`
 
+	// PreferredChain is the chain to use if the ACME server outputs multiple.
+	// PreferredChain is no guarantee that this one gets delivered by the ACME
+	// endpoint.
+	// For example, for Let's Encrypt's DST crosssign you would use:
+	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// +optional
+	PreferredChain string `json:"preferredChain"`
+
 	// Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have their TLS certificate
 	// validated (i.e. insecure connections will be allowed).

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -47,7 +47,10 @@ type ACMEIssuer struct {
 	// endpoint.
 	// For example, for Let's Encrypt's DST crosssign you would use:
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// This value picks the first certificate bundle in the ACME alternative
+	// chains that has a certificate with this value as its issuer's CN
 	// +optional
+	// +kubebuilder:validation:MaxLength=64
 	PreferredChain string `json:"preferredChain"`
 
 	// Enables or disables validation of the ACME server TLS certificate.

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -42,6 +42,14 @@ type ACMEIssuer struct {
 	// Only ACME v2 endpoints (i.e. RFC 8555) are supported.
 	Server string `json:"server"`
 
+	// PreferredChain is the chain to use if the ACME server outputs multiple.
+	// PreferredChain is no guarantee that this one gets delivered by the ACME
+	// endpoint.
+	// For example, for Let's Encrypt's DST crosssign you would use:
+	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	// +optional
+	PreferredChain string `json:"preferredChain"`
+
 	// Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have their TLS certificate
 	// validated (i.e. insecure connections will be allowed).

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -477,7 +477,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 						return nil, errors.New("Cert URL is incorrect")
 					}
 
-					return [][][]byte{[][]byte{rawTestCert.Bytes}}, nil
+					return [][][]byte{{rawTestCert.Bytes}}, nil
 				},
 				FakeHTTP01ChallengeResponse: func(s string) (string, error) {
 					// TODO: assert s = "token"

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -41,6 +41,13 @@ type ACMEIssuer struct {
 	// Only ACME v2 endpoints (i.e. RFC 8555) are supported.
 	Server string
 
+	// PreferredChain is the chain to use if the ACME server outputs multiple.
+	// PreferredChain is no guarantee that this one gets delivered by the ACME
+	// endpoint.
+	// For example, for Let's Encrypt's DST crosssign you would use:
+	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
+	PreferredChain string `json:"preferredChain"`
+
 	// Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have their TLS certificate
 	// validated (i.e. insecure connections will be allowed).

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -685,6 +685,7 @@ func Convert_acme_ACMEExternalAccountBinding_To_v1_ACMEExternalAccountBinding(in
 func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*acme.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?
@@ -703,6 +704,7 @@ func Convert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.ACMEI
 func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*v1.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -685,6 +685,7 @@ func Convert_acme_ACMEExternalAccountBinding_To_v1alpha2_ACMEExternalAccountBind
 func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer, out *acme.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*acme.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?
@@ -703,6 +704,7 @@ func Convert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer, out
 func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out *v1alpha2.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*v1alpha2.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -685,6 +685,7 @@ func Convert_acme_ACMEExternalAccountBinding_To_v1alpha3_ACMEExternalAccountBind
 func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer, out *acme.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*acme.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?
@@ -703,6 +704,7 @@ func Convert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer, out
 func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out *v1alpha3.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*v1alpha3.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -685,6 +685,7 @@ func Convert_acme_ACMEExternalAccountBinding_To_v1beta1_ACMEExternalAccountBindi
 func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, out *acme.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*acme.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?
@@ -703,6 +704,7 @@ func Convert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, out *
 func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out *v1beta1.ACMEIssuer, s conversion.Scope) error {
 	out.Email = in.Email
 	out.Server = in.Server
+	out.PreferredChain = in.PreferredChain
 	out.SkipTLSVerify = in.SkipTLSVerify
 	out.ExternalAccountBinding = (*v1beta1.ACMEExternalAccountBinding)(unsafe.Pointer(in.ExternalAccountBinding))
 	// TODO: Inefficient conversion - can we improve it?


### PR DESCRIPTION
**What this PR does / why we need it**:

The ACME API now allows for alternate certificates being fetched signed by different CAs. Let's Encrypt does this by serving both their cross signed and own CA root certificates. We currently do not support specifying a preference for one. 
certbot recently added support for this with the upcoming switch to the ISRG CA, they added:

```
  --preferred-chain PREFERRED_CHAIN
                        If the CA offers multiple certificate chains, prefer
                        the chain with an issuer matching this Subject Common
                        Name. If no match, the default offered chain will be
```

This PR adds similar behavior to cert-manager, while I didn't look at the exact checks it does and error handling it seems I wrote the exact dame thing :smiley_cat: 


**Which issue this PR fixes**:
Fixes https://github.com/jetstack/cert-manager/issues/1700

**Special notes for your reviewer**:
* Please also look at my fork of the Go library, we should make an upstream PR just like we did with EAB (not yet merged...)

* ~~Needs unit and e2e tests, thus WIP~~

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add support for alternate certs with `prefferedChain` in ACME
```
