### PR TITLE
Bug: the issuing controller does not wait until the request matches the certificate before setting the certificate to "Issuing = False"

### DIFF
--- a/pkg/controller/certificates/internal/test/test.go
+++ b/pkg/controller/certificates/internal/test/test.go
@@ -72,14 +72,14 @@ type CryptoBundle struct {
 }
 
 func MustCreateCryptoBundle(t *testing.T, crt *cmapi.Certificate, fixedClock *fakeclock.FakeClock) CryptoBundle {
-	c, err := CreateCryptoBundle(crt, fixedClock)
+	c, err := createCryptoBundle(crt, fixedClock)
 	if err != nil {
 		t.Fatalf("error generating crypto bundle: %v", err)
 	}
 	return *c
 }
 
-func CreateCryptoBundle(originalCert *cmapi.Certificate, fixedClock *fakeclock.FakeClock) (*CryptoBundle, error) {
+func createCryptoBundle(originalCert *cmapi.Certificate, fixedClock *fakeclock.FakeClock) (*CryptoBundle, error) {
 	crt := originalCert.DeepCopy()
 	if crt.Spec.PrivateKey == nil {
 		crt.Spec.PrivateKey = &cmapi.CertificatePrivateKey{}

--- a/pkg/controller/certificates/internal/test/test.go
+++ b/pkg/controller/certificates/internal/test/test.go
@@ -72,14 +72,14 @@ type CryptoBundle struct {
 }
 
 func MustCreateCryptoBundle(t *testing.T, crt *cmapi.Certificate, fixedClock *fakeclock.FakeClock) CryptoBundle {
-	c, err := createCryptoBundle(crt, fixedClock)
+	c, err := CreateCryptoBundle(crt, fixedClock)
 	if err != nil {
 		t.Fatalf("error generating crypto bundle: %v", err)
 	}
 	return *c
 }
 
-func createCryptoBundle(originalCert *cmapi.Certificate, fixedClock *fakeclock.FakeClock) (*CryptoBundle, error) {
+func CreateCryptoBundle(originalCert *cmapi.Certificate, fixedClock *fakeclock.FakeClock) (*CryptoBundle, error) {
 	crt := originalCert.DeepCopy()
 	if crt.Spec.PrivateKey == nil {
 		crt.Spec.PrivateKey = &cmapi.CertificatePrivateKey{}


### PR DESCRIPTION
| This PR is part of the work on PR https://github.com/jetstack/cert-manager/pull/3444 |
| ---- |


**Goal**: after hours and hours of reading logs, I [discovered](https://github.com/jetstack/cert-manager/pull/3444#issuecomment-727598771) an unexpected behavior of the issuing controller: it would update the certificate's status when the certificate request has a failure ("Reason = Failed"), but the controller might have picked up an out-of-date certificate request. The consequence is that the issuing controller would set the certificate to "Issuing = False". This bug happens when a re-issuance is triggered with an old failing certificate request still around.

This PR adds a unit test that reproduces the issue; I'll then propose a fix to it, which is just moving a block of lines 13 lines up!! This fix is needed for https://github.com/jetstack/cert-manager/pull/3444 since the re-issuance of a failing certificate will happen immediately instead of backing off for one hour.

Here is what the output of the failing test looks like ([prow job link](https://prow.build-infra.jetstack.net/view/gcs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/3478/pull-cert-manager-bazel/1331237977375903745)):

```
--- FAIL: TestIssuingController (8.60s)
    --- FAIL: TestIssuingController/if_certificate_is_in_Issuing_state,_one_CertificateRequest,_but_has_failed_and_does_not_match_the_certificate_spec,_do_nothing (0.79s)
        context_builder.go:167: unexpected action: update "cert-manager.io/v1, Resource=certificates" in namespace default-unit-test-ns
        context_builder.go:170: got unexpected events, exp='[]' got='[Warning Failed The certificate request has failed to complete and will be retried: The certificate request failed because of reasons]'
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->

```release-note
NONE
```
