### PR TITLE
Disable Go's ACME retry logic

### DIFF
--- a/pkg/acme/util/BUILD.bazel
+++ b/pkg/acme/util/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = ["util.go"],
     importpath = "github.com/jetstack/cert-manager/pkg/acme/util",
     visibility = ["//visibility:public"],
+    deps = ["@org_golang_x_crypto//acme:go_default_library"],
 )
 
 filegroup(

--- a/pkg/acme/util/BUILD.bazel
+++ b/pkg/acme/util/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -19,4 +19,10 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["util_test.go"],
+    embed = [":go_default_library"],
 )

--- a/pkg/acme/util/BUILD.bazel
+++ b/pkg/acme/util/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = ["util.go"],
     importpath = "github.com/jetstack/cert-manager/pkg/acme/util",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/logs:go_default_library"],
 )
 
 filegroup(

--- a/pkg/acme/util/BUILD.bazel
+++ b/pkg/acme/util/BUILD.bazel
@@ -5,7 +5,6 @@ go_library(
     srcs = ["util.go"],
     importpath = "github.com/jetstack/cert-manager/pkg/acme/util",
     visibility = ["//visibility:public"],
-    deps = ["@org_golang_x_crypto//acme:go_default_library"],
 )
 
 filegroup(

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -31,7 +31,7 @@ func RetryBackoff(n int, r *http.Request, resp *http.Response) time.Duration {
 	// However, we can not use the request body in here as it is closed already.
 	// So we're using it's status code instead: 400
 	if resp.StatusCode == http.StatusBadRequest {
-		// don't retry more than 5 times, if we get 5 nonce mismatches something is quite wrong
+		// don't retry more than 6 times, if we get 6 nonce mismatches something is quite wrong
 		if n > 5 {
 			return -1
 		} else if n < 1 {

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -17,46 +17,12 @@ limitations under the License.
 package util
 
 import (
-	"crypto/rand"
-	"math/big"
 	"net/http"
 	"time"
-
-	"github.com/jetstack/cert-manager/pkg/logs"
 )
 
-// RetryBackoff is the ACME client RetryBackoff that filters rate limit errors to our retry loop
-// inspired by acme/http.go
+// RetryBackoff is the ACME client RetryBackoff that does not retry
+// all retries will be handled by cert-manager
 func RetryBackoff(n int, r *http.Request, res *http.Response) time.Duration {
-	var jitter time.Duration
-	if x, err := rand.Int(rand.Reader, big.NewInt(1000)); err == nil {
-		// Set the minimum to 1ms to avoid a case where
-		// an invalid Retry-After value is parsed into 0 below,
-		// resulting in the 0 returned value which would unintentionally
-		// stop the retries.
-		jitter = (1 + time.Duration(x.Int64())) * time.Millisecond
-	}
-	if _, ok := res.Header["Retry-After"]; ok {
-		// if Retry-After is set we should
-		// error and let the cert-manager logic retry instead
-		return -1
-	}
-
-	// don't retry more than 10 times
-	if n > 10 {
-		return -1
-	}
-
-	// classic backoff here in case we got no reply
-	// eg. flakes
-	if n < 1 {
-		n = 1
-	}
-
-	d := time.Duration(1<<uint(n-1))*time.Second + jitter
-	logs.Log.V(logs.DebugLevel).WithValues("backoff", d).Info("Hit an error in golang.org/x/crypto/acme, retrying")
-	if d > 10*time.Second {
-		return 10 * time.Second
-	}
-	return d
+	return -1
 }

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -29,12 +29,13 @@ func RetryBackoff(n int, r *http.Request, resp *http.Response) time.Duration {
 
 	// According to the spec badNonce is urn:ietf:params:acme:error:badNonce.
 	// However, we can not use the request body in here as it is closed already.
-	// So we're using it's status code instead: 400
+	// So we're using its status code instead: 400
 	if resp.StatusCode == http.StatusBadRequest {
 		// don't retry more than 6 times, if we get 6 nonce mismatches something is quite wrong
 		if n > 5 {
 			return -1
-		} else if n < 1 {
+		}
+		if n < 1 {
 			// n is used for the backoff time below
 			n = 1
 		}

--- a/pkg/acme/util/util.go
+++ b/pkg/acme/util/util.go
@@ -17,12 +17,85 @@ limitations under the License.
 package util
 
 import (
+	"crypto/rand"
+	"encoding/json"
+	"io/ioutil"
+	"math/big"
 	"net/http"
+	"strings"
 	"time"
+
+	"golang.org/x/crypto/acme"
 )
+
+// wireError is a subset of fields of the Problem Details object
+// as described in https://tools.ietf.org/html/rfc7807#section-3.1.
+// it is used to check for badNonce errors in the retry logic
+type wireError struct {
+	Status   int
+	Type     string
+	Detail   string
+	Instance string
+}
+
+func (e *wireError) error(h http.Header) *acme.Error {
+	return &acme.Error{
+		StatusCode:  e.Status,
+		ProblemType: e.Type,
+		Detail:      e.Detail,
+		Instance:    e.Instance,
+		Header:      h,
+	}
+}
 
 // RetryBackoff is the ACME client RetryBackoff that does not retry
 // all retries will be handled by cert-manager
-func RetryBackoff(n int, r *http.Request, res *http.Response) time.Duration {
+func RetryBackoff(n int, r *http.Request, resp *http.Response) time.Duration {
+
+	// reaging the error response to check for any errors we MUST retry
+	// don't care if ReadAll returns an error:
+	// json.Unmarshal will fail in that case anyway
+	b, _ := ioutil.ReadAll(resp.Body)
+	e := &wireError{Status: resp.StatusCode}
+	if err := json.Unmarshal(b, e); err != nil {
+		// this is not a regular error response:
+		// populate detail with anything we received,
+		// e.Status will already contain HTTP response code value
+		e.Detail = string(b)
+		if e.Detail == "" {
+			e.Detail = resp.Status
+		}
+	}
+
+	// According to the spec badNonce is urn:ietf:params:acme:error:badNonce.
+	// However, ACME servers in the wild return their versions of the error.
+	// See https://tools.ietf.org/html/draft-ietf-acme-acme-02#section-5.4
+	// and https://github.com/letsencrypt/boulder/blob/0e07eacb/docs/acme-divergences.md#section-66.
+	if strings.HasSuffix(strings.ToLower(e.error(resp.Header).ProblemType), ":badnonce") {
+		// don't retry more than 10 times, if we get 10 nonce mismatches something is quite wrong
+		if n > 10 {
+			return -1
+		} else if n < 1 {
+			// n is used for the backoff time below
+			n = 1
+		}
+
+		var jitter time.Duration
+		if x, err := rand.Int(rand.Reader, big.NewInt(1000)); err == nil {
+			// Set the minimum to 1ms to avoid a case where
+			// an invalid Retry-After value is parsed into 0 below,
+			// resulting in the 0 returned value which would unintentionally
+			// stop the retries.
+			jitter = (1 + time.Duration(x.Int64())) * time.Millisecond
+		}
+
+		d := time.Duration(1<<uint(n-1))*time.Second + jitter
+		if d > 3*time.Second {
+			return 3 * time.Second
+		}
+		return d
+	}
+
+	// do not retry any non badNonce errors
 	return -1
 }

--- a/pkg/acme/util/util_test.go
+++ b/pkg/acme/util/util_test.go
@@ -1,0 +1,72 @@
+package util
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestRetryBackoff(t *testing.T) {
+	type args struct {
+		n    int
+		r    *http.Request
+		resp *http.Response
+	}
+	tests := []struct {
+		name            string
+		args            args
+		validdateOutput func(time.Duration) bool
+	}{
+		{
+			name: "Do not retry a non 400 error",
+			args: args{
+				n:    0,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusUnauthorized},
+			},
+			validdateOutput: func(duration time.Duration) bool {
+				return duration == -1
+			},
+		},
+		{
+			name: "Retry a 400 error when the first time",
+			args: args{
+				n:    0,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusBadRequest},
+			},
+			validdateOutput: func(duration time.Duration) bool {
+				return duration > 0
+			},
+		},
+		{
+			name: "Retry a 400 error when when less than 6 times",
+			args: args{
+				n:    5,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusBadRequest},
+			},
+			validdateOutput: func(duration time.Duration) bool {
+				return duration > 0
+			},
+		},
+		{
+			name: "Do not retry a 400 error after 6 tries",
+			args: args{
+				n:    6,
+				r:    &http.Request{},
+				resp: &http.Response{StatusCode: http.StatusBadRequest},
+			},
+			validdateOutput: func(duration time.Duration) bool {
+				return duration == -1
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := RetryBackoff(tt.args.n, tt.args.r, tt.args.resp); !tt.validdateOutput(got) {
+				t.Errorf("RetryBackoff() = %v which is not valid according to the validdateOutput()", got)
+			}
+		})
+	}
+}

--- a/pkg/acme/util/util_test.go
+++ b/pkg/acme/util/util_test.go
@@ -63,7 +63,7 @@ func TestRetryBackoff(t *testing.T) {
 				resp: &http.Response{StatusCode: http.StatusBadRequest},
 			},
 			validdateOutput: func(duration time.Duration) bool {
-				return duration > 0
+				return duration > 5
 			},
 		},
 		{

--- a/pkg/acme/util/util_test.go
+++ b/pkg/acme/util/util_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (


### PR DESCRIPTION
**What this PR does / why we need it**:

If an error is thrown the system now retries for 10 times often being ~15 seconds, for a blocking function this is quite long.
On creating a lot of ACME resources this might be limiting the controllers from functioning correctly.

Fixes https://github.com/jetstack/cert-manager/issues/3218

**Special notes for your reviewer**:

This replaces the built in logic with a custom one that will do a few checks. Totally disabling it causes too many errors to be surfaced as invalid tokens often happen (especially in Pebble by design) and should be retried immediately. We cannot read the body of the error thus it looks at the HTTP status code to see if it is the one matching the token issues, if so it retries only less and faster than before. Any other status codes immediately return the error to let cert-manager handle it.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Replace Go's ACME retry logic with custom logic
```
