### PR TITLE
Cast conversion request in the correct API group

### DIFF
--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -347,7 +347,7 @@ func (s *Server) convert(obj runtime.Object) (runtime.Object, error) {
 	review, isV1 := obj.(*apiextensionsv1.ConversionReview)
 	if !isV1 {
 		outputVersion = apiextensionsv1beta1.SchemeGroupVersion
-		reviewv1beta1, isV1beta1 := obj.(*admissionv1beta1.AdmissionReview)
+		reviewv1beta1, isV1beta1 := obj.(*apiextensionsv1beta1.ConversionReview)
 		if !isV1beta1 {
 			return nil, errors.New("request is not of type apiextensions v1 or v1beta1")
 		}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -351,7 +351,7 @@ func (s *Server) convert(obj runtime.Object) (runtime.Object, error) {
 		if !isV1beta1 {
 			return nil, errors.New("request is not of type apiextensions v1 or v1beta1")
 		}
-		convertedReview, err := defaultScheme.ConvertToVersion(reviewv1beta1, admissionv1.SchemeGroupVersion)
+		convertedReview, err := defaultScheme.ConvertToVersion(reviewv1beta1, apiextensionsv1.SchemeGroupVersion)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:
Do internal version conversion in the conversion webhook

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes https://kubernetes.slack.com/archives/C4NV3DWUC/p1599054237050400

**Special notes for your reviewer**:

This will patch the CI issue in #3241 also

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix conversion webhook when given v1beta1 requests
```
