### PR TITLE
pkg/util/pki: fix dropped errors

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -203,6 +203,10 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 	}
 
 	ku, ekus, err := BuildKeyUsages(crt.Spec.Usages, crt.Spec.IsCA)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build key usages: %w", err)
+	}
+
 	usage, err := buildASN1KeyUsageRequest(ku)
 	if err != nil {
 		return nil, fmt.Errorf("failed to asn1 encode usages: %w", err)

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -375,6 +375,9 @@ func TestRemoveDuplicates(t *testing.T) {
 func TestGenerateCSR(t *testing.T) {
 	// 0xa0 = DigitalSignature and Encipherment usage
 	asn1KeyUsage, err := asn1.Marshal(asn1.BitString{Bytes: []byte{0xa0}, BitLength: asn1BitLength([]byte{0xa0})})
+	if err != nil {
+		t.Fatal(err)
+	}
 	asn1ExtKeyUsage, err := asn1.Marshal([]asn1.ObjectIdentifier{})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This fixes two dropped `err` variables in `pkg/util/pki`.

```release-note
NONE
```
