### PR TITLE
Implement ACME backoff in the correct place + improve logic

### DIFF
--- a/pkg/acme/BUILD.bazel
+++ b/pkg/acme/BUILD.bazel
@@ -25,6 +25,7 @@ filegroup(
         ":package-srcs",
         "//pkg/acme/accounts:all-srcs",
         "//pkg/acme/client:all-srcs",
+        "//pkg/acme/util:all-srcs",
         "//pkg/acme/webhook:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/acme/accounts/BUILD.bazel
+++ b/pkg/acme/accounts/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/acme/client:go_default_library",
+        "//pkg/acme/util:go_default_library",
         "//pkg/apis/acme/v1:go_default_library",
         "//pkg/metrics:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -26,6 +26,7 @@ import (
 	acmeapi "golang.org/x/crypto/acme"
 
 	acmecl "github.com/jetstack/cert-manager/pkg/acme/client"
+	acmeutil "github.com/jetstack/cert-manager/pkg/acme/util"
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	"github.com/jetstack/cert-manager/pkg/metrics"
 	"github.com/jetstack/cert-manager/pkg/util"
@@ -38,6 +39,7 @@ func NewClient(client *http.Client, config cmacme.ACMEIssuer, privateKey *rsa.Pr
 		HTTPClient:   client,
 		DirectoryURL: config.Server,
 		UserAgent:    util.CertManagerUserAgent,
+		RetryBackoff: acmeutil.RetryBackoff,
 	}
 }
 

--- a/pkg/acme/client/BUILD.bazel
+++ b/pkg/acme/client/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/acme/client",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/acme/util:go_default_library",
         "//pkg/metrics:go_default_library",
         "@org_golang_x_crypto//acme:go_default_library",
     ],

--- a/pkg/acme/util.go
+++ b/pkg/acme/util.go
@@ -17,10 +17,9 @@ limitations under the License.
 package acme
 
 import (
-	corev1 "k8s.io/api/core/v1"
-
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	corev1 "k8s.io/api/core/v1"
 )
 
 // IsFinalState will return true if the given ACME State is a 'final' state.

--- a/pkg/acme/util.go
+++ b/pkg/acme/util.go
@@ -17,9 +17,10 @@ limitations under the License.
 package acme
 
 import (
+	corev1 "k8s.io/api/core/v1"
+
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // IsFinalState will return true if the given ACME State is a 'final' state.

--- a/pkg/acme/util/BUILD.bazel
+++ b/pkg/acme/util/BUILD.bazel
@@ -1,0 +1,23 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["util.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/acme/util",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/logs:go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"crypto/rand"
+	"math/big"
+	"net/http"
+	"time"
+
+	"github.com/jetstack/cert-manager/pkg/logs"
+)
+
+// RetryBackoff is the ACME client RetryBackoff that filters rate limit errors to our retry loop
+// inspired by acme/http.go
+func RetryBackoff(n int, r *http.Request, res *http.Response) time.Duration {
+	var jitter time.Duration
+	if x, err := rand.Int(rand.Reader, big.NewInt(1000)); err == nil {
+		// Set the minimum to 1ms to avoid a case where
+		// an invalid Retry-After value is parsed into 0 below,
+		// resulting in the 0 returned value which would unintentionally
+		// stop the retries.
+		jitter = (1 + time.Duration(x.Int64())) * time.Millisecond
+	}
+	if _, ok := res.Header["Retry-After"]; ok {
+		// if Retry-After is set we should
+		// error and let the cert-manager logic retry instead
+		return -1
+	}
+
+	// classic backoff here in case we got no reply
+	// eg. flakes
+	if n < 1 {
+		n = 1
+	}
+
+	// don't retry more than 10 times
+	if n > 10 {
+		return -1
+	}
+	d := time.Duration(1<<uint(n-1))*time.Second + jitter
+	if d > 10*time.Second {
+		return 10 * time.Second
+	}
+
+	logs.Log.V(logs.DebugLevel).WithValues("backoff", d).Info("Hit an error in golang.org/x/crypto/acme, retrying")
+
+	return d
+}

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -37,9 +37,8 @@ func RetryBackoff(n int, r *http.Request, res *http.Response) time.Duration {
 		n = 1
 	}
 
-	logs.Log.V(logs.DebugLevel).WithValues("backoff", d).Info("Hit an error in golang.org/x/crypto/acme, retrying")
-
 	d := time.Duration(1<<uint(n-1))*time.Second + jitter
+	logs.Log.V(logs.DebugLevel).WithValues("backoff", d).Info("Hit an error in golang.org/x/crypto/acme, retrying")
 	if d > 10*time.Second {
 		return 10 * time.Second
 	}

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -26,22 +26,22 @@ func RetryBackoff(n int, r *http.Request, res *http.Response) time.Duration {
 		return -1
 	}
 
+	// don't retry more than 10 times
+	if n > 10 {
+		return -1
+	}
+
 	// classic backoff here in case we got no reply
 	// eg. flakes
 	if n < 1 {
 		n = 1
 	}
 
-	// don't retry more than 10 times
-	if n > 10 {
-		return -1
-	}
+	logs.Log.V(logs.DebugLevel).WithValues("backoff", d).Info("Hit an error in golang.org/x/crypto/acme, retrying")
+
 	d := time.Duration(1<<uint(n-1))*time.Second + jitter
 	if d > 10*time.Second {
 		return 10 * time.Second
 	}
-
-	logs.Log.V(logs.DebugLevel).WithValues("backoff", d).Info("Hit an error in golang.org/x/crypto/acme, retrying")
-
 	return d
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

This improves the logic added in #3215 to:
* be used in the correct place (insert facepalm)
* stop the Go retry logic after 10 attempts, some calls ended up with an infinite retry

**Which issue this PR fixes**:

fixes #3267

**Special notes for your reviewer**:
Let's backport this to v1.0 as many hit this bug


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Improve ACME backoff logic + prevent infinity retry without surfacing errors
```
