### PR TITLE
Error on validation if more than 1 solver has no selector

### DIFF
--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -115,8 +115,16 @@ func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) field
 		}
 	}
 
+	solversWithoutSelector := 0
 	for i, sol := range iss.Solvers {
 		el = append(el, ValidateACMEIssuerChallengeSolverConfig(&sol, fldPath.Child("solvers").Index(i))...)
+		if sol.Selector == nil {
+			solversWithoutSelector++
+		}
+	}
+
+	if solversWithoutSelector > 1 {
+		el = append(el, field.Required(fldPath.Child("solvers"), "More than 1 solvers do not have a selector set"))
 	}
 
 	return el

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -150,6 +150,12 @@ func ValidateACMEIssuerChallengeSolverConfig(sol *cmacme.ACMEChallengeSolver, fl
 		el = append(el, field.Required(fldPath, "no solver type configured"))
 	}
 
+	if sol.Selector != nil {
+		if len(sol.Selector.DNSNames) == 0 && len(sol.Selector.DNSZones) == 0 && len(sol.Selector.MatchLabels) == 0 {
+			el = append(el, field.Required(fldPath.Child("selector"), "selector need at least 1 item in dnsNames, dnsZones or matchLabels"))
+		}
+	}
+
 	return el
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Error on validation if more than 1 solver has no selector, thus there being 2 default solvers this can cause unwanted behaviour for the user 

**Which issue this PR fixes**

fixes https://kubernetes.slack.com/archives/C4NV3DWUC/p1598357241088000

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Error on validation if more than 1 solver has no selector
```

/kind cleanup