### PR TITLE
[chart templates] fix mutating & validating webhook templates for legacy Helm

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -2,7 +2,7 @@
 {{- if (or (not (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1")) (.Capabilities.APIVersions.Has "hacking-helm.i-wish-this-wasnt-required.cert-manager.io/force-v1beta1-webhooks") ) }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
-{{- $isV1AdmissionRegistration = true -}}
+{{- $isV1AdmissionRegistration := true -}}
 apiVersion: admissionregistration.k8s.io/v1
 {{- end }}
 kind: MutatingWebhookConfiguration

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -2,7 +2,7 @@
 {{- if (or (not (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1")) (.Capabilities.APIVersions.Has "hacking-helm.i-wish-this-wasnt-required.cert-manager.io/force-v1beta1-webhooks") ) }}
 apiVersion: admissionregistration.k8s.io/v1beta1
 {{- else }}
-{{- $isV1AdmissionRegistration = true -}}
+{{- $isV1AdmissionRegistration := true -}}
 apiVersion: admissionregistration.k8s.io/v1
 {{- end }}
 kind: ValidatingWebhookConfiguration


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: this PR fixes Helm template syntax for the following templates, enabling the chart to be applied by older versions of Helm

* deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
* deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3315

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
 fix mutating & validating webhook chart templates for legacy Helm
```
