### PR TITLE
Fail early when e2e flag validation fails

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -53,8 +53,7 @@ func TestE2E(t *testing.T) {
 	flag.Parse()
 
 	if err := framework.DefaultConfig.Validate(); err != nil {
-		t.Errorf("Invalid test config: %v", err)
-		t.Fail()
+		t.Fatalf("Invalid test config: %v", err)
 	}
 
 	gomega.NewWithT(t)


### PR DESCRIPTION
I added some new validation checks to the TPP addon configuration, 
but the tests still ran, despite my deliberate mistakes in the supplied TPP config.

This makes the e2e tests fail fast if the validation fails.

**Release note**:
```release-note
NONE
```