### PR TITLE
Add duration into ACME

### DIFF
--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -121,9 +124,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1090,6 +1090,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1136,9 +1139,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2107,6 +2107,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2153,9 +2156,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3124,6 +3124,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3170,9 +3173,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -75,9 +75,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -124,6 +121,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1090,9 +1090,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1139,6 +1136,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2107,9 +2107,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2156,6 +2153,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3124,9 +3124,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3173,6 +3170,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1087,6 +1090,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2101,6 +2107,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3115,6 +3124,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -121,9 +124,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1104,6 +1104,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1150,9 +1153,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2135,6 +2135,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2181,9 +2184,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3166,6 +3166,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3212,9 +3215,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1101,6 +1104,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2129,6 +2135,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3157,6 +3166,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -75,9 +75,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -124,6 +121,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1104,9 +1104,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1153,6 +1150,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2135,9 +2135,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2184,6 +2181,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3166,9 +3166,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3215,6 +3212,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -121,9 +124,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1090,6 +1090,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1136,9 +1139,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2107,6 +2107,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2153,9 +2156,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3124,6 +3124,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3170,9 +3173,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -75,9 +75,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -124,6 +121,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1090,9 +1090,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1139,6 +1136,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2107,9 +2107,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2156,6 +2153,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3124,9 +3124,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3173,6 +3170,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1087,6 +1090,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2101,6 +2107,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3115,6 +3124,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -121,9 +124,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1104,6 +1104,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1150,9 +1153,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2135,6 +2135,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2181,9 +2184,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3166,6 +3166,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableDurationFeature:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3212,9 +3215,6 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
-                    requestDuration:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -75,6 +75,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1101,6 +1104,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2129,6 +2135,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3157,6 +3166,9 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
+                    enableNotAfterDate:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -75,9 +75,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -124,6 +121,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -1104,9 +1104,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -1153,6 +1150,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -2135,9 +2135,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -2184,6 +2181,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string
@@ -3166,9 +3166,6 @@ spec:
                     email:
                       description: Email is the email address to be associated with the ACME account. This field is optional, but it is strongly recommended to be set. It will be used to contact you in case of issues with your account or certificates, including expiry notification emails. This field may be updated after the account is initially registered.
                       type: string
-                    enableNotAfterDate:
-                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
-                      type: boolean
                     externalAccountBinding:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
@@ -3215,6 +3212,9 @@ spec:
                         name:
                           description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                           type: string
+                    requestDuration:
+                      description: Enables requesting a Not After date on certificates that matches the duration of the certificate. This is not supported by all ACME servers like Let's Encrypt. If set to true when the ACME server does not support it it will create an error on the Order. Defaults to false.
+                      type: boolean
                     server:
                       description: 'Server is the URL used to access the ACME server''s ''directory'' endpoint. For example, for Let''s Encrypt''s staging endpoint, you would use: "https://acme-staging-v02.api.letsencrypt.org/directory". Only ACME v2 endpoints (i.e. RFC 8555) are supported.'
                       type: string

--- a/deploy/crds/crd-orders.v1beta1.yaml
+++ b/deploy/crds/crd-orders.v1beta1.yaml
@@ -103,9 +103,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
             status:
               type: object
               properties:
@@ -243,9 +242,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
             status:
               type: object
               properties:
@@ -380,9 +378,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string
@@ -521,9 +518,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string

--- a/deploy/crds/crd-orders.v1beta1.yaml
+++ b/deploy/crds/crd-orders.v1beta1.yaml
@@ -102,6 +102,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
             status:
               type: object
               properties:
@@ -238,6 +242,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
             status:
               type: object
               properties:
@@ -371,6 +379,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string
@@ -508,6 +520,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string

--- a/deploy/crds/crd-orders.v1beta1.yaml
+++ b/deploy/crds/crd-orders.v1beta1.yaml
@@ -82,6 +82,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -102,9 +105,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
             status:
               type: object
               properties:
@@ -221,6 +221,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -241,9 +244,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
             status:
               type: object
               properties:
@@ -357,6 +357,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -377,9 +380,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string
@@ -497,6 +497,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -517,9 +520,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -103,9 +103,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
             status:
               type: object
               properties:
@@ -261,9 +260,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
             status:
               type: object
               properties:
@@ -416,9 +414,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string
@@ -575,9 +572,8 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 notAfter:
-                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
                   type: string
-                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -82,6 +82,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -102,9 +105,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
             status:
               type: object
               properties:
@@ -239,6 +239,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -259,9 +262,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
             status:
               type: object
               properties:
