### PR TITLE
Remove the Venafi e2e skip

### DIFF
--- a/devel/ci-run-e2e.sh
+++ b/devel/ci-run-e2e.sh
@@ -67,9 +67,7 @@ echo "Ensuring all e2e test dependencies are installed..."
 "${SCRIPT_ROOT}/setup-e2e-deps.sh"
 
 echo "Running e2e test suite..."
-# Skip Venafi end-to-end tests in CI
 FLAKE_ATTEMPTS=2 "${SCRIPT_ROOT}/run-e2e.sh" \
-  --ginkgo.skip=Venafi \
   "$@"
 
 export_logs

--- a/test/e2e/suite/conformance/certificates/featureset.go
+++ b/test/e2e/suite/conformance/certificates/featureset.go
@@ -116,4 +116,8 @@ const (
 	// KeyUsages denotes whether the target issuer is able to sign certificates
 	// with arbitrary key usages.
 	KeyUsagesFeature = "KeyUsages"
+
+	// OnlySAN denotes whether the target issuer is able to sign certificates
+	// with only SANs set
+	OnlySAN = "OnlySAN"
 )

--- a/test/e2e/suite/conformance/certificates/suite.go
+++ b/test/e2e/suite/conformance/certificates/suite.go
@@ -145,7 +145,7 @@ func (s *Suite) Define() {
 			By("Waiting for the Certificate to be issued...")
 			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
-		})
+		}, OnlySAN)
 
 		it("should issue an ECDSA, defaulted certificate for a single distinct dnsName", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -169,7 +169,7 @@ func (s *Suite) Define() {
 			By("Waiting for the Certificate to be issued...")
 			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
-		}, ECDSAFeature)
+		}, ECDSAFeature, OnlySAN)
 
 		it("should issue a basic, defaulted certificate for a single Common Name", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -257,7 +257,7 @@ func (s *Suite) Define() {
 			By("Waiting for the Certificate to be issued...")
 			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
-		}, EmailSANsFeature)
+		}, EmailSANsFeature, OnlySAN)
 
 		it("should issue a certificate that defines a CommonName and URI SAN", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -358,7 +358,7 @@ func (s *Suite) Define() {
 			// We set a 30 second buffer time here since Vault issues certificates
 			// with an extra 30 seconds on its duration.
 			f.CertificateDurationValid(testCertificate, time.Hour*896, 30*time.Second)
-		}, DurationFeature)
+		}, DurationFeature, OnlySAN)
 
 		it("should issue a certificate which has a wildcard DNS name defined", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -379,7 +379,7 @@ func (s *Suite) Define() {
 			By("Waiting for the Certificate to be issued...")
 			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
-		}, WildcardsFeature)
+		}, WildcardsFeature, OnlySAN)
 
 		it("should issue a certificate that includes only a URIs name", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -402,7 +402,7 @@ func (s *Suite) Define() {
 			By("Waiting for the Certificate to be issued...")
 			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
-		}, URISANsFeature)
+		}, URISANsFeature, OnlySAN)
 
 		it("should issue a certificate that includes arbitrary key usages", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -427,7 +427,7 @@ func (s *Suite) Define() {
 			By("Waiting for the Certificate to be issued...")
 			err = f.Helper().WaitCertificateIssuedValid(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
-		}, KeyUsagesFeature)
+		}, KeyUsagesFeature, OnlySAN)
 
 		it("should issue another certificate with the same private key if the existing certificate and CertificateRequest are deleted", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{
@@ -479,7 +479,7 @@ func (s *Suite) Define() {
 			if !match {
 				Fail("Both signed certificates not signed by same private key")
 			}
-		}, ReusePrivateKeyFeature)
+		}, ReusePrivateKeyFeature, OnlySAN)
 
 		it("should issue a basic, defaulted certificate for a single commonName and distinct dnsName defined by an ingress with annotations", func(issuerRef cmmeta.ObjectReference) {
 			ingClient := f.KubeClientSet.ExtensionsV1beta1().Ingresses(f.Namespace.Name)

--- a/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/venafi/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/util/errors:go_default_library",
+        "//test/e2e/suite/conformance/certificates:go_default_library",
         "//test/e2e/suite/issuers/venafi/addon:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -42,6 +42,7 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		// key or using the same private key multiple times.
 		certificates.ECDSAFeature,
 		certificates.ReusePrivateKeyFeature,
+		certificates.OnlySAN,
 	)
 
 	provisioner := new(venafiProvisioner)

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -19,6 +19,8 @@ package venafi
 import (
 	"context"
 
+	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,31 +33,31 @@ import (
 )
 
 var _ = framework.ConformanceDescribe("Certificates", func() {
-	//// unsupportedFeatures is a list of features that are not supported by the
-	//// Venafi issuer.
-	//var unsupportedFeatures = certificates.NewFeatureSet(
-	//	certificates.DurationFeature,
-	//	// Due to the current configuration of the test environment, it does not
-	//	// support signing certificates that pair with an elliptic curve private
-	//	// key or using the same private key multiple times.
-	//	certificates.ECDSAFeature,
-	//	certificates.ReusePrivateKeyFeature,
-	//)
-	//
-	//provisioner := new(venafiProvisioner)
-	//(&certificates.Suite{
-	//	Name:                "Venafi Issuer",
-	//	CreateIssuerFunc:    provisioner.createIssuer,
-	//	DeleteIssuerFunc:    provisioner.delete,
-	//	UnsupportedFeatures: unsupportedFeatures,
-	//}).Define()
+	// unsupportedFeatures is a list of features that are not supported by the
+	// Venafi issuer.
+	var unsupportedFeatures = certificates.NewFeatureSet(
+		certificates.DurationFeature,
+		// Due to the current configuration of the test environment, it does not
+		// support signing certificates that pair with an elliptic curve private
+		// key or using the same private key multiple times.
+		certificates.ECDSAFeature,
+		certificates.ReusePrivateKeyFeature,
+	)
 
-	//(&certificates.Suite{
-	//	Name:                "Venafi ClusterIssuer",
-	//	CreateIssuerFunc:    provisioner.createClusterIssuer,
-	//	DeleteIssuerFunc:    provisioner.delete,
-	//	UnsupportedFeatures: unsupportedFeatures,
-	//}).Define()
+	provisioner := new(venafiProvisioner)
+	(&certificates.Suite{
+		Name:                "Venafi Issuer",
+		CreateIssuerFunc:    provisioner.createIssuer,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
+
+	(&certificates.Suite{
+		Name:                "Venafi ClusterIssuer",
+		CreateIssuerFunc:    provisioner.createClusterIssuer,
+		DeleteIssuerFunc:    provisioner.delete,
+		UnsupportedFeatures: unsupportedFeatures,
+	}).Define()
 })
 
 type venafiProvisioner struct {

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -41,7 +41,9 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		// support signing certificates that pair with an elliptic curve private
 		// key or using the same private key multiple times.
 		certificates.ECDSAFeature,
-		certificates.ReusePrivateKeyFeature,
+		certificates.EmailSANsFeature,
+		certificates.URISANsFeature,
+		certificates.IPAddressFeature,
 		certificates.OnlySAN,
 	)
 

--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -84,7 +84,7 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying the Certificate is valid")
-		err = h.WaitCertificateIssuedValid(f.Namespace.Name, certificateName, time.Second*30)
+		err = h.WaitCertificateIssuedValid(f.Namespace.Name, certificateName, time.Second*90)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
**What this PR does / why we need it**:

Set up new credentials inside the CI cluster. Tests are passing again!

FIxes https://github.com/jetstack/cert-manager/issues/2175

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Run e2e tests against Venafi TPP
```


/kind cleanup