### PR TITLE
WIP: investigate stale CertificateRequest after a failing Certificate is updated

### DIFF
--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -18,6 +18,8 @@ package certificate
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"strings"
 	"time"
@@ -268,6 +270,63 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 		By("Validating the issued Certificate...")
 		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow updating the dns name of a failing certificate that had a wrong dns name", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a failing Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames("google.com"),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Making sure the Certificate fails")
+		notReadyCondition := v1.CertificateCondition{
+			Type:   v1.CertificateConditionReady,
+			Status: cmmeta.ConditionFalse,
+		}
+		Eventually(cert, "30s", "1s").Should(HaveCondition(f, notReadyCondition))
+		Consistently(cert, "1m", "10s").Should(HaveCondition(f, notReadyCondition))
+
+		By("Getting the latest version of the Certificate")
+		cert, err = certClient.Get(context.TODO(), certificateName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Replacing dnsNames with a valid dns name")
+		cert.Spec.DNSNames = []string{fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)}
+		_, err = certClient.Update(context.TODO(), cert, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be not ready")
+		_, err = h.WaitForCertificateNotReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to become ready & valid")
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking that the secret contains this dns name")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, func(cert *v1.Certificate, secret *corev1.Secret) error {
+			dnsnames, err := findDNSNames(secret)
+			if err != nil {
+				return err
+			}
+			Expect(dnsnames).To(Equal(cert.Spec.DNSNames))
+			return nil
+		})
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -564,3 +623,27 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 	})
 
 })
+
+// findDNSNames decodes and returns the dns names (SANs) contained in a
+// certificate secret.
+func findDNSNames(s *corev1.Secret) ([]string, error) {
+	if s.Data == nil {
+		return nil, fmt.Errorf("secret contains no data")
+	}
+	pkData := s.Data[corev1.TLSPrivateKeyKey]
+	certData := s.Data[corev1.TLSCertKey]
+	if len(pkData) == 0 || len(certData) == 0 {
+		return nil, fmt.Errorf("missing data in CA secret")
+	}
+	cert, err := tls.X509KeyPair(certData, pkData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse data in CA secret: %w", err)
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("internal error parsing x509 certificate: %w", err)
+	}
+
+	return x509Cert.DNSNames, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does**: this PR adds a simple e2e test case that aims at showcasing the "certificate updated but order not updated" bug presented in #3250: whenever a certificate is created with an invalid dns name or common name (such as google.com), editing the dns name (or common name) won't do anything.

**Note**: this test does not work as intended; this PR is just here to spawn a conversation about the next steps I could take, see https://github.com/jetstack/cert-manager/issues/3250#issuecomment-722453505

