### PR TITLE
Allow Azure User Managed Identities in Azure DNS provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Set DOCKER_REGISTRY to customise the image docker repo, e.g. "quay.io/jetstack"
-DOCKER_REGISTRY :=
+DOCKER_REGISTRY := digitalbackbonecr.azurecr.io
 APP_VERSION :=
 HACK_DIR ?= hack
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Set DOCKER_REGISTRY to customise the image docker repo, e.g. "quay.io/jetstack"
-DOCKER_REGISTRY := digitalbackbonecr.azurecr.io
+DOCKER_REGISTRY :=
 APP_VERSION :=
 HACK_DIR ?= hack
 

--- a/deploy/crds/crd-challenges.v1beta1.yaml
+++ b/deploy/crds/crd-challenges.v1beta1.yaml
@@ -213,6 +213,10 @@ spec:
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
                               type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityID:
+                              type: string
                         clouddns:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                           type: object
@@ -1020,6 +1024,10 @@ spec:
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityId:
                               type: string
                         clouddns:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -1830,6 +1838,10 @@ spec:
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
                               type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityId:
+                              type: string
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                           type: object
@@ -2638,6 +2650,10 @@ spec:
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityID:
                               type: string
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-challenges.v1beta1.yaml
+++ b/deploy/crds/crd-challenges.v1beta1.yaml
@@ -1027,7 +1027,7 @@ spec:
                               type: string
                             useUserManagedIdentity:
                               type: boolean
-                            userManagedIdentityId:
+                            userManagedIdentityID:
                               type: string
                         clouddns:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -1840,7 +1840,7 @@ spec:
                               type: string
                             useUserManagedIdentity:
                               type: boolean
-                            userManagedIdentityId:
+                            userManagedIdentityID:
                               type: string
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -1042,7 +1042,7 @@ spec:
                               type: string
                             useUserManagedIdentity:
                               type: boolean
-                            userManagedIdentityId:
+                            userManagedIdentityID:
                               type: string
                         clouddns:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -1872,7 +1872,7 @@ spec:
                               type: string
                             useUserManagedIdentity:
                               type: boolean
-                            userManagedIdentityId:
+                            userManagedIdentityID:
                               type: string
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -211,6 +211,10 @@ spec:
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
                               type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityID:
+                              type: string
                         clouddns:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                           type: object
@@ -1035,6 +1039,10 @@ spec:
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityId:
                               type: string
                         clouddns:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -1862,6 +1870,10 @@ spec:
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
                               type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityId:
+                              type: string
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                           type: object
@@ -2687,6 +2699,10 @@ spec:
                               type: string
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
+                              type: string
+                            useUserManagedIdentity:
+                              type: boolean
+                            userManagedIdentityID:
                               type: string
                         cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -1262,7 +1262,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2280,7 +2280,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-clusterissuers.v1beta1.yaml
+++ b/deploy/crds/crd-clusterissuers.v1beta1.yaml
@@ -244,6 +244,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
+                                    type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -1255,6 +1259,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2270,6 +2278,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
+                                    type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -3283,6 +3295,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1276,7 +1276,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2308,7 +2308,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -244,6 +244,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
+                                    type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -1269,6 +1273,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2298,6 +2306,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
+                                    type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -3325,6 +3337,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -1262,7 +1262,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2280,7 +2280,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-issuers.v1beta1.yaml
+++ b/deploy/crds/crd-issuers.v1beta1.yaml
@@ -244,6 +244,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
+                                    type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -1255,6 +1259,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2270,6 +2278,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
+                                    type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -3283,6 +3295,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1276,7 +1276,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2308,7 +2308,7 @@ spec:
                                     type: string
                                   useUserManagedIdentity:
                                     type: boolean
-                                  userManagedIdentityId:
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -244,6 +244,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
+                                    type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -1269,6 +1273,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
                                     type: string
                               clouddns:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
@@ -2298,6 +2306,10 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityId:
+                                    type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
@@ -3325,6 +3337,10 @@ spec:
                                     type: string
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
+                                    type: string
+                                  useUserManagedIdentity:
+                                    type: boolean
+                                  userManagedIdentityID:
                                     type: string
                               cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -463,10 +463,10 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 
 	// +optional
