### PR TITLE
Add API defaulting for Venafi Issuer config

### DIFF
--- a/pkg/apis/certmanager/v1/BUILD.bazel
+++ b/pkg/apis/certmanager/v1/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "types_certificate.go",
         "types_certificaterequest.go",
         "types_issuer.go",
+        "venafi.go",
         "zz_generated.deepcopy.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1",

--- a/pkg/apis/certmanager/v1/venafi.go
+++ b/pkg/apis/certmanager/v1/venafi.go
@@ -14,23 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha3
+package v1
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
-
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
+const (
+	DefaultVenafiCloudURL                  = "https://api.venafi.cloud/v1"
+	DefaultVenafiCloudAPITokenSecretRefKey = "api-key"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
-
-func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
-	if o.URL == "" {
-		o.URL = cmapi.DefaultVenafiCloudURL
-	}
-	if o.APITokenSecretRef.Key == "" {
-		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
-	}
-}

--- a/pkg/apis/certmanager/v1alpha2/BUILD.bazel
+++ b/pkg/apis/certmanager/v1alpha2/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "types_certificate.go",
         "types_certificaterequest.go",
         "types_issuer.go",
+        "venafi.go",
         "zz_generated.deepcopy.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2",

--- a/pkg/apis/certmanager/v1alpha2/venafi.go
+++ b/pkg/apis/certmanager/v1alpha2/venafi.go
@@ -14,23 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha3
+package v1alpha2
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
-
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
+const (
+	DefaultVenafiCloudURL                  = "https://api.venafi.cloud/v1"
+	DefaultVenafiCloudAPITokenSecretRefKey = "api-key"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
-
-func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
-	if o.URL == "" {
-		o.URL = cmapi.DefaultVenafiCloudURL
-	}
-	if o.APITokenSecretRef.Key == "" {
-		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
-	}
-}

--- a/pkg/apis/certmanager/v1alpha3/BUILD.bazel
+++ b/pkg/apis/certmanager/v1alpha3/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "types_certificate.go",
         "types_certificaterequest.go",
         "types_issuer.go",
+        "venafi.go",
         "zz_generated.deepcopy.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3",

--- a/pkg/apis/certmanager/v1alpha3/venafi.go
+++ b/pkg/apis/certmanager/v1alpha3/venafi.go
@@ -16,21 +16,7 @@ limitations under the License.
 
 package v1alpha3
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
-
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
+const (
+	DefaultVenafiCloudURL                  = "https://api.venafi.cloud/v1"
+	DefaultVenafiCloudAPITokenSecretRefKey = "api-key"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
-
-func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
-	if o.URL == "" {
-		o.URL = cmapi.DefaultVenafiCloudURL
-	}
-	if o.APITokenSecretRef.Key == "" {
-		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
-	}
-}

--- a/pkg/apis/certmanager/v1beta1/BUILD.bazel
+++ b/pkg/apis/certmanager/v1beta1/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "types_certificate.go",
         "types_certificaterequest.go",
         "types_issuer.go",
+        "venafi.go",
         "zz_generated.deepcopy.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1",

--- a/pkg/apis/certmanager/v1beta1/venafi.go
+++ b/pkg/apis/certmanager/v1beta1/venafi.go
@@ -14,23 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1alpha3
+package v1beta1
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
-
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
+const (
+	DefaultVenafiCloudURL                  = "https://api.venafi.cloud/v1"
+	DefaultVenafiCloudAPITokenSecretRefKey = "api-key"
 )
-
-func addDefaultingFuncs(scheme *runtime.Scheme) error {
-	return RegisterDefaults(scheme)
-}
-
-func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
-	if o.URL == "" {
-		o.URL = cmapi.DefaultVenafiCloudURL
-	}
-	if o.APITokenSecretRef.Key == "" {
-		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
-	}
-}

--- a/pkg/internal/BUILD.bazel
+++ b/pkg/internal/BUILD.bazel
@@ -9,7 +9,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
-        "//pkg/internal/api/validation:all-srcs",
+        "//pkg/internal/api:all-srcs",
         "//pkg/internal/apis/acme:all-srcs",
         "//pkg/internal/apis/certmanager:all-srcs",
         "//pkg/internal/apis/meta:all-srcs",

