### PR TITLE
Patch mistake made in patchDuplicateKeyUsage

### DIFF
--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -135,7 +135,7 @@ func patchDuplicateKeyUsage(usages []cmapi.KeyUsage) []cmapi.KeyUsage {
 			newUsages = append(newUsages, cmapi.UsageDigitalSignature)
 			// prevent having 2 UsageDigitalSignature in the slice
 			hasUsageSigning = true
-		} else {
+		} else if usage != cmapi.UsageSigning && usage != cmapi.UsageDigitalSignature {
 			newUsages = append(newUsages, usage)
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:
Patch mistake made in patchDuplicateKeyUsage and write tests for it for the case of a double signing key usage.

**Which issue this PR fixes**:

fixes https://github.com/jetstack/cert-manager/issues/3274

**Special notes for your reviewer**:

Was made before some error in the logic made it not fully functional.

/cherry-pick v1.0

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix logic in patchDuplicateKeyUsage when signing and digital signature were set
```
