### PR TITLE
http_proxy_lowercase

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -126,13 +126,19 @@ spec:
           {{- if .Values.http_proxy }}
           - name: HTTP_PROXY
             value: {{ .Values.http_proxy }}
+          - name: http_proxy
+            value: {{ .Values.http_proxy }}
           {{- end }}
           {{- if .Values.https_proxy }}
           - name: HTTPS_PROXY
             value: {{ .Values.https_proxy }}
+          - name: http_proxy
+            value: {{ .Values.https_proxy }}
           {{- end }}
           {{- if .Values.no_proxy }}
           - name: NO_PROXY
+            value: {{ .Values.no_proxy }}
+          - name: no_proxy
             value: {{ .Values.no_proxy }}
           {{- end }}
           resources:


### PR DESCRIPTION
Signed-off-by: kranthi guttikonda <kranthi.guttikonda@b-yond.com>

* support for proxy values to environment in lowercase since few applications require them. Not all application will use proxy values in CAPITALS. Especially when it comes to curl/wget in RHEL (https://unix.stackexchange.com/questions/212894/whats-the-right-format-for-the-http-proxy-environment-variable-caps-or-no-ca)
* When the proxy variables are configured then we shall configure HTTP_PROXY and http_proxy both to accommodate all OS and apps
```release-note
NONE
```