### PR TITLE
Add `inspect secret` command

### DIFF
--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -34,6 +34,7 @@ filegroup(
         "//cmd/ctl/cmd:all-srcs",
         "//cmd/ctl/pkg/convert:all-srcs",
         "//cmd/ctl/pkg/create:all-srcs",
+        "//cmd/ctl/pkg/inspect:all-srcs",
         "//cmd/ctl/pkg/renew:all-srcs",
         "//cmd/ctl/pkg/status:all-srcs",
         "//cmd/ctl/pkg/util:all-srcs",

--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/convert"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/create"
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/inspect"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/status"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/version"
@@ -67,6 +68,7 @@ kubectl cert-manager is a CLI tool manage and configure cert-manager resources f
 	cmds.AddCommand(create.NewCmdCreate(ioStreams, factory))
 	cmds.AddCommand(renew.NewCmdRenew(ioStreams, factory))
 	cmds.AddCommand(status.NewCmdStatus(ioStreams, factory))
+	cmds.AddCommand(inspect.NewCmdInspect(ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/pkg/inspect/BUILD.bazel
+++ b/cmd/ctl/pkg/inspect/BUILD.bazel
@@ -2,20 +2,13 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["cmd.go"],
-    importpath = "github.com/jetstack/cert-manager/cmd/ctl/cmd",
+    srcs = ["inspect.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/inspect",
     visibility = ["//visibility:public"],
     deps = [
-        "//cmd/ctl/pkg/convert:go_default_library",
-        "//cmd/ctl/pkg/create:go_default_library",
-        "//cmd/ctl/pkg/inspect:go_default_library",
-        "//cmd/ctl/pkg/renew:go_default_library",
-        "//cmd/ctl/pkg/status:go_default_library",
-        "//cmd/ctl/pkg/version:go_default_library",
+        "//cmd/ctl/pkg/inspect/secret:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
-        "@io_k8s_client_go//plugin/pkg/client/auth:go_default_library",
-        "@io_k8s_klog_v2//:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
     ],
 )
@@ -29,7 +22,10 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//cmd/ctl/pkg/inspect/secret:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/ctl/pkg/inspect/inspect.go
+++ b/cmd/ctl/pkg/inspect/inspect.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Jetstack cert-manager contributors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ctl/pkg/inspect/inspect.go
+++ b/cmd/ctl/pkg/inspect/inspect.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inspect
+
+import (
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/inspect/secret"
+)
+
+func NewCmdInspect(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+	cmds := &cobra.Command{
+		Use:   "inspect",
+		Short: "Get details on certificate related resources",
+		Long:  `Get details on certificate related resources, e.g. secrets`,
+	}
+
+	cmds.AddCommand(secret.NewCmdInspectSecret(ioStreams, factory))
+
+	return cmds
+}

--- a/cmd/ctl/pkg/inspect/secret/BUILD.bazel
+++ b/cmd/ctl/pkg/inspect/secret/BUILD.bazel
@@ -1,0 +1,53 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "secret.go",
+        "util.go",
+    ],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/inspect/secret",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+        "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
+        "@io_k8s_kubectl//pkg/util/templates:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["secret_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/acme/v1beta1:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//test/unit/gen:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/cmd/ctl/pkg/inspect/secret/BUILD.bazel
+++ b/cmd/ctl/pkg/inspect/secret/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util/pki:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
@@ -20,6 +21,7 @@ go_library(
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
         "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
         "@io_k8s_kubectl//pkg/util/templates:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
         "@org_golang_x_crypto//ocsp:go_default_library",
     ],
 )
@@ -40,15 +42,14 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["secret_test.go"],
+    srcs = [
+        "secret_test.go",
+        "util_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/acme/v1beta1:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
-        "//pkg/apis/meta/v1:go_default_library",
-        "//test/unit/gen:go_default_library",
-        "@com_github_stretchr_testify//assert:go_default_library",
-        "@io_k8s_api//core/v1:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )

--- a/cmd/ctl/pkg/inspect/secret/BUILD.bazel
+++ b/cmd/ctl/pkg/inspect/secret/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
         "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
         "@io_k8s_kubectl//pkg/util/templates:go_default_library",
+        "@org_golang_x_crypto//ocsp:go_default_library",
     ],
 )
 

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Jetstack cert-manager contributors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -316,7 +316,7 @@ func describeCRL(cert *x509.Certificate) string {
 	for _, crlURL := range cert.CRLDistributionPoints {
 		u, err := url.Parse(crlURL)
 		if err != nil {
-			continue // not a valid URL
+			return fmt.Sprintf("Invalid CRL URL: %v", err)
 		}
 		if u.Scheme != "ldap" && u.Scheme != "https" {
 			continue

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -121,7 +121,8 @@ func (o *Options) Run(args []string) error {
 		return fmt.Errorf("error when finding Secret %q: %w\n", args[0], err)
 	}
 
-	output, err := DescribeCertificate(secret.Data[corev1.TLSCertKey])
+	// TODO: use cmmeta
+	output, err := DescribeCertificate(secret.Data[corev1.TLSCertKey], secret.Data["ca.crt"])
 	if err != nil {
 		return fmt.Errorf("error when describing Secret %q: %w\n", args[0], err)
 	}

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -27,6 +27,8 @@ import (
 
 	"github.com/spf13/cobra"
 
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -35,10 +37,10 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
-
-	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"github.com/jetstack/cert-manager/pkg/util/pki"
+	k8sclock "k8s.io/utils/clock"
 )
+
+var clock k8sclock.Clock = k8sclock.RealClock{}
 
 const validForTemplate = `Valid for:
 	DNS Names: %s
@@ -320,7 +322,7 @@ func describeTrusted(cert *x509.Certificate, intermediates [][]byte) string {
 	}
 	_, err = cert.Verify(x509.VerifyOptions{
 		Roots:       systemPool,
-		CurrentTime: time.Now(),
+		CurrentTime: clock.Now(),
 	})
 	if err == nil {
 		return "yes"

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/kubernetes"
+	restclient "k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+)
+
+var (
+	long = templates.LongDesc(i18n.T(`
+Get details about a kubernetes.io/tls typed secret`))
+
+	example = templates.Examples(i18n.T(`
+# Query information about a secret with name 'my-crt' in namespace 'my-namespace'
+kubectl cert-manager inspect secret my-crt --namespace my-namespace
+`))
+)
+
+// Options is a struct to support status certificate command
+type Options struct {
+	RESTConfig *restclient.Config
+	// The Namespace that the Certificate to be queried about resides in.
+	// This flag registration is handled by cmdutil.Factory
+	Namespace string
+
+	clientSet *kubernetes.Clientset
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns initialized Options
+func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: ioStreams,
+	}
+}
+
+// NewCmdInspectSecret returns a cobra command for status certificate
+func NewCmdInspectSecret(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+	o := NewOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:     "secret",
+		Short:   "Get details about a kubernetes.io/tls typed secret",
+		Long:    long,
+		Example: example,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Validate(args))
+			cmdutil.CheckErr(o.Complete(factory))
+			cmdutil.CheckErr(o.Run(args))
+		},
+	}
+	return cmd
+}
+
+// Validate validates the provided options
+func (o *Options) Validate(args []string) error {
+	if len(args) < 1 {
+		return errors.New("the name of the Secret has to be provided as argument")
+	}
+	if len(args) > 1 {
+		return errors.New("only one argument can be passed in: the name of the Secret")
+	}
+	return nil
+}
+
+// Complete takes the factory and infers any remaining options.
+func (o *Options) Complete(f cmdutil.Factory) error {
+	var err error
+
+	o.Namespace, _, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.RESTConfig, err = f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	o.clientSet, err = kubernetes.NewForConfig(o.RESTConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run executes status certificate command
+func (o *Options) Run(args []string) error {
+	ctx := context.TODO()
+
+	secret, err := o.clientSet.CoreV1().Secrets(o.Namespace).Get(ctx, args[0], metav1.GetOptions{})
+	if err != nil {
+		return fmt.Errorf("error when finding Secret %q: %w\n", args[0], err)
+	}
+
+	output, err := DescribeCertificate(secret.Data[corev1.TLSCertKey])
+	if err != nil {
+		return fmt.Errorf("error when describing Secret %q: %w\n", args[0], err)
+	}
+	fmt.Println(output)
+
+	return nil
+}

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -26,9 +26,6 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-
-	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"github.com/jetstack/cert-manager/pkg/util/pki"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -38,6 +35,9 @@ import (
 	"k8s.io/kubectl/pkg/util/i18n"
 	"k8s.io/kubectl/pkg/util/templates"
 	k8sclock "k8s.io/utils/clock"
+
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 var clock k8sclock.Clock = k8sclock.RealClock{}

--- a/cmd/ctl/pkg/inspect/secret/secret_test.go
+++ b/cmd/ctl/pkg/inspect/secret/secret_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Jetstack cert-manager contributors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ctl/pkg/inspect/secret/secret_test.go
+++ b/cmd/ctl/pkg/inspect/secret/secret_test.go
@@ -89,7 +89,7 @@ func Test_describeCertificate(t *testing.T) {
 			want: `Certificate:
 	Signing Algorithm:	SHA256-RSA
 	Public Key Algorithm: 	ECDSA
-	Serial Number:	318510152735780923476564623737462169902
+	Serial Number:	135264542196636937349115151139823201377
 	Fingerprints: 	A9:4D:28:6F:1E:78:4A:72:C7:38:01:7C:31:CC:42:09:C7:46:9C:6A:26:C5:71:1A:F1:35:11:6E:BA:C3:BA:5A
 	Is a CA certificate: false
 	CRL:	<none>
@@ -275,7 +275,7 @@ func Test_describeValidFor(t *testing.T) {
 	Email Addresses: 
 		- test@cert-manager.io
 	Usages: 
-		- signing
+		- digital signature
 		- key encipherment
 		- any
 		- server auth

--- a/cmd/ctl/pkg/inspect/secret/secret_test.go
+++ b/cmd/ctl/pkg/inspect/secret/secret_test.go
@@ -1,0 +1,486 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package secret
+
+import (
+	"crypto/x509"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1beta1"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+func TestFormatStringSlice(t *testing.T) {
+	tests := map[string]struct {
+		slice     []string
+		expOutput string
+	}{
+		// Newlines are part of the expected output
+		"Empty slice returns empty string": {
+			slice:     []string{},
+			expOutput: ``,
+		},
+		"Slice with one element returns string with one line": {
+			slice: []string{"hello"},
+			expOutput: `- hello
+`,
+		},
+		"Slice with multiple elements returns string with multiple lines": {
+			slice: []string{"hello", "World", "another line"},
+			expOutput: `- hello
+- World
+- another line
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if actualOutput := formatStringSlice(test.slice); actualOutput != test.expOutput {
+				t.Errorf("Unexpected output; expected: \n%s\nactual: \n%s", test.expOutput, actualOutput)
+			}
+		})
+	}
+}
+
+func TestCRInfoString(t *testing.T) {
+	tests := map[string]struct {
+		cr        *cmapi.CertificateRequest
+		err       error
+		expOutput string
+	}{
+		// Newlines are part of the expected output
+		"Nil pointer output correct": {
+			cr:  nil,
+			err: errors.New("No CertificateRequest found for this Certificate\n"),
+			expOutput: `No CertificateRequest found for this Certificate
+`,
+		},
+		"CR with no condition output correct": {
+			cr: &cmapi.CertificateRequest{Status: cmapi.CertificateRequestStatus{Conditions: []cmapi.CertificateRequestCondition{}}},
+			expOutput: `CertificateRequest:
+  Name: 
+  Namespace: 
+  Conditions:
+    No Conditions set
+  Events:  <none>
+`,
+		},
+		"CR with conditions output correct": {
+			cr: &cmapi.CertificateRequest{
+				Status: cmapi.CertificateRequestStatus{
+					Conditions: []cmapi.CertificateRequestCondition{
+						{Type: cmapi.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue, Message: "example"},
+					}}},
+			expOutput: `CertificateRequest:
+  Name: 
+  Namespace: 
+  Conditions:
+    Ready: True, Reason: , Message: example
+  Events:  <none>
+`,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualOutput := (&CertificateStatus{}).withCR(test.cr, nil, test.err).CRStatus.String()
+			if strings.TrimSpace(actualOutput) != strings.TrimSpace(test.expOutput) {
+				t.Errorf("Unexpected output; expected: \n%s\nactual: \n%s", test.expOutput, actualOutput)
+			}
+		})
+	}
+}
+
+func TestKeyUsageToString(t *testing.T) {
+	tests := map[string]struct {
+		usage     x509.KeyUsage
+		expOutput string
+	}{
+		"no key usage set": {
+			usage:     x509.KeyUsage(0),
+			expOutput: "",
+		},
+		"key usage Digital Signature": {
+			usage:     x509.KeyUsageDigitalSignature,
+			expOutput: "Digital Signature",
+		},
+		"key usage Digital Signature and Data Encipherment": {
+			usage:     x509.KeyUsageDigitalSignature | x509.KeyUsageDataEncipherment,
+			expOutput: "Digital Signature, Data Encipherment",
+		},
+		"key usage with three usages is ordered": {
+			usage:     x509.KeyUsageDigitalSignature | x509.KeyUsageDataEncipherment | x509.KeyUsageContentCommitment,
+			expOutput: "Digital Signature, Content Commitment, Data Encipherment",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if actualOutput := keyUsageToString(test.usage); actualOutput != test.expOutput {
+				t.Errorf("Unexpected output; expected: \n%s\nactual: \n%s", test.expOutput, actualOutput)
+			}
+		})
+	}
+}
+
+func TestExtKeyUsageToString(t *testing.T) {
+	tests := map[string]struct {
+		extUsage       []x509.ExtKeyUsage
+		expOutput      string
+		expError       bool
+		expErrorOutput string
+	}{
+		"no extended key usage": {
+			extUsage:  []x509.ExtKeyUsage{},
+			expOutput: "",
+		},
+		"extended key usage Any": {
+			extUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+			expOutput: "Any",
+		},
+		"multiple extended key usages": {
+			extUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageEmailProtection},
+			expOutput: "Client Authentication, Email Protection",
+		},
+		"undefined extended key usage": {
+			extUsage:       []x509.ExtKeyUsage{x509.ExtKeyUsage(42)},
+			expOutput:      "",
+			expError:       true,
+			expErrorOutput: "error when converting Extended Usages to string: encountered unknown Extended Usage with code 42",
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			actualOutput, err := extKeyUsageToString(test.extUsage)
+			if err != nil {
+				if !test.expError || test.expErrorOutput != err.Error() {
+					t.Errorf("got unexpected error. This test expects an error: %t. expected error: %q, actual error: %q",
+						test.expError, test.expErrorOutput, err.Error())
+				}
+			} else if test.expError {
+				t.Errorf("expects error: %q, but did not get any", test.expErrorOutput)
+			}
+			if actualOutput != test.expOutput {
+				t.Errorf("Unexpected output; expected: \n%s\nactual: \n%s", test.expOutput, actualOutput)
+			}
+		})
+	}
+}
+
+func TestStatusFromResources(t *testing.T) {
+	timestamp, err := time.Parse(time.RFC3339, "2020-09-16T09:26:18Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tlsCrt := []byte(`-----BEGIN CERTIFICATE-----
+MIICyTCCAbGgAwIBAgIRAOL4jtyULBSEYyGdqQn9YzowDQYJKoZIhvcNAQELBQAw
+DzENMAsGA1UEAxMEdGVzdDAeFw0yMDA3MzAxNjExNDNaFw0yMDEwMjgxNjExNDNa
+MA8xDTALBgNVBAMTBHRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIB
+AQDdfNmjh5ag7f6U1hj1OAx/dEN9kQzPsSlBMXGb/Ho4k5iegrFd6w8JkYdCthFv
+lfg3bIhw5tCKaw1o57HnWKBKKGt7XpeIu1mEcv8pveMIPO7TZ4+oElgX880NfJmL
+DkjEcctEo/+FurudO1aEbNfbNWpzudYKj7gGtYshBytqaYt4/APqWARJBFCYVVys
+wexZ0fLi5cBD8H1bQ1Ec3OCr5Mrq9thAGkj+rVlgYR0AZVGa9+SCOj27t6YCmyzR
+AJSEQ35v58Zfxp5tNyYd6wcAswJ9YipnUXvwahF95PNlRmMhp3Eo15m9FxehcVXU
+BOfxykMwZN7onMhuHiiwiB+NAgMBAAGjIDAeMA4GA1UdDwEB/wQEAwIFoDAMBgNV
+HRMBAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQALrnldWjTBTvV5WKapUHUG0rhA
+vp2Cf+5FsPw8vKScXp4L+wKGdPOjhHz6NOiw5wu8A0HxlVUFawRpagkjFkeTL78O
+9ghBHLiqn9xNPIKC6ID3WpnN5terwQxQeO/M54sVMslUWCcZm9Pu4Eb//2e6wEdu
+eMmpfeISQmCsBC1CTmpxUjeUg5DEQ0X1TQykXq+bG2iso6RYPxZTFTHJFzXiDYEc
+/X7H+bOmpo/dMrXapwfvp2gD+BEq96iVpf/DBzGYNs/657LAHJ4YtxtAZCa1CK9G
+MA6koCR/K23HZfML8vT6lcHvQJp9XXaHRIe9NX/M/2f6VpfO7JjKWLou5k5a
+-----END CERTIFICATE-----`)
+
+	serialNum, _ := new(big.Int).SetString("301696114246524167282555582613204853562", 10)
+	ns := "ns1"
+	dummyEventList := &corev1.EventList{
+		Items: []corev1.Event{{
+			Type:    "type",
+			Reason:  "reason",
+			Message: "message",
+		}},
+	}
+
+	tests := map[string]struct {
+		inputData *Data
+		expOutput *CertificateStatus
+	}{
+		"Correct information extracted from Certificate resource": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns),
+					gen.SetCertificateNotAfter(metav1.Time{Time: timestamp}),
+					gen.SetCertificateNotBefore(metav1.Time{Time: timestamp}),
+					gen.SetCertificateRenewalTIme(metav1.Time{Time: timestamp}),
+					gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady,
+						Status: cmmeta.ConditionTrue, Message: "Certificate is up to date and has not expired"}),
+					gen.SetCertificateDNSNames("example.com"),
+				),
+				CrtEvents: dummyEventList,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				Conditions: []cmapi.CertificateCondition{{Type: cmapi.CertificateConditionReady,
+					Status: cmmeta.ConditionTrue, Message: "Certificate is up to date and has not expired"}},
+				DNSNames:    []string{"example.com"},
+				Events:      dummyEventList,
+				NotBefore:   &metav1.Time{Time: timestamp},
+				NotAfter:    &metav1.Time{Time: timestamp},
+				RenewalTime: &metav1.Time{Time: timestamp},
+			},
+		},
+		"Issuer correctly with Kind Issuer": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Issuer:       gen.Issuer("test-issuer"),
+				IssuerKind:   "Issuer",
+				IssuerError:  nil,
+				IssuerEvents: dummyEventList,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				IssuerStatus: &IssuerStatus{
+					Name:   "test-issuer",
+					Kind:   "Issuer",
+					Events: dummyEventList,
+				},
+			},
+		},
+		"Issuer correctly with Kind ClusterIssuer": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Issuer:       gen.Issuer("test-clusterissuer"),
+				IssuerKind:   "ClusterIssuer",
+				IssuerError:  nil,
+				IssuerEvents: dummyEventList,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				IssuerStatus: &IssuerStatus{
+					Name:   "test-clusterissuer",
+					Kind:   "ClusterIssuer",
+					Events: dummyEventList,
+				},
+			},
+		},
+		"Correct information extracted from Secret resource": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Secret: gen.Secret("existing-tls-secret",
+					gen.SetSecretNamespace(ns),
+					gen.SetSecretData(map[string][]byte{"tls.crt": tlsCrt})),
+				SecretError:  nil,
+				SecretEvents: dummyEventList,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				SecretStatus: &SecretStatus{
+					Error:              nil,
+					Name:               "existing-tls-secret",
+					IssuerCountry:      nil,
+					IssuerOrganisation: nil,
+					IssuerCommonName:   "test",
+					KeyUsage:           x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
+					ExtKeyUsage:        nil,
+					PublicKeyAlgorithm: x509.RSA,
+					SignatureAlgorithm: x509.SHA256WithRSA,
+					SubjectKeyId:       nil,
+					AuthorityKeyId:     nil,
+					SerialNumber:       serialNum,
+					Events:             dummyEventList,
+				},
+			},
+		},
+		"Correct information extracted from CR resource": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Req: gen.CertificateRequest("test-req",
+					gen.SetCertificateRequestNamespace(ns),
+					gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{Type: cmapi.CertificateRequestConditionReady, Status: cmmeta.ConditionFalse, Reason: "Pending", Message: "Waiting on certificate issuance from order default/example-order: \"pending\""})),
+				ReqError:  nil,
+				ReqEvents: dummyEventList,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				CRStatus: &CRStatus{
+					Error:      nil,
+					Name:       "test-req",
+					Namespace:  ns,
+					Conditions: []cmapi.CertificateRequestCondition{{Type: cmapi.CertificateRequestConditionReady, Status: cmmeta.ConditionFalse, Reason: "Pending", Message: "Waiting on certificate issuance from order default/example-order: \"pending\""}},
+					Events:     dummyEventList,
+				},
+			},
+		},
+		"Correct information extracted from Order resource": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Order: &cmacme.Order{
+					TypeMeta:   metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{Name: "example-order", Namespace: ns},
+					Spec:       cmacme.OrderSpec{Request: []byte("dummyCSR"), DNSNames: []string{"www.example.com"}},
+					Status:     cmacme.OrderStatus{},
+				},
+				OrderError: nil,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				OrderStatus: &OrderStatus{
+					Error:          nil,
+					Name:           "example-order",
+					State:          "",
+					Reason:         "",
+					Authorizations: nil,
+					FailureTime:    nil,
+				},
+			},
+		},
+		"Correct information extracted from Challenge resources": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				Challenges: []*cmacme.Challenge{
+					{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "test-challenge1", Namespace: ns},
+						Spec: cmacme.ChallengeSpec{
+							Type:  "HTTP-01",
+							Token: "token",
+							Key:   "key",
+						},
+						Status: cmacme.ChallengeStatus{
+							Processing: false,
+							Presented:  false,
+							Reason:     "reason",
+							State:      "state",
+						},
+					},
+					{
+						TypeMeta:   metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{Name: "test-challenge2", Namespace: ns},
+						Spec: cmacme.ChallengeSpec{
+							Type:  "HTTP-01",
+							Token: "token",
+							Key:   "key",
+						},
+						Status: cmacme.ChallengeStatus{
+							Processing: false,
+							Presented:  false,
+							Reason:     "reason",
+							State:      "state",
+						},
+					},
+				},
+				ChallengeErr: nil,
+			},
+			expOutput: &CertificateStatus{
+				Name:         "test-crt",
+				Namespace:    ns,
+				CreationTime: metav1.Time{},
+				ChallengeStatusList: &ChallengeStatusList{
+					ChallengeStatuses: []*ChallengeStatus{
+						{
+							Name:       "test-challenge1",
+							Type:       "HTTP-01",
+							Token:      "token",
+							Key:        "key",
+							State:      "state",
+							Reason:     "reason",
+							Processing: false,
+							Presented:  false,
+						},
+						{
+							Name:       "test-challenge2",
+							Type:       "HTTP-01",
+							Token:      "token",
+							Key:        "key",
+							State:      "state",
+							Reason:     "reason",
+							Processing: false,
+							Presented:  false,
+						},
+					},
+				},
+			},
+		},
+		"When error, ignore rest of the info about the resource": {
+			inputData: &Data{
+				Certificate: gen.Certificate("test-crt",
+					gen.SetCertificateNamespace(ns)),
+				CrtEvents:    nil,
+				Issuer:       gen.Issuer("test-issuer"),
+				IssuerKind:   "",
+				IssuerError:  errors.New("dummy error"),
+				IssuerEvents: dummyEventList,
+				Secret:       gen.Secret("test-secret"),
+				SecretError:  errors.New("dummy error"),
+				SecretEvents: dummyEventList,
+				Req:          gen.CertificateRequest("test-req"),
+				ReqError:     errors.New("dummy error"),
+				ReqEvents:    dummyEventList,
+				Order: &cmacme.Order{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-order"},
+				},
+				OrderError:   errors.New("dummy error"),
+				Challenges:   []*cmacme.Challenge{{ObjectMeta: metav1.ObjectMeta{Name: "test-challenge"}}},
+				ChallengeErr: errors.New("dummy error"),
+			},
+			expOutput: &CertificateStatus{
+				Name:                "test-crt",
+				Namespace:           ns,
+				CreationTime:        metav1.Time{},
+				IssuerStatus:        &IssuerStatus{Error: errors.New("dummy error")},
+				SecretStatus:        &SecretStatus{Error: errors.New("dummy error")},
+				CRStatus:            &CRStatus{Error: errors.New("dummy error")},
+				OrderStatus:         &OrderStatus{Error: errors.New("dummy error")},
+				ChallengeStatusList: &ChallengeStatusList{Error: errors.New("dummy error")},
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := StatusFromResources(test.inputData)
+			assert.Equal(t, test.expOutput, got)
+		})
+	}
+}

--- a/cmd/ctl/pkg/inspect/secret/secret_test.go
+++ b/cmd/ctl/pkg/inspect/secret/secret_test.go
@@ -90,7 +90,7 @@ func Test_describeCertificate(t *testing.T) {
 	Signing Algorithm:	SHA256-RSA
 	Public Key Algorithm: 	ECDSA
 	Serial Number:	318510152735780923476564623737462169902
-	Fingerprints: 	7A:E1:78:65:17:68:70:74:BD:69:80:4B:0F:C7:6B:C6:2E:B1:55:20:B6:78:51:8F:67:BB:47:BC:25:0E:99:1C
+	Fingerprints: 	A9:4D:28:6F:1E:78:4A:72:C7:38:01:7C:31:CC:42:09:C7:46:9C:6A:26:C5:71:1A:F1:35:11:6E:BA:C3:BA:5A
 	Is a CA certificate: false
 	CRL:	<none>
 	OCSP:	<none>`,
@@ -275,7 +275,7 @@ func Test_describeValidFor(t *testing.T) {
 	Email Addresses: 
 		- test@cert-manager.io
 	Usages: 
-		- digital signature
+		- signing
 		- key encipherment
 		- any
 		- server auth

--- a/cmd/ctl/pkg/inspect/secret/secret_test.go
+++ b/cmd/ctl/pkg/inspect/secret/secret_test.go
@@ -18,6 +18,7 @@ package secret
 
 import (
 	"crypto/x509"
+	"strings"
 	"testing"
 	"time"
 
@@ -71,7 +72,7 @@ func Test_describeCRL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeCRL(tt.cert); got != tt.want {
-				t.Errorf("describeCRL() = %v, want %v", got, tt.want)
+				t.Errorf("describeCRL() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -99,7 +100,7 @@ func Test_describeCertificate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeCertificate(tt.cert); got != tt.want {
-				t.Errorf("describeCertificate() = %v, want %v", got, tt.want)
+				t.Errorf("describeCertificate() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -133,7 +134,7 @@ func Test_describeDebugging(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeDebugging(tt.args.cert, tt.args.intermediates, tt.args.ca); got != tt.want {
-				t.Errorf("describeDebugging() = %v, want %v", got, tt.want)
+				t.Errorf("describeDebugging() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -149,16 +150,16 @@ func Test_describeIssuedBy(t *testing.T) {
 			name: "Describe test certificate",
 			cert: MustParseCertificate(t, testCert),
 			want: `Issued By:
-	Common Name		test-ca
-	Organization		cncf
-	OrganizationalUnit	cert-manager
-	Country: 		BE`,
+	Common Name:	test-ca
+	Organization:	test-ca
+	OrganizationalUnit:	cncf
+	Country:	BE`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeIssuedBy(tt.cert); got != tt.want {
-				t.Errorf("describeIssuedBy() = %v, want %v", got, tt.want)
+				t.Errorf("describeIssuedBy() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -174,16 +175,16 @@ func Test_describeIssuedFor(t *testing.T) {
 			name: "Describe test cert",
 			cert: MustParseCertificate(t, testCert),
 			want: `Issued For:
-	Common Name		Test Cert
-	Organization		cncf
-	OrganizationalUnit	cert-manager
-	Country: 		BE`,
+	Common Name:	Test Cert
+	Organization:	Test Cert
+	OrganizationalUnit:	cncf
+	Country:	BE`,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeIssuedFor(tt.cert); got != tt.want {
-				t.Errorf("describeIssuedFor() = %v, want %v", got, tt.want)
+				t.Errorf("describeIssuedFor() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -211,7 +212,7 @@ func Test_describeOCSP(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeOCSP(tt.args.cert, tt.args.intermediates, tt.args.ca); got != tt.want {
-				t.Errorf("describeOCSP() = %v, want %v", got, tt.want)
+				t.Errorf("describeOCSP() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -250,7 +251,7 @@ func Test_describeTrusted(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeTrusted(tt.args.cert, tt.args.intermediates); got != tt.want {
-				t.Errorf("describeTrusted() = %v, want %v", got, tt.want)
+				t.Errorf("describeTrusted() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -285,7 +286,7 @@ func Test_describeValidFor(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeValidFor(tt.cert); got != tt.want {
-				t.Errorf("describeValidFor() = %v, want %v", got, tt.want)
+				t.Errorf("describeValidFor() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
@@ -308,8 +309,15 @@ func Test_describeValidityPeriod(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := describeValidityPeriod(tt.cert); got != tt.want {
-				t.Errorf("describeValidityPeriod() = %v, want %v", got, tt.want)
+				t.Errorf("describeValidityPeriod() = %v, want %v", makeInvisibleVisible(got), makeInvisibleVisible(tt.want))
 			}
 		})
 	}
+}
+
+func makeInvisibleVisible(in string) string {
+	in = strings.Replace(in, "\n", "\\n\n", -1)
+	in = strings.Replace(in, "\t", "\\t", -1)
+
+	return in
 }

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Jetstack cert-manager contributors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -12,230 +12,13 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
-	"time"
 
 	"golang.org/x/crypto/ocsp"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-
-	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
-const validForTemplate = `Valid for:
-	DNS Names: %s
-	URIs: %s
-	IP Addresses: %s
-	Email Addresses: %s
-	Usages: %s`
-
-const validityPeriodTemplate = `Validity period:
-	Not Before: %s
-	Not After: %s`
-
-const issuedByTemplate = `Issued By:
-	Common Name		%s
-	Organization		%s
-	OrganizationalUnit	%s
-	Country: 		%s`
-
-const issuedForTemplate = `Issued For:
-	Common Name		%s
-	Organization		%s
-	OrganizationalUnit	%s
-	Country: 		%s`
-
-const certificateTemplate = `Certificate:
-	Signing Algorithm:	%s
-	Public Key Algorithm: 	%s
-	Serial Number:	%s
-	Fingerprints: 	%s
-	Is a CA certificate: %v
-	CRL:	%s
-	OCSP:	%s`
-
-const debuggingTemplate = `Debugging:
-	Trusted by this computer:	%s
-	CRL Status:	%s
-	OCSP Status:	%s`
-
-// DescribeCertificate retutring describing a PEM encoded X.509 certificate
-func DescribeCertificate(certData []byte, ca []byte) (string, error) {
-
-	certs := [][]byte(nil)
-	for {
-		block, rest := pem.Decode(certData)
-		if block == nil {
-			break // got no more certs to decode
-		}
-		// ignore private key data
-		if block.Type == "CERTIFICATE" {
-			buf := bytes.NewBuffer(nil)
-			err := pem.Encode(buf, block)
-			if err != nil {
-				return "", fmt.Errorf("error when reencoding PEM: %s", err)
-			}
-			certs = append(certs, buf.Bytes())
-
-		}
-		certData = rest
-	}
-
-	if len(certs) < 1 {
-		return "", errors.New("no PEM data found in secret")
-	}
-
-	// we only want to inspect the leaf
-	x509Cert, err := pki.DecodeX509CertificateBytes(certs[0])
-	if err != nil {
-		return "", fmt.Errorf("error when parsing 'tls.crt': %w", err)
-	}
-
-	intermediates := [][]byte(nil)
-	if len(certs) > 1 {
-		intermediates = certs[1:]
-	}
-
-	out := []string{
-		describeValidFor(x509Cert),
-		describeValidityPeriod(x509Cert),
-		describeIssuedBy(x509Cert),
-		describeIssuedFor(x509Cert),
-		describeCertificate(x509Cert),
-		describeDebugging(x509Cert, intermediates, ca),
-	}
-
-	return strings.Join(out, "\n\n"), nil
-}
-
-func describeValidFor(cert *x509.Certificate) string {
-	return fmt.Sprintf(validForTemplate,
-		printSlice(cert.DNSNames),
-		printSlice(pki.URLsToString(cert.URIs)),
-		printSlice(pki.IPAddressesToString(cert.IPAddresses)),
-		printSlice(cert.EmailAddresses),
-		printKeyUsage(pki.BuildCertManagerKeyUsages(cert.KeyUsage, cert.ExtKeyUsage)),
-	)
-}
-
-func describeValidityPeriod(cert *x509.Certificate) string {
-	return fmt.Sprintf(validityPeriodTemplate,
-		cert.NotBefore.Format(time.RFC1123),
-		cert.NotAfter.Format(time.RFC1123),
-	)
-}
-
-func describeIssuedBy(cert *x509.Certificate) string {
-	return fmt.Sprintf(issuedByTemplate,
-		printOrNone(cert.Issuer.CommonName),
-		printSliceOrOne(cert.Issuer.Organization),
-		printSliceOrOne(cert.Issuer.OrganizationalUnit),
-		printSliceOrOne(cert.Issuer.Country),
-	)
-}
-
-func describeIssuedFor(cert *x509.Certificate) string {
-	return fmt.Sprintf(issuedForTemplate,
-		printOrNone(cert.Subject.CommonName),
-		printSliceOrOne(cert.Subject.Organization),
-		printSliceOrOne(cert.Subject.OrganizationalUnit),
-		printSliceOrOne(cert.Subject.Country),
-	)
-}
-
-func describeCertificate(cert *x509.Certificate) string {
-	return fmt.Sprintf(certificateTemplate,
-		cert.SignatureAlgorithm.String(),
-		cert.PublicKeyAlgorithm.String(),
-		cert.SerialNumber.String(),
-		fingerprint(cert),
-		cert.IsCA,
-		printSliceOrOne(cert.CRLDistributionPoints),
-		printSliceOrOne(cert.OCSPServer),
-	)
-}
-
-func describeDebugging(cert *x509.Certificate, intermediates [][]byte, ca []byte) string {
-	return fmt.Sprintf(debuggingTemplate,
-		describeTrusted(cert, intermediates),
-		describeCRL(cert),
-		describeOCSP(cert, intermediates, ca),
-	)
-}
-
-func describeCRL(cert *x509.Certificate) string {
-	if len(cert.CRLDistributionPoints) < 1 {
-		return "No CRL endpoints set"
-	}
-
-	hasChecked := false
-	for _, crlURL := range cert.CRLDistributionPoints {
-		u, err := url.Parse(crlURL)
-		if err != nil {
-			continue // not a valid URL
-		}
-		if u.Scheme != "ldap" && u.Scheme != "https" {
-			continue
-		}
-
-		valid, err := checkCRLValidCert(cert, crlURL)
-		if err != nil {
-			return fmt.Sprintf("Cannot check CRL: %s", err.Error())
-		}
-		if !valid {
-			return fmt.Sprintf("Revoked by %s", crlURL)
-		}
-	}
-
-	if !hasChecked {
-		return "No CRL endpoints we support found"
-	}
-
-	return "Valid"
-}
-
-func describeOCSP(cert *x509.Certificate, intermediates [][]byte, ca []byte) string {
-	if len(ca) > 1 {
-		intermediates = append([][]byte{ca}, intermediates...)
-	}
-	if len(intermediates) < 1 {
-		return "Cannot check OCSP, does not have a CA or intermediate certificate provided"
-	}
-	issuerCert, err := pki.DecodeX509CertificateBytes(intermediates[len(intermediates)-1])
-	if err != nil {
-		return fmt.Sprintf("Cannot parse intermediate certificate: %s", err.Error())
-	}
-
-	valid, err := checkOCSPValidCert(cert, issuerCert)
-	if err != nil {
-		return fmt.Sprintf("Cannot check OCSP: %s", err.Error())
-	}
-
-	if !valid {
-		return "Marked as revoked"
-	}
-
-	return "valid"
-}
-
-func describeTrusted(cert *x509.Certificate, intermediates [][]byte) string {
-	systemPool, err := x509.SystemCertPool()
-	for _, intermediate := range intermediates {
-		systemPool.AppendCertsFromPEM(intermediate)
-	}
-	if err != nil {
-		return fmt.Sprintf("error loading system CA trusts: %s", err.Error())
-	}
-	_, err = cert.Verify(x509.VerifyOptions{
-		Roots:       systemPool,
-		CurrentTime: time.Now(),
-	})
-	if err == nil {
-		return "yes"
-	}
-	return fmt.Sprintf("no: %s", err.Error())
-}
-
-func fingerprint(cert *x509.Certificate) string {
+func fingerprintCert(cert *x509.Certificate) string {
 	fingerprint := sha256.Sum256(cert.Raw)
 
 	var buf bytes.Buffer
@@ -359,4 +142,26 @@ func printKeyUsage(in []cmapi.KeyUsage) string {
 	}
 
 	return "\n\t\t- " + strings.Trim(strings.Join(usageStrings, "\n\t\t- "), " ")
+}
+
+func splitPEMs(certData []byte) ([][]byte, error) {
+	certs := [][]byte(nil)
+	for {
+		block, rest := pem.Decode(certData)
+		if block == nil {
+			break // got no more certs to decode
+		}
+		// ignore private key data
+		if block.Type == "CERTIFICATE" {
+			buf := bytes.NewBuffer(nil)
+			err := pem.Encode(buf, block)
+			if err != nil {
+				return nil, fmt.Errorf("error when reencoding PEM: %s", err)
+			}
+			certs = append(certs, buf.Bytes())
+
+		}
+		certData = rest
+	}
+	return certs, nil
 }

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -1,10 +1,20 @@
 package secret
 
 import (
+	"bytes"
+	"crypto"
+	"crypto/sha256"
 	"crypto/x509"
+	"encoding/pem"
+	"errors"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"strings"
 	"time"
+
+	"golang.org/x/crypto/ocsp"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 
@@ -28,33 +38,61 @@ const issuedByTemplate = `Issued By:
 	OrganizationalUnit	%s
 	Country: 		%s`
 
-const issuedForTemplate = `Issued By:
+const issuedForTemplate = `Issued For:
 	Common Name		%s
 	Organization		%s
 	OrganizationalUnit	%s
 	Country: 		%s`
 
-// TODO: implement these
-const template = `
-Certificate:
-	Signing Algorithm:
-	Public Key Algorithm:
-	Serial Number:
-	Fingerprints:
-	Is a CA certificate:
+const certificateTemplate = `Certificate:
+	Signing Algorithm:	%s
+	Public Key Algorithm: 	%s
+	Serial Number:	%s
+	Fingerprints: 	%s
+	Is a CA certificate: %v
+	CRL:	%s
+	OCSP:	%s`
 
-OCSP:
-	
-
-Debugging:
-	Trusted by this computer: no
-`
+const debuggingTemplate = `Debugging:
+	Trusted by this computer:	%s
+	CRL Status:	%s
+	OCSP Status:	%s`
 
 // DescribeCertificate retutring describing a PEM encoded X.509 certificate
-func DescribeCertificate(certData []byte) (string, error) {
-	x509Cert, err := pki.DecodeX509CertificateBytes(certData)
+func DescribeCertificate(certData []byte, ca []byte) (string, error) {
+
+	certs := [][]byte(nil)
+	for {
+		block, rest := pem.Decode(certData)
+		if block == nil {
+			break // got no more certs to decode
+		}
+		// ignore private key data
+		if block.Type == "CERTIFICATE" {
+			buf := bytes.NewBuffer(nil)
+			err := pem.Encode(buf, block)
+			if err != nil {
+				return "", fmt.Errorf("error when reencoding PEM: %s", err)
+			}
+			certs = append(certs, buf.Bytes())
+
+		}
+		certData = rest
+	}
+
+	if len(certs) < 1 {
+		return "", errors.New("no PEM data found in secret")
+	}
+
+	// we only want to inspect the leaf
+	x509Cert, err := pki.DecodeX509CertificateBytes(certs[0])
 	if err != nil {
 		return "", fmt.Errorf("error when parsing 'tls.crt': %w", err)
+	}
+
+	intermediates := [][]byte(nil)
+	if len(certs) > 1 {
+		intermediates = certs[1:]
 	}
 
 	out := []string{
@@ -62,6 +100,8 @@ func DescribeCertificate(certData []byte) (string, error) {
 		describeValidityPeriod(x509Cert),
 		describeIssuedBy(x509Cert),
 		describeIssuedFor(x509Cert),
+		describeCertificate(x509Cert),
+		describeDebugging(x509Cert, intermediates, ca),
 	}
 
 	return strings.Join(out, "\n\n"), nil
@@ -100,6 +140,186 @@ func describeIssuedFor(cert *x509.Certificate) string {
 		printSliceOrOne(cert.Subject.OrganizationalUnit),
 		printSliceOrOne(cert.Subject.Country),
 	)
+}
+
+func describeCertificate(cert *x509.Certificate) string {
+	return fmt.Sprintf(certificateTemplate,
+		cert.SignatureAlgorithm.String(),
+		cert.PublicKeyAlgorithm.String(),
+		cert.SerialNumber.String(),
+		fingerprint(cert),
+		cert.IsCA,
+		printSliceOrOne(cert.CRLDistributionPoints),
+		printSliceOrOne(cert.OCSPServer),
+	)
+}
+
+func describeDebugging(cert *x509.Certificate, intermediates [][]byte, ca []byte) string {
+	return fmt.Sprintf(debuggingTemplate,
+		describeTrusted(cert, intermediates),
+		describeCRL(cert),
+		describeOCSP(cert, intermediates, ca),
+	)
+}
+
+func describeCRL(cert *x509.Certificate) string {
+	if len(cert.CRLDistributionPoints) < 1 {
+		return "No CRL endpoints set"
+	}
+
+	hasChecked := false
+	for _, crlURL := range cert.CRLDistributionPoints {
+		u, err := url.Parse(crlURL)
+		if err != nil {
+			continue // not a valid URL
+		}
+		if u.Scheme != "ldap" && u.Scheme != "https" {
+			continue
+		}
+
+		valid, err := checkCRLValidCert(cert, crlURL)
+		if err != nil {
+			return fmt.Sprintf("Cannot check CRL: %s", err.Error())
+		}
+		if !valid {
+			return fmt.Sprintf("Revoked by %s", crlURL)
+		}
+	}
+
+	if !hasChecked {
+		return "No CRL endpoints we support found"
+	}
+
+	return "Valid"
+}
+
+func describeOCSP(cert *x509.Certificate, intermediates [][]byte, ca []byte) string {
+	if len(ca) > 1 {
+		intermediates = append([][]byte{ca}, intermediates...)
+	}
+	if len(intermediates) < 1 {
+		return "Cannot check OCSP, does not have a CA or intermediate certificate provided"
+	}
+	issuerCert, err := pki.DecodeX509CertificateBytes(intermediates[len(intermediates)-1])
+	if err != nil {
+		return fmt.Sprintf("Cannot parse intermediate certificate: %s", err.Error())
+	}
+
+	valid, err := checkOCSPValidCert(cert, issuerCert)
+	if err != nil {
+		return fmt.Sprintf("Cannot check OCSP: %s", err.Error())
+	}
+
+	if !valid {
+		return "Marked as revoked"
+	}
+
+	return "valid"
+}
+
+func describeTrusted(cert *x509.Certificate, intermediates [][]byte) string {
+	systemPool, err := x509.SystemCertPool()
+	for _, intermediate := range intermediates {
+		systemPool.AppendCertsFromPEM(intermediate)
+	}
+	if err != nil {
+		return fmt.Sprintf("error loading system CA trusts: %s", err.Error())
+	}
+	_, err = cert.Verify(x509.VerifyOptions{
+		Roots:       systemPool,
+		CurrentTime: time.Now(),
+	})
+	if err == nil {
+		return "yes"
+	}
+	return fmt.Sprintf("no: %s", err.Error())
+}
+
+func fingerprint(cert *x509.Certificate) string {
+	fingerprint := sha256.Sum256(cert.Raw)
+
+	var buf bytes.Buffer
+	for i, f := range fingerprint {
+		if i > 0 {
+			fmt.Fprintf(&buf, ":")
+		}
+		fmt.Fprintf(&buf, "%02X", f)
+	}
+
+	return buf.String()
+}
+
+func checkOCSPValidCert(leafCert, issuerCert *x509.Certificate) (bool, error) {
+	if len(leafCert.OCSPServer) < 1 {
+		return false, errors.New("No OCSP Server set")
+	}
+	buffer, err := ocsp.CreateRequest(leafCert, issuerCert, &ocsp.RequestOptions{Hash: crypto.SHA1})
+	if err != nil {
+		return false, fmt.Errorf("error creating OCSP request: %w", err)
+	}
+
+	for _, ocspServer := range leafCert.OCSPServer {
+		httpRequest, err := http.NewRequest(http.MethodPost, ocspServer, bytes.NewBuffer(buffer))
+		if err != nil {
+			return false, fmt.Errorf("error creating HTTP request: %w", err)
+		}
+		ocspUrl, err := url.Parse(ocspServer)
+		if err != nil {
+			return false, fmt.Errorf("error parsing OCSP URL: %w", err)
+		}
+		httpRequest.Header.Add("Content-Type", "application/ocsp-request")
+		httpRequest.Header.Add("Accept", "application/ocsp-response")
+		httpRequest.Header.Add("Host", ocspUrl.Host)
+		httpClient := &http.Client{}
+		httpResponse, err := httpClient.Do(httpRequest)
+		if err != nil {
+			return false, fmt.Errorf("error making HTTP request: %w", err)
+		}
+		defer httpResponse.Body.Close()
+		output, err := ioutil.ReadAll(httpResponse.Body)
+		if err != nil {
+			return false, fmt.Errorf("error reading HTTP body: %w", err)
+		}
+		ocspResponse, err := ocsp.ParseResponse(output, issuerCert)
+		if err != nil {
+			return false, fmt.Errorf("error reading OCSP response: %w", err)
+		}
+
+		if ocspResponse.Status == ocsp.Revoked {
+			// one OCSP revoked it do not trust
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+func checkCRLValidCert(cert *x509.Certificate, url string) (bool, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return false, fmt.Errorf("error getting HTTP response: %w", err)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return false, fmt.Errorf("error reading HTTP body: %w", err)
+	}
+	resp.Body.Close()
+
+	crl, err := x509.ParseCRL(body)
+	if err != nil {
+		return false, fmt.Errorf("error parsing HTTP body: %w", err)
+	}
+
+	// TODO: check CRL signature
+
+	for _, revoked := range crl.TBSCertList.RevokedCertificates {
+		if cert.SerialNumber.Cmp(revoked.SerialNumber) == 0 {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 func printSlice(in []string) string {

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -19,6 +19,9 @@ import (
 )
 
 func fingerprintCert(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
 	fingerprint := sha256.Sum256(cert.Raw)
 
 	var buf bytes.Buffer
@@ -120,7 +123,7 @@ func printSliceOrOne(in []string) string {
 		return in[0]
 	}
 
-	return "\n\t\t- " + strings.Trim(strings.Join(in, "\n\t\t- "), " ")
+	return printSlice(in)
 }
 
 func printOrNone(in string) string {
@@ -159,7 +162,6 @@ func splitPEMs(certData []byte) ([][]byte, error) {
 				return nil, fmt.Errorf("error when reencoding PEM: %s", err)
 			}
 			certs = append(certs, buf.Bytes())
-
 		}
 		certData = rest
 	}

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package secret
 
 import (

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -1,0 +1,142 @@
+package secret
+
+import (
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+const validForTemplate = `Valid for:
+	DNS Names: %s
+	URIs: %s
+	IP Addresses: %s
+	Email Addresses: %s
+	Usages: %s`
+
+const validityPeriodTemplate = `Validity period:
+	Not Before: %s
+	Not After: %s`
+
+const issuedByTemplate = `Issued By:
+	Common Name		%s
+	Organization		%s
+	OrganizationalUnit	%s
+	Country: 		%s`
+
+const issuedForTemplate = `Issued By:
+	Common Name		%s
+	Organization		%s
+	OrganizationalUnit	%s
+	Country: 		%s`
+
+// TODO: implement these
+const template = `
+Certificate:
+	Signing Algorithm:
+	Public Key Algorithm:
+	Serial Number:
+	Fingerprints:
+	Is a CA certificate:
+
+OCSP:
+	
+
+Debugging:
+	Trusted by this computer: no
+`
+
+// DescribeCertificate retutring describing a PEM encoded X.509 certificate
+func DescribeCertificate(certData []byte) (string, error) {
+	x509Cert, err := pki.DecodeX509CertificateBytes(certData)
+	if err != nil {
+		return "", fmt.Errorf("error when parsing 'tls.crt': %w", err)
+	}
+
+	out := []string{
+		describeValidFor(x509Cert),
+		describeValidityPeriod(x509Cert),
+		describeIssuedBy(x509Cert),
+		describeIssuedFor(x509Cert),
+	}
+
+	return strings.Join(out, "\n\n"), nil
+}
+
+func describeValidFor(cert *x509.Certificate) string {
+	return fmt.Sprintf(validForTemplate,
+		printSlice(cert.DNSNames),
+		printSlice(pki.URLsToString(cert.URIs)),
+		printSlice(pki.IPAddressesToString(cert.IPAddresses)),
+		printSlice(cert.EmailAddresses),
+		printKeyUsage(pki.BuildCertManagerKeyUsages(cert.KeyUsage, cert.ExtKeyUsage)),
+	)
+}
+
+func describeValidityPeriod(cert *x509.Certificate) string {
+	return fmt.Sprintf(validityPeriodTemplate,
+		cert.NotBefore.Format(time.RFC1123),
+		cert.NotAfter.Format(time.RFC1123),
+	)
+}
+
+func describeIssuedBy(cert *x509.Certificate) string {
+	return fmt.Sprintf(issuedByTemplate,
+		printOrNone(cert.Issuer.CommonName),
+		printSliceOrOne(cert.Issuer.Organization),
+		printSliceOrOne(cert.Issuer.OrganizationalUnit),
+		printSliceOrOne(cert.Issuer.Country),
+	)
+}
+
+func describeIssuedFor(cert *x509.Certificate) string {
+	return fmt.Sprintf(issuedForTemplate,
+		printOrNone(cert.Subject.CommonName),
+		printSliceOrOne(cert.Subject.Organization),
+		printSliceOrOne(cert.Subject.OrganizationalUnit),
+		printSliceOrOne(cert.Subject.Country),
+	)
+}
+
+func printSlice(in []string) string {
+	if len(in) < 1 {
+		return "<none>"
+	}
+
+	return "\n\t\t- " + strings.Trim(strings.Join(in, "\n\t\t- "), " ")
+}
+
+func printSliceOrOne(in []string) string {
+	if len(in) < 1 {
+		return "<none>"
+	} else if len(in) == 1 {
+		return in[0]
+	}
+
+	return "\n\t\t- " + strings.Trim(strings.Join(in, "\n\t\t- "), " ")
+}
+
+func printOrNone(in string) string {
+	if in == "" {
+		return "<none>"
+	}
+
+	return in
+}
+
+func printKeyUsage(in []cmapi.KeyUsage) string {
+	if len(in) < 1 {
+		return " <none>"
+	}
+
+	var usageStrings []string
+	for _, usage := range in {
+		usageStrings = append(usageStrings, string(usage))
+	}
+
+	return "\n\t\t- " + strings.Trim(strings.Join(usageStrings, "\n\t\t- "), " ")
+}

--- a/cmd/ctl/pkg/inspect/secret/util_test.go
+++ b/cmd/ctl/pkg/inspect/secret/util_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2020 The Jetstack cert-manager contributors.
+Copyright 2020 The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/cmd/ctl/pkg/inspect/secret/util_test.go
+++ b/cmd/ctl/pkg/inspect/secret/util_test.go
@@ -1,0 +1,202 @@
+package secret
+
+import (
+	"crypto/x509"
+	"reflect"
+	"testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+)
+
+func Test_fingerprintCert(t *testing.T) {
+	tests := []struct {
+		name string
+		cert *x509.Certificate
+		want string
+	}{
+		{
+			name: "Fingerprint a valid cert",
+			cert: MustParseCertificate(t, testCert),
+			want: "A9:4D:28:6F:1E:78:4A:72:C7:38:01:7C:31:CC:42:09:C7:46:9C:6A:26:C5:71:1A:F1:35:11:6E:BA:C3:BA:5A",
+		},
+		{
+			name: "Fingerprint nil",
+			cert: nil,
+			want: "",
+		},
+		{
+			name: "Fingerprint invalid cert",
+			cert: &x509.Certificate{Raw: []byte("fake")},
+			want: "B5:D5:4C:39:E6:66:71:C9:73:1B:9F:47:1E:58:5D:82:62:CD:4F:54:96:3F:0C:93:08:2D:8D:CF:33:4D:4C:78",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fingerprintCert(tt.cert); got != tt.want {
+				t.Errorf("fingerprintCert() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_printKeyUsage(t *testing.T) {
+	type args struct {
+		in []cmapi.KeyUsage
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := printKeyUsage(tt.args.in); got != tt.want {
+				t.Errorf("printKeyUsage() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_printOrNone(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "Print none on empty",
+			in:   "",
+			want: "<none>",
+		},
+		{
+			name: "Print value on not empty",
+			in:   "ok",
+			want: "ok",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := printOrNone(tt.in); got != tt.want {
+				t.Errorf("printOrNone() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_printSlice(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{
+			name: "Print test slice multiple objects",
+			in:   []string{"test", "ok"},
+			want: `
+		- test
+		- ok`,
+		},
+		{
+			name: "Print test slice one object",
+			in:   []string{"test"},
+			want: "\n\t\t- test",
+		},
+		{
+			name: "Print nil slice",
+			in:   nil,
+			want: "<none>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := printSlice(tt.in); got != tt.want {
+				t.Errorf("printSlice() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_printSliceOrOne(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want string
+	}{
+		{
+			name: "Print test slice multiple objects",
+			in:   []string{"test", "ok"},
+			want: `
+		- test
+		- ok`,
+		},
+		{
+			name: "Print test slice one object",
+			in:   []string{"test"},
+			want: "test",
+		},
+		{
+			name: "Print nil slice",
+			in:   nil,
+			want: "<none>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := printSliceOrOne(tt.in); got != tt.want {
+				t.Errorf("printSliceOrOne() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitPEMs(t *testing.T) {
+	type args struct {
+		certData []byte
+	}
+	tests := []struct {
+		name     string
+		certData []byte
+		want     [][]byte
+		wantErr  bool
+	}{
+		{
+			name:     "Single PEM in file",
+			certData: []byte(testCert),
+			want:     [][]byte{[]byte(testCert)},
+			wantErr:  false,
+		},
+		{
+			name:     "2 PEMs in file",
+			certData: []byte(testCert + "\n" + testCert),
+			want:     [][]byte{[]byte(testCert), []byte(testCert)},
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid input after a valid PEM",
+			certData: []byte(testCert + "\n\ninvalid"),
+			want:     [][]byte{[]byte(testCert)},
+			wantErr:  false,
+		},
+		{
+			name:     "Invalid input without PEM block",
+			certData: []byte("invalid"),
+			want:     nil,
+			wantErr:  false,
+		},
+		// TODO: somehow find an error case the PEM encoder/decoder is quite error resistant
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitPEMs(tt.certData)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("splitPEMs() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("splitPEMs() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/ctl/pkg/inspect/secret/util_test.go
+++ b/cmd/ctl/pkg/inspect/secret/util_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2020 The Jetstack cert-manager contributors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package secret
 
 import (

--- a/pkg/api/util/usages.go
+++ b/pkg/api/util/usages.go
@@ -91,6 +91,9 @@ func ExtKeyUsageStrings(usage []x509.ExtKeyUsage) []cmapi.KeyUsage {
 // keyUsageString returns the cmapi.KeyUsage and "unknown" if not found
 func keyUsageString(usage x509.KeyUsage) cmapi.KeyUsage {
 	for k, v := range keyUsages {
+		if usage == x509.KeyUsageDigitalSignature {
+			return cmapi.UsageDigitalSignature // we have KeyUsageDigitalSignature twice in our array, we should be consistent when parsing
+		}
 		if usage == v {
 			return k
 		}

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -52,7 +52,7 @@ type controller struct {
 	secretLister        corelisters.SecretLister
 
 	// used for testing
-	clock clock.Clock
+	clock.Clock
 	// used to record Events about resources to the API
 	recorder record.EventRecorder
 	// clientset used to update cert-manager API resources

--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -52,7 +52,7 @@ type controller struct {
 	secretLister        corelisters.SecretLister
 
 	// used for testing
-	clock.Clock
+	clock clock.Clock
 	// used to record Events about resources to the API
 	recorder record.EventRecorder
 	// clientset used to update cert-manager API resources


### PR DESCRIPTION
**What this PR does / why we need it**:

How many times have you done `echo ... | base64 -d | openssl x509 --noout --text`? Yup that's right!

This PR aims to print info about a cert in a Kubernetes secret

example output (WIP)
```
user@penguin ~/g/s/g/j/cert-manager> go run ./cmd/ctl/ inspect secret --namespace dispatch princess-tls
Valid for:
        DNS Names: 
                - princess.maartje.dev
        URIs: <none>
        IP Addresses: <none>
        Email Addresses: 
                - maartje@eyskens.me
                - maartje@jetstack.io
        Usages: 
                - signing
                - key encipherment
                - server auth
                - client auth
                - netscape sgc

Validity period:
        Not Before: Wed, 25 Nov 2020 15:50:07 UTC
        Not After: Wed, 25 Nov 2020 16:50:07 UTC

Issued By:
        Common Name             Jetstack Royal CA
        Organization            <none>
        OrganizationalUnit      <none>
        Country:                <none>

Issued For:
        Common Name             X.509 Princess Maartje Eyskens
        Organization            
                - MECT
                - jetstack
        OrganizationalUnit      Royal Family
        Country:                
                - BE
                - GB

Certificate:
        Signing Algorithm:      SHA256-RSA
        Public Key Algorithm:   RSA
        Serial Number:  148695954904709944925975302750116637780
        Fingerprints:   6D:C8:69:E1:F3:08:AA:53:A3:7C:B1:22:46:BE:96:CB:42:25:1A:1D:7A:AC:F3:DE:7C:0B:01:76:08:D2:D9:FD
        Is a CA certificate: false
        CRL:    <none>
        OCSP:   <none>

Debugging:
        Trusted by this computer:       no: x509: certificate signed by unknown authority
        CRL Status:     No CRL endpoints set
        OCSP Status:    Cannot check OCSP: No OCSP Server set

```


```
Valid for:
        DNS Names: 
                - thomasmore.instructure.be
        URIs: <none>
        IP Addresses: <none>
        Email Addresses: <none>
        Usages: 
                - digital signature
                - key encipherment
                - server auth
                - client auth

Validity period:
        Not Before: Sun, 15 Nov 2020 10:28:24 UTC
        Not After: Sat, 13 Feb 2021 10:28:24 UTC

Issued By:
        Common Name             Let's Encrypt Authority X3
        Organization            Let's Encrypt
        OrganizationalUnit      <none>
        Country:                US

Issued For:
        Common Name             thomasmore.instructure.be
        Organization            <none>
        OrganizationalUnit      <none>
        Country:                <none>

Certificate:
        Signing Algorithm:      SHA256-RSA
        Public Key Algorithm:   RSA
        Serial Number:  405279461838505481608804555009933739543992
        Fingerprints:   85:2A:60:10:B3:D9:89:92:C2:68:C4:8D:9B:85:BF:26:68:E0:C2:AD:83:97:83:89:4B:27:B2:7B:F6:58:8F:0C
        Is a CA certificate: false
        CRL:    <none>
        OCSP:   http://ocsp.int-x3.letsencrypt.org

Debugging:
        Trusted by this computer:       yes
        CRL Status:     No CRL endpoints set
        OCSP Status:    valid
```

**Which issue this PR fixes** 
fixes https://github.com/jetstack/cert-manager/issues/3206

**Special notes for your reviewer**:

naming is hard... not too fond of `kubectl cert-manager inspect secret`

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add `kubectl cert-manager inspect secret` to print certificate info from a secret resource
```
