### PR TITLE
Remove Helm hack for webhook API versions

### DIFF
--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -27,21 +27,15 @@ webhooks:
           - UPDATE
         resources:
           - "*/*"
-    {{- if $isV1AdmissionRegistration }}
     admissionReviewVersions: ["v1", "v1beta1"]
     timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
-    {{- end }}
     failurePolicy: Fail
-{{- if (semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
     # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
-{{- end }}
     clientConfig:
-{{- if (semverCompare "<=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
       # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
       # in Kubernetes 1.12 and below.
       caBundle: ""
-{{- end }}
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -33,9 +33,6 @@ webhooks:
     # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
     clientConfig:
-      # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
-      # in Kubernetes 1.12 and below.
-      caBundle: ""
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -1,10 +1,4 @@
-{{- $isV1AdmissionRegistration := false -}}
-{{- if (or (not (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1")) (.Capabilities.APIVersions.Has "hacking-helm.i-wish-this-wasnt-required.cert-manager.io/force-v1beta1-webhooks") ) }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- else }}
-{{- $isV1AdmissionRegistration = true -}}
 apiVersion: admissionregistration.k8s.io/v1
-{{- end }}
 kind: MutatingWebhookConfiguration
 metadata:
   name: {{ include "webhook.fullname" . }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -42,9 +42,6 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     clientConfig:
-      # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
-      # in Kubernetes 1.12 and below.
-      caBundle: ""
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -1,10 +1,4 @@
-{{- $isV1AdmissionRegistration := false -}}
-{{- if (or (not (.Capabilities.APIVersions.Has "admissionregistration.k8s.io/v1")) (.Capabilities.APIVersions.Has "hacking-helm.i-wish-this-wasnt-required.cert-manager.io/force-v1beta1-webhooks") ) }}
-apiVersion: admissionregistration.k8s.io/v1beta1
-{{- else }}
-{{- $isV1AdmissionRegistration = true -}}
 apiVersion: admissionregistration.k8s.io/v1
-{{- end }}
 kind: ValidatingWebhookConfiguration
 metadata:
   name: {{ include "webhook.fullname" . }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -37,21 +37,14 @@ webhooks:
           - UPDATE
         resources:
           - "*/*"
-    {{- if $isV1AdmissionRegistration }}
     admissionReviewVersions: ["v1", "v1beta1"]
     timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
-    {{- end }}
     failurePolicy: Fail
-{{- if (semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
-    # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
-{{- end }}
     clientConfig:
-{{- if (semverCompare "<=1.12-0" .Capabilities.KubeVersion.GitVersion) }}
       # Set caBundle to empty to avoid https://github.com/kubernetes/kubernetes/pull/70138
       # in Kubernetes 1.12 and below.
       caBundle: ""
-{{- end }}
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace | quote }}


### PR DESCRIPTION
**What this PR does / why we need it**:

We now can use admissionregistration.k8s.io/v1 in all cases, removing the ugly helm hack which we put into place

**Which issue this PR fixes**:

Part of #3413

**Special notes for your reviewer**:

https://github.com/jetstack/cert-manager/pull/3507 went a bit too far, this is a lite version

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Always install using admissionregistration.k8s.io/v1
```
