### PR TITLE
Add duration and renew-before Ingress annotations to set those fields on the Certificate

### DIFF
--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -30,6 +30,9 @@ const (
 	// Annotation key for certificate common name.
 	CommonNameAnnotationKey = "cert-manager.io/common-name"
 
+	// Duration key for certificate duration.
+	DurationAnnotationKey = "cert-manager.io/duration"
+
 	// Annotation key for certificate renewBefore.
 	RenewBeforeAnnotationKey = "cert-manager.io/renew-before"
 

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -30,6 +30,9 @@ const (
 	// Annotation key for certificate common name.
 	CommonNameAnnotationKey = "cert-manager.io/common-name"
 
+	// Annotation key for certificate renewBefore.
+	RenewBeforeAnnotationKey = "cert-manager.io/renew-before"
+
 	// Annotation key the 'name' of the Issuer resource.
 	IssuerNameAnnotationKey = "cert-manager.io/issuer-name"
 

--- a/pkg/controller/ingress-shim/BUILD.bazel
+++ b/pkg/controller/ingress-shim/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "checks.go",
         "controller.go",
+        "helper.go",
         "sync.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/controller/ingress-shim",
@@ -36,7 +37,10 @@ go_library(
 
 go_test(
     name = "go_default_test",
-    srcs = ["sync_test.go"],
+    srcs = [
+        "helper_test.go",
+        "sync_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/acme/v1:go_default_library",
@@ -44,6 +48,7 @@ go_test(
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/controller/test:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@io_k8s_api//networking/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/pkg/controller/ingress-shim/helper.go
+++ b/pkg/controller/ingress-shim/helper.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+)
+
+var (
+	errNilCertificate           = errors.New("the supplied Certificate pointer was nil")
+	errInvalidIngressAnnotation = errors.New("invalid ingress annotation")
+)
+
+func translateIngressAnnotations(crt *cmapi.Certificate, annotations map[string]string) error {
+	if crt == nil {
+		return errNilCertificate
+	}
+	if commonName, found := annotations[cmapi.CommonNameAnnotationKey]; found {
+		crt.Spec.CommonName = commonName
+	}
+	if renewBefore, found := annotations[cmapi.RenewBeforeAnnotationKey]; found {
+		duration, err := time.ParseDuration(renewBefore)
+		if err != nil {
+			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.RenewBeforeAnnotationKey, err)
+		}
+		crt.Spec.RenewBefore = &metav1.Duration{Duration: duration}
+	}
+	return nil
+}

--- a/pkg/controller/ingress-shim/helper.go
+++ b/pkg/controller/ingress-shim/helper.go
@@ -38,6 +38,13 @@ func translateIngressAnnotations(crt *cmapi.Certificate, annotations map[string]
 	if commonName, found := annotations[cmapi.CommonNameAnnotationKey]; found {
 		crt.Spec.CommonName = commonName
 	}
+	if duration, found := annotations[cmapi.DurationAnnotationKey]; found {
+		duration, err := time.ParseDuration(duration)
+		if err != nil {
+			return fmt.Errorf("%w %q: %v", errInvalidIngressAnnotation, cmapi.DurationAnnotationKey, err)
+		}
+		crt.Spec.Duration = &metav1.Duration{Duration: duration}
+	}
 	if renewBefore, found := annotations[cmapi.RenewBeforeAnnotationKey]; found {
 		duration, err := time.ParseDuration(renewBefore)
 		if err != nil {

--- a/pkg/controller/ingress-shim/helper_test.go
+++ b/pkg/controller/ingress-shim/helper_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+func TestTranslateIngressAnnotations(t *testing.T) {
+	type testCase struct {
+		crt           *cmapi.Certificate
+		annotations   map[string]string
+		mutate        func(*testCase)
+		check         func(*assert.Assertions, *cmapi.Certificate)
+		expectedError error
+	}
+
+	validAnnotations := func() map[string]string {
+		return map[string]string{
+			cmapi.CommonNameAnnotationKey:  "www.example.com",
+			cmapi.RenewBeforeAnnotationKey: "24h",
+		}
+	}
+
+	tests := map[string]testCase{
+		"success": {
+			crt:         gen.Certificate("example-cert"),
+			annotations: validAnnotations(),
+			check: func(a *assert.Assertions, crt *cmapi.Certificate) {
+				a.Equal("www.example.com", crt.Spec.CommonName)
+				a.Equal(&metav1.Duration{Duration: time.Hour * 24}, crt.Spec.RenewBefore)
+			},
+		},
+		"nil annotations": {
+			crt:         gen.Certificate("example-cert"),
+			annotations: nil,
+		},
+		"empty annotations": {
+			crt:         gen.Certificate("example-cert"),
+			annotations: map[string]string{},
+		},
+		"nil certificate": {
+			crt:           nil,
+			annotations:   validAnnotations(),
+			expectedError: errNilCertificate,
+		},
+		"bad renewBefore": {
+			crt:         gen.Certificate("example-cert"),
+			annotations: validAnnotations(),
+			mutate: func(tc *testCase) {
+				tc.annotations[cmapi.RenewBeforeAnnotationKey] = "an un-parsable duration string"
+			},
+			expectedError: errInvalidIngressAnnotation,
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			if tc.mutate != nil {
+				tc.mutate(&tc)
+			}
+			crt := tc.crt.DeepCopy()
+
+			err := translateIngressAnnotations(crt, tc.annotations)
+
+			if tc.expectedError != nil {
+				assertErrorIs(t, err, tc.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+			if tc.check != nil {
+				tc.check(assert.New(t), crt)
+			}
+		})
+	}
+}
+
+// assertErrorIs checks that the supplied error has the target error in its chain.
+// TODO Upgrade to next release of testify package which has this built in.
+func assertErrorIs(t *testing.T, err, target error) {
+	if assert.Error(t, err) {
+		assert.Truef(t, errors.Is(err, target), "unexpected error type. err: %v, target: %v", err, target)
+	}
+}

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -156,12 +156,8 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 			},
 		}
 
-		err = c.setIssuerSpecificConfig(crt, ing, tls)
-		if err != nil {
-			return nil, nil, err
-		}
-
-		c.setCommonName(crt, ing)
+		setIssuerSpecificConfig(crt, ing)
+		setCommonName(crt, ing)
 
 		// check if a Certificate for this TLS entry already exists, and if it
 		// does then skip this entry
@@ -188,10 +184,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 
 			updateCrt.Spec = crt.Spec
 			updateCrt.Labels = crt.Labels
-			err = c.setIssuerSpecificConfig(updateCrt, ing, tls)
-			if err != nil {
-				return nil, nil, err
-			}
+			setIssuerSpecificConfig(updateCrt, ing)
 			updateCrts = append(updateCrts, updateCrt)
 		} else {
 			newCrts = append(newCrts, crt)
@@ -273,7 +266,7 @@ func certNeedsUpdate(a, b *cmapi.Certificate) bool {
 	return false
 }
 
-func (c *controller) setIssuerSpecificConfig(crt *cmapi.Certificate, ing *networkingv1beta1.Ingress, tls networkingv1beta1.IngressTLS) error {
+func setIssuerSpecificConfig(crt *cmapi.Certificate, ing *networkingv1beta1.Ingress) {
 	ingAnnotations := ing.Annotations
 	if ingAnnotations == nil {
 		ingAnnotations = map[string]string{}
@@ -299,11 +292,9 @@ func (c *controller) setIssuerSpecificConfig(crt *cmapi.Certificate, ing *networ
 		}
 		crt.Annotations[cmacme.ACMECertificateHTTP01IngressClassOverride] = ingressClassVal
 	}
-
-	return nil
 }
 
-func (c *controller) setCommonName(crt *cmapi.Certificate, ing *networkingv1beta1.Ingress) {
+func setCommonName(crt *cmapi.Certificate, ing *networkingv1beta1.Ingress) {
 	// if annotation is set use that as CN
 	if ing.Annotations != nil && ing.Annotations[cmapi.CommonNameAnnotationKey] != "" {
 		crt.Spec.CommonName = ing.Annotations[cmapi.CommonNameAnnotationKey]

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -157,7 +157,9 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 		}
 
 		setIssuerSpecificConfig(crt, ing)
-		setCommonName(crt, ing)
+		if err := translateIngressAnnotations(crt, ing.Annotations); err != nil {
+			return nil, nil, err
+		}
 
 		// check if a Certificate for this TLS entry already exists, and if it
 		// does then skip this entry

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -960,6 +960,32 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:   "Failure to translateIngressAnnotations",
+			Issuer: acmeIssuer,
+			Ingress: &networkingv1beta1.Ingress{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ingress-name",
+					Namespace: gen.DefaultTestNamespace,
+					Annotations: map[string]string{
+						cmapi.IngressIssuerNameAnnotationKey: "issuer-name",
+						cmapi.IssuerKindAnnotationKey:        "Issuer",
+						cmapi.IssuerGroupAnnotationKey:       "cert-manager.io",
+						cmapi.RenewBeforeAnnotationKey:       "invalid renew before value",
+					},
+					UID: types.UID("ingress-name"),
+				},
+				Spec: networkingv1beta1.IngressSpec{
+					TLS: []networkingv1beta1.IngressTLS{
+						{
+							Hosts:      []string{"example.com"},
+							SecretName: "example-com-tls",
+						},
+					},
+				},
+			},
+			Err: true,
+		},
 	}
 	testFn := func(test testT) func(t *testing.T) {
 		return func(t *testing.T) {


### PR DESCRIPTION
Part of: #3396

**Release note**:
```release-note
The ingress-shim now checks for `cert-manager.io/duration` and `cert-manager.io/renew-before` annotations and uses those values to set the Certificate.Spec.Duration and Certificate.Spec.RenewBefore fields.
```