### PR TITLE
Timestamp the static manifest's licences

### DIFF
--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -33,7 +33,7 @@ DOCKERIZED_BINARIES = {
     # Since the multi_arch_container macro replaces the {ARCH} format string,
     # we need to escape the stamping vars.
     docker_tags = ["{{STABLE_DOCKER_REGISTRY}}/cert-manager-%s-{ARCH}:{{STABLE_DOCKER_TAG}}" % binary],
-    stamp = True,
+    stamp = 1,
     symlinks = {
         # Some cluster startup scripts expect to find the binaries in /usr/local/bin,
         # but the debs install the binaries into /usr/bin.

--- a/build/licensing.bzl
+++ b/build/licensing.bzl
@@ -19,7 +19,7 @@ def licensed_file(
     # This uses '#' as a way to denote a comment.
     # This will likely need changing depending on the type of the file being
     # generated.
-    license_boilerplate = "//hack/boilerplate:boilerplate.bzl.txt",
+    license_boilerplate = "//hack/boilerplate:boilerplate.bzl.timestamped.txt",
     **kwargs,
 ):
     native.genrule(

--- a/hack/boilerplate/BUILD.bazel
+++ b/hack/boilerplate/BUILD.bazel
@@ -20,9 +20,10 @@ genrule(
     outs = ["boilerplate.bzl.timestamped.txt.out"],
     cmd = " ".join([
         "sed",
-        "s/YEAR/$$(date +\"%Y\")/",
+        "s/YEAR/$$(grep '^STABLE_LAST_COMMIT_YEAR' bazel-out/stable-status.txt | awk '{print $$2}')/",
         "$(location :boilerplate.bzl.txt)",
         "> $@",
     ]),
+    stamp = 1,
     visibility = ["//visibility:public"],
 )

--- a/hack/boilerplate/BUILD.bazel
+++ b/hack/boilerplate/BUILD.bazel
@@ -13,3 +13,16 @@ filegroup(
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )
+
+genrule(
+    name = "boilerplate.bzl.timestamped.txt",
+    srcs = [":boilerplate.bzl.txt"],
+    outs = ["boilerplate.bzl.timestamped.txt.out"],
+    cmd = " ".join([
+        "sed",
+        "s/YEAR/$$(date +\"%Y\")/",
+        "$(location :boilerplate.bzl.txt)",
+        "> $@",
+    ]),
+    visibility = ["//visibility:public"],
+)

--- a/hack/build/print-workspace-status.sh
+++ b/hack/build/print-workspace-status.sh
@@ -33,6 +33,7 @@ if [ ! -z "$(git status --porcelain)" ]; then
 fi
 
 cat <<EOF
+STABLE_LAST_COMMIT_YEAR $(git log -1 --date=format:"%Y" --format="%ad")
 STABLE_BUILD_GIT_COMMIT ${KUBE_GIT_COMMIT-}
 STABLE_BUILD_SCM_STATUS ${KUBE_GIT_TREE_STATE-}
 STABLE_BUILD_SCM_REVISION ${KUBE_GIT_VERSION-}


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds a timestamped license boilerplate option used in static manifests.

**Which issue this PR fixes**:

fixes https://github.com/jetstack/cert-manager/issues/3263

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Put current year into manifest license
```