@@ -393,6 +393,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -413,9 +416,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string
@@ -551,6 +551,9 @@ spec:
                   type: array
                   items:
                     type: string
+                duration:
+                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
+                  type: string
                 ipAddresses:
                   description: IPAddresses is a list of IP addresses that should be included as part of the Order validation process. This field must match the corresponding field on the DER encoded CSR.
                   type: array
@@ -571,9 +574,6 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
-                notAfter:
-                  description: Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.
-                  type: string
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -102,6 +102,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
             status:
               type: object
               properties:
@@ -256,6 +260,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
             status:
               type: object
               properties:
@@ -407,6 +415,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string
@@ -562,6 +574,10 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                notAfter:
+                  description: NotAfter is the date for the requested certificate's Not Valid After date
+                  type: string
+                  format: date-time
                 request:
                   description: Certificate signing request bytes in DER encoding. This will be used when finalizing the order. This field must be set on the order.
                   type: string

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -93,6 +93,14 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
+
+	// Enables requesting a Not After date on certificates that matches the
+	// duration of the certificate. This is not supported by all ACME servers
+	// like Let's Encrypt. If set to true when the ACME server does not support
+	// it it will create an error on the Order.
+	// Defaults to false.
+	// +optional
+	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	RequestDuration bool `json:"requestDuration,omitempty"`
+	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
+	RequestDuration bool `json:"requestDuration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1/types_order.go
+++ b/pkg/apis/acme/v1/types_order.go
@@ -81,7 +81,7 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	// +optional
-	Duration *metav1.Duration `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"duration,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1/types_order.go
+++ b/pkg/apis/acme/v1/types_order.go
@@ -69,7 +69,7 @@ type OrderSpec struct {
 	// DNSNames is a list of DNS names that should be included as part of the Order
 	// validation process.
 	// This field must match the corresponding field on the DER encoded CSR.
-	//+optonal
+	//+optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// IPAddresses is a list of IP addresses that should be included as part of the Order
@@ -77,6 +77,10 @@ type OrderSpec struct {
 	// This field must match the corresponding field on the DER encoded CSR.
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
+
+	// NotAfter is the date for the requested certificate's Not Valid After date
+	// +optional
+	NotAfter *metav1.Time `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1/types_order.go
+++ b/pkg/apis/acme/v1/types_order.go
@@ -78,9 +78,10 @@ type OrderSpec struct {
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 
-	// NotAfter is the date for the requested certificate's Not Valid After date
+	// Duration is the duration for the not after date for the requested certificate.
+	// this is set on order creation as pe the ACME spec.
 	// +optional
-	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	corev1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -789,9 +790,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.NotAfter != nil {
-		in, out := &in.NotAfter, &out.NotAfter
-		*out = (*in).DeepCopy()
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(apismetav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/acme/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1/zz_generated.deepcopy.go
@@ -789,6 +789,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NotAfter != nil {
+		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -93,6 +93,14 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
+
+	// Enables requesting a Not After date on certificates that matches the
+	// duration of the certificate. This is not supported by all ACME servers
+	// like Let's Encrypt. If set to true when the ACME server does not support
+	// it it will create an error on the Order.
+	// Defaults to false.
+	// +optional
+	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	RequestDuration bool `json:"requestDuration,omitempty"`
+	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
+	RequestDuration bool `json:"requestDuration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha2/types_order.go
+++ b/pkg/apis/acme/v1alpha2/types_order.go
@@ -76,9 +76,10 @@ type OrderSpec struct {
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 
-	// NotAfter is the date for the requested certificate's Not Valid After date
+	// Duration is the duration for the not after date for the requested certificate.
+	// this is set on order creation as pe the ACME spec.
 	// +optional
-	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1alpha2/types_order.go
+++ b/pkg/apis/acme/v1alpha2/types_order.go
@@ -79,7 +79,7 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	// +optional
-	Duration *metav1.Duration `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"duration,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1alpha2/types_order.go
+++ b/pkg/apis/acme/v1alpha2/types_order.go
@@ -67,7 +67,7 @@ type OrderSpec struct {
 	// DNSNames is a list of DNS names that should be included as part of the Order
 	// validation process.
 	// This field must match the corresponding field on the DER encoded CSR.
-	//+optonal
+	//+optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// IPAddresses is a list of IP addresses that should be included as part of the Order
@@ -75,6 +75,10 @@ type OrderSpec struct {
 	// This field must match the corresponding field on the DER encoded CSR.
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
+
+	// NotAfter is the date for the requested certificate's Not Valid After date
+	// +optional
+	NotAfter *metav1.Time `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1alpha2/zz_generated.deepcopy.go
@@ -789,6 +789,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NotAfter != nil {
+		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/acme/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1alpha2/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -789,9 +790,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.NotAfter != nil {
-		in, out := &in.NotAfter, &out.NotAfter
-		*out = (*in).DeepCopy()
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(apismetav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -93,6 +93,14 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
+
+	// Enables requesting a Not After date on certificates that matches the
+	// duration of the certificate. This is not supported by all ACME servers
+	// like Let's Encrypt. If set to true when the ACME server does not support
+	// it it will create an error on the Order.
+	// Defaults to false.
+	// +optional
+	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	RequestDuration bool `json:"requestDuration,omitempty"`
+	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
+	RequestDuration bool `json:"requestDuration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1alpha3/types_order.go
+++ b/pkg/apis/acme/v1alpha3/types_order.go
@@ -76,9 +76,10 @@ type OrderSpec struct {
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 
-	// NotAfter is the date for the requested certificate's Not Valid After date
+	// Duration is the duration for the not after date for the requested certificate.
+	// this is set on order creation as pe the ACME spec.
 	// +optional
-	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1alpha3/types_order.go
+++ b/pkg/apis/acme/v1alpha3/types_order.go
@@ -79,7 +79,7 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	// +optional
-	Duration *metav1.Duration `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"duration,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1alpha3/types_order.go
+++ b/pkg/apis/acme/v1alpha3/types_order.go
@@ -67,7 +67,7 @@ type OrderSpec struct {
 	// DNSNames is a list of DNS names that should be included as part of the Order
 	// validation process.
 	// This field must match the corresponding field on the DER encoded CSR.
-	//+optonal
+	//+optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// IPAddresses is a list of IP addresses that should be included as part of the Order
@@ -75,6 +75,10 @@ type OrderSpec struct {
 	// This field must match the corresponding field on the DER encoded CSR.
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
+
+	// NotAfter is the date for the requested certificate's Not Valid After date
+	// +optional
+	NotAfter *metav1.Time `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1alpha3/zz_generated.deepcopy.go
@@ -789,6 +789,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NotAfter != nil {
+		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/apis/acme/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1alpha3/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -789,9 +790,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.NotAfter != nil {
-		in, out := &in.NotAfter, &out.NotAfter
-		*out = (*in).DeepCopy()
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(apismetav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -93,6 +93,14 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
+
+	// Enables requesting a Not After date on certificates that matches the
+	// duration of the certificate. This is not supported by all ACME servers
+	// like Let's Encrypt. If set to true when the ACME server does not support
+	// it it will create an error on the Order.
+	// Defaults to false.
+	// +optional
+	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	RequestDuration bool `json:"requestDuration,omitempty"`
+	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -100,7 +100,7 @@ type ACMEIssuer struct {
 	// it it will create an error on the Order.
 	// Defaults to false.
 	// +optional
-	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
+	RequestDuration bool `json:"requestDuration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/apis/acme/v1beta1/types_order.go
+++ b/pkg/apis/acme/v1beta1/types_order.go
@@ -68,7 +68,7 @@ type OrderSpec struct {
 	// DNSNames is a list of DNS names that should be included as part of the Order
 	// validation process.
 	// This field must match the corresponding field on the DER encoded CSR.
-	//+optonal
+	//+optional
 	DNSNames []string `json:"dnsNames,omitempty"`
 
 	// IPAddresses is a list of IP addresses that should be included as part of the Order
@@ -76,6 +76,10 @@ type OrderSpec struct {
 	// This field must match the corresponding field on the DER encoded CSR.
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
+
+	// NotAfter is the date for the requested certificate's Not Valid After date
+	// +optional
+	NotAfter *metav1.Time `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1beta1/types_order.go
+++ b/pkg/apis/acme/v1beta1/types_order.go
@@ -80,7 +80,7 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	// +optional
-	Duration *metav1.Duration `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"duration,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1beta1/types_order.go
+++ b/pkg/apis/acme/v1beta1/types_order.go
@@ -77,9 +77,10 @@ type OrderSpec struct {
 	// +optional
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 
-	// NotAfter is the date for the requested certificate's Not Valid After date
+	// Duration is the duration for the not after date for the requested certificate.
+	// this is set on order creation as pe the ACME spec.
 	// +optional
-	NotAfter *metav1.Time `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/apis/acme/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1beta1/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	metav1 "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	v1 "k8s.io/api/core/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	apismetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -789,9 +790,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.NotAfter != nil {
-		in, out := &in.NotAfter, &out.NotAfter
-		*out = (*in).DeepCopy()
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(apismetav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/pkg/apis/acme/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/acme/v1beta1/zz_generated.deepcopy.go
@@ -789,6 +789,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NotAfter != nil {
+		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -202,8 +202,8 @@ func (c *controller) createOrder(ctx context.Context, cl acmecl.Interface, o *cm
 	// create a new order with the acme server
 
 	var options []acmeapi.OrderOption
-	if o.Spec.NotAfter != nil {
-		options = append(options, acmeapi.WithOrderNotAfter(o.Spec.NotAfter.Time))
+	if o.Spec.Duration != nil {
+		options = append(options, acmeapi.WithOrderNotAfter(c.clock.Now().Add(o.Spec.Duration.Duration)))
 	}
 	acmeOrder, err := cl.AuthorizeOrder(ctx, authzIDs, options...)
 	if acmeErr, ok := err.(*acmeapi.Error); ok {

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -200,7 +200,12 @@ func (c *controller) createOrder(ctx context.Context, cl acmecl.Interface, o *cm
 	authzIDs := acmeapi.DomainIDs(dnsIdentifierSet.List()...)
 	authzIDs = append(authzIDs, acmeapi.IPIDs(ipIdentifierSet.List()...)...)
 	// create a new order with the acme server
-	acmeOrder, err := cl.AuthorizeOrder(ctx, authzIDs)
+
+	var options []acmeapi.OrderOption
+	if o.Spec.NotAfter != nil {
+		options = append(options, acmeapi.WithOrderNotAfter(o.Spec.NotAfter.Time))
+	}
+	acmeOrder, err := cl.AuthorizeOrder(ctx, authzIDs, options...)
 	if acmeErr, ok := err.(*acmeapi.Error); ok {
 		if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 			log.Error(err, "failed to create Order resource due to bad request, marking Order as failed")

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -105,7 +105,7 @@ func (a *ACME) Sign(ctx context.Context, cr *v1.CertificateRequest, issuer v1.Ge
 	}
 
 	// If we fail to build the order we have to hard fail.
-	expectedOrder, err := buildOrder(cr, csr, issuer)
+	expectedOrder, err := buildOrder(cr, csr, issuer.GetSpec().ACME.EnableDurationFeature)
 	if err != nil {
 		message := "Failed to build order"
 
@@ -199,7 +199,7 @@ func (a *ACME) Sign(ctx context.Context, cr *v1.CertificateRequest, issuer v1.Ge
 }
 
 // Build order. If we error here it is a terminating failure.
-func buildOrder(cr *v1.CertificateRequest, csr *x509.CertificateRequest, issuer v1.GenericIssuer) (*cmacme.Order, error) {
+func buildOrder(cr *v1.CertificateRequest, csr *x509.CertificateRequest, enableDurationFeature bool) (*cmacme.Order, error) {
 	var ipAddresses []string
 	for _, ip := range csr.IPAddresses {
 		ipAddresses = append(ipAddresses, ip.String())
@@ -218,7 +218,7 @@ func buildOrder(cr *v1.CertificateRequest, csr *x509.CertificateRequest, issuer 
 		IPAddresses: ipAddresses,
 	}
 
-	if issuer.GetSpec().ACME.RequestDuration {
+	if enableDurationFeature {
 		spec.Duration = cr.Spec.Duration
 	}
 

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -218,7 +218,7 @@ func buildOrder(cr *v1.CertificateRequest, csr *x509.CertificateRequest, issuer 
 		IPAddresses: ipAddresses,
 	}
 
-	if issuer.GetSpec().ACME.EnableNotAfterDate {
+	if issuer.GetSpec().ACME.RequestDuration {
 		spec.Duration = cr.Spec.Duration
 	}
 

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"time"
 
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -220,14 +219,12 @@ func buildOrder(cr *v1.CertificateRequest, csr *x509.CertificateRequest, issuer 
 	}
 
 	if issuer.GetSpec().ACME.EnableNotAfterDate {
-		notAfterTime := metav1.NewTime(time.Now().Add(cr.Spec.Duration.Duration))
-		spec.NotAfter = &notAfterTime
+		spec.Duration = cr.Spec.Duration
 	}
 
 	computeNameSpec := spec.DeepCopy()
 	// create a deep copy of the OrderSpec so we can overwrite the Request and NotAfter field
 	computeNameSpec.Request = nil
-	computeNameSpec.NotAfter = nil // NotAfter is time based and will shift, confusing the controller to reconcile
 	name, err := apiutil.ComputeName(cr.Name, computeNameSpec)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -153,7 +153,7 @@ func TestSign(t *testing.T) {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}
 
-	baseOrder, err := buildOrder(baseCR, csr)
+	baseOrder, err := buildOrder(baseCR, csr, baseIssuer)
 	if err != nil {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -25,6 +25,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	cmacmelisters "github.com/jetstack/cert-manager/pkg/client/listers/acme/v1"
 	"github.com/jetstack/cert-manager/pkg/controller/certificaterequests"
@@ -148,12 +150,12 @@ func TestSign(t *testing.T) {
 		t.Fatal(err)
 	}
 	ipBaseCR := gen.CertificateRequestFrom(baseCR, gen.SetCertificateRequestCSR(ipCSRPEM))
-	ipBaseOrder, err := buildOrder(ipBaseCR, ipCSR, baseIssuer)
+	ipBaseOrder, err := buildOrder(ipBaseCR, ipCSR, baseIssuer.GetSpec().ACME.EnableDurationFeature)
 	if err != nil {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}
 
-	baseOrder, err := buildOrder(baseCR, csr, baseIssuer)
+	baseOrder, err := buildOrder(baseCR, csr, baseIssuer.GetSpec().ACME.EnableDurationFeature)
 	if err != nil {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}
@@ -517,4 +519,78 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	test.builder.CheckAndFinish(err)
+}
+
+func Test_buildOrder(t *testing.T) {
+	sk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrPEM := generateCSR(t, sk, "example.com", "example.com")
+	csr, err := pki.DecodeX509CertificateRequestBytes(csrPEM)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cr := gen.CertificateRequest("test", gen.SetCertificateRequestDuration(&metav1.Duration{Duration: time.Hour}), gen.SetCertificateRequestCSR(csrPEM))
+	type args struct {
+		cr                    *v1.CertificateRequest
+		csr                   *x509.CertificateRequest
+		enableDurationFeature bool
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    *cmacme.Order
+		wantErr bool
+	}{
+		{
+			name: "Normal building of order",
+			args: args{
+				cr:                    cr,
+				csr:                   csr,
+				enableDurationFeature: false,
+			},
+			want: &cmacme.Order{
+				Spec: cmacme.OrderSpec{
+					Request:    csrPEM,
+					CommonName: "example.com",
+					DNSNames:   []string{"example.com"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Building with enableDurationFeature",
+			args: args{
+				cr:                    cr,
+				csr:                   csr,
+				enableDurationFeature: true,
+			},
+			want: &cmacme.Order{
+				Spec: cmacme.OrderSpec{
+					Request:    csrPEM,
+					CommonName: "example.com",
+					DNSNames:   []string{"example.com"},
+					Duration:   &metav1.Duration{Duration: time.Hour},
+				},
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := buildOrder(tt.args.cr, tt.args.csr, tt.args.enableDurationFeature)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("buildOrder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			// for the current purpose we only test the spec
+			if !reflect.DeepEqual(got.Spec, tt.want.Spec) {
+				t.Errorf("buildOrder() got = %v, want %v", got.Spec, tt.want.Spec)
+			}
+		})
+	}
 }

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -148,7 +148,7 @@ func TestSign(t *testing.T) {
 		t.Fatal(err)
 	}
 	ipBaseCR := gen.CertificateRequestFrom(baseCR, gen.SetCertificateRequestCSR(ipCSRPEM))
-	ipBaseOrder, err := buildOrder(ipBaseCR, ipCSR)
+	ipBaseOrder, err := buildOrder(ipBaseCR, ipCSR, baseIssuer)
 	if err != nil {
 		t.Fatalf("failed to build order during testing: %s", err)
 	}

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -91,7 +91,7 @@ type ACMEIssuer struct {
 	// like Let's Encrypt. If set to true when the ACME server does not support
 	// it it will create an error on the Order.
 	// Defaults to false.
-	RequestDuration bool `json:"requestDuration,omitempty"`
+	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -46,7 +46,7 @@ type ACMEIssuer struct {
 	// endpoint.
 	// For example, for Let's Encrypt's DST crosssign you would use:
 	// "DST Root CA X3" or "ISRG Root X1" for the newer Let's Encrypt root CA.
-	PreferredChain string `json:"preferredChain"`
+	PreferredChain string
 
 	// Enables or disables validation of the ACME server TLS certificate.
 	// If true, requests to the ACME server will not have their TLS certificate
@@ -83,15 +83,14 @@ type ACMEIssuer struct {
 	// If false, the cert-manager system will generate a new ACME account key
 	// for the Issuer.
 	// Defaults to false.
-	// +optional
-	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
+	DisableAccountKeyGeneration bool
 
 	// Enables requesting a Not After date on certificates that matches the
 	// duration of the certificate. This is not supported by all ACME servers
 	// like Let's Encrypt. If set to true when the ACME server does not support
 	// it it will create an error on the Order.
 	// Defaults to false.
-	EnableDurationFeature bool `json:"enableDurationFeature,omitempty"`
+	EnableDurationFeature bool
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -91,7 +91,7 @@ type ACMEIssuer struct {
 	// like Let's Encrypt. If set to true when the ACME server does not support
 	// it it will create an error on the Order.
 	// Defaults to false.
-	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
+	RequestDuration bool `json:"requestDuration,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -85,6 +85,13 @@ type ACMEIssuer struct {
 	// Defaults to false.
 	// +optional
 	DisableAccountKeyGeneration bool `json:"disableAccountKeyGeneration,omitempty"`
+
+	// Enables requesting a Not After date on certificates that matches the
+	// duration of the certificate. This is not supported by all ACME servers
+	// like Let's Encrypt. If set to true when the ACME server does not support
+	// it it will create an error on the Order.
+	// Defaults to false.
+	EnableNotAfterDate bool `json:"enableNotAfterDate,omitempty"`
 }
 
 // ACMEExternalAccountBinding is a reference to a CA external account of the ACME

--- a/pkg/internal/apis/acme/types_order.go
+++ b/pkg/internal/apis/acme/types_order.go
@@ -74,7 +74,7 @@ type OrderSpec struct {
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
 	// +optional
-	Duration *metav1.Duration `json:"notAfter,omitempty"`
+	Duration *metav1.Duration `json:"duration,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/internal/apis/acme/types_order.go
+++ b/pkg/internal/apis/acme/types_order.go
@@ -70,6 +70,9 @@ type OrderSpec struct {
 	// validation process.
 	// This field must match the corresponding field on the DER encoded CSR.
 	IPAddresses []string
+
+	// NotAfter is the date for the requested certificate's Not Valid After date
+	NotAfter *metav1.Time `json:"notAfter"`
 }
 
 type OrderStatus struct {

--- a/pkg/internal/apis/acme/types_order.go
+++ b/pkg/internal/apis/acme/types_order.go
@@ -73,8 +73,7 @@ type OrderSpec struct {
 
 	// Duration is the duration for the not after date for the requested certificate.
 	// this is set on order creation as pe the ACME spec.
-	// +optional
-	Duration *metav1.Duration `json:"duration,omitempty"`
+	Duration *metav1.Duration
 }
 
 type OrderStatus struct {

--- a/pkg/internal/apis/acme/types_order.go
+++ b/pkg/internal/apis/acme/types_order.go
@@ -71,8 +71,10 @@ type OrderSpec struct {
 	// This field must match the corresponding field on the DER encoded CSR.
 	IPAddresses []string
 
-	// NotAfter is the date for the requested certificate's Not Valid After date
-	NotAfter *metav1.Time `json:"notAfter"`
+	// Duration is the duration for the not after date for the requested certificate.
+	// this is set on order creation as pe the ACME spec.
+	// +optional
+	Duration *metav1.Duration `json:"notAfter,omitempty"`
 }
 
 type OrderStatus struct {

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -694,6 +694,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -714,6 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 	}
 	out.Solvers = *(*[]v1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -1245,6 +1247,7 @@ func autoConvert_v1_OrderSpec_To_acme_OrderSpec(in *v1.OrderSpec, out *acme.Orde
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 
@@ -1262,6 +1265,7 @@ func autoConvert_acme_OrderSpec_To_v1_OrderSpec(in *acme.OrderSpec, out *v1.Orde
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 	}
 	out.Solvers = *(*[]v1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1247,7 +1247,7 @@ func autoConvert_v1_OrderSpec_To_acme_OrderSpec(in *v1.OrderSpec, out *acme.Orde
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 
@@ -1265,7 +1265,7 @@ func autoConvert_acme_OrderSpec_To_v1_OrderSpec(in *acme.OrderSpec, out *v1.Orde
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1_ACMEIssuer_To_acme_ACMEIssuer(in *v1.ACMEIssuer, out *acme.A
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1_ACMEIssuer(in *acme.ACMEIssuer, out *v1.A
 	}
 	out.Solvers = *(*[]v1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer,
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.Solvers = *(*[]v1alpha2.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer,
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.Solvers = *(*[]v1alpha2.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -694,6 +694,7 @@ func autoConvert_v1alpha2_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha2.ACMEIssuer,
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -714,6 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha2_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.Solvers = *(*[]v1alpha2.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -1255,6 +1257,7 @@ func autoConvert_v1alpha2_OrderSpec_To_acme_OrderSpec(in *v1alpha2.OrderSpec, ou
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 
@@ -1267,6 +1270,7 @@ func autoConvert_acme_OrderSpec_To_v1alpha2_OrderSpec(in *acme.OrderSpec, out *v
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -1257,7 +1257,7 @@ func autoConvert_v1alpha2_OrderSpec_To_acme_OrderSpec(in *v1alpha2.OrderSpec, ou
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 
@@ -1270,7 +1270,7 @@ func autoConvert_acme_OrderSpec_To_v1alpha2_OrderSpec(in *acme.OrderSpec, out *v
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -694,6 +694,7 @@ func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer,
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -714,6 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.Solvers = *(*[]v1alpha3.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -1255,6 +1257,7 @@ func autoConvert_v1alpha3_OrderSpec_To_acme_OrderSpec(in *v1alpha3.OrderSpec, ou
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 
@@ -1267,6 +1270,7 @@ func autoConvert_acme_OrderSpec_To_v1alpha3_OrderSpec(in *acme.OrderSpec, out *v
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer,
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.Solvers = *(*[]v1alpha3.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1alpha3_ACMEIssuer_To_acme_ACMEIssuer(in *v1alpha3.ACMEIssuer,
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1alpha3_ACMEIssuer(in *acme.ACMEIssuer, out
 	}
 	out.Solvers = *(*[]v1alpha3.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -1257,7 +1257,7 @@ func autoConvert_v1alpha3_OrderSpec_To_acme_OrderSpec(in *v1alpha3.OrderSpec, ou
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 
@@ -1270,7 +1270,7 @@ func autoConvert_acme_OrderSpec_To_v1alpha3_OrderSpec(in *acme.OrderSpec, out *v
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, o
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out 
 	}
 	out.Solvers = *(*[]v1beta1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.EnableNotAfterDate = in.EnableNotAfterDate
+	out.RequestDuration = in.RequestDuration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -1247,7 +1247,7 @@ func autoConvert_v1beta1_OrderSpec_To_acme_OrderSpec(in *v1beta1.OrderSpec, out 
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 
@@ -1265,7 +1265,7 @@ func autoConvert_acme_OrderSpec_To_v1beta1_OrderSpec(in *acme.OrderSpec, out *v1
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
-	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
+	out.Duration = (*apismetav1.Duration)(unsafe.Pointer(in.Duration))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -694,6 +694,7 @@ func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, o
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -714,6 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out 
 	}
 	out.Solvers = *(*[]v1beta1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
+	out.EnableNotAfterDate = in.EnableNotAfterDate
 	return nil
 }
 
@@ -1245,6 +1247,7 @@ func autoConvert_v1beta1_OrderSpec_To_acme_OrderSpec(in *v1beta1.OrderSpec, out 
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 
@@ -1262,6 +1265,7 @@ func autoConvert_acme_OrderSpec_To_v1beta1_OrderSpec(in *acme.OrderSpec, out *v1
 	out.CommonName = in.CommonName
 	out.DNSNames = *(*[]string)(unsafe.Pointer(&in.DNSNames))
 	out.IPAddresses = *(*[]string)(unsafe.Pointer(&in.IPAddresses))
+	out.NotAfter = (*apismetav1.Time)(unsafe.Pointer(in.NotAfter))
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -694,7 +694,7 @@ func autoConvert_v1beta1_ACMEIssuer_To_acme_ACMEIssuer(in *v1beta1.ACMEIssuer, o
 	}
 	out.Solvers = *(*[]acme.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 
@@ -715,7 +715,7 @@ func autoConvert_acme_ACMEIssuer_To_v1beta1_ACMEIssuer(in *acme.ACMEIssuer, out 
 	}
 	out.Solvers = *(*[]v1beta1.ACMEChallengeSolver)(unsafe.Pointer(&in.Solvers))
 	out.DisableAccountKeyGeneration = in.DisableAccountKeyGeneration
-	out.RequestDuration = in.RequestDuration
+	out.EnableDurationFeature = in.EnableDurationFeature
 	return nil
 }
 

--- a/pkg/internal/apis/acme/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/acme/zz_generated.deepcopy.go
@@ -24,6 +24,7 @@ import (
 	meta "github.com/jetstack/cert-manager/pkg/internal/apis/meta"
 	v1 "k8s.io/api/core/v1"
 	v1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -789,9 +790,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
-	if in.NotAfter != nil {
-		in, out := &in.NotAfter, &out.NotAfter
-		*out = (*in).DeepCopy()
+	if in.Duration != nil {
+		in, out := &in.Duration, &out.Duration
+		*out = new(metav1.Duration)
+		**out = **in
 	}
 	return
 }

--- a/pkg/internal/apis/acme/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/acme/zz_generated.deepcopy.go
@@ -789,6 +789,10 @@ func (in *OrderSpec) DeepCopyInto(out *OrderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.NotAfter != nil {
+		in, out := &in.NotAfter, &out.NotAfter
+		*out = (*in).DeepCopy()
+	}
 	return
 }
 

--- a/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/certificate/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dns01.go",
         "http01.go",
+        "notafter.go",
         "webhook.go",
     ],
     importpath = "github.com/jetstack/cert-manager/test/e2e/suite/issuers/acme/certificate",
@@ -16,6 +17,7 @@ go_library(
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/pki:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/log:go_default_library",

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -51,7 +51,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 	BeforeEach(func() {
 		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
 		// Enable NotAfter feature
-		acmeIssuer.Spec.ACME.EnableNotAfterDate = true
+		acmeIssuer.Spec.ACME.RequestDuration = true
 		acmeIssuer.Spec.ACME.Solvers = []cmacme.ACMEChallengeSolver{
 			{
 				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	corev1 "k8s.io/api/core/v1"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	frameworkutil "github.com/jetstack/cert-manager/test/e2e/framework/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", func() {
+	f := framework.NewDefaultFramework("create-acme-certificate-duration")
+
+	var acmeIngressDomain string
+	issuerName := "test-acme-issuer"
+	certificateName := "test-acme-certificate"
+	certificateSecretName := "test-acme-certificate"
+	// fixedIngressName is the name of an ingress resource that is configured
+	// with a challenge solve.
+	// To utilise this solver, add the 'testing.cert-manager.io/fixed-ingress: "true"' label.
+	fixedIngressName := "testingress"
+
+	BeforeEach(func() {
+		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
+		// Enable NotAfter feature
+		acmeIssuer.Spec.ACME.EnableNotAfterDate = true
+		acmeIssuer.Spec.ACME.Solvers = []cmacme.ACMEChallengeSolver{
+			{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Class: &f.Config.Addons.IngressController.IngressClass,
+					},
+				},
+			},
+			{
+				Selector: &cmacme.CertificateDNSNameSelector{
+					MatchLabels: map[string]string{
+						"testing.cert-manager.io/fixed-ingress": "true",
+					},
+				},
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Name: fixedIngressName,
+					},
+				},
+			},
+		}
+		By("Creating an Issuer")
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying the ACME account URI is set")
+		err = util.WaitForIssuerStatusFunc(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			func(i *v1.Issuer) (bool, error) {
+				if i.GetStatus().ACMEStatus().URI == "" {
+					return false, nil
+				}
+				return true, nil
+			})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying ACME account private key exists")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), testingACMEPrivateKey, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if len(secret.Data) != 1 {
+			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
+		}
+	})
+
+	JustBeforeEach(func() {
+		acmeIngressDomain = frameworkutil.RandomSubdomain(f.Config.Addons.IngressController.Domain)
+	})
+
+	AfterEach(func() {
+		By("Cleaning up")
+		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), testingACMEPrivateKey, metav1.DeleteOptions{})
+	})
+
+	It("should obtain a signed certificate with a single CN from the ACME server with 1 hour validity", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateDuration(time.Hour),
+			gen.SetCertificateRenewBefore(45*time.Minute),
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(acmeIngressDomain),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName)
+		Expect(err).NotTo(HaveOccurred())
+
+		sec, err := f.Helper().WaitForSecretCertificateData(f.Namespace.Name, certificateSecretName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred(), "failed to wait for secret")
+
+		crtPEM := sec.Data[corev1.TLSCertKey]
+		crt, err := pki.DecodeX509CertificateBytes(crtPEM)
+		Expect(err).NotTo(HaveOccurred(), "failed to get decode signed certificate data")
+
+		// checking losely to tot hit too many timing issues as the date is defined in the controller
+		if crt.NotAfter.After(time.Now().Add(time.Hour)) {
+			Fail(fmt.Sprintf("Certificate has a NotAfter time after more than 1 hour (requested duration), got %s, current time %s", crt.NotAfter.String(), time.Now().String()))
+		}
+	})
+})


### PR DESCRIPTION
**What this PR does / why we need it**:

Add a Not After date request to ACME, currently not supported by let's encrypt but it is by Step CA and allows it to be used once a CA adopts it.

**Which issue this PR fixes**:
fixes https://github.com/jetstack/cert-manager/issues/3092

**Special notes for your reviewer**:

Would love some thoughts on how to enable/disable this as it is is allowed per ACME spec to error if it is set but not supported

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add option to pass the Certificate duration to ACME (not supported by Let's Encrypt yet)
```
