### PR TITLE
Always set the ready condition on Venafi issuer

### DIFF
--- a/pkg/issuer/venafi/setup.go
+++ b/pkg/issuer/venafi/setup.go
@@ -21,37 +21,41 @@ import (
 	"fmt"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
-	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 	corev1 "k8s.io/api/core/v1"
 )
 
-func (v *Venafi) Setup(ctx context.Context) error {
+func (v *Venafi) Setup(ctx context.Context) (err error) {
+	defer func() {
+		if err != nil {
+			errorMessage := "Failed to setup Venafi issuer"
+			v.log.Error(err, errorMessage)
+			apiutil.SetIssuerCondition(v.issuer, cmapi.IssuerConditionReady, cmmeta.ConditionFalse, "ErrorSetup", fmt.Sprintf("%s: %v", errorMessage, err))
+			err = fmt.Errorf("%s: %v", errorMessage, err)
+		}
+	}()
+
 	client, err := v.clientBuilder(v.resourceNamespace, v.secretsLister, v.issuer)
 	if err != nil {
-		return err
+		return fmt.Errorf("error building client: %v", err)
 	}
-
 	err = client.Ping()
 	if err != nil {
-		v.log.Error(err, "Issuer could not connect to endpoint with provided credentials. Issuer failed to connect to endpoint")
-		apiutil.SetIssuerCondition(v.issuer, v1.IssuerConditionReady, cmmeta.ConditionFalse,
-			"ErrorPing", fmt.Sprintf("Failed to connect to Venafi endpoint"))
-		return fmt.Errorf("error verifying Venafi client: %s", err.Error())
+		return fmt.Errorf("error pinging Venafi API: %v", err)
 	}
 
 	// If it does not already have a 'ready' condition, we'll also log an event
 	// to make it really clear to users that this Issuer is ready.
-	if !apiutil.IssuerHasCondition(v.issuer, v1.IssuerCondition{
-		Type:   v1.IssuerConditionReady,
+	if !apiutil.IssuerHasCondition(v.issuer, cmapi.IssuerCondition{
+		Type:   cmapi.IssuerConditionReady,
 		Status: cmmeta.ConditionTrue,
 	}) {
 		v.Recorder.Eventf(v.issuer, corev1.EventTypeNormal, "Ready", "Verified issuer with Venafi server")
 	}
-
 	v.log.V(logf.DebugLevel).Info("Venafi issuer started")
-	apiutil.SetIssuerCondition(v.issuer, v1.IssuerConditionReady, cmmeta.ConditionTrue, "Venafi issuer started", "Venafi issuer started")
+	apiutil.SetIssuerCondition(v.issuer, cmapi.IssuerConditionReady, cmmeta.ConditionTrue, "Venafi issuer started", "Venafi issuer started")
 
 	return nil
 }

--- a/pkg/issuer/venafi/setup_test.go
+++ b/pkg/issuer/venafi/setup_test.go
@@ -65,6 +65,11 @@ func TestSetup(t *testing.T) {
 			clientBuilder: failingClientBuilder,
 			expectedErr:   true,
 			iss:           baseIssuer.DeepCopy(),
+			expectedCondition: &cmapi.IssuerCondition{
+				Reason:  "ErrorSetup",
+				Message: "Failed to setup Venafi issuer: error building client: this is an error",
+				Status:  "False",
+			},
 		},
 
 		"if ping fails then should error": {
@@ -72,8 +77,8 @@ func TestSetup(t *testing.T) {
 			iss:           baseIssuer.DeepCopy(),
 			expectedErr:   true,
 			expectedCondition: &cmapi.IssuerCondition{
-				Reason:  "ErrorPing",
-				Message: "Failed to connect to Venafi endpoint",
+				Reason:  "ErrorSetup",
+				Message: "Failed to setup Venafi issuer: error pinging Venafi API: this is a ping error",
 				Status:  "False",
 			},
 		},


### PR DESCRIPTION
And always set a meaningful error message on the condition when the issuer setup
has failed.

Previously it would only set the Ready condition: false if there was a Ping failure.
Not if there was an error during the client setup, which implicitly connects to the API and performs authentication steps.


This makes it much easier to debug TPP e2e test failures because the issuer Ready condition will now correctly be added to the test failure output when the venafi addon fails to wait for the issuer to become ready. E.g.


```
• Failure in Spec Setup (BeforeEach) [60.109 seconds]                                                                                                                                                                                     
[cert-manager] [Venafi] [TPP] Certificate with a properly configured Issuer                                                                                                                                                               
test/e2e/framework/framework.go:266                                                                                                                                                                                                       
  should obtain a signed certificate for a single domain [BeforeEach]                                                                                                                                                                     
  test/e2e/suite/issuers/venafi/tpp/certificate.go:75                                                                                                                                                                                     
                                                                                                                                                                                                                                          
  Unexpected error:                                                                                                                                                                                                                       
      <*errors.errorString | 0xc0006891e0>: {                                                                                                                                                                                             
          s: "timed out waiting for the condition: Last Status: 'False' Reason: 'ErrorSetup', Message: 'Failed to setup Venafi issuer: error building client: error creating Venafi client: vcert error: your data contains problems: auth
 error: Post \"https://uvo1sr0unnn0exm4ih0.env.cloudshare.com/vedsdk/authorize/\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)'",                                                                          
      }                                                                                                                                                                                                                                   
      timed out waiting for the condition: Last Status: 'False' Reason: 'ErrorSetup', Message: 'Failed to setup Venafi issuer: error building client: error creating Venafi client: vcert error: your data contains problems: auth error: 
Post "https://uvo1sr0unnn0exm4ih0.env.cloudshare.com/vedsdk/authorize/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)'                                                                                      
  occurred                                                                                                                                                                                                                                
                                                                                                                                                                                                                                          
  test/e2e/suite/issuers/venafi/tpp/certificate.go:67                                                                                                                                                                                     
------------------------------                                                                                                                                                                                                            
STEP: Retrieving logs for global addons                                                                                                                                                                                                   
STEP: Cleaning up the provisioned globals                                                                                                                                                                                                 
                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                          
Summarizing 2 Failures:                                                                                                                                                                                                                   
                                                                                                                                                                                                                                          
[Fail] [cert-manager] [Venafi] [TPP] CertificateRequest with a properly configured Issuer [BeforeEach] should obtain a signed certificate for a single domain                                                                             
test/e2e/suite/issuers/venafi/tpp/certificaterequest.go:68                                                                                                                                                                                
                                                                                                                                                                                                                                          
[Fail] [cert-manager] [Venafi] [TPP] Certificate with a properly configured Issuer [BeforeEach] should obtain a signed certificate for a single domain                                                                                    
test/e2e/suite/issuers/venafi/tpp/certificate.go:67                                                                                                                                                                                       
                                                                                                                     
Ran 2 of 324 Specs in 60.340 seconds                                                                                                                                                                                                      
FAIL! -- 0 Passed | 2 Failed | 0 Pending | 322 Skipped                                                               
                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                          
Ginkgo ran 1 suite in 1m0.492694544s                                                                                 
Test Suite Failed                                                                                       
```


```release-note
Fix a bug where the Venafi Issuer and ClusterIssuer did not set the Ready condition and message if there was an API connection or API authentication failure. The Ready condition will now always be set, including details of any errors during setup.
```