--- a/pkg/internal/api/BUILD.bazel
+++ b/pkg/internal/api/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["scheme.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/internal/api",
+    visibility = ["//pkg:__subpackages__"],
+    deps = [
+        "//pkg/internal/api/validation:go_default_library",
+        "//pkg/internal/apis/acme/install:go_default_library",
+        "//pkg/internal/apis/certmanager/install:go_default_library",
+        "//pkg/internal/apis/meta/install:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//pkg/internal/api/validation:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/internal/api/scheme.go
+++ b/pkg/internal/api/scheme.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2019 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/jetstack/cert-manager/pkg/internal/api/validation"
+	acmeinstall "github.com/jetstack/cert-manager/pkg/internal/apis/acme/install"
+	cminstall "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager/install"
+	metainstall "github.com/jetstack/cert-manager/pkg/internal/apis/meta/install"
+)
+
+// Define a Scheme that has all cert-manager API types registered, including
+// the internal API version, defaulting functions and conversion functions for
+// all external versions.
+// This scheme should *only* be used by the webhook as the conversion/defaulter
+// functions are likely to change in future, and all controllers consuming
+// cert-manager APIs should have a consistent view of all API kinds.
+
+var (
+	// Scheme is a Kubernetes runtime.Scheme with all internal and external API
+	// versions for cert-manager types registered.
+	Scheme = runtime.NewScheme()
+
+	// ValidationRegistry is a validation registry with all required
+	// validations that should be enforced by the webhook component.
+	ValidationRegistry = validation.NewRegistry(Scheme)
+)
+
+func init() {
+	cminstall.Install(Scheme)
+	acmeinstall.Install(Scheme)
+	metainstall.Install(Scheme)
+
+	cminstall.InstallValidation(ValidationRegistry)
+	acmeinstall.InstallValidation(ValidationRegistry)
+}

--- a/pkg/internal/apis/certmanager/fuzzer/fuzzer.go
+++ b/pkg/internal/apis/certmanager/fuzzer/fuzzer.go
@@ -55,5 +55,16 @@ var Funcs = func(codecs runtimeserializer.CodecFactory) []interface{} {
 				s.Spec.Duration = &metav1.Duration{Duration: v1.DefaultCertificateDuration}
 			}
 		},
+		func(s *certmanager.VenafiCloud, c fuzz.Continue) {
+			c.FuzzNoCustom(s) // fuzz self without calling this function again
+			// Match defaulting
+			if s.URL == "" {
+				s.URL = v1.DefaultVenafiCloudURL
+			}
+			// Match defaulting
+			if s.APITokenSecretRef.Key == "" {
+				s.APITokenSecretRef.Key = v1.DefaultVenafiCloudAPITokenSecretRefKey
+			}
+		},
 	}...)
 }

--- a/pkg/internal/apis/certmanager/v1/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/v1/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -39,4 +39,15 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/internal/apis/certmanager/v1/defaults.go
+++ b/pkg/internal/apis/certmanager/v1/defaults.go
@@ -18,8 +18,19 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
+	if o.URL == "" {
+		o.URL = cmapi.DefaultVenafiCloudURL
+	}
+	if o.APITokenSecretRef.Key == "" {
+		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
+	}
 }

--- a/pkg/internal/apis/certmanager/v1/defaults_test.go
+++ b/pkg/internal/apis/certmanager/v1/defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestSetDefaultsVenafiCloud(t *testing.T) {
+	t.Run("set-defaults", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, cmapi.DefaultVenafiCloudURL, o.URL)
+		assert.Equal(t, cmapi.DefaultVenafiCloudAPITokenSecretRefKey, o.APITokenSecretRef.Key)
+	})
+
+	t.Run("no-clobber", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{
+			URL: "https://custom-url",
+			APITokenSecretRef: cmmeta.SecretKeySelector{
+				Key: "foo",
+			},
+		}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, "https://custom-url", o.URL)
+		assert.Equal(t, "foo", o.APITokenSecretRef.Key)
+	})
+}

