### PR TITLE
Use separate methods for each ConversionReview type

### DIFF
--- a/pkg/webhook/handlers/BUILD.bazel
+++ b/pkg/webhook/handlers/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "@com_github_mattbaird_jsonpatch//:go_default_library",
         "@io_k8s_api//admission/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",

--- a/pkg/webhook/handlers/BUILD.bazel
+++ b/pkg/webhook/handlers/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "@com_github_mattbaird_jsonpatch//:go_default_library",
         "@io_k8s_api//admission/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",

--- a/pkg/webhook/handlers/conversion_test.go
+++ b/pkg/webhook/handlers/conversion_test.go
@@ -211,7 +211,7 @@ func TestConvertTestType(t *testing.T) {
 
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
-			runConversionTest(t, c.Convert, test)
+			runConversionTest(t, c.ConvertV1, test)
 		})
 	}
 }

--- a/pkg/webhook/handlers/interfaces.go
+++ b/pkg/webhook/handlers/interfaces.go
@@ -19,6 +19,7 @@ package handlers
 import (
 	admissionv1 "k8s.io/api/admission/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 )
 
 type ValidatingAdmissionHook interface {
@@ -34,6 +35,8 @@ type MutatingAdmissionHook interface {
 }
 
 type ConversionHook interface {
-	// Convert is called to convert a resource in one version into a different version.
-	Convert(conversionSpec *apiextensionsv1.ConversionRequest) *apiextensionsv1.ConversionResponse
+	// ConvertV1 is called to convert a resource in one version into a different version.
+	ConvertV1(conversionSpec *apiextensionsv1.ConversionRequest) *apiextensionsv1.ConversionResponse
+	// ConvertV1beta1 is called to convert a resource in one version into a different version.
+	ConvertV1Beta1(conversionSpec *apiextensionsv1beta1.ConversionRequest) *apiextensionsv1beta1.ConversionResponse
 }

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -14,6 +14,7 @@ go_library(
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//admission/v1:go_default_library",
         "@io_k8s_api//admission/v1beta1:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/install:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
@@ -41,4 +42,19 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["server_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/logs/testing:go_default_library",
+        "//pkg/webhook/handlers:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1:go_default_library",
+        "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/v1beta1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+    ],
 )

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -33,7 +33,6 @@ func TestConvert(t *testing.T) {
 	type testCase struct {
 		name string
 		in   runtime.Object
-		out  runtime.Object
 		err  string
 	}
 	tests := []testCase{

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package server
 
 import (

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	testingcmlogs "github.com/jetstack/cert-manager/pkg/logs/testing"
+	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
+)
+
+func TestConvert(t *testing.T) {
+	type testCase struct {
+		name string
+		in   runtime.Object
+		out  runtime.Object
+		err  string
+	}
+	tests := []testCase{
+		{
+			name: "unsupported conversion review type",
+			in:   &apiextensionsv1.CustomResourceDefinition{},
+			err:  "unsupported conversion review type: *v1.CustomResourceDefinition",
+		},
+		{
+			name: "v1beta1 conversion review",
+			in: &apiextensionsv1beta1.ConversionReview{
+				Request: &apiextensionsv1beta1.ConversionRequest{},
+			},
+		},
+		{
+			name: "v1 conversion review",
+			in: &apiextensionsv1.ConversionReview{
+				Request: &apiextensionsv1.ConversionRequest{},
+			},
+		},
+		{
+			name: "v1 conversion review with nil Request",
+			in:   &apiextensionsv1.ConversionReview{},
+			err:  "review.request was nil",
+		},
+		{
+			name: "v1beta1 conversion review with nil Request",
+			in:   &apiextensionsv1beta1.ConversionReview{},
+			err:  "review.request was nil",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			log := &testingcmlogs.TestLogger{T: t}
+			s := &Server{
+				ConversionWebhook: handlers.NewSchemeBackedConverter(log, defaultScheme),
+				Log:               log,
+			}
+			out, err := s.convert(tc.in)
+			if tc.err != "" {
+				assert.EqualError(t, err, tc.err)
+				assert.Nil(t, out)
+				return
+			}
+			require.NoError(t, err)
+			assert.NotNil(t, out)
+		})
+	}
+}


### PR DESCRIPTION
We had assumed that there were conversions for the ConversionReview types, 
but there are not.
The unit tests revealed that.

So instead I've refactored the schema based conversion webhook dependency to have ConversionReview version specific methods which dispatch to a common method that performs the conversion of the object list.

Fixes: https://github.com/jetstack/cert-manager/issues/3244



**Release note**:
```release-note
NONE
```