### PR TITLE
Allow custom timeout value for webhook calls

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -133,6 +133,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `https_proxy` | Value of the `HTTPS_PROXY` environment variable in the cert-manager pod | |
 | `no_proxy` | Value of the `NO_PROXY` environment variable in the cert-manager pod | |
 | `webhook.replicaCount` | Number of cert-manager webhook replicas | `1` |
+| `webhook.timeoutSeconds` | Seconds the API server should wait the webhook to respond before treating the call as a failure. | `10` |
 | `webhook.podAnnotations` | Annotations to add to the webhook pods | `{}` |
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
 | `webhook.mutatingWebhookConfigurationAnnotations` | Annotations to add to the mutating webhook configuration | `{}` |

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -35,6 +35,7 @@ webhooks:
           - "*/*"
     {{- if $isV1AdmissionRegistration }}
     admissionReviewVersions: ["v1", "v1beta1"]
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
     {{- end }}
     failurePolicy: Fail
 {{- if (semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -45,6 +45,7 @@ webhooks:
           - "*/*"
     {{- if $isV1AdmissionRegistration }}
     admissionReviewVersions: ["v1", "v1beta1"]
+    timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
     {{- end }}
     failurePolicy: Fail
 {{- if (semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion) }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -178,6 +178,7 @@ tolerations: []
 
 webhook:
   replicaCount: 1
+  timeoutSeconds: 10
 
   strategy: {}
     # type: RollingUpdate


### PR DESCRIPTION
Because webhooks add to API request latency, they should evaluate as
quickly as possible. `timeoutSeconds` allows configuring how long the
API server should wait for a webhook to respond before treating the call
as a failure.

The default values from Kubernetes are, however, too large. For
`admissionregistration.k8s.io/v1` the default value is 10 seconds while
for `admissionregistration.k8s.io/v1beta1` is 30 seconds!

This custom/default value of 10 seconds should be more than enough for
standard installs.


```release-note
Helm: Allow custom timeout value for webhook calls
``` 