--- a/pkg/internal/apis/certmanager/v1/zz_generated.defaults.go
+++ b/pkg/internal/apis/certmanager/v1/zz_generated.defaults.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1
 
 import (
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,5 +29,39 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&v1.ClusterIssuer{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuer(obj.(*v1.ClusterIssuer)) })
+	scheme.AddTypeDefaultingFunc(&v1.ClusterIssuerList{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuerList(obj.(*v1.ClusterIssuerList)) })
+	scheme.AddTypeDefaultingFunc(&v1.Issuer{}, func(obj interface{}) { SetObjectDefaults_Issuer(obj.(*v1.Issuer)) })
+	scheme.AddTypeDefaultingFunc(&v1.IssuerList{}, func(obj interface{}) { SetObjectDefaults_IssuerList(obj.(*v1.IssuerList)) })
 	return nil
+}
+
+func SetObjectDefaults_ClusterIssuer(in *v1.ClusterIssuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_ClusterIssuerList(in *v1.ClusterIssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_ClusterIssuer(a)
+	}
+}
+
+func SetObjectDefaults_Issuer(in *v1.Issuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_IssuerList(in *v1.IssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Issuer(a)
+	}
 }

--- a/pkg/internal/apis/certmanager/v1alpha2/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/v1alpha2/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -39,4 +39,15 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/internal/apis/certmanager/v1alpha2/defaults.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/defaults.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Jetstack cert-manager contributors.
+Copyright 2020 The Jetstack cert-manager contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -18,8 +18,19 @@ package v1alpha2
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
+	if o.URL == "" {
+		o.URL = cmapi.DefaultVenafiCloudURL
+	}
+	if o.APITokenSecretRef.Key == "" {
+		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
+	}
 }

--- a/pkg/internal/apis/certmanager/v1alpha2/defaults_test.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestSetDefaultsVenafiCloud(t *testing.T) {
+	t.Run("set-defaults", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, cmapi.DefaultVenafiCloudURL, o.URL)
+		assert.Equal(t, cmapi.DefaultVenafiCloudAPITokenSecretRefKey, o.APITokenSecretRef.Key)
+	})
+
+	t.Run("no-clobber", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{
+			URL: "https://custom-url",
+			APITokenSecretRef: cmmeta.SecretKeySelector{
+				Key: "foo",
+			},
+		}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, "https://custom-url", o.URL)
+		assert.Equal(t, "foo", o.APITokenSecretRef.Key)
+	})
+}

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.defaults.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.defaults.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha2
 
 import (
+	v1alpha2 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,5 +29,39 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&v1alpha2.ClusterIssuer{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuer(obj.(*v1alpha2.ClusterIssuer)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha2.ClusterIssuerList{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuerList(obj.(*v1alpha2.ClusterIssuerList)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha2.Issuer{}, func(obj interface{}) { SetObjectDefaults_Issuer(obj.(*v1alpha2.Issuer)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha2.IssuerList{}, func(obj interface{}) { SetObjectDefaults_IssuerList(obj.(*v1alpha2.IssuerList)) })
 	return nil
+}
+
+func SetObjectDefaults_ClusterIssuer(in *v1alpha2.ClusterIssuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_ClusterIssuerList(in *v1alpha2.ClusterIssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_ClusterIssuer(a)
+	}
+}
+
+func SetObjectDefaults_Issuer(in *v1alpha2.Issuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_IssuerList(in *v1alpha2.IssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Issuer(a)
+	}
 }

--- a/pkg/internal/apis/certmanager/v1alpha3/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/v1alpha3/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -39,4 +39,15 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha3:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/internal/apis/certmanager/v1alpha3/defaults_test.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha3
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestSetDefaultsVenafiCloud(t *testing.T) {
+	t.Run("set-defaults", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, cmapi.DefaultVenafiCloudURL, o.URL)
+		assert.Equal(t, cmapi.DefaultVenafiCloudAPITokenSecretRefKey, o.APITokenSecretRef.Key)
+	})
+
+	t.Run("no-clobber", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{
+			URL: "https://custom-url",
+			APITokenSecretRef: cmmeta.SecretKeySelector{
+				Key: "foo",
+			},
+		}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, "https://custom-url", o.URL)
+		assert.Equal(t, "foo", o.APITokenSecretRef.Key)
+	})
+}

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.defaults.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.defaults.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1alpha3
 
 import (
+	v1alpha3 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha3"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,5 +29,39 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&v1alpha3.ClusterIssuer{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuer(obj.(*v1alpha3.ClusterIssuer)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha3.ClusterIssuerList{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuerList(obj.(*v1alpha3.ClusterIssuerList)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha3.Issuer{}, func(obj interface{}) { SetObjectDefaults_Issuer(obj.(*v1alpha3.Issuer)) })
+	scheme.AddTypeDefaultingFunc(&v1alpha3.IssuerList{}, func(obj interface{}) { SetObjectDefaults_IssuerList(obj.(*v1alpha3.IssuerList)) })
 	return nil
+}
+
+func SetObjectDefaults_ClusterIssuer(in *v1alpha3.ClusterIssuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_ClusterIssuerList(in *v1alpha3.ClusterIssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_ClusterIssuer(a)
+	}
+}
+
+func SetObjectDefaults_Issuer(in *v1alpha3.Issuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_IssuerList(in *v1alpha3.IssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Issuer(a)
+	}
 }

--- a/pkg/internal/apis/certmanager/v1beta1/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/v1beta1/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -38,4 +38,15 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["defaults_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1beta1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+    ],
 )

--- a/pkg/internal/apis/certmanager/v1beta1/defaults.go
+++ b/pkg/internal/apis/certmanager/v1beta1/defaults.go
@@ -18,8 +18,19 @@ package v1beta1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
 	return RegisterDefaults(scheme)
+}
+
+func SetDefaults_VenafiCloud(o *cmapi.VenafiCloud) {
+	if o.URL == "" {
+		o.URL = cmapi.DefaultVenafiCloudURL
+	}
+	if o.APITokenSecretRef.Key == "" {
+		o.APITokenSecretRef.Key = cmapi.DefaultVenafiCloudAPITokenSecretRefKey
+	}
 }

