### PR TITLE
Fix a panic when changing the max concurrent challenges

### DIFF
--- a/pkg/controller/acmechallenges/scheduler/scheduler.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler.go
@@ -69,6 +69,9 @@ func (s *Scheduler) scheduleN(n int, allChallenges []*cmacme.Challenge) ([]*cmac
 
 	numberToSelect := n
 	remainingNumberAllowedChallenges := s.maxConcurrentChallenges - inProgressChallengeCount
+	if remainingNumberAllowedChallenges < 0 {
+		remainingNumberAllowedChallenges = 0
+	}
 	if numberToSelect > remainingNumberAllowedChallenges {
 		numberToSelect = remainingNumberAllowedChallenges
 	}

--- a/pkg/controller/acmechallenges/scheduler/scheduler_test.go
+++ b/pkg/controller/acmechallenges/scheduler/scheduler_test.go
@@ -142,6 +142,12 @@ func TestScheduleN(t *testing.T) {
 			expected:   ascendingChallengeN(maxConcurrentChallenges),
 		},
 		{
+			name:       "schedule no new if current number is higher than MaxConcurrentChallenges",
+			n:          maxConcurrentChallenges,
+			challenges: ascendingChallengeN(maxConcurrentChallenges * 4),
+			expected:   ascendingChallengeN(maxConcurrentChallenges),
+		},
+		{
 			name: "schedule duplicate challenge if second challenge is in a final state",
 			n:    5,
 			challenges: []*cmacme.Challenge{


### PR DESCRIPTION
**What this PR does / why we need it**:
Found this one in testing, when you change the max-concurrent-challenges value to a lower one that challenges currently in progress you end up with a negative number for a slice index,

This fixes this preventing a panic() from stopping cert-manager

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix a panic when changing the max concurrent challenges to a lower value
```

/kind bug
