### PR TITLE
make propagation check period configurable

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,8 +3,10 @@ approvers:
 - joshvanl
 - meyskens
 - wallrj
+- jakexks
 reviewers:
 - munnerz
 - joshvanl
 - meyskens
 - wallrj
+- jakexks

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -216,6 +216,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 			DNS01CheckAuthoritative:           !opts.DNS01RecursiveNameserversOnly,
 			DNS01Nameservers:                  nameservers,
 			AccountRegistry:                   acmeAccountRegistry,
+			DNS01CheckRetryPeriod:             opts.DNS01CheckRetryPeriod,
 		},
 		IssuerOptions: controller.IssuerOptions{
 			ClusterIssuerAmbientCredentials: opts.ClusterIssuerAmbientCredentials,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -87,6 +87,8 @@ type ControllerOptions struct {
 	// The host and port address, separated by a ':', that the Prometheus server
 	// should expose metrics on.
 	MetricsListenAddress string
+
+	DNS01CheckRetryPeriod time.Duration
 }
 
 const (
@@ -115,6 +117,8 @@ const (
 	defaultMaxConcurrentChallenges = 60
 
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
+
+	defaultDNS01CheckRetryPeriod = 10 * time.Second
 )
 
 var (
@@ -169,6 +173,7 @@ func NewControllerOptions() *ControllerOptions {
 		DNS01RecursiveNameserversOnly:     defaultDNS01RecursiveNameserversOnly,
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
+		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
 	}
 }
 
@@ -264,6 +269,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
 	fs.IntVar(&s.MaxConcurrentChallenges, "max-concurrent-challenges", defaultMaxConcurrentChallenges, ""+
 		"The maximum number of challenges that can be scheduled as 'processing' at once.")
+	fs.DurationVar(&s.DNS01CheckRetryPeriod, "dns01-check-retry-period", defaultDNS01CheckRetryPeriod, ""+
+		"The duration the controller should wait between checking if a ACME dns entry exists."+
+		"This should be a valid duration string, for example 180s or 1h")
 
 	fs.StringVar(&s.MetricsListenAddress, "metrics-listen-address", defaultPrometheusMetricsServerAddress, ""+
 		"The host and port that the metrics endpoint should listen on.")

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -77,6 +77,8 @@ type controller struct {
 	log logr.Logger
 
 	dns01Nameservers []string
+
+	DNS01CheckRetryPeriod time.Duration
 }
 
 func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
@@ -137,6 +139,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	// read options from context
 	c.dns01Nameservers = ctx.ACMEOptions.DNS01Nameservers
+	c.DNS01CheckRetryPeriod = ctx.ACMEOptions.DNS01CheckRetryPeriod
 
 	return c.queue, mustSync, nil
 }

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	acmeapi "golang.org/x/crypto/acme"
 	corev1 "k8s.io/api/core/v1"
@@ -189,8 +188,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 			return err
 		}
 
-		// retry after 10s
-		c.queue.AddAfter(key, time.Second*10)
+		c.queue.AddAfter(key, c.DNS01CheckRetryPeriod)
 
 		return nil
 	}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -126,6 +126,9 @@ type ACMEOptions struct {
 	// AccountRegistry is used as a cache of ACME accounts between various
 	// components of cert-manager
 	AccountRegistry accounts.Registry
+
+	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
+	DNS01CheckRetryPeriod time.Duration
 }
 
 type IngressShimOptions struct {

--- a/pkg/internal/apis/certmanager/validation/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/validation/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
     srcs = [
         "certificate_for_issuer_test.go",
         "certificate_test.go",
+        "certificaterequest_test.go",
         "issuer_test.go",
     ],
     embed = [":go_default_library"],
@@ -42,6 +43,7 @@ go_test(
         "//pkg/internal/apis/acme:go_default_library",
         "//pkg/internal/apis/certmanager:go_default_library",
         "//pkg/internal/apis/meta:go_default_library",
+        "//pkg/util/pki:go_default_library",
         "//test/unit/gen:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -123,13 +123,21 @@ func getCSRKeyUsage(crSpec *cmapi.CertificateRequestSpec, fldPath *field.Path, c
 
 func patchDuplicateKeyUsage(usages []cmapi.KeyUsage) []cmapi.KeyUsage {
 	// usage signing and digital signature are the same key use in x509
-	for i, usage := range usages {
-		if usage == cmapi.UsageSigning {
-			usages[i] = cmapi.UsageDigitalSignature
+	// we should patch this for proper validation
+
+	newUsages := []cmapi.KeyUsage(nil)
+	hasUsageSigning := false
+	for _, usage := range usages {
+		if (usage == cmapi.UsageSigning || usage == cmapi.UsageDigitalSignature) && !hasUsageSigning {
+			newUsages = append(newUsages, cmapi.UsageDigitalSignature)
+			// prevent having 2 UsageDigitalSignature in the slice
+			hasUsageSigning = true
+		} else {
+			newUsages = append(newUsages, usage)
 		}
 	}
 
-	return usages
+	return newUsages
 }
 
 func isUsageEqual(a, b []cmapi.KeyUsage) bool {

--- a/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
@@ -76,6 +76,26 @@ func TestValidateCertificateRequestSpec(t *testing.T) {
 			want: []*field.Error{},
 		},
 		{
+			name: "Test csr that is CA with usages set",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageAny, cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageCertSign), gen.SetCertificateIsCA(true))),
+				IssuerRef: validIssuerRef,
+				IsCA:      true,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageAny, cminternal.UsageDigitalSignature, cminternal.UsageKeyEncipherment, cminternal.UsageCertSign},
+			},
+			want: []*field.Error{},
+		},
+		{
+			name: "Test csr that is CA but no cert sign in usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageAny, cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageClientAuth, cmapi.UsageServerAuth), gen.SetCertificateIsCA(true))),
+				IssuerRef: validIssuerRef,
+				IsCA:      true,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageAny, cminternal.UsageDigitalSignature, cminternal.UsageKeyEncipherment, cminternal.UsageClientAuth, cminternal.UsageServerAuth},
+			},
+			want: []*field.Error{},
+		},
+		{
 			name: "Error on csr not having all usages",
 			crSpec: &cminternal.CertificateRequestSpec{
 				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageServerAuth))),

