### PR TITLE
Add encodeUsagesInRequest to Certificate spec (fix #3301)

### DIFF
--- a/deploy/crds/crd-certificates.v1beta1.yaml
+++ b/deploy/crds/crd-certificates.v1beta1.yaml
@@ -91,6 +91,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array
@@ -364,6 +367,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array
@@ -639,6 +645,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array
@@ -914,6 +923,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -91,6 +91,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array
@@ -385,6 +388,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array
@@ -681,6 +687,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array
@@ -977,6 +986,9 @@ spec:
                   type: array
                   items:
                     type: string
+                encodeUsagesInRequest:
+                  description: EncodeUsagesInRequest controls whether key usages should be present in the CertificateRequest
+                  type: boolean
                 ipAddresses:
                   description: IPAddresses is a list of IP address subjectAltNames to be set on the Certificate.
                   type: array

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -160,6 +160,11 @@ type CertificateSpec struct {
 	// Options to control private keys used for the Certificate.
 	// +optional
 	PrivateKey *CertificatePrivateKey `json:"privateKey,omitempty"`
+
+	// EncodeUsagesInRequest controls whether key usages should be present
+	// in the CertificateRequest
+	// +optional
+	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -375,6 +375,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(CertificatePrivateKey)
 		**out = **in
 	}
+	if in.EncodeUsagesInRequest != nil {
+		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -188,6 +188,11 @@ type CertificateSpec struct {
 	// Options to control private keys used for the Certificate.
 	// +optional
 	PrivateKey *CertificatePrivateKey `json:"privateKey,omitempty"`
+
+	// EncodeUsagesInRequest controls whether key usages should be present
+	// in the CertificateRequest
+	// +optional
+	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -380,6 +380,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(CertificatePrivateKey)
 		**out = **in
 	}
+	if in.EncodeUsagesInRequest != nil {
+		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -186,6 +186,11 @@ type CertificateSpec struct {
 	// Options to control private keys used for the Certificate.
 	// +optional
 	PrivateKey *CertificatePrivateKey `json:"privateKey,omitempty"`
+
+	// EncodeUsagesInRequest controls whether key usages should be present
+	// in the CertificateRequest
+	// +optional
+	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
@@ -375,6 +375,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(CertificatePrivateKey)
 		**out = **in
 	}
+	if in.EncodeUsagesInRequest != nil {
+		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -159,6 +159,11 @@ type CertificateSpec struct {
 	// Options to control private keys used for the Certificate.
 	// +optional
 	PrivateKey *CertificatePrivateKey `json:"privateKey,omitempty"`
+
+	// EncodeUsagesInRequest controls whether key usages should be present
+	// in the CertificateRequest
+	// +optional
+	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
@@ -375,6 +375,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(CertificatePrivateKey)
 		**out = **in
 	}
+	if in.EncodeUsagesInRequest != nil {
+		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -142,6 +142,10 @@ type CertificateSpec struct {
 
 	// Options to control private keys used for the Certificate.
 	PrivateKey *CertificatePrivateKey
+
+	// EncodeUsagesInRequest controls whether key usages should be present
+	// in the CertificateRequest
+	EncodeUsagesInRequest *bool
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -696,6 +696,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *v1.Certif
 	out.IsCA = in.IsCA
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 
@@ -717,6 +718,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
 	out.IsCA = in.IsCA
 	out.Usages = *(*[]v1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*v1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -718,6 +718,7 @@ func autoConvert_v1alpha2_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 	} else {
 		out.PrivateKey = nil
 	}
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 
@@ -755,6 +756,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha2_CertificateSpec(in *cer
 	} else {
 		out.PrivateKey = nil
 	}
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -717,6 +717,7 @@ func autoConvert_v1alpha3_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 	} else {
 		out.PrivateKey = nil
 	}
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 
@@ -754,6 +755,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha3_CertificateSpec(in *cer
 	} else {
 		out.PrivateKey = nil
 	}
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -676,6 +676,7 @@ func autoConvert_v1beta1_CertificateSpec_To_certmanager_CertificateSpec(in *v1be
 	out.IsCA = in.IsCA
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 
@@ -702,6 +703,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1beta1_CertificateSpec(in *cert
 	out.IsCA = in.IsCA
 	out.Usages = *(*[]v1beta1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*v1beta1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
+	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -375,6 +375,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(CertificatePrivateKey)
 		**out = **in
 	}
+	if in.EncodeUsagesInRequest != nil {
+		in, out := &in.EncodeUsagesInRequest, &out.EncodeUsagesInRequest
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -202,9 +202,12 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 		return nil, err
 	}
 
-	extraExtensions, err := extensionsForCertificate(crt)
-	if err != nil {
-		return nil, err
+	var extraExtensions []pkix.Extension
+	if crt.Spec.EncodeUsagesInRequest == nil || *crt.Spec.EncodeUsagesInRequest {
+		extraExtensions, err = buildKeyUsagesExtensionsForCertificate(crt)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &x509.CertificateRequest{
@@ -230,7 +233,7 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 	}, nil
 }
 
-func extensionsForCertificate(crt *v1.Certificate) ([]pkix.Extension, error) {
+func buildKeyUsagesExtensionsForCertificate(crt *v1.Certificate) ([]pkix.Extension, error) {
 	ku, ekus, err := BuildKeyUsages(crt.Spec.Usages, crt.Spec.IsCA)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build key usages: %w", err)

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -467,7 +467,7 @@ func TestGenerateCSR(t *testing.T) {
 	}
 }
 
-func Test_extensionsForCertificate(t *testing.T) {
+func Test_buildKeyUsagesExtensionsForCertificate(t *testing.T) {
 	// 0xa0 = DigitalSignature and Encipherment usage
 	asn1DefaultKeyUsage, err := asn1.Marshal(asn1.BitString{Bytes: []byte{0xa0}, BitLength: asn1BitLength([]byte{0xa0})})
 	if err != nil {
@@ -542,13 +542,13 @@ func Test_extensionsForCertificate(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := extensionsForCertificate(tt.crt)
+			got, err := buildKeyUsagesExtensionsForCertificate(tt.crt)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("extensionsForCertificate() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("buildKeyUsagesExtensionsForCertificate() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("extensionsForCertificate() got = %v, want %v", got, tt.want)
+				t.Errorf("buildKeyUsagesExtensionsForCertificate() got = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR intends to fix #3301 by adding a new `encode_usages_in_request` option to certificates.

```release-note
Add encodeUsagesInRequest to Certificate spec to disable encoding usages in the CSR
```