### PR TITLE
Only encode EKUs if there are EKUs to be encoded

### DIFF
--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -217,12 +217,18 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 			asn1ExtendedUsages = append(asn1ExtendedUsages, oid)
 		}
 	}
-	extendedUsage := pkix.Extension{
-		Id: OIDExtensionExtendedKeyUsage,
-	}
-	extendedUsage.Value, err = asn1.Marshal(asn1ExtendedUsages)
-	if err != nil {
-		return nil, fmt.Errorf("failed to asn1 encode extended usages: %w", err)
+
+	extraExtensions := []pkix.Extension{usage}
+	if len(ekus) > 0 {
+		extendedUsage := pkix.Extension{
+			Id: OIDExtensionExtendedKeyUsage,
+		}
+		extendedUsage.Value, err = asn1.Marshal(asn1ExtendedUsages)
+		if err != nil {
+			return nil, fmt.Errorf("failed to asn1 encode extended usages: %w", err)
+		}
+
+		extraExtensions = append(extraExtensions, extendedUsage)
 	}
 
 	return &x509.CertificateRequest{
@@ -244,7 +250,7 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 		IPAddresses:     iPAddresses,
 		URIs:            uriNames,
 		EmailAddresses:  crt.Spec.EmailAddresses,
-		ExtraExtensions: []pkix.Extension{usage, extendedUsage},
+		ExtraExtensions: extraExtensions,
 	}, nil
 }
 

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -378,22 +378,14 @@ func TestGenerateCSR(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	asn1ExtKeyUsage, err := asn1.Marshal([]asn1.ObjectIdentifier{})
-	if err != nil {
-		t.Fatal(err)
-	}
 	defaultExtraExtensions := []pkix.Extension{
 		{
 			Id:    OIDExtensionKeyUsage,
 			Value: asn1KeyUsage,
 		},
-		{
-			Id:    OIDExtensionExtendedKeyUsage,
-			Value: asn1ExtKeyUsage,
-		},
 	}
 
-	asn1ExtKeyUsage, err = asn1.Marshal([]asn1.ObjectIdentifier{oidExtKeyUsageIPSECEndSystem})
+	asn1ExtKeyUsage, err := asn1.Marshal([]asn1.ObjectIdentifier{oidExtKeyUsageIPSECEndSystem})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
This fixes an ASN `0.` which got added it no extended key usages got requested in the certificate

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes https://github.com/jetstack/cert-manager/issues/3260

**Special notes for your reviewer**:


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Do not encode EextendedKeyUsage in the CSR is none is needed
```
