### PR TITLE
Make Kubernetes API QPS throtteling configurable

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -139,6 +139,9 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		return nil, nil, fmt.Errorf("error creating rest config: %s", err.Error())
 	}
 
+	kubeCfg.QPS = opts.KubernetesAPIQPS
+	kubeCfg.Burst = opts.KubernetesAPIBurst
+
 	// Add User-Agent to client
 	kubeCfg = rest.AddUserAgent(kubeCfg, util.CertManagerUserAgent)
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -97,8 +97,8 @@ type ControllerOptions struct {
 const (
 	defaultAPIServerHost              = ""
 	defaultKubeconfig                 = ""
-	defaultKubernetesAPIQPS   float32 = 5
-	defaultKubernetesAPIBurst         = 10
+	defaultKubernetesAPIQPS   float32 = 20
+	defaultKubernetesAPIBurst         = 50
 
 	defaultClusterResourceNamespace = "kube-system"
 	defaultNamespace                = ""
@@ -191,8 +191,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"will be attempted.")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", defaultKubeconfig, ""+
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
-	fs.Float32Var(&s.KubernetesAPIQPS, "kubernetes-api-qps", defaultKubernetesAPIQPS, "indicates the maximum queries-per-second requests to the Kubernetes apiserver")
-	fs.IntVar(&s.KubernetesAPIBurst, "kubernetes-api-burst", defaultKubernetesAPIBurst, "the maximum burst queries-per-second of requests sent to the Kubernetes apiserver")
+	fs.Float32Var(&s.KubernetesAPIQPS, "kube-api-qps", defaultKubernetesAPIQPS, "indicates the maximum queries-per-second requests to the Kubernetes apiserver")
+	fs.IntVar(&s.KubernetesAPIBurst, "kube-api-burst", defaultKubernetesAPIBurst, "the maximum burst queries-per-second of requests sent to the Kubernetes apiserver")
 	fs.StringVar(&s.ClusterResourceNamespace, "cluster-resource-namespace", defaultClusterResourceNamespace, ""+
 		"Namespace to store resources owned by cluster scoped resources such as ClusterIssuer in. "+
 		"This must be specified if ClusterIssuers are enabled.")
@@ -295,8 +295,16 @@ func (o *ControllerOptions) Validate() error {
 		return fmt.Errorf("invalid default issuer kind: %v", o.DefaultIssuerKind)
 	}
 
+	if o.KubernetesAPIBurst <= 0 {
+		return fmt.Errorf("invalid value for kube-api-burst: %v must be higher than 0", o.KubernetesAPIBurst)
+	}
+
+	if o.KubernetesAPIQPS <= 0 {
+		return fmt.Errorf("invalid value for kube-api-qps: %v must be higher than 0", o.KubernetesAPIQPS)
+	}
+
 	if float32(o.KubernetesAPIBurst) < o.KubernetesAPIQPS {
-		return fmt.Errorf("invalid value for kubernetes-api-burst: %v must be higheror equal to kubernetes-api-qps: %v", o.KubernetesAPIQPS, o.KubernetesAPIQPS)
+		return fmt.Errorf("invalid value for kube-api-burst: %v must be higheror equal to kube-api-qps: %v", o.KubernetesAPIQPS, o.KubernetesAPIQPS)
 	}
 
 	for _, server := range o.DNS01RecursiveNameservers {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -45,8 +45,11 @@ import (
 )
 
 type ControllerOptions struct {
-	APIServerHost            string
-	Kubeconfig               string
+	APIServerHost      string
+	Kubeconfig         string
+	KubernetesAPIQPS   float32
+	KubernetesAPIBurst int
+
 	ClusterResourceNamespace string
 	Namespace                string
 
@@ -92,8 +95,11 @@ type ControllerOptions struct {
 }
 
 const (
-	defaultAPIServerHost            = ""
-	defaultKubeconfig               = ""
+	defaultAPIServerHost              = ""
+	defaultKubeconfig                 = ""
+	defaultKubernetesAPIQPS   float32 = 10
+	defaultKubernetesAPIBurst         = 20
+
 	defaultClusterResourceNamespace = "kube-system"
 	defaultNamespace                = ""
 
@@ -155,6 +161,8 @@ func NewControllerOptions() *ControllerOptions {
 	return &ControllerOptions{
 		APIServerHost:                     defaultAPIServerHost,
 		ClusterResourceNamespace:          defaultClusterResourceNamespace,
+		KubernetesAPIQPS:                  defaultKubernetesAPIQPS,
+		KubernetesAPIBurst:                defaultKubernetesAPIBurst,
 		Namespace:                         defaultNamespace,
 		LeaderElect:                       defaultLeaderElect,
 		LeaderElectionNamespace:           defaultLeaderElectionNamespace,
@@ -183,6 +191,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"will be attempted.")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", defaultKubeconfig, ""+
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
+	fs.Float32Var(&s.KubernetesAPIQPS, "kubernetes-api-qps", defaultKubernetesAPIQPS, "indicates the maximum QPS requests to the Kubernetes master")
+	fs.IntVar(&s.KubernetesAPIBurst, "kubernetes-api-burst", defaultKubernetesAPIBurst, "maximum burst for throttle requests to the Kubernetes master")
 	fs.StringVar(&s.ClusterResourceNamespace, "cluster-resource-namespace", defaultClusterResourceNamespace, ""+
 		"Namespace to store resources owned by cluster scoped resources such as ClusterIssuer in. "+
 		"This must be specified if ClusterIssuers are enabled.")

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -97,8 +97,8 @@ type ControllerOptions struct {
 const (
 	defaultAPIServerHost              = ""
 	defaultKubeconfig                 = ""
-	defaultKubernetesAPIQPS   float32 = 10
-	defaultKubernetesAPIBurst         = 20
+	defaultKubernetesAPIQPS   float32 = 5
+	defaultKubernetesAPIBurst         = 10
 
 	defaultClusterResourceNamespace = "kube-system"
 	defaultNamespace                = ""
@@ -191,8 +191,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"will be attempted.")
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", defaultKubeconfig, ""+
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
-	fs.Float32Var(&s.KubernetesAPIQPS, "kubernetes-api-qps", defaultKubernetesAPIQPS, "indicates the maximum QPS requests to the Kubernetes master")
-	fs.IntVar(&s.KubernetesAPIBurst, "kubernetes-api-burst", defaultKubernetesAPIBurst, "maximum burst for throttle requests to the Kubernetes master")
+	fs.Float32Var(&s.KubernetesAPIQPS, "kubernetes-api-qps", defaultKubernetesAPIQPS, "indicates the maximum queries-per-second requests to the Kubernetes apiserver")
+	fs.IntVar(&s.KubernetesAPIBurst, "kubernetes-api-burst", defaultKubernetesAPIBurst, "maximum burst for throttle requests to the Kubernetes apiserver")
 	fs.StringVar(&s.ClusterResourceNamespace, "cluster-resource-namespace", defaultClusterResourceNamespace, ""+
 		"Namespace to store resources owned by cluster scoped resources such as ClusterIssuer in. "+
 		"This must be specified if ClusterIssuers are enabled.")
@@ -293,6 +293,10 @@ func (o *ControllerOptions) Validate() error {
 	case "ClusterIssuer":
 	default:
 		return fmt.Errorf("invalid default issuer kind: %v", o.DefaultIssuerKind)
+	}
+
+	if float32(o.KubernetesAPIBurst) < o.KubernetesAPIQPS {
+		return fmt.Errorf("invalid value for kubernetes-api-burst: %v must be higheror equal to kubernetes-api-qps: %v", o.KubernetesAPIQPS, o.KubernetesAPIQPS)
 	}
 
 	for _, server := range o.DNS01RecursiveNameservers {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -192,7 +192,7 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Kubeconfig, "kubeconfig", defaultKubeconfig, ""+
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
 	fs.Float32Var(&s.KubernetesAPIQPS, "kubernetes-api-qps", defaultKubernetesAPIQPS, "indicates the maximum queries-per-second requests to the Kubernetes apiserver")
-	fs.IntVar(&s.KubernetesAPIBurst, "kubernetes-api-burst", defaultKubernetesAPIBurst, "maximum burst for throttle requests to the Kubernetes apiserver")
+	fs.IntVar(&s.KubernetesAPIBurst, "kubernetes-api-burst", defaultKubernetesAPIBurst, "the maximum burst queries-per-second of requests sent to the Kubernetes apiserver")
 	fs.StringVar(&s.ClusterResourceNamespace, "cluster-resource-namespace", defaultClusterResourceNamespace, ""+
 		"Namespace to store resources owned by cluster scoped resources such as ClusterIssuer in. "+
 		"This must be specified if ClusterIssuers are enabled.")

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -304,7 +304,7 @@ func (o *ControllerOptions) Validate() error {
 	}
 
 	if float32(o.KubernetesAPIBurst) < o.KubernetesAPIQPS {
-		return fmt.Errorf("invalid value for kube-api-burst: %v must be higheror equal to kube-api-qps: %v", o.KubernetesAPIQPS, o.KubernetesAPIQPS)
+		return fmt.Errorf("invalid value for kube-api-burst: %v must be higher or equal to kube-api-qps: %v", o.KubernetesAPIQPS, o.KubernetesAPIQPS)
 	}
 
 	for _, server := range o.DNS01RecursiveNameservers {


### PR DESCRIPTION
**What this PR does / why we need it**:

With the new controllers independently checking and setting state we caused more requests to be made to the API.
In large deployments this will cause a lot of throttling errors. Setting it much higher for all users would not be a good idea.
So I decided to make it a config flag on the controller.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make Kubernetes API QPS throttling configurable
```
