### PR TITLE
Revert "Refactor the cainjector to only have 1 leader election"

### DIFF
--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -98,6 +98,20 @@ servers and webhook servers.`,
 }
 
 func (o InjectorControllerOptions) RunInjectorController(stopCh <-chan struct{}) {
+	eitherStopCh := make(chan struct{})
+	go func() {
+		defer close(eitherStopCh)
+		o.runCertificateBasedInjector(stopCh)
+	}()
+	go func() {
+		defer close(eitherStopCh)
+		o.runSecretBasedInjector(stopCh)
+	}()
+
+	<-eitherStopCh
+}
+
+func (o InjectorControllerOptions) runCertificateBasedInjector(stopCh <-chan struct{}) {
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme:                  api.Scheme,
 		Namespace:               o.Namespace,
@@ -112,17 +126,41 @@ func (o InjectorControllerOptions) RunInjectorController(stopCh <-chan struct{})
 		os.Exit(1)
 	}
 
-	err = cainjector.RegisterCertificateBased(mgr)
-	if err != nil {
+	// TODO(directxman12): enabled controllers for separate injectors?
+	if err := cainjector.RegisterCertificateBased(mgr); err != nil {
 		o.log.Error(err, "error registering controllers")
-	}
-	err = cainjector.RegisterSecretBased(mgr)
-	if err != nil {
-		o.log.Error(err, "error registering controllers")
+		os.Exit(1)
 	}
 
 	if err := mgr.Start(stopCh); err != nil {
 		o.log.Error(err, "error running manager")
+		os.Exit(1)
+	}
+}
+
+func (o InjectorControllerOptions) runSecretBasedInjector(stopCh <-chan struct{}) {
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+		Scheme:                  api.Scheme,
+		Namespace:               o.Namespace,
+		LeaderElection:          o.LeaderElect,
+		LeaderElectionNamespace: o.LeaderElectionNamespace,
+		LeaderElectionID:        "cert-manager-cainjector-leader-election-core",
+		MetricsBindAddress:      "0",
+	})
+
+	if err != nil {
+		o.log.Error(err, "error creating core-only manager")
+		os.Exit(1)
+	}
+
+	// TODO(directxman12): enabled controllers for separate injectors?
+	if err := cainjector.RegisterSecretBased(mgr); err != nil {
+		o.log.Error(err, "error registering core-only controllers")
+		os.Exit(1)
+	}
+
+	if err := mgr.Start(stopCh); err != nil {
+		o.log.Error(err, "error running core-only manager")
 		os.Exit(1)
 	}
 }


### PR DESCRIPTION
Reverts jetstack/cert-manager#3187

Fixes: https://github.com/jetstack/cert-manager/issues/3251

```release-note
Revert de-duplication of cainjector leader-election to fix scenario where it crashes at startup due to broken webhook.
```