### PR TITLE
Make maximum challenges per schedule configurable

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -225,6 +225,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 			DNS01Nameservers:                  nameservers,
 			AccountRegistry:                   acmeAccountRegistry,
 			DNS01CheckRetryPeriod:             opts.DNS01CheckRetryPeriod,
+			MaxChallengesPerSchedule:          opts.MaxChallengesPerSchedule,
 		},
 		IssuerOptions: controller.IssuerOptions{
 			ClusterIssuerAmbientCredentials: opts.ClusterIssuerAmbientCredentials,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -97,7 +97,6 @@ type ControllerOptions struct {
 	DNS01CheckRetryPeriod time.Duration
 
 	// Maximum number of challenges that can be scheduled with a single call to the scheduler.
-	// This provides a very crude rate limit on how many challenges will be scheduled.
 	MaxChallengesPerSchedule int
 }
 
@@ -301,8 +300,7 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enable profiling for controller.")
 
 	fs.IntVar(&s.MaxChallengesPerSchedule, "max-challenges-per-schedule", defaultMaxChallengesPerSchedule, ""+
-		"The maximum number of challenges that can be scheduled with a single call to the scheduler. "+
-		"This provides a very crude rate limit on how many challenges will be scheduled")
+		"The maximum number of challenges that can be scheduled with a single call to the scheduler.")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -97,6 +97,7 @@ type ControllerOptions struct {
 	DNS01CheckRetryPeriod time.Duration
 
 	// Maximum number of challenges that can be scheduled with a single call to the scheduler.
+	// This provides a very crude rate limit on how many challenges will be scheduled.
 	MaxChallengesPerSchedule int
 }
 
@@ -300,7 +301,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Enable profiling for controller.")
 
 	fs.IntVar(&s.MaxChallengesPerSchedule, "max-challenges-per-schedule", defaultMaxChallengesPerSchedule, ""+
-		"The maximum number of challenges that can be scheduled with a single call to the scheduler.")
+		"The maximum number of challenges that can be scheduled with a single call to the scheduler. "+
+		"This provides a very crude rate limit on how many challenges will be scheduled")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -95,6 +95,9 @@ type ControllerOptions struct {
 	EnablePprof bool
 
 	DNS01CheckRetryPeriod time.Duration
+
+	// Maximum number of challenges that can be scheduled with a single call to the scheduler.
+	MaxChallengesPerSchedule int
 }
 
 const (
@@ -128,6 +131,8 @@ const (
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
 
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
+
+	defaultMaxChallengesPerSchedule = 20
 )
 
 var (
@@ -185,6 +190,7 @@ func NewControllerOptions() *ControllerOptions {
 		EnableCertificateOwnerRef:         defaultEnableCertificateOwnerRef,
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
 		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
+		MaxChallengesPerSchedule:          defaultMaxChallengesPerSchedule,
 		EnablePprof:                       false,
 	}
 }
@@ -292,6 +298,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The host and port that the metrics endpoint should listen on.")
 	fs.BoolVar(&s.EnablePprof, "enable-profiling", false, ""+
 		"Enable profiling for controller.")
+
+	fs.IntVar(&s.MaxChallengesPerSchedule, "max-challenges-per-schedule", defaultMaxChallengesPerSchedule, ""+
+		"The maximum number of challenges that can be scheduled with a single call to the scheduler.")
 }
 
 func (o *ControllerOptions) Validate() error {
@@ -320,6 +329,10 @@ func (o *ControllerOptions) Validate() error {
 		if err != nil {
 			return fmt.Errorf("invalid DNS server (%v): %v", err, server)
 		}
+	}
+
+	if o.MaxChallengesPerSchedule <= 0 {
+		return fmt.Errorf("invalid value for max-challenges-per-schedule: %v must be higher than or equal to 1", o.MaxChallengesPerSchedule)
 	}
 
 	return nil

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -124,6 +124,13 @@ type ACMEOptions struct {
 
 	// DNS01CheckRetryPeriod is the time the controller should wait between checking if a ACME dns entry exists.
 	DNS01CheckRetryPeriod time.Duration
+
+	// MaxChallengesPerSchedule is the maximum number of challenges that can be
+	// scheduled with a single call to the scheduler.
+	// This provides a very crude rate limit on how many challenges we will schedule
+	// per second. It may be better to remove this altogether in favour of some
+	// other method of rate limiting creations.
+	MaxChallengesPerSchedule int
 }
 
 type IngressShimOptions struct {


### PR DESCRIPTION
Introduces a max-challenges-per-schedule flag that is used to configure the maximum number
of challenges that can be scheduled with a single call to the scheduler in the acme
challenges controller.

Signed-off-by: davidsbond <davidsbond93@gmail.com>

**What this PR does / why we need it**:

Was looking for something simple to contribute and I noticed a `TODO` comment to make `MaxChallengesPerSchedule` configurable, so I've created a command-line flag that gets passed down to the controller that defaults to the value it was originally as a constant. It is also validated to make sure it's greater than 1.

**Release note**:

```release-note
Added command-line flag to make the maximum number of challenges that can be scheduled in a single call configurable
```
