### PR TITLE
Change issue templates to use HTML comments + tip about code blocks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -4,27 +4,36 @@ about: Report a bug to help us improve cert-manager
 
 ---
 
-> Bugs should be filed for issues encountered whilst operating cert-manager.
-> You should first attempt to resolve your issues through the community support
-> channels, e.g. Slack, in order to rule out individual configuration errors.
-> Please provide as much detail as possible.
+<!--
+Bugs should be filed for issues encountered whilst operating cert-manager.
+You should first attempt to resolve your issues through the community support
+channels, e.g. Slack, in order to rule out individual configuration errors.
+Please provide as much detail as possible. 
+-->
 
 **Describe the bug**:
-A clear and concise description of what the bug is.
+<!--
+A clear and concise description of what the bug is. 
+Tip: you can use 
+```
+<code here>
+```
+for code blocks of your kubectl output or YAML files.
+-->
 
 **Expected behaviour**:
-A concise description of what you expected to happen.
+<!--A concise description of what you expected to happen.-->
 
 **Steps to reproduce the bug**:
-Steps to reproduce the bug should be clear and easily reproducible to help people
-gain an understanding of the problem.
+<!--Steps to reproduce the bug should be clear and easily reproducible to help people
+gain an understanding of the problem.-->
 
 **Anything else we need to know?**:
 
 **Environment details:**:
-- Kubernetes version (e.g. v1.10.2):
-- Cloud-provider/provisioner (e.g. GKE, kops AWS, etc):
-- cert-manager version (e.g. v0.4.0):
-- Install method (e.g. helm or static manifests):
+- Kubernetes version:
+- Cloud-provider/provisioner:
+- cert-manager version: 
+- Install method: e.g. helm/static manifests
 
 /kind bug

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -5,21 +5,22 @@ about: Suggest an idea to improve cert-manager
 ---
 
 **Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is
+<!--A clear and concise description of what the problem is-->
 
 **Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+<!--A clear and concise description of what you want to happen.-->
 
 **Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+<!--A clear and concise description of any alternative solutions or features you've considered.-->
 
 **Additional context**
-Add any other context about the feature request here.
+<!--Add any other context about the feature request here.-->
 
-**Environment details (if applicable)**:
-- Kubernetes version (e.g. v1.10.2):
-- Cloud-provider/provisioner (e.g. GKE, kops AWS, etc):
-- cert-manager version (e.g. v0.4.0):
-- Install method (e.g. helm or static manifests):
+**Environment details (remove if not applicable)**:
+- Kubernetes version:
+- Cloud-provider/provisioner:
+- cert-manager version: 
+- Install method: e.g. helm/static manifests
+
 
 /kind feature


### PR DESCRIPTION
**What this PR does / why we need it**:

When going through issues I often spend a lot of time cleaning up the text in there to be more readable using code blocks or removing boilerplate. By looking at the most made mistakes I tried to improve our templates this way.
Suggestions welcome!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
