### PR TITLE
Extended key usages into CSR

### DIFF
--- a/deploy/crds/crd-certificaterequests.v1beta1.yaml
+++ b/deploy/crds/crd-certificaterequests.v1beta1.yaml
@@ -474,7 +474,7 @@ spec:
                   type: string
                   format: byte
                 usages:
-                  description: Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.
+                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they should be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
                   type: array
                   items:
                     description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'

--- a/deploy/crds/crd-certificaterequests.v1beta1.yaml
+++ b/deploy/crds/crd-certificaterequests.v1beta1.yaml
@@ -474,7 +474,7 @@ spec:
                   type: string
                   format: byte
                 usages:
-                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they should be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
+                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
                   type: array
                   items:
                     description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'

--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -528,7 +528,7 @@ spec:
                   type: string
                   format: byte
                 usages:
-                  description: Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.
+                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they should be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
                   type: array
                   items:
                     description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'

--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -528,7 +528,7 @@ spec:
                   type: string
                   format: byte
                 usages:
-                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they should be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
+                  description: Usages is the set of x509 usages that are requested for the certificate. If usages are set they SHOULD be encoded inside the CSR spec Defaults to `digital signature` and `key encipherment` if not specified.
                   type: array
                   items:
                     description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -98,6 +98,7 @@ type CertificateRequestSpec struct {
 	IsCA bool `json:"isCA,omitempty"`
 
 	// Usages is the set of x509 usages that are requested for the certificate.
+	// If usages are set they should be encoded inside the CSR spec
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional
 	Usages []KeyUsage `json:"usages,omitempty"`

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -98,7 +98,7 @@ type CertificateRequestSpec struct {
 	IsCA bool `json:"isCA,omitempty"`
 
 	// Usages is the set of x509 usages that are requested for the certificate.
-	// If usages are set they should be encoded inside the CSR spec
+	// If usages are set they SHOULD be encoded inside the CSR spec
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional
 	Usages []KeyUsage `json:"usages,omitempty"`

--- a/pkg/internal/apis/certmanager/validation/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/validation/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/internal/apis/certmanager:go_default_library",
         "//pkg/internal/apis/certmanager/validation/util:go_default_library",
         "//pkg/internal/apis/meta:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/pki:go_default_library",
         "@com_github_kr_pretty//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/pkg/internal/apis/certmanager/validation/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/validation/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/internal/apis/certmanager/validation/util:go_default_library",
         "//pkg/internal/apis/meta:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "@com_github_kr_pretty//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -87,6 +87,12 @@ func ValidateCertificate(obj runtime.Object) field.ErrorList {
 	return allErrs
 }
 
+func ValidateUpdateCertificate(oldObj, obj runtime.Object) field.ErrorList {
+	crt := obj.(*internalcmapi.Certificate)
+	allErrs := ValidateCertificateSpec(&crt.Spec, field.NewPath("spec"))
+	return allErrs
+}
+
 func validateIssuerRef(issuerRef cmmeta.ObjectReference, fldPath *field.Path) field.ErrorList {
 	el := field.ErrorList{}
 

--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -20,13 +20,14 @@ import (
 	"crypto/x509"
 	"encoding/asn1"
 	"fmt"
-	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/kr/pretty"
 	"reflect"
+
+	"github.com/kr/pretty"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmapi "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager"
 	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
@@ -73,7 +74,7 @@ func getCSRKeyUsage(crSpec *cmapi.CertificateRequestSpec, fldPath *field.Path, c
 			var asn1ExtendedUsages []asn1.ObjectIdentifier
 			_, err = asn1.Unmarshal(extention.Value, &asn1ExtendedUsages)
 			if err != nil {
-				el = append(el, field.Invalid(fldPath.Child("request"), crSpec.Request, fmt.Sprintf("failed to decode csr extended usages: %s", err)
+				el = append(el, field.Invalid(fldPath.Child("request"), crSpec.Request, fmt.Sprintf("failed to decode csr extended usages: %s", err)))
 			} else {
 				for _, asnExtUsage := range asn1ExtendedUsages {
 					eku, ok := pki.ExtKeyUsageFromOID(asnExtUsage)

--- a/pkg/internal/apis/certmanager/validation/clusterissuer.go
+++ b/pkg/internal/apis/certmanager/validation/clusterissuer.go
@@ -30,3 +30,9 @@ func ValidateClusterIssuer(obj runtime.Object) field.ErrorList {
 	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
 	return allErrs
 }
+
+func ValidateUpdateClusterIssuer(oldObj, obj runtime.Object) field.ErrorList {
+	iss := obj.(*cmapi.ClusterIssuer)
+	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
+	return allErrs
+}

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -39,6 +39,12 @@ func ValidateIssuer(obj runtime.Object) field.ErrorList {
 	return allErrs
 }
 
+func ValidateUpdateIssuer(oldObj, obj runtime.Object) field.ErrorList {
+	iss := obj.(*certmanager.Issuer)
+	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
+	return allErrs
+}
+
 func ValidateIssuerSpec(iss *certmanager.IssuerSpec, fldPath *field.Path) field.ErrorList {
 	return ValidateIssuerConfig(&iss.IssuerConfig, fldPath)
 }

--- a/pkg/internal/apis/certmanager/validation/register.go
+++ b/pkg/internal/apis/certmanager/validation/register.go
@@ -25,13 +25,28 @@ func AddToValidationRegistry(reg *validation.Registry) error {
 	if err := reg.AddValidateFunc(&cmapi.Certificate{}, ValidateCertificate); err != nil {
 		return err
 	}
+	if err := reg.AddValidateUpdateFunc(&cmapi.Certificate{}, ValidateUpdateCertificate); err != nil {
+		return err
+	}
+
 	if err := reg.AddValidateFunc(&cmapi.CertificateRequest{}, ValidateCertificateRequest); err != nil {
 		return err
 	}
+	if err := reg.AddValidateUpdateFunc(&cmapi.CertificateRequest{}, ValidateUpdateCertificateRequest); err != nil {
+		return err
+	}
+
 	if err := reg.AddValidateFunc(&cmapi.ClusterIssuer{}, ValidateClusterIssuer); err != nil {
 		return err
 	}
+	if err := reg.AddValidateUpdateFunc(&cmapi.ClusterIssuer{}, ValidateUpdateClusterIssuer); err != nil {
+		return err
+	}
+
 	if err := reg.AddValidateFunc(&cmapi.Issuer{}, ValidateIssuer); err != nil {
+		return err
+	}
+	if err := reg.AddValidateUpdateFunc(&cmapi.Issuer{}, ValidateUpdateIssuer); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/util/pki/BUILD.bazel
+++ b/pkg/util/pki/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "csr.go",
         "generate.go",
+        "keyusage.go",
         "parse.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/util/pki",

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -166,6 +166,13 @@ func BuildKeyUsages(usages []v1.KeyUsage, isCA bool) (ku x509.KeyUsage, eku []x5
 	return
 }
 
+func BuildCertManagerKeyUsages(ku x509.KeyUsage, eku []x509.ExtKeyUsage) []v1.KeyUsage {
+	usages := apiutil.KeyUsageStrings(ku)
+	usages = append(usages, apiutil.ExtKeyUsageStrings(eku)...)
+
+	return usages
+}
+
 // GenerateCSR will generate a new *x509.CertificateRequest template to be used
 // by issuers that utilise CSRs to obtain Certificates.
 // The CSR will not be signed, and should be passed to either EncodeCSR or
@@ -207,7 +214,7 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 		}
 	}
 	extendedUsage := pkix.Extension{
-		Id: oidExtensionExtendedKeyUsage,
+		Id: OIDExtensionExtendedKeyUsage,
 	}
 	extendedUsage.Value, err = asn1.Marshal(asn1ExtendedUsages)
 	if err != nil {

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -202,13 +202,13 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 		return nil, err
 	}
 
-	ku, eku, err := BuildKeyUsages(crt.Spec.Usages, crt.Spec.IsCA)
-	usage, err := buildANS1KeyUsageRequest(ku)
+	ku, ekus, err := BuildKeyUsages(crt.Spec.Usages, crt.Spec.IsCA)
+	usage, err := buildASN1KeyUsageRequest(ku)
 	if err != nil {
 		return nil, fmt.Errorf("failed to asn1 encode usages: %w", err)
 	}
 	asn1ExtendedUsages := []asn1.ObjectIdentifier{}
-	for _, eku := range eku {
+	for _, eku := range ekus {
 		if oid, ok := OIDFromExtKeyUsage(eku); ok {
 			asn1ExtendedUsages = append(asn1ExtendedUsages, oid)
 		}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -23,13 +23,13 @@ import (
 	"reflect"
 	"testing"
 
-	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/jetstack/cert-manager/pkg/util"
 )
 
-func buildCertificate(cn string, dnsNames ...string) *v1.Certificate {
-	return &v1.Certificate{
-		Spec: v1.CertificateSpec{
+func buildCertificate(cn string, dnsNames ...string) *cmapi.Certificate {
+	return &cmapi.Certificate{
+		Spec: cmapi.CertificateSpec{
 			CommonName: cn,
 			DNSNames:   dnsNames,
 		},
@@ -39,7 +39,7 @@ func buildCertificate(cn string, dnsNames ...string) *v1.Certificate {
 func TestBuildUsages(t *testing.T) {
 	type testT struct {
 		name                string
-		usages              []v1.KeyUsage
+		usages              []cmapi.KeyUsage
 		isCa                bool
 		expectedKeyUsage    x509.KeyUsage
 		expectedExtKeyUsage []x509.ExtKeyUsage
@@ -48,43 +48,43 @@ func TestBuildUsages(t *testing.T) {
 	tests := []testT{
 		{
 			name:             "default",
-			usages:           []v1.KeyUsage{},
+			usages:           []cmapi.KeyUsage{},
 			expectedKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
 			expectedError:    false,
 		},
 		{
 			name:             "isCa",
-			usages:           []v1.KeyUsage{},
+			usages:           []cmapi.KeyUsage{},
 			isCa:             true,
 			expectedKeyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment | x509.KeyUsageCertSign,
 			expectedError:    false,
 		},
 		{
 			name:             "existing keyusage",
-			usages:           []v1.KeyUsage{"crl sign"},
+			usages:           []cmapi.KeyUsage{"crl sign"},
 			expectedKeyUsage: x509.KeyUsageCRLSign,
 			expectedError:    false,
 		},
 		{
 			name:          "nonexisting keyusage error",
-			usages:        []v1.KeyUsage{"nonexistant"},
+			usages:        []cmapi.KeyUsage{"nonexistant"},
 			expectedError: true,
 		},
 		{
 			name:             "duplicate keyusage",
-			usages:           []v1.KeyUsage{"signing", "signing"},
+			usages:           []cmapi.KeyUsage{"signing", "signing"},
 			expectedKeyUsage: x509.KeyUsageDigitalSignature,
 			expectedError:    false,
 		},
 		{
 			name:                "existing extkeyusage",
-			usages:              []v1.KeyUsage{"server auth"},
+			usages:              []cmapi.KeyUsage{"server auth"},
 			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
 			expectedError:       false,
 		},
 		{
 			name:                "duplicate extkeyusage",
-			usages:              []v1.KeyUsage{"s/mime", "s/mime"},
+			usages:              []cmapi.KeyUsage{"s/mime", "s/mime"},
 			expectedExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageEmailProtection, x509.ExtKeyUsageEmailProtection},
 			expectedError:       false,
 		},
@@ -220,7 +220,7 @@ func TestDNSNamesForCertificate(t *testing.T) {
 func TestSignatureAlgorithmForCertificate(t *testing.T) {
 	type testT struct {
 		name            string
-		keyAlgo         v1.PrivateKeyAlgorithm
+		keyAlgo         cmapi.PrivateKeyAlgorithm
 		keySize         int
 		expectErr       bool
 		expectedSigAlgo x509.SignatureAlgorithm
@@ -230,79 +230,79 @@ func TestSignatureAlgorithmForCertificate(t *testing.T) {
 	tests := []testT{
 		{
 			name:      "certificate with KeyAlgorithm rsa and size 1024",
-			keyAlgo:   v1.RSAKeyAlgorithm,
+			keyAlgo:   cmapi.RSAKeyAlgorithm,
 			keySize:   1024,
 			expectErr: true,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and no size set should default to rsa256",
-			keyAlgo:         v1.RSAKeyAlgorithm,
+			keyAlgo:         cmapi.RSAKeyAlgorithm,
 			expectedSigAlgo: x509.SHA256WithRSA,
 			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm not set",
-			keyAlgo:         v1.PrivateKeyAlgorithm(""),
+			keyAlgo:         cmapi.PrivateKeyAlgorithm(""),
 			expectedSigAlgo: x509.SHA256WithRSA,
 			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and size 2048",
-			keyAlgo:         v1.RSAKeyAlgorithm,
+			keyAlgo:         cmapi.RSAKeyAlgorithm,
 			keySize:         2048,
 			expectedSigAlgo: x509.SHA256WithRSA,
 			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and size 3072",
-			keyAlgo:         v1.RSAKeyAlgorithm,
+			keyAlgo:         cmapi.RSAKeyAlgorithm,
 			keySize:         3072,
 			expectedSigAlgo: x509.SHA384WithRSA,
 			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm rsa and size 4096",
-			keyAlgo:         v1.RSAKeyAlgorithm,
+			keyAlgo:         cmapi.RSAKeyAlgorithm,
 			keySize:         4096,
 			expectedSigAlgo: x509.SHA512WithRSA,
 			expectedKeyType: x509.RSA,
 		},
 		{
 			name:            "certificate with ecdsa key algorithm set and no key size default to ecdsa256",
-			keyAlgo:         v1.ECDSAKeyAlgorithm,
+			keyAlgo:         cmapi.ECDSAKeyAlgorithm,
 			expectedSigAlgo: x509.ECDSAWithSHA256,
 			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 256",
-			keyAlgo:         v1.ECDSAKeyAlgorithm,
+			keyAlgo:         cmapi.ECDSAKeyAlgorithm,
 			keySize:         256,
 			expectedSigAlgo: x509.ECDSAWithSHA256,
 			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 384",
-			keyAlgo:         v1.ECDSAKeyAlgorithm,
+			keyAlgo:         cmapi.ECDSAKeyAlgorithm,
 			keySize:         384,
 			expectedSigAlgo: x509.ECDSAWithSHA384,
 			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:            "certificate with KeyAlgorithm ecdsa and size 521",
-			keyAlgo:         v1.ECDSAKeyAlgorithm,
+			keyAlgo:         cmapi.ECDSAKeyAlgorithm,
 			keySize:         521,
 			expectedSigAlgo: x509.ECDSAWithSHA512,
 			expectedKeyType: x509.ECDSA,
 		},
 		{
 			name:      "certificate with KeyAlgorithm ecdsa and size 100",
-			keyAlgo:   v1.ECDSAKeyAlgorithm,
+			keyAlgo:   cmapi.ECDSAKeyAlgorithm,
 			keySize:   100,
 			expectErr: true,
 		},
 		{
 			name:      "certificate with KeyAlgorithm set to unknown key algo",
-			keyAlgo:   v1.PrivateKeyAlgorithm("blah"),
+			keyAlgo:   cmapi.PrivateKeyAlgorithm("blah"),
 			expectErr: true,
 		},
 	}
@@ -373,12 +373,13 @@ func TestRemoveDuplicates(t *testing.T) {
 }
 
 func TestGenerateCSR(t *testing.T) {
+	// 0xa0 = DigitalSignature and Encipherment usage
 	asn1KeyUsage, err := asn1.Marshal(asn1.BitString{Bytes: []byte{0xa0}, BitLength: asn1BitLength([]byte{0xa0})})
 	asn1ExtKeyUsage, err := asn1.Marshal([]asn1.ObjectIdentifier{})
 	if err != nil {
 		t.Fatal(err)
 	}
-	dafaultExtraExtensions := []pkix.Extension{
+	defaultExtraExtensions := []pkix.Extension{
 		{
 			Id:    OIDExtensionKeyUsage,
 			Value: asn1KeyUsage,
@@ -406,33 +407,33 @@ func TestGenerateCSR(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		crt     *v1.Certificate
+		crt     *cmapi.Certificate
 		want    *x509.CertificateRequest
 		wantErr bool
 	}{
 		{
 			name: "Generate CSR from certificate with only DNS",
-			crt:  &v1.Certificate{Spec: v1.CertificateSpec{DNSNames: []string{"example.org"}}},
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{DNSNames: []string{"example.org"}}},
 			want: &x509.CertificateRequest{Version: 3,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
 				DNSNames:           []string{"example.org"},
-				ExtraExtensions:    dafaultExtraExtensions,
+				ExtraExtensions:    defaultExtraExtensions,
 			},
 		},
 		{
 			name: "Generate CSR from certificate with only CN",
-			crt:  &v1.Certificate{Spec: v1.CertificateSpec{CommonName: "example.org"}},
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org"}},
 			want: &x509.CertificateRequest{Version: 3,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
 				Subject:            pkix.Name{CommonName: "example.org"},
-				ExtraExtensions:    dafaultExtraExtensions,
+				ExtraExtensions:    defaultExtraExtensions,
 			},
 		},
 		{
 			name: "Generate CSR from certificate with extended key usages",
-			crt:  &v1.Certificate{Spec: v1.CertificateSpec{CommonName: "example.org", Usages: []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageIPsecEndSystem}}},
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", Usages: []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageIPsecEndSystem}}},
 			want: &x509.CertificateRequest{Version: 3,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
@@ -442,7 +443,7 @@ func TestGenerateCSR(t *testing.T) {
 		},
 		{
 			name:    "Error on generating CSR from certificate with no subject",
-			crt:     &v1.Certificate{Spec: v1.CertificateSpec{}},
+			crt:     &cmapi.Certificate{Spec: cmapi.CertificateSpec{}},
 			wantErr: true,
 		},
 	}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -373,25 +373,34 @@ func TestRemoveDuplicates(t *testing.T) {
 }
 
 func TestGenerateCSR(t *testing.T) {
-	asn1Value, err := asn1.Marshal([]asn1.ObjectIdentifier{})
+	asn1KeyUsage, err := asn1.Marshal(asn1.BitString{Bytes: []byte{0xa0}, BitLength: asn1BitLength([]byte{0xa0})})
+	asn1ExtKeyUsage, err := asn1.Marshal([]asn1.ObjectIdentifier{})
 	if err != nil {
 		t.Fatal(err)
 	}
 	dafaultExtraExtensions := []pkix.Extension{
 		{
+			Id:    oidExtensionKeyUsage,
+			Value: asn1KeyUsage,
+		},
+		{
 			Id:    oidExtensionExtendedKeyUsage,
-			Value: asn1Value,
+			Value: asn1ExtKeyUsage,
 		},
 	}
 
-	asn1Value, err = asn1.Marshal([]asn1.ObjectIdentifier{oidExtKeyUsageIPSECEndSystem})
+	asn1ExtKeyUsage, err = asn1.Marshal([]asn1.ObjectIdentifier{oidExtKeyUsageIPSECEndSystem})
 	if err != nil {
 		t.Fatal(err)
 	}
 	ipsecExtraExtensions := []pkix.Extension{
 		{
+			Id:    oidExtensionKeyUsage,
+			Value: asn1KeyUsage,
+		},
+		{
 			Id:    oidExtensionExtendedKeyUsage,
-			Value: asn1Value,
+			Value: asn1ExtKeyUsage,
 		},
 	}
 
@@ -423,7 +432,7 @@ func TestGenerateCSR(t *testing.T) {
 		},
 		{
 			name: "Generate CSR from certificate with extended key usages",
-			crt:  &v1.Certificate{Spec: v1.CertificateSpec{CommonName: "example.org", Usages: []v1.KeyUsage{v1.UsageIPsecEndSystem}}},
+			crt:  &v1.Certificate{Spec: v1.CertificateSpec{CommonName: "example.org", Usages: []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageIPsecEndSystem}}},
 			want: &x509.CertificateRequest{Version: 3,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -380,11 +380,11 @@ func TestGenerateCSR(t *testing.T) {
 	}
 	dafaultExtraExtensions := []pkix.Extension{
 		{
-			Id:    oidExtensionKeyUsage,
+			Id:    OIDExtensionKeyUsage,
 			Value: asn1KeyUsage,
 		},
 		{
-			Id:    oidExtensionExtendedKeyUsage,
+			Id:    OIDExtensionExtendedKeyUsage,
 			Value: asn1ExtKeyUsage,
 		},
 	}
@@ -395,11 +395,11 @@ func TestGenerateCSR(t *testing.T) {
 	}
 	ipsecExtraExtensions := []pkix.Extension{
 		{
-			Id:    oidExtensionKeyUsage,
+			Id:    OIDExtensionKeyUsage,
 			Value: asn1KeyUsage,
 		},
 		{
-			Id:    oidExtensionExtendedKeyUsage,
+			Id:    OIDExtensionExtendedKeyUsage,
 			Value: asn1ExtKeyUsage,
 		},
 	}

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -239,7 +239,7 @@ func signTestCert(key crypto.Signer) *x509.Certificate {
 		SerialNumber:          serialNumber,
 		SignatureAlgorithm:    x509.SHA256WithRSA,
 		Subject: pkix.Name{
-			Organization: []string{defaultOrganization},
+			Organization: []string{"cert-manager"},
 			CommonName:   commonName,
 		},
 		NotBefore: time.Now(),

--- a/pkg/util/pki/keyusage.go
+++ b/pkg/util/pki/keyusage.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package pki
 
 import (

--- a/pkg/util/pki/keyusage.go
+++ b/pkg/util/pki/keyusage.go
@@ -24,8 +24,8 @@ import (
 
 // Copied from x509.go
 var (
-	oidExtensionKeyUsage         = []int{2, 5, 29, 15}
-	oidExtensionExtendedKeyUsage = []int{2, 5, 29, 37}
+	OIDExtensionKeyUsage         = []int{2, 5, 29, 15}
+	OIDExtensionExtendedKeyUsage = []int{2, 5, 29, 37}
 )
 
 // RFC 5280, 4.2.1.12  Extended Key Usage
@@ -88,6 +88,15 @@ func OIDFromExtKeyUsage(eku x509.ExtKeyUsage) (oid asn1.ObjectIdentifier, ok boo
 	return
 }
 
+func ExtKeyUsageFromOID(oid asn1.ObjectIdentifier) (eku x509.ExtKeyUsage, ok bool) {
+	for _, pair := range extKeyUsageOIDs {
+		if oid.Equal(pair.oid) {
+			return pair.extKeyUsage, true
+		}
+	}
+	return
+}
+
 // asn1BitLength returns the bit-length of bitString by considering the
 // most-significant bit in a byte to be the "first" bit. This convention
 // matches ASN.1, but differs from almost everything else.
@@ -116,8 +125,8 @@ func reverseBitsInAByte(in byte) byte {
 }
 
 func buildANS1KeyUsageRequest(usage x509.KeyUsage) (pkix.Extension, error) {
-	oidExtensionKeyUsage := pkix.Extension{
-		Id: oidExtensionKeyUsage,
+	OIDExtensionKeyUsage := pkix.Extension{
+		Id: OIDExtensionKeyUsage,
 	}
 	var a [2]byte
 	a[0] = reverseBitsInAByte(byte(usage))
@@ -130,10 +139,10 @@ func buildANS1KeyUsageRequest(usage x509.KeyUsage) (pkix.Extension, error) {
 
 	bitString := a[:l]
 	var err error
-	oidExtensionKeyUsage.Value, err = asn1.Marshal(asn1.BitString{Bytes: bitString, BitLength: asn1BitLength(bitString)})
+	OIDExtensionKeyUsage.Value, err = asn1.Marshal(asn1.BitString{Bytes: bitString, BitLength: asn1BitLength(bitString)})
 	if err != nil {
 		return pkix.Extension{}, err
 	}
 
-	return oidExtensionKeyUsage, nil
+	return OIDExtensionKeyUsage, nil
 }

--- a/pkg/util/pki/keyusage.go
+++ b/pkg/util/pki/keyusage.go
@@ -1,0 +1,69 @@
+package pki
+
+import (
+	"crypto/x509"
+	"encoding/asn1"
+)
+
+// Copied from x509.go
+var oidExtensionExtendedKeyUsage = []int{2, 5, 29, 37}
+
+// RFC 5280, 4.2.1.12  Extended Key Usage
+//
+// anyExtendedKeyUsage OBJECT IDENTIFIER ::= { id-ce-extKeyUsage 0 }
+//
+// id-kp OBJECT IDENTIFIER ::= { id-pkix 3 }
+//
+// id-kp-serverAuth             OBJECT IDENTIFIER ::= { id-kp 1 }
+// id-kp-clientAuth             OBJECT IDENTIFIER ::= { id-kp 2 }
+// id-kp-codeSigning            OBJECT IDENTIFIER ::= { id-kp 3 }
+// id-kp-emailProtection        OBJECT IDENTIFIER ::= { id-kp 4 }
+// id-kp-timeStamping           OBJECT IDENTIFIER ::= { id-kp 8 }
+// id-kp-OCSPSigning            OBJECT IDENTIFIER ::= { id-kp 9 }
+var (
+	oidExtKeyUsageAny                            = asn1.ObjectIdentifier{2, 5, 29, 37, 0}
+	oidExtKeyUsageServerAuth                     = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 1}
+	oidExtKeyUsageClientAuth                     = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 2}
+	oidExtKeyUsageCodeSigning                    = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 3}
+	oidExtKeyUsageEmailProtection                = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 4}
+	oidExtKeyUsageIPSECEndSystem                 = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 5}
+	oidExtKeyUsageIPSECTunnel                    = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 6}
+	oidExtKeyUsageIPSECUser                      = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 7}
+	oidExtKeyUsageTimeStamping                   = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 8}
+	oidExtKeyUsageOCSPSigning                    = asn1.ObjectIdentifier{1, 3, 6, 1, 5, 5, 7, 3, 9}
+	oidExtKeyUsageMicrosoftServerGatedCrypto     = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 10, 3, 3}
+	oidExtKeyUsageNetscapeServerGatedCrypto      = asn1.ObjectIdentifier{2, 16, 840, 1, 113730, 4, 1}
+	oidExtKeyUsageMicrosoftCommercialCodeSigning = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 2, 1, 22}
+	oidExtKeyUsageMicrosoftKernelCodeSigning     = asn1.ObjectIdentifier{1, 3, 6, 1, 4, 1, 311, 61, 1, 1}
+)
+
+// extKeyUsageOIDs contains the mapping between an ExtKeyUsage and its OID.
+var extKeyUsageOIDs = []struct {
+	extKeyUsage x509.ExtKeyUsage
+	oid         asn1.ObjectIdentifier
+}{
+	{x509.ExtKeyUsageAny, oidExtKeyUsageAny},
+	{x509.ExtKeyUsageServerAuth, oidExtKeyUsageServerAuth},
+	{x509.ExtKeyUsageClientAuth, oidExtKeyUsageClientAuth},
+	{x509.ExtKeyUsageCodeSigning, oidExtKeyUsageCodeSigning},
+	{x509.ExtKeyUsageEmailProtection, oidExtKeyUsageEmailProtection},
+	{x509.ExtKeyUsageIPSECEndSystem, oidExtKeyUsageIPSECEndSystem},
+	{x509.ExtKeyUsageIPSECTunnel, oidExtKeyUsageIPSECTunnel},
+	{x509.ExtKeyUsageIPSECUser, oidExtKeyUsageIPSECUser},
+	{x509.ExtKeyUsageTimeStamping, oidExtKeyUsageTimeStamping},
+	{x509.ExtKeyUsageOCSPSigning, oidExtKeyUsageOCSPSigning},
+	{x509.ExtKeyUsageMicrosoftServerGatedCrypto, oidExtKeyUsageMicrosoftServerGatedCrypto},
+	{x509.ExtKeyUsageNetscapeServerGatedCrypto, oidExtKeyUsageNetscapeServerGatedCrypto},
+	{x509.ExtKeyUsageMicrosoftCommercialCodeSigning, oidExtKeyUsageMicrosoftCommercialCodeSigning},
+	{x509.ExtKeyUsageMicrosoftKernelCodeSigning, oidExtKeyUsageMicrosoftKernelCodeSigning},
+}
+
+// OIDFromExtKeyUsage returns the ASN1 Identifier for a x509.ExtKeyUsage
+func OIDFromExtKeyUsage(eku x509.ExtKeyUsage) (oid asn1.ObjectIdentifier, ok bool) {
+	for _, pair := range extKeyUsageOIDs {
+		if eku == pair.extKeyUsage {
+			return pair.oid, true
+		}
+	}
+	return
+}

--- a/pkg/util/pki/keyusage.go
+++ b/pkg/util/pki/keyusage.go
@@ -117,6 +117,7 @@ func asn1BitLength(bitString []byte) int {
 	return 0
 }
 
+// Copied from x509.go
 func reverseBitsInAByte(in byte) byte {
 	b1 := in>>4 | in<<4
 	b2 := b1>>2&0x33 | b1<<2&0xcc
@@ -124,7 +125,8 @@ func reverseBitsInAByte(in byte) byte {
 	return b3
 }
 
-func buildANS1KeyUsageRequest(usage x509.KeyUsage) (pkix.Extension, error) {
+// Adapted from x509.go
+func buildASN1KeyUsageRequest(usage x509.KeyUsage) (pkix.Extension, error) {
 	OIDExtensionKeyUsage := pkix.Extension{
 		Id: OIDExtensionKeyUsage,
 	}

--- a/pkg/webhook/handlers/validation.go
+++ b/pkg/webhook/handlers/validation.go
@@ -89,9 +89,11 @@ func (r *registryBackedValidator) Validate(admissionSpec *admissionv1.AdmissionR
 		}
 	}
 	errs := field.ErrorList{}
-	// perform validation on new version of resource
-	errs = append(errs, r.registry.Validate(obj, gvk)...)
-	if oldObj != nil {
+
+	if admissionSpec.Operation == admissionv1.Create {
+		// perform validation on new version of resource
+		errs = append(errs, r.registry.Validate(obj, gvk)...)
+	} else if admissionSpec.Operation == admissionv1.Update {
 		// perform update validation on resource
 		errs = append(errs, r.registry.ValidateUpdate(oldObj, obj, gvk)...)
 	}

--- a/pkg/webhook/handlers/validation_test.go
+++ b/pkg/webhook/handlers/validation_test.go
@@ -55,6 +55,7 @@ func TestRegistryBackedValidator(t *testing.T) {
 			inputRequest: admissionv1.AdmissionRequest{
 				UID:         types.UID("abc"),
 				RequestKind: testTypeGVK,
+				Operation:   admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {
@@ -82,6 +83,7 @@ func TestRegistryBackedValidator(t *testing.T) {
 		"should allow setting immutable field if it is not already set": {
 			inputRequest: admissionv1.AdmissionRequest{
 				RequestKind: testTypeGVK,
+				Operation:   admissionv1.Update,
 				OldObject: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {
@@ -117,6 +119,7 @@ func TestRegistryBackedValidator(t *testing.T) {
 		"should not allow setting immutable field if it is already set": {
 			inputRequest: admissionv1.AdmissionRequest{
 				RequestKind: testTypeGVK,
+				Operation:   admissionv1.Update,
 				OldObject: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {
@@ -157,6 +160,7 @@ func TestRegistryBackedValidator(t *testing.T) {
 		"should not allow setting immutable field if it is already set (v2)": {
 			inputRequest: admissionv1.AdmissionRequest{
 				RequestKind: testTypeGVKV2,
+				Operation:   admissionv1.Update,
 				OldObject: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {
@@ -198,6 +202,7 @@ func TestRegistryBackedValidator(t *testing.T) {
 			inputRequest: admissionv1.AdmissionRequest{
 				UID:         types.UID("abc"),
 				RequestKind: testTypeGVKV2,
+				Operation:   admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {
@@ -226,6 +231,7 @@ func TestRegistryBackedValidator(t *testing.T) {
 			inputRequest: admissionv1.AdmissionRequest{
 				UID:         types.UID("abc"),
 				RequestKind: testTypeGVK,
+				Operation:   admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {
@@ -248,8 +254,9 @@ func TestRegistryBackedValidator(t *testing.T) {
 		},
 		"should validate in the current APIVersion if RequestKind is not set (for Kubernetes <1.15 support)": {
 			inputRequest: admissionv1.AdmissionRequest{
-				UID:  types.UID("abc"),
-				Kind: *testTypeGVKV2,
+				UID:       types.UID("abc"),
+				Kind:      *testTypeGVKV2,
+				Operation: admissionv1.Create,
 				Object: runtime.RawExtension{
 					Raw: []byte(fmt.Sprintf(`
 {

--- a/test/integration/BUILD.bazel
+++ b/test/integration/BUILD.bazel
@@ -13,6 +13,7 @@ filegroup(
         "//test/integration/conversion:all-srcs",
         "//test/integration/ctl:all-srcs",
         "//test/integration/framework:all-srcs",
+        "//test/integration/validation:all-srcs",
         "//test/integration/webhook:all-srcs",
     ],
     tags = ["automanaged"],

--- a/test/integration/validation/BUILD.bazel
+++ b/test/integration/validation/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["certificaterequest_test.go"],
+    deps = [
+        "//pkg/api:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "//test/integration/framework:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+    ],
+)

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -1,9 +1,12 @@
 /*
 Copyright 2020 The Jetstack cert-manager contributors.
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
+
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/jetstack/cert-manager/pkg/api"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/integration/framework"
+)
+
+var certGVK = schema.GroupVersionKind{
+	Group:   "cert-manager.io",
+	Version: "v1",
+	Kind:    "CertificateRequest",
+}
+
+func TestValidationCertificateRequests(t *testing.T) {
+	tests := map[string]struct {
+		input       runtime.Object
+		errorSuffix string // is a suffix as the API server sends the whole value back in the error
+		expectError bool
+	}{
+		"No errors on valid certificaterequest with no usages set": {
+			input: &v1.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &v1.Certificate{
+						Spec: v1.CertificateSpec{
+							DNSNames: []string{"example.com"},
+						},
+					}),
+					Usages:    []v1.KeyUsage{},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"No errors on  valid certificaterequest with special usages set": {
+			input: &v1.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &v1.Certificate{
+						Spec: v1.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
+						},
+					}),
+					Usages:    []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"Errors on certificaterequest with mismatch of usages": {
+			input: &v1.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &v1.Certificate{
+						Spec: v1.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
+						},
+					}),
+					Usages:    []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageCodeSigning},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: true,
+			errorSuffix: "csr key usages do not match specified usages: [[2]: \"client auth\" != \"code signing\"]",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			cert := test.input.(*v1.CertificateRequest)
+			cert.SetGroupVersionKind(certGVK)
+
+			config, stop := framework.RunControlPlane(t)
+			defer stop()
+			framework.WaitForOpenAPIResourcesToBeLoaded(t, config, certGVK)
+
+			// create the object to get any errors back from the webhook
+			cl, err := client.New(config, client.Options{Scheme: api.Scheme})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = cl.Create(context.Background(), cert)
+
+			if !test.expectError && err != nil {
+				t.Fatalf("Didn't expect error and got error: %v", err)
+			} else if test.expectError && err == nil {
+				t.Errorf("Expected error %v but got nil", test.errorSuffix)
+
+			} else if test.expectError && !strings.HasSuffix(err.Error(), test.errorSuffix) {
+				t.Errorf("Expected error %q but got %q", test.errorSuffix, err)
+			}
+		})
+	}
+}
+
+func mustGenerateCSR(t *testing.T, cert *v1.Certificate) []byte {
+	request, err := pki.GenerateCSR(cert)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrBytes, err := pki.EncodeCSR(request, sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csr := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrBytes,
+	})
+
+	return csr
+}

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -64,7 +64,7 @@ func TestValidationCertificateRequests(t *testing.T) {
 			},
 			expectError: false,
 		},
-		"No errors on  valid certificaterequest with special usages set": {
+		"No errors on valid certificaterequest with special usages set": {
 			input: &v1.CertificateRequest{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
@@ -75,6 +75,43 @@ func TestValidationCertificateRequests(t *testing.T) {
 						Spec: v1.CertificateSpec{
 							DNSNames: []string{"example.com"},
 							Usages:   []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
+						},
+					}),
+					Usages:    []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"No errors on valid certificaterequest with special usages set only in CSR": {
+			input: &v1.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &v1.Certificate{
+						Spec: v1.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
+						},
+					}),
+					IssuerRef: cmmeta.ObjectReference{Name: "test"},
+				},
+			},
+			expectError: false,
+		},
+		"No errors on valid certificaterequest with special usages only set in spec": {
+			input: &v1.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1.CertificateRequestSpec{
+					Request: mustGenerateCSR(t, &v1.Certificate{
+						Spec: v1.CertificateSpec{
+							DNSNames: []string{"example.com"},
+							Usages:   []v1.KeyUsage{},
 						},
 					}),
 					Usages:    []v1.KeyUsage{v1.UsageDigitalSignature, v1.UsageKeyEncipherment, v1.UsageClientAuth},
@@ -101,7 +138,7 @@ func TestValidationCertificateRequests(t *testing.T) {
 				},
 			},
 			expectError: true,
-			errorSuffix: "csr key usages do not match specified usages: [[2]: \"client auth\" != \"code signing\"]",
+			errorSuffix: "csr key usages do not match specified usages, these should match if both are set: [[2]: \"client auth\" != \"code signing\"]",
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

This encodes the ExtKeyUsages into the CSR so supported issuers can pick those up and assign them.

**Which issue this PR fixes**:

Fixes https://github.com/jetstack/cert-manager/issues/3136 

**Special notes for your reviewer**:
~~From my research is isn't possible to define the "old" key usages into the CSR. Prove me wrong is your mission ;)~~
I read more code in the evening, it works :D 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add key usages into the CSR body
```
