### PR TITLE
make ACME dns01 propagation check period configurable 

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -216,6 +216,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 			DNS01CheckAuthoritative:           !opts.DNS01RecursiveNameserversOnly,
 			DNS01Nameservers:                  nameservers,
 			AccountRegistry:                   acmeAccountRegistry,
+			DNS01CheckRetryPeriod:             opts.DNS01CheckRetryPeriod,
 		},
 		IssuerOptions: controller.IssuerOptions{
 			ClusterIssuerAmbientCredentials: opts.ClusterIssuerAmbientCredentials,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -87,6 +87,8 @@ type ControllerOptions struct {
 	// The host and port address, separated by a ':', that the Prometheus server
 	// should expose metrics on.
 	MetricsListenAddress string
+
+	DNS01CheckRetryPeriod time.Duration
 }
 
 const (
@@ -115,6 +117,8 @@ const (
 	defaultMaxConcurrentChallenges = 60
 
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
+
+	defaultDNS01CheckRetryPeriod = 10 * time.Second
 )
 
 var (
@@ -169,6 +173,7 @@ func NewControllerOptions() *ControllerOptions {
 		DNS01RecursiveNameserversOnly:     defaultDNS01RecursiveNameserversOnly,
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
+		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
 	}
 }
 
@@ -264,6 +269,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"When this flag is enabled, the secret will be automatically removed when the certificate resource is deleted.")
 	fs.IntVar(&s.MaxConcurrentChallenges, "max-concurrent-challenges", defaultMaxConcurrentChallenges, ""+
 		"The maximum number of challenges that can be scheduled as 'processing' at once.")
+	fs.DurationVar(&s.DNS01CheckRetryPeriod, "dns01-check-retry-period", defaultDNS01CheckRetryPeriod, ""+
+		"The duration the controller should wait between checking if a ACME dns entry exists."+
+		"This should be a valid duration string, for example 180s or 1h")
 
 	fs.StringVar(&s.MetricsListenAddress, "metrics-listen-address", defaultPrometheusMetricsServerAddress, ""+
 		"The host and port that the metrics endpoint should listen on.")

--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -77,6 +77,8 @@ type controller struct {
 	log logr.Logger
 
 	dns01Nameservers []string
+
+	DNS01CheckRetryPeriod time.Duration
 }
 
 func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
@@ -137,6 +139,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 
 	// read options from context
 	c.dns01Nameservers = ctx.ACMEOptions.DNS01Nameservers
+	c.DNS01CheckRetryPeriod = ctx.ACMEOptions.DNS01CheckRetryPeriod
 
 	return c.queue, mustSync, nil
 }

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	acmeapi "golang.org/x/crypto/acme"
 	corev1 "k8s.io/api/core/v1"
@@ -189,8 +188,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 			return err
 		}
 
-		// retry after 10s
-		c.queue.AddAfter(key, time.Second*10)
+		c.queue.AddAfter(key, c.DNS01CheckRetryPeriod)
 
 		return nil
 	}

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -126,6 +126,9 @@ type ACMEOptions struct {
 	// AccountRegistry is used as a cache of ACME accounts between various
 	// components of cert-manager
 	AccountRegistry accounts.Registry
+
+	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
+	DNS01CheckRetryPeriod time.Duration
 }
 
 type IngressShimOptions struct {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR makes it possible to configure the time cert-manager should wait between checking if a ACME dns entry exists instead of the static 10 seconds.

Why we need this:
At our org new dns entries are only synced every 2 hours from the internal DNS servers with the external dns server (do not ask why). With the default time the controller logs will be filled up with a lot of error messages.


**Special notes for your reviewer**:
I messed up the old PR when i rebased the old branch. Sorry for the inconvenience

**Release note**:

```release-note
make ACME dns01 propagation check period configurable 
```

/kind feature
/assign @JoshVanL
