### PR TITLE
Wait for order-controller to add certificate data to the Order

### DIFF
--- a/pkg/controller/certificaterequests/acme/BUILD.bazel
+++ b/pkg/controller/certificaterequests/acme/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/issuer:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/util/errors:go_default_library",
         "//pkg/util/pki:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -176,6 +176,15 @@ func (a *ACME) Sign(ctx context.Context, cr *v1.CertificateRequest, issuer v1.Ge
 		return nil, nil
 	}
 
+	if len(order.Status.Certificate) == 0 {
+		a.reporter.Pending(cr, nil, "OrderPending",
+			fmt.Sprintf("Waiting for order-controller to add certificate data to Order %s/%s",
+				expectedOrder.Namespace, order.Name))
+
+		log.V(logf.DebugLevel).Info("Order controller has not added certificate data to the Order, waiting...")
+		return nil, nil
+	}
+
 	// Order valid, return cert. The calling controller will update with ready if its happy with the cert.
 	x509Cert, err := pki.DecodeX509CertificateBytes(order.Status.Certificate)
 	if errors.IsInvalidData(err) {


### PR DESCRIPTION
Added a check for the length of Order.Status.Certificate before attempting to decode it and copy it to the CertificateRequest.

I also considered adding a Ready condition to the Order which would only be set to true once all the ACME operations had been completed by the order controller.
That might be a cleaner way for the certificaterequest-controller to know when it should examine the Order.

Fixes: #2667

**Release note**:
```release-note
NONE
```