### PR TITLE
Fix typo in _artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@
 bazel-*
 /.settings/
 /.project
-_artifatcs/
+_artifacts/


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a typo made in #3320 

```release-note
NONE
```

/kind cleanup