--- a/pkg/internal/apis/certmanager/v1beta1/defaults_test.go
+++ b/pkg/internal/apis/certmanager/v1beta1/defaults_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+func TestSetDefaultsVenafiCloud(t *testing.T) {
+	t.Run("set-defaults", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, cmapi.DefaultVenafiCloudURL, o.URL)
+		assert.Equal(t, cmapi.DefaultVenafiCloudAPITokenSecretRefKey, o.APITokenSecretRef.Key)
+	})
+
+	t.Run("no-clobber", func(t *testing.T) {
+		o := &cmapi.VenafiCloud{
+			URL: "https://custom-url",
+			APITokenSecretRef: cmmeta.SecretKeySelector{
+				Key: "foo",
+			},
+		}
+		SetDefaults_VenafiCloud(o)
+		assert.Equal(t, "https://custom-url", o.URL)
+		assert.Equal(t, "foo", o.APITokenSecretRef.Key)
+	})
+}

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.defaults.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.defaults.go
@@ -21,6 +21,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	v1beta1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1beta1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -28,5 +29,39 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&v1beta1.ClusterIssuer{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuer(obj.(*v1beta1.ClusterIssuer)) })
+	scheme.AddTypeDefaultingFunc(&v1beta1.ClusterIssuerList{}, func(obj interface{}) { SetObjectDefaults_ClusterIssuerList(obj.(*v1beta1.ClusterIssuerList)) })
+	scheme.AddTypeDefaultingFunc(&v1beta1.Issuer{}, func(obj interface{}) { SetObjectDefaults_Issuer(obj.(*v1beta1.Issuer)) })
+	scheme.AddTypeDefaultingFunc(&v1beta1.IssuerList{}, func(obj interface{}) { SetObjectDefaults_IssuerList(obj.(*v1beta1.IssuerList)) })
 	return nil
+}
+
+func SetObjectDefaults_ClusterIssuer(in *v1beta1.ClusterIssuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_ClusterIssuerList(in *v1beta1.ClusterIssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_ClusterIssuer(a)
+	}
+}
+
+func SetObjectDefaults_Issuer(in *v1beta1.Issuer) {
+	if in.Spec.IssuerConfig.Venafi != nil {
+		if in.Spec.IssuerConfig.Venafi.Cloud != nil {
+			SetDefaults_VenafiCloud(in.Spec.IssuerConfig.Venafi.Cloud)
+		}
+	}
+}
+
+func SetObjectDefaults_IssuerList(in *v1beta1.IssuerList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Issuer(a)
+	}
 }

