### PR TITLE
Add creation of truststore.p12 from CA

### DIFF
--- a/deploy/crds/crd-certificates.v1beta1.yaml
+++ b/deploy/crds/crd-certificates.v1beta1.yaml
@@ -422,7 +422,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -444,7 +444,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.
@@ -961,7 +961,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -983,7 +983,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.

--- a/deploy/crds/crd-certificates.v1beta1.yaml
+++ b/deploy/crds/crd-certificates.v1beta1.yaml
@@ -422,7 +422,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority.
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -444,7 +444,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority.
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.
@@ -961,7 +961,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -983,7 +983,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -443,7 +443,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -465,7 +465,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority.
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.
@@ -1024,7 +1024,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
@@ -1046,7 +1046,7 @@ spec:
                         - passwordSecretRef
                       properties:
                         create:
-                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance.
+                          description: Create enables PKCS12 keystore creation for the Certificate. If true, a file named `keystore.p12` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.p12` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
                           description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the PKCS12 keystore.

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -279,6 +279,9 @@ type JKSKeystore struct {
 	// Secret resource, encrypted using the password stored in
 	// `passwordSecretRef`.
 	// The keystore file will only be updated upon re-issuance.
+	// A file named `truststore.jks` will also be created in the target
+	// Secret resource, encrypted using the password stored in
+	// `passwordSecretRef` containing the issuing Certificate Authority
 	Create bool `json:"create"`
 
 	// PasswordSecretRef is a reference to a key in a Secret resource
@@ -294,6 +297,9 @@ type PKCS12Keystore struct {
 	// Secret resource, encrypted using the password stored in
 	// `passwordSecretRef`.
 	// The keystore file will only be updated upon re-issuance.
+	// A file named `truststore.p12` will also be created in the target
+	// Secret resource, encrypted using the password stored in
+	// `passwordSecretRef` containing the issuing Certificate Authority
 	Create bool `json:"create"`
 
 	// PasswordSecretRef is a reference to a key in a Secret resource

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -274,6 +274,9 @@ type JKSKeystore struct {
 	// Secret resource, encrypted using the password stored in
 	// `passwordSecretRef`.
 	// The keystore file will only be updated upon re-issuance.
+	// A file named `truststore.jks` will also be created in the target
+	// Secret resource, encrypted using the password stored in
+	// `passwordSecretRef` containing the issuing Certificate Authority.
 	Create bool `json:"create"`
 
 	// PasswordSecretRef is a reference to a key in a Secret resource
@@ -289,6 +292,9 @@ type PKCS12Keystore struct {
 	// Secret resource, encrypted using the password stored in
 	// `passwordSecretRef`.
 	// The keystore file will only be updated upon re-issuance.
+	// A file named `truststore.p12` will also be created in the target
+	// Secret resource, encrypted using the password stored in
+	// `passwordSecretRef` containing the issuing Certificate Authority.
 	Create bool `json:"create"`
 
 	// PasswordSecretRef is a reference to a key in a Secret resource

--- a/pkg/controller/certificates/internal/secretsmanager/keystore.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore.go
@@ -72,11 +72,7 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 	if len(certs) > 1 {
 		cas = append(certs[1:], cas...)
 	}
-	keystoreData, err := pkcs12.Encode(rand.Reader, key, certs[0], cas, password)
-	if err != nil {
-		return nil, err
-	}
-	return keystoreData, nil
+	return pkcs12.Encode(rand.Reader, key, certs[0], cas, password)
 }
 
 func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
@@ -86,11 +82,7 @@ func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
 	}
 
 	var cas = []*x509.Certificate{ca}
-	truststoreData, err := pkcs12.EncodeTrustStore(rand.Reader, cas, password)
-	if err != nil {
-		return nil, err
-	}
-	return truststoreData, nil
+	return pkcs12.EncodeTrustStore(rand.Reader, cas, password)
 }
 
 func encodeJKSKeystore(password []byte, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {

--- a/pkg/controller/certificates/internal/secretsmanager/keystore.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore.go
@@ -37,7 +37,8 @@ import (
 const (
 	// pkcs12SecretKey is the name of the data entry in the Secret resource
 	// used to store the p12 file.
-	pkcs12SecretKey = "keystore.p12"
+	pkcs12SecretKey     = "keystore.p12"
+	pkcs12TruststoreKey = "truststore.p12"
 
 	// jksSecretKey is the name of the data entry in the Secret resource
 	// used to store the jks file.
@@ -76,6 +77,20 @@ func encodePKCS12Keystore(password string, rawKey []byte, certPem []byte, caPem 
 		return nil, err
 	}
 	return keystoreData, nil
+}
+
+func encodePKCS12Truststore(password string, caPem []byte) ([]byte, error) {
+	ca, err := pki.DecodeX509CertificateBytes(caPem)
+	if err != nil {
+		return nil, err
+	}
+
+	var cas = []*x509.Certificate{ca}
+	truststoreData, err := pkcs12.EncodeTrustStore(rand.Reader, cas, password)
+	if err != nil {
+		return nil, err
+	}
+	return truststoreData, nil
 }
 
 func encodeJKSKeystore(password []byte, rawKey []byte, certPem []byte, caPem []byte) ([]byte, error) {

--- a/pkg/controller/certificates/internal/secretsmanager/keystore.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore.go
@@ -37,12 +37,14 @@ import (
 const (
 	// pkcs12SecretKey is the name of the data entry in the Secret resource
 	// used to store the p12 file.
-	pkcs12SecretKey     = "keystore.p12"
+	pkcs12SecretKey = "keystore.p12"
+	// Data Entry Name in the Secret resource for PKCS12 containing Certificate Authority
 	pkcs12TruststoreKey = "truststore.p12"
 
 	// jksSecretKey is the name of the data entry in the Secret resource
 	// used to store the jks file.
-	jksSecretKey     = "keystore.jks"
+	jksSecretKey = "keystore.jks"
+	// Data Entry Name in the Secret resource for JKS containing Certificate Authority
 	jksTruststoreKey = "truststore.jks"
 )
 

--- a/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
@@ -347,14 +347,14 @@ func TestEncodePKCS12Keystore(t *testing.T) {
 
 func TestEncodePKCS12Truststore(t *testing.T) {
 	tests := map[string]struct {
-		password		string
-		caPEM			[]byte
-		verify			func(t *testing.T, caPEM []byte, out []byte, err error)
-		run				func(t testing.T)
+		password string
+		caPEM    []byte
+		verify   func(t *testing.T, caPEM []byte, out []byte, err error)
+		run      func(t testing.T)
 	}{
 		"encode a PKCS12 bundle for a CA": {
 			password: "password",
-			caPEM: mustSelfSignCertificate(t, nil),
+			caPEM:    mustSelfSignCertificate(t, nil),
 			verify: func(t *testing.T, caPEM []byte, out []byte, err error) {
 				if err != nil {
 					t.Errorf("expected no error but got: %v", err)

--- a/pkg/controller/certificates/internal/secretsmanager/secret.go
+++ b/pkg/controller/certificates/internal/secretsmanager/secret.go
@@ -154,8 +154,18 @@ func (s *SecretsManager) setValues(crt *cmapi.Certificate, secret *corev1.Secret
 			}
 			// always overwrite the keystore entry for now
 			secret.Data[pkcs12SecretKey] = keystoreData
+
+			if len(data.CA) > 0 {
+				truststoreData, err := encodePKCS12Truststore(string(pw), data.CA)
+				if err != nil {
+					return fmt.Errorf("error encoding PKCS12 trust store bundle: %w", err)
+				}
+				// always overwrite the truststore entry
+				secret.Data[pkcs12TruststoreKey] = truststoreData
+			}
 		} else {
 			delete(secret.Data, pkcs12SecretKey)
+			delete(secret.Data, pkcs12TruststoreKey)
 		}
 
 		// Handle the experimental JKS support


### PR DESCRIPTION
**What this PR does / why we need it**:

Add support for creation of PKCS12 truststore.p12 using Certificate Authority.  This implementations follows the same pattern as the creation of truststore.jks and leverages the go-pkcs12 EncodeTrustStore function to produce a PKCS12 trust store that is compatible with Java 8 and greater.

**Which issue this PR fixes**:
fixes #3373

**Special notes for your reviewer**:

**Release note**:
```release-note
Add creation of PKCS12 truststore.p12 using Certificate Authority
```

Signed-off-by: David Handermann <exceptionfactory@gmail.com>