### PR TITLE
Rename the User Agent fields

### DIFF
--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -165,7 +165,7 @@ func newVRequest(cert *x509.Certificate) *certificate.Request {
 	req.CustomFields = []certificate.CustomField{
 		{
 			Type:  certificate.CustomFieldOrigin,
-			Value: "Jetstack cert-manager",
+			Value: "cert-manager",
 		},
 	}
 	return req

--- a/pkg/util/useragent.go
+++ b/pkg/util/useragent.go
@@ -17,4 +17,4 @@ limitations under the License.
 package util
 
 // CertManagerUserAgent is the user agent that http clients in this codebase should use
-var CertManagerUserAgent = "jetstack-cert-manager/" + version()
+var CertManagerUserAgent = "cert-manager/" + version()


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove Jetstaqck from the User Agent now it's under the CNCF


**Which issue this PR fixes**:

fixes https://github.com/jetstack/cert-manager/issues/3480

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Remove Jetstack from user-agent fields
```
