### PR TITLE
Suppress GPG signatures when getting the git last revision year

### DIFF
--- a/hack/build/print-workspace-status.sh
+++ b/hack/build/print-workspace-status.sh
@@ -33,7 +33,7 @@ if [ ! -z "$(git status --porcelain)" ]; then
 fi
 
 cat <<EOF
-STABLE_LAST_COMMIT_YEAR $(git log -1 --date=format:"%Y" --format="%ad")
+STABLE_LAST_COMMIT_YEAR $(git log -1 --date=format:"%Y" --format="%ad" --no-show-signature)
 STABLE_BUILD_GIT_COMMIT ${KUBE_GIT_COMMIT-}
 STABLE_BUILD_SCM_STATUS ${KUBE_GIT_TREE_STATE-}
 STABLE_BUILD_SCM_REVISION ${KUBE_GIT_VERSION-}


### PR DESCRIPTION
With git log signatures enabled, in my `.gitconfig` file:

``` 
[log]
	showSignature = true

```

...the build script would fail...

```
./devel/addon/certmanager/install.sh
...
Target //devel/addon/certmanager:bundle up-to-date (nothing to build)
INFO: Elapsed time: 4.904s, Critical Path: 4.40s
INFO: 25 processes: 1 internal, 24 linux-sandbox.
INFO: Build completed successfully, 25 total actions
INFO: Build completed successfully, 25 total actions
/tmp/tmp.1romCJipzn: line 9: export: `gpg:=         There is no indication that the signature belongs to the owner.': not a valid identifier

```

This patch disables the printing of signatures in the command which gets the copyright YEAR of the last revision,
introduced in https://github.com/jetstack/cert-manager/pull/3357


/kind cleanup

```release-note
NONE
```