--- a/pkg/issuer/venafi/client/BUILD.bazel
+++ b/pkg/issuer/venafi/client/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/internal/apis/certmanager/v1:go_default_library",
         "//pkg/issuer/venafi/client/api:go_default_library",
         "//pkg/util/pki:go_default_library",
         "@com_github_venafi_vcert_v4//:go_default_library",

--- a/pkg/issuer/venafi/client/venaficlient_test.go
+++ b/pkg/issuer/venafi/client/venaficlient_test.go
@@ -153,7 +153,7 @@ func TestConfigForIssuerT(t *testing.T) {
 			iss: cloudIssuer,
 			secretsLister: generateSecretLister(&corev1.Secret{
 				Data: map[string][]byte{
-					defaultAPIKeyKey: []byte(apiKey),
+					cmapi.DefaultVenafiCloudAPITokenSecretRefKey: []byte(apiKey),
 				},
 			}, nil),
 			CheckFn: func(t *testing.T, cnf *vcert.Config) {

--- a/pkg/webhook/BUILD.bazel
+++ b/pkg/webhook/BUILD.bazel
@@ -1,19 +1,5 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
-go_library(
-    name = "go_default_library",
-    srcs = ["scheme.go"],
-    importpath = "github.com/jetstack/cert-manager/pkg/webhook",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/internal/api/validation:go_default_library",
-        "//pkg/internal/apis/acme/install:go_default_library",
-        "//pkg/internal/apis/certmanager/install:go_default_library",
-        "//pkg/internal/apis/meta/install:go_default_library",
-        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
-    ],
-)
-
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -31,4 +17,12 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["scheme.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/webhook",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/internal/api:go_default_library"],
 )

--- a/pkg/webhook/scheme.go
+++ b/pkg/webhook/scheme.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 The Jetstack cert-manager contributors.
+Copyright 2020 The Jetstack cert-manager contributors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,37 +16,11 @@ limitations under the License.
 
 package webhook
 
-import (
-	"k8s.io/apimachinery/pkg/runtime"
+import internalcmapi "github.com/jetstack/cert-manager/pkg/internal/api"
 
-	"github.com/jetstack/cert-manager/pkg/internal/api/validation"
-	acmeinstall "github.com/jetstack/cert-manager/pkg/internal/apis/acme/install"
-	cminstall "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager/install"
-	metainstall "github.com/jetstack/cert-manager/pkg/internal/apis/meta/install"
-)
-
-// Define a Scheme that has all cert-manager API types registered, including
-// the internal API version, defaulting functions and conversion functions for
-// all external versions.
-// This scheme should *only* be used by the webhook as the conversion/defaulter
-// functions are likely to change in future, and all controllers consuming
-// cert-manager APIs should have a consistent view of all API kinds.
-
+// These public aliases are required because the ./cmd/webhook packages can't import them from ./pkg/internal
+// TODO: Create a top-level ./internal package which can be used by ./cmd and ./test
 var (
-	// Scheme is a Kubernetes runtime.Scheme with all internal and external API
-	// versions for cert-manager types registered.
-	Scheme = runtime.NewScheme()
-
-	// ValidationRegistry is a validation registry with all required
-	// validations that should be enforced by the webhook component.
-	ValidationRegistry = validation.NewRegistry(Scheme)
+	Scheme             = internalcmapi.Scheme
+	ValidationRegistry = internalcmapi.ValidationRegistry
 )
-
-func init() {
-	cminstall.Install(Scheme)
-	acmeinstall.Install(Scheme)
-	metainstall.Install(Scheme)
-
-	cminstall.InstallValidation(ValidationRegistry)
-	acmeinstall.InstallValidation(ValidationRegistry)
-}


### PR DESCRIPTION
This avoids having to perform adhoc defaulting in the Venafi client code.

**Release note**:
```release-note
Improved API defaulting for Venafi Issuer configuration
```