### PR TITLE
Add support for long lived TPP access-token credentials

### DIFF
--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -30,8 +30,9 @@ import (
 )
 
 const (
-	tppUsernameKey = "username"
-	tppPasswordKey = "password"
+	tppUsernameKey    = "username"
+	tppPasswordKey    = "password"
+	tppAccessTokenKey = "access-token"
 
 	defaultAPIKeyKey = "api-key"
 )
@@ -101,6 +102,7 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister corelisters.SecretLi
 
 		username := string(tppSecret.Data[tppUsernameKey])
 		password := string(tppSecret.Data[tppPasswordKey])
+		accessToken := string(tppSecret.Data[tppAccessTokenKey])
 		caBundle := string(tpp.CABundle)
 
 		return &vcert.Config{
@@ -111,8 +113,9 @@ func configForIssuer(iss cmapi.GenericIssuer, secretsLister corelisters.SecretLi
 			LogVerbose:      true,
 			ConnectionTrust: caBundle,
 			Credentials: &endpoint.Authentication{
-				User:     username,
-				Password: password,
+				User:        username,
+				Password:    password,
+				AccessToken: accessToken,
 			},
 		}, nil
 	case venCfg.Cloud != nil:

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -64,6 +64,7 @@ func TestConfigForIssuerT(t *testing.T) {
 	zone := "test-zone"
 	username := "test-username"
 	password := "test-password"
+	accessToken := "KT2EEVTIjWM/37L78dqJAg=="
 	apiKey := "test-api-key"
 	customKey := "test-custom-key"
 
@@ -122,6 +123,21 @@ func TestConfigForIssuerT(t *testing.T) {
 				}
 				if pass := cnf.Credentials.Password; pass != password {
 					t.Errorf("got unexpected password: %s", pass)
+				}
+				checkZone(t, zone, cnf)
+			},
+			expectedErr: false,
+		},
+		"if TPP and secret returns access-token, should return config with those credentials": {
+			iss: tppIssuer,
+			secretsLister: generateSecretLister(&corev1.Secret{
+				Data: map[string][]byte{
+					tppAccessTokenKey: []byte(accessToken),
+				},
+			}, nil),
+			CheckFn: func(t *testing.T, cnf *vcert.Config) {
+				if actualAccessToken := cnf.Credentials.AccessToken; actualAccessToken != accessToken {
+					t.Errorf("got unexpected accessToken: %q", actualAccessToken)
 				}
 				checkZone(t, zone, cnf)
 			},

--- a/test/e2e/framework/config/venafi.go
+++ b/test/e2e/framework/config/venafi.go
@@ -28,10 +28,11 @@ type Venafi struct {
 }
 
 type VenafiTPPConfiguration struct {
-	URL      string
-	Zone     string
-	Username string
-	Password string
+	URL         string
+	Zone        string
+	Username    string
+	Password    string
+	AccessToken string
 }
 
 type VenafiCloudConfiguration struct {
@@ -53,6 +54,7 @@ func (v *VenafiTPPConfiguration) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&v.Zone, "global.venafi-tpp-zone", os.Getenv("VENAFI_TPP_ZONE"), "Zone to use during Venafi TPP end-to-end tests")
 	fs.StringVar(&v.Username, "global.venafi-tpp-username", os.Getenv("VENAFI_TPP_USERNAME"), "Username to use when authenticating with the Venafi TPP instance")
 	fs.StringVar(&v.Password, "global.venafi-tpp-password", os.Getenv("VENAFI_TPP_PASSWORD"), "Password to use when authenticating with the Venafi TPP instance")
+	fs.StringVar(&v.AccessToken, "global.venafi-tpp-access-token", os.Getenv("VENAFI_TPP_ACCESS_TOKEN"), "Access token to use when authenticating with the Venafi TPP instance")
 }
 
 func (v *VenafiTPPConfiguration) Validate() []error {

--- a/test/e2e/suite/issuers/venafi/addon/tpp.go
+++ b/test/e2e/suite/issuers/venafi/addon/tpp.go
@@ -63,11 +63,14 @@ func (v *VenafiTPP) Setup(cfg *config.Config) error {
 	if v.config.Addons.Venafi.TPP.Zone == "" {
 		return errors.NewSkip(fmt.Errorf("Venafi TPP Zone must be set"))
 	}
-	if v.config.Addons.Venafi.TPP.Username == "" {
-		return errors.NewSkip(fmt.Errorf("Venafi TPP Username must be set"))
-	}
-	if v.config.Addons.Venafi.TPP.Password == "" {
-		return errors.NewSkip(fmt.Errorf("Venafi TPP Password must be set"))
+
+	if v.config.Addons.Venafi.TPP.AccessToken == "" {
+		if v.config.Addons.Venafi.TPP.Username == "" {
+			return errors.NewSkip(fmt.Errorf("Venafi TPP requires either an access-token or username-password to be set: missing username"))
+		}
+		if v.config.Addons.Venafi.TPP.Password == "" {
+			return errors.NewSkip(fmt.Errorf("Venafi TPP requires either an access-token or username-password to be set: missing password"))
+		}
 	}
 
 	return nil
@@ -80,8 +83,9 @@ func (v *VenafiTPP) Provision() error {
 			Namespace:    v.Namespace,
 		},
 		Data: map[string][]byte{
-			"username": []byte(v.config.Addons.Venafi.TPP.Username),
-			"password": []byte(v.config.Addons.Venafi.TPP.Password),
+			"username":     []byte(v.config.Addons.Venafi.TPP.Username),
+			"password":     []byte(v.config.Addons.Venafi.TPP.Password),
+			"access-token": []byte(v.config.Addons.Venafi.TPP.AccessToken),
 		},
 	}
 


### PR DESCRIPTION
Add support for access-token credentials. This is for users who have configured TPP with refresh tokens disabled and / or with a long lived access token which they prefer to refresh using an external process.

The access-token is generated using `vcert getcred`, as described in the [draft documentation](https://github.com/cert-manager/website/pull/346).

This PR does not add any validation of the supplied credentials. I assumed that vcert library would do that, but it does not, for example validate that you only supply one credential mechanism. 

I've added support for access-token credentials to the E2E tests, and I've run them locally.

Part of: #3140 

See draft documentation at: https://github.com/cert-manager/website/pull/346/files

**Release note**:
```release-note
TPP issuer now supports access-token credentials. See https://cert-manager.io/docs/configuration/venafi/#creating-a-venafi-trust-protection-platform-issuer for details.
```
