### PR TITLE
Add _artifacts/ to the .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 bazel-*
 /.settings/
 /.project
+_artifatcs/


### PR DESCRIPTION
**What this PR does / why we need it**:

Because I keep messing up

**Special notes for your reviewer**:

This is added by the e2e tests and should be ignored

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