-	UseUserManagedIdentities bool `json:"useUserAssignedIdentities,omitempty"`
+	UseUserManagedIdentity bool `json:"useUserManagedIdentity"`
 
 	// +optional
-	UserManagedIdentityId string `json:"userManagedIdentityId,omitempty"`
+	UserManagedIdentityID string `json:"userManagedIdentityID"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
@@ -485,10 +485,6 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host string `json:"host"`
 
 	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
-
-	UseUserAssignedID bool `json:"useUserAssignedID"`
-
-	UserAssignedID string `json:"userAssignedID"`
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -461,6 +461,12 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 
 	// +optional
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
+
+	// +optional
+	UseUserManagedIdentities bool `json:"useUserAssignedIdentities,omitempty"`
+
+	// +optional
+	UserManagedIdentityId string `json:"userManagedIdentityId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud
@@ -479,6 +485,10 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 	Host string `json:"host"`
 
 	AccountSecret cmmeta.SecretKeySelector `json:"accountSecretRef"`
+
+	UseUserAssignedID bool `json:"useUserAssignedID"`
+
+	UserAssignedID string `json:"userAssignedID"`
 }
 
 // ACMEIssuerDNS01ProviderRFC2136 is a structure containing the

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -463,10 +463,10 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 
 	// +optional
-	UseUserManagedIdentity bool `json:"useUserManagedIdentity"`
+	UseUserManagedIdentity bool `json:"useUserManagedIdentity,omitempty"`
 
 	// +optional
-	UserManagedIdentityID string `json:"userManagedIdentityID"`
+	UserManagedIdentityID string `json:"userManagedIdentityID,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -463,10 +463,10 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
 
 	// +optional
-	UseUserManagedIdentity bool `json:"useUserManagedIdentity"`
+	UseUserManagedIdentity bool `json:"useUserManagedIdentity,omitempty"`
 
 	// +optional
-	UserManagedIdentityID string `json:"userManagedIdentityID"`
+	UserManagedIdentityID string `json:"userManagedIdentityID,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -461,6 +461,12 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 
 	// +optional
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
+
+	// +optional
+	UseUserManagedIdentity bool `json:"useUserManagedIdentity"`
+
+	// +optional
+	UserManagedIdentityID string `json:"userManagedIdentityID"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -466,7 +466,7 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	UseUserManagedIdentity bool `json:"useUserManagedIdentity,omitempty"`
 
 	// +optional
-	UserManagedIdentityID string `json:"userManagedIdentityId,omitempty"`
+	UserManagedIdentityID string `json:"userManagedIdentityID,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -461,6 +461,12 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 
 	// +optional
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
+
+	// +optional
+	UseUserManagedIdentity bool `json:"useUserManagedIdentity,omitempty"`
+
+	// +optional
+	UserManagedIdentityID string `json:"userManagedIdentityId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -466,7 +466,7 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	UseUserManagedIdentity bool `json:"useUserManagedIdentity,omitempty"`
 
 	// +optional
-	UserManagedIdentityID string `json:"userManagedIdentityId,omitempty"`
+	UserManagedIdentityID string `json:"userManagedIdentityID,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -461,6 +461,12 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 
 	// +optional
 	Environment AzureDNSEnvironment `json:"environment,omitempty"`
