### PR TITLE
Change chart version v0.1.0 to v1.0.0 [#3348]

### DIFF
--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: cert-manager
 # The version and appVersion fields are set automatically by the release tool
-version: v0.1.0
-appVersion: v0.1.0
+version: v1.0.0
+appVersion: v1.0.0
 description: A Helm chart for cert-manager
 home: https://github.com/jetstack/cert-manager
 icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png


### PR DESCRIPTION
**What this PR does / why we need it**:
- Change chart version v0.1.0 to v1.0.0 [#3348]

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3348 


It doesn't have to change v1.0.0.
You could change any version tag which be stabled.