### PR TITLE
Add an option to control the resync period

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"os"
 	"sync"
-	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -193,8 +192,8 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 	eventBroadcaster.StartRecordingToSink(&clientv1.EventSinkImpl{Interface: cl.CoreV1().Events("")})
 	recorder := eventBroadcaster.NewRecorder(scheme.Scheme, corev1.EventSource{Component: controllerAgentName})
 
-	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(intcl, time.Second*30, informers.WithNamespace(opts.Namespace))
-	kubeSharedInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(cl, time.Second*30, kubeinformers.WithNamespace(opts.Namespace))
+	sharedInformerFactory := informers.NewSharedInformerFactoryWithOptions(intcl, opts.ResyncPeriod, informers.WithNamespace(opts.Namespace))
+	kubeSharedInformerFactory := kubeinformers.NewSharedInformerFactoryWithOptions(cl, opts.ResyncPeriod, kubeinformers.WithNamespace(opts.Namespace))
 
 	acmeAccountRegistry := accounts.NewDefaultRegistry()
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -92,6 +92,9 @@ type ControllerOptions struct {
 	MetricsListenAddress string
 
 	DNS01CheckRetryPeriod time.Duration
+
+	// ResyncPeriod sets the resync of our informers
+	ResyncPeriod time.Duration
 }
 
 const (
@@ -125,6 +128,8 @@ const (
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
 
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
+
+	defaultResyncPeriod = 30 * time.Second
 )
 
 var (
@@ -182,6 +187,7 @@ func NewControllerOptions() *ControllerOptions {
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
 		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
+		ResyncPeriod:                      defaultResyncPeriod,
 	}
 }
 
@@ -193,6 +199,7 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Paths to a kubeconfig. Only required if out-of-cluster.")
 	fs.Float32Var(&s.KubernetesAPIQPS, "kube-api-qps", defaultKubernetesAPIQPS, "indicates the maximum queries-per-second requests to the Kubernetes apiserver")
 	fs.IntVar(&s.KubernetesAPIBurst, "kube-api-burst", defaultKubernetesAPIBurst, "the maximum burst queries-per-second of requests sent to the Kubernetes apiserver")
+	fs.DurationVar(&s.ResyncPeriod, "resync-period", defaultResyncPeriod, "the resync period for the informers being used")
 	fs.StringVar(&s.ClusterResourceNamespace, "cluster-resource-namespace", defaultClusterResourceNamespace, ""+
 		"Namespace to store resources owned by cluster scoped resources such as ClusterIssuer in. "+
 		"This must be specified if ClusterIssuers are enabled.")

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -129,7 +129,7 @@ const (
 
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
 
-	defaultResyncPeriod = 30 * time.Second
+	defaultResyncPeriod = 10 * time.Hour
 )
 
 var (


### PR DESCRIPTION
**What this PR does / why we need it**:
This makes the resync period of our main conrrollers configurable just like we did with QPS. In large deployments updating the caches every 30 seconds could be problematic. Running tests with 5K certs this gave no issues.

**Special notes for your reviewer**:

@wallrj while discussing noticed that 30 seconds is quite short, worth thinking about changing the defaults?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add an option to control the resync period
```