+
+	// +optional
+	UseUserManagedIdentity bool `json:"useUserManagedIdentity,omitempty"`
+
+	// +optional
+	UserManagedIdentityID string `json:"userManagedIdentityId,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=AzurePublicCloud;AzureChinaCloud;AzureGermanCloud;AzureUSGovernmentCloud

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -402,9 +402,9 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 
 	Environment AzureDNSEnvironment
 
-	UseUserAssignedID bool
+	UseUserManagedIdentity bool
 
-	UserAssignedID string
+	UserManagedIdentityID string
 }
 
 type AzureDNSEnvironment string

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -401,6 +401,10 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	HostedZoneName string
 
 	Environment AzureDNSEnvironment
+
+	UseUserAssignedID bool
+
+	UserAssignedID string
 }
 
 type AzureDNSEnvironment string

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -802,6 +802,8 @@ func autoConvert_v1_ACMEIssuerDNS01ProviderAzureDNS_To_acme_ACMEIssuerDNS01Provi
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = acme.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 
@@ -818,6 +820,8 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAzureDNS_To_v1_ACMEIssuerDNS01Provi
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = v1.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -802,6 +802,8 @@ func autoConvert_v1alpha2_ACMEIssuerDNS01ProviderAzureDNS_To_acme_ACMEIssuerDNS0
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = acme.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 
@@ -818,6 +820,8 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAzureDNS_To_v1alpha2_ACMEIssuerDNS0
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = v1alpha2.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -802,6 +802,8 @@ func autoConvert_v1alpha3_ACMEIssuerDNS01ProviderAzureDNS_To_acme_ACMEIssuerDNS0
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = acme.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 
@@ -818,6 +820,8 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAzureDNS_To_v1alpha3_ACMEIssuerDNS0
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = v1alpha3.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -802,6 +802,8 @@ func autoConvert_v1beta1_ACMEIssuerDNS01ProviderAzureDNS_To_acme_ACMEIssuerDNS01
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = acme.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 
@@ -818,6 +820,8 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAzureDNS_To_v1beta1_ACMEIssuerDNS01
 	out.ResourceGroupName = in.ResourceGroupName
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = v1beta1.AzureDNSEnvironment(in.Environment)
+	out.UseUserManagedIdentity = in.UseUserManagedIdentity
+	out.UserManagedIdentityID = in.UserManagedIdentityID
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -287,6 +287,11 @@ func ValidateACMEChallengeSolverDNS01(p *cmacme.ACMEChallengeSolverDNS01, fldPat
 			el = append(el, field.Forbidden(fldPath.Child("azureDNS"), "may not specify more than one provider type"))
 		} else {
 			numProviders++
+
+			if p.AzureDNS.UseUserManagedIdentity && len(p.AzureDNS.UserManagedIdentityID) == 0 {
+				el = append(el, field.Required(fldPath.Child("azureDNS", "userManagedIdentityID"), ""))
+			}
+
 			// if ClientID or ClientSecret or TenantID are defined then all of ClientID, ClientSecret and tenantID must be defined
 			// We check things separately because
 			if len(p.AzureDNS.ClientID) > 0 || len(p.AzureDNS.TenantID) > 0 || p.AzureDNS.ClientSecret != nil {

--- a/pkg/internal/apis/certmanager/validation/issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/issuer_test.go
@@ -734,6 +734,17 @@ func TestValidateACMEIssuerDNS01Config(t *testing.T) {
 				field.Required(fldPath.Child("azureDNS", "resourceGroupName"), ""),
 			},
 		},
+		"user assigned identity not supplied": {
+			cfg: &cmacme.ACMEChallengeSolverDNS01{
+				AzureDNS: &cmacme.ACMEIssuerDNS01ProviderAzureDNS{
+					UseUserAssignedID: true,
+					UserAssignedID:    "",
+				},
+			},
+			errs: []*field.Error{
+				field.Forbidden(fldPath.Child("cloudflare"), "may not specify more than one provider type"),
+			},
+		},
 		"missing akamai config": {
 			cfg: &cmacme.ACMEChallengeSolverDNS01{
 				Akamai: &cmacme.ACMEIssuerDNS01ProviderAkamai{},

--- a/pkg/issuer/acme/dns/azuredns/azuredns_test.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_test.go
@@ -45,7 +45,7 @@ func TestLiveAzureDnsPresent(t *testing.T) {
 	if !azureLiveTest {
 		t.Skip("skipping live test")
 	}
-	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers, false)
+	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers, false, false, "")
 	assert.NoError(t, err)
 
 	err = provider.Present(azureDomain, "_acme-challenge."+azureDomain+".", "123d==")
@@ -59,7 +59,7 @@ func TestLiveAzureDnsCleanUp(t *testing.T) {
 
 	time.Sleep(time.Second * 5)
 
-	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers, false)
+	provider, err := NewDNSProviderCredentials("", azureClientID, azureClientSecret, azuresubscriptionID, azureTenantID, azureResourceGroupName, azureHostedZoneName, util.RecursiveNameservers, false, false, "")
 	assert.NoError(t, err)
 
 	err = provider.CleanUp(azureDomain, "_acme-challenge."+azureDomain+".", "123d==")
@@ -69,10 +69,10 @@ func TestLiveAzureDnsCleanUp(t *testing.T) {
 func TestInvalidAzureDns(t *testing.T) {
 	validEnv := []string{"", "AzurePublicCloud", "AzureChinaCloud", "AzureGermanCloud", "AzureUSGovernmentCloud"}
 	for _, env := range validEnv {
-		_, err := NewDNSProviderCredentials(env, "cid", "secret", "", "", "", "", util.RecursiveNameservers, false)
+		_, err := NewDNSProviderCredentials(env, "cid", "secret", "", "", "", "", util.RecursiveNameservers, false, false, "")
 		assert.NoError(t, err)
 	}
 
-	_, err := NewDNSProviderCredentials("invalid env", "cid", "secret", "", "", "", "", util.RecursiveNameservers, false)
+	_, err := NewDNSProviderCredentials("invalid env", "cid", "secret", "", "", "", "", util.RecursiveNameservers, false, false, "")
 	assert.Error(t, err)
 }

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -349,8 +349,8 @@ func (s *Solver) solverForChallenge(ctx context.Context, issuer v1.GenericIssuer
 			providerConfig.AzureDNS.HostedZoneName,
 			s.DNS01Nameservers,
 			canUseAmbientCredentials,
-			providerConfig.AcmeDNS.UseUserAssignedID,
-			providerConfig.AcmeDNS.UserAssignedID,
+			providerConfig.AzureDNS.UseUserManagedIdentity,
+			providerConfig.AzureDNS.UserManagedIdentityID,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating azuredns challenge solver: %s", err)

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -60,7 +60,7 @@ type dnsProviderConstructors struct {
 	cloudDNS     func(project string, serviceAccount []byte, dns01Nameservers []string, ambient bool, hostedZoneName string) (*clouddns.DNSProvider, error)
 	cloudFlare   func(email, apikey, apiToken string, dns01Nameservers []string) (*cloudflare.DNSProvider, error)
 	route53      func(accessKey, secretKey, hostedZoneID, region, role string, ambient bool, dns01Nameservers []string) (*route53.DNSProvider, error)
-	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool) (*azuredns.DNSProvider, error)
+	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, useUserAssignedID bool, userAssignedID string) (*azuredns.DNSProvider, error)
 	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error)
 	digitalOcean func(token string, dns01Nameservers []string) (*digitalocean.DNSProvider, error)
 }
@@ -338,6 +338,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, issuer v1.GenericIssuer
 			}
 			secret = string(clientSecretBytes)
 		}
+
 		impl, err = s.dnsProviderConstructors.azureDNS(
 			string(providerConfig.AzureDNS.Environment),
 			providerConfig.AzureDNS.ClientID,
@@ -348,6 +349,8 @@ func (s *Solver) solverForChallenge(ctx context.Context, issuer v1.GenericIssuer
 			providerConfig.AzureDNS.HostedZoneName,
 			s.DNS01Nameservers,
 			canUseAmbientCredentials,
+			providerConfig.AcmeDNS.UseUserAssignedID,
+			providerConfig.AcmeDNS.UserAssignedID,
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating azuredns challenge solver: %s", err)

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -143,8 +143,8 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, ambient, util.RecursiveNameservers)
 			return nil, nil
 		},
-		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool) (*azuredns.DNSProvider, error) {
-			f.call("azuredns", clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName, util.RecursiveNameservers, ambient)
+		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, useUserAssignedIdentities bool, userAssignedIdentityId string) (*azuredns.DNSProvider, error) {
+			f.call("azuredns", clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName, util.RecursiveNameservers, ambient, useUserAssignedIdentities, userAssignedIdentityId)
 			return nil, nil
 		},
 		acmeDNS: func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Because, for compatibility with Azure Pod Identities, it is necessary to enable the controller to fetch tokens using the Azure User Assigned Identities.

For now, certmanager only uses the `NewServicePrincipalTokenFromMSI` endpoint. This PR adds 2 fields to the ACMEIssuerDNS01ProviderAzureDNS struct, `UseUserManagedIdentities` and `UserManagedIdentityId`. 

```release-note
Adds Azure DNS solver options to use Azure User Assigned Identities
```