--- a/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
@@ -67,6 +67,15 @@ func TestValidateCertificateRequestSpec(t *testing.T) {
 			want: []*field.Error{},
 		},
 		{
+			name: "Test csr with reordered usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageServerAuth, cmapi.UsageClientAuth))),
+				IssuerRef: validIssuerRef,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageServerAuth, cminternal.UsageClientAuth, cminternal.UsageKeyEncipherment, cminternal.UsageDigitalSignature},
+			},
+			want: []*field.Error{},
+		},
+		{
 			name: "Error on csr not having all usages",
 			crSpec: &cminternal.CertificateRequestSpec{
 				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageServerAuth))),

--- a/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"bytes"
+	"encoding/pem"
+	"reflect"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/util/validation/field"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cminternal "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	utilpki "github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+func TestValidateCertificateRequestSpec(t *testing.T) {
+	fldPath := field.NewPath("test")
+
+	tests := []struct {
+		name   string
+		crSpec *cminternal.CertificateRequestSpec
+		want   field.ErrorList
+	}{
+		{
+			name: "Test csr with no usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"))),
+				IssuerRef: validIssuerRef,
+				Usages:    nil,
+			},
+			want: []*field.Error{},
+		},
+		{
+			name: "Test csr with double signature usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageSigning, cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment))),
+				IssuerRef: validIssuerRef,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment},
+			},
+			want: []*field.Error{},
+		},
+		{
+			name: "Test csr with double extended usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageServerAuth, cmapi.UsageClientAuth))),
+				IssuerRef: validIssuerRef,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment, cminternal.UsageServerAuth, cminternal.UsageClientAuth},
+			},
+			want: []*field.Error{},
+		},
+		{
+			name: "Error on csr not having all usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageServerAuth))),
+				IssuerRef: validIssuerRef,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment, cminternal.UsageServerAuth, cminternal.UsageClientAuth},
+			},
+			want: []*field.Error{
+				field.Invalid(fldPath.Child("request"), nil, "csr key usages do not match specified usages, these should match if both are set: [[]certmanager.KeyUsage[3] != []certmanager.KeyUsage[4]]"),
+			},
+		},
+		{
+			name: "Error on cr not having all usages",
+			crSpec: &cminternal.CertificateRequestSpec{
+				Request:   mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"), gen.SetCertificateKeyUsages(cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageServerAuth, cmapi.UsageClientAuth))),
+				IssuerRef: validIssuerRef,
+				Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment},
+			},
+			want: []*field.Error{
+				field.Invalid(fldPath.Child("request"), nil, "csr key usages do not match specified usages, these should match if both are set: [[]certmanager.KeyUsage[4] != []certmanager.KeyUsage[2]]"),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ValidateCertificateRequestSpec(tt.crSpec, field.NewPath("test"), true)
+			for i := range got {
+				// filter out the value so it does not print the full CSR in tests
+				got[i].BadValue = nil
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ValidateCertificateRequestSpec() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func mustGenerateCSR(t *testing.T, crt *cmapi.Certificate) []byte {
+	// Create a new private key
+	pk, err := utilpki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	x509CSR, err := pki.GenerateCSR(crt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	csrDER, err := pki.EncodeCSR(x509CSR, pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrPEM := bytes.NewBuffer([]byte{})
+	err = pem.Encode(csrPEM, &pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrDER})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return csrPEM.Bytes()
+}

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -438,6 +438,16 @@ func TestGenerateCSR(t *testing.T) {
 			},
 		},
 		{
+			name: "Generate CSR from certificate with double signing key usages",
+			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", Usages: []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageSigning}}},
+			want: &x509.CertificateRequest{Version: 3,
+				SignatureAlgorithm: x509.SHA256WithRSA,
+				PublicKeyAlgorithm: x509.RSA,
+				Subject:            pkix.Name{CommonName: "example.org"},
+				ExtraExtensions:    defaultExtraExtensions,
+			},
+		},
+		{
 			name:    "Error on generating CSR from certificate with no subject",
 			crt:     &cmapi.Certificate{Spec: cmapi.CertificateSpec{}},
 			wantErr: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: 

This PR makes it possible to configure the time cert-manager should wait between checking if a ACME dns entry exists instead of the static 10 seconds.

Why we need this:
At our org new dns entries are only synced every 2 hours  from the internal DNS servers with the external dns server (do not ask why). With the default time the controller logs will be filled up with a lot of error messages.

**Special notes for your reviewer**:

I am a beginner in golang. Have I forgotten something or done something wrong?

```release-note
make ACME dns01 propagation check period configurable 
```

/kind feature
/assign @joshvanl