### PR TITLE
Strip X-Amzn-RequestId to avoid spurious challenge updates

### DIFF
--- a/pkg/issuer/acme/dns/route53/BUILD.bazel
+++ b/pkg/issuer/acme/dns/route53/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/issuer/acme/dns/util:go_default_library",
         "//pkg/logs:go_default_library",
         "@com_github_aws_aws_sdk_go//aws:go_default_library",
+        "@com_github_aws_aws_sdk_go//aws/awserr:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/credentials:go_default_library",
         "@com_github_aws_aws_sdk_go//aws/session:go_default_library",
         "@com_github_aws_aws_sdk_go//service/route53:go_default_library",

--- a/pkg/issuer/acme/dns/route53/fixtures_test.go
+++ b/pkg/issuer/acme/dns/route53/fixtures_test.go
@@ -40,6 +40,16 @@ var ListHostedZonesByNameResponse = `<?xml version="1.0" encoding="UTF-8"?>
          </Config>
          <ResourceRecordSetCount>10</ResourceRecordSetCount>
       </HostedZone>
+      <HostedZone>
+         <Id>/hostedzone/OPQRSTU</Id>
+         <Name>bar.example.com.</Name>
+         <CallerReference>D2224C5B-684A-DB4A-BB9A-E09E3BAFEA7A</CallerReference>
+         <Config>
+            <Comment>Test comment</Comment>
+            <PrivateZone>false</PrivateZone>
+         </Config>
+         <ResourceRecordSetCount>10</ResourceRecordSetCount>
+      </HostedZone>
    </HostedZones>
    <IsTruncated>true</IsTruncated>
    <NextDNSName>example2.com</NextDNSName>
@@ -55,3 +65,13 @@ var GetChangeResponse = `<?xml version="1.0" encoding="UTF-8"?>
       <SubmittedAt>2016-02-10T01:36:41.958Z</SubmittedAt>
    </ChangeInfo>
 </GetChangeResponse>`
+
+var ChangeResourceRecordSets403Response = `<?xml version="1.0"?>
+<ErrorResponse xmlns="https://route53.amazonaws.com/doc/2013-04-01/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>AccessDenied</Code>
+    <Message>User: arn:aws:iam::0123456789:user/test-cert-manager is not authorized to perform: route53:ChangeResourceRecordSets on resource: arn:aws:route53:::hostedzone/OPQRSTU</Message>
+  </Error>
+  <RequestId>SOMEREQUESTID</RequestId>
+</ErrorResponse>`

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -12,7 +12,6 @@ package route53
 
 import (
 	"fmt"
-	"net/http"
 	"strings"
 	"time"
 
@@ -82,7 +81,6 @@ func (d *sessionProvider) GetSession() (*session.Session, error) {
 		sessionOpts.Config.Credentials = credentials.NewStaticCredentials(d.AccessKeyID, d.SecretAccessKey, "")
 		// also disable 'ambient' region sources
 		sessionOpts.SharedConfigState = session.SharedConfigDisable
-		sessionOpts.Config.HTTPClient = http.DefaultClient
 	}
 
 	sess, err := session.NewSessionWithOptions(sessionOpts)

--- a/pkg/issuer/acme/dns/route53/testutil_test.go
+++ b/pkg/issuer/acme/dns/route53/testutil_test.go
@@ -37,8 +37,9 @@ func newMockServer(t *testing.T, responses MockResponseMap) *httptest.Server {
 		}
 
 		w.Header().Set("Content-Type", "application/xml")
+		w.Header().Set("X-Amzn-Requestid", "SOMEREQUESTID")
 		w.WriteHeader(resp.StatusCode)
-		w.Write([]byte(resp.Body))
+		_, _ = w.Write([]byte(resp.Body))
 	}))
 
 	time.Sleep(100 * time.Millisecond)


### PR DESCRIPTION
**Goal**: in #3222, we realized that some errors returned by aws-sdk-go would contain a request id. And since the Challenge controller updates the status using this error and that the request id changes for every request, the Challenge would get resynced over and over.

Here is an example of two errors (stringified) returned by [Present](https://github.com/maelvls/cert-manager/blob/d63b12f0334593c84608e9ea6b097959db6da631/pkg/issuer/acme/dns/route53/route53.go#L182-L185) would look like this; the only difference is the request id:

```
Failed to change Route 53 record set: AccessDenied: [...]\n\tstatus code: 403, request id: 5de26eaf-ae10-47fa-ac63-78d5d661f471
Failed to change Route 53 record set: AccessDenied: [...]\n\tstatus code: 403, request id: e40a0163-0055-4331-acff-cf0add32d971
```

In order to fix this issue, the idea is to:

1. [x] create a unit test that shows that Present won't show the request id when the `err.Error()` is called;
2. [x] strip the request id from any error that may contain an `awserr.Error` + unit tests

Fixes #3222

**Release note**:

```release-note
Fix a bug in the AWS Route53 DNS01 challenge that to retrying over and over instead of observing an exponential back off
```

Signed-off-by: Maël Valais <mael.valais@gmail.com>