### PR TITLE
Attempt to retrieve a pre-existing ACME account when ACME DisableAccountKeyGeneration flag is enabled

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -82,10 +82,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string
@@ -1111,10 +1115,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string
@@ -2142,10 +2150,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string
@@ -3173,10 +3185,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -82,10 +82,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string
@@ -1111,10 +1115,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string
@@ -2142,10 +2150,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string
@@ -3173,10 +3185,14 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
+                        - disableAccountKeyRegistration
                         - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
+                        disableAccountKeyRegistration:
+                          description: disableAccountKeyRegistration disables registering a new ACME External Account with the CA. If true, the issuer will only attempt to retrieve an existing account associated with the Account Key. Defaults to false.
+                          type: boolean
                         keyAlgorithm:
                           description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
                           type: string

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -121,6 +121,12 @@ type ACMEExternalAccountBinding struct {
 	// keyAlgorithm is the MAC key algorithm that the key is used for.
 	// Valid values are "HS256", "HS384" and "HS512".
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+
+	// disableAccountKeyRegistration disables registering a new ACME External Account
+	// with the CA. If true, the issuer will only attempt to retrieve an existing account
+	// associated with the Account Key.
+	// Defaults to false.
+	DisableAccountKeyRegistration bool `json:"disableAccountKeyRegistration"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -121,6 +121,12 @@ type ACMEExternalAccountBinding struct {
 	// keyAlgorithm is the MAC key algorithm that the key is used for.
 	// Valid values are "HS256", "HS384" and "HS512".
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+
+	// disableAccountKeyRegistration disables registering a new ACME External Account
+	// with the CA. If true, the issuer will only attempt to retrieve an existing account
+	// associated with the Account Key.
+	// Defaults to false.
+	DisableAccountKeyRegistration bool `json:"disableAccountKeyRegistration"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -121,6 +121,12 @@ type ACMEExternalAccountBinding struct {
 	// keyAlgorithm is the MAC key algorithm that the key is used for.
 	// Valid values are "HS256", "HS384" and "HS512".
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+
+	// disableAccountKeyRegistration disables registering a new ACME External Account
+	// with the CA. If true, the issuer will only attempt to retrieve an existing account
+	// associated with the Account Key.
+	// Defaults to false.
+	DisableAccountKeyRegistration bool `json:"disableAccountKeyRegistration"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -121,6 +121,12 @@ type ACMEExternalAccountBinding struct {
 	// keyAlgorithm is the MAC key algorithm that the key is used for.
 	// Valid values are "HS256", "HS384" and "HS512".
 	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+
+	// disableAccountKeyRegistration disables registering a new ACME External Account
+	// with the CA. If true, the issuer will only attempt to retrieve an existing account
+	// associated with the Account Key.
+	// Defaults to false.
+	DisableAccountKeyRegistration bool `json:"disableAccountKeyRegistration"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -111,6 +111,12 @@ type ACMEExternalAccountBinding struct {
 	// keyAlgorithm is the MAC key algorithm that the key is used for.
 	// Valid values are "HS256", "HS384" and "HS512".
 	KeyAlgorithm HMACKeyAlgorithm
+
+	// disableAccountKeyRegistration disables registering a new ACME External Account
+	// with the CA. If true, the issuer will only attempt to retrieve an existing account
+	// associated with the Account Key.
+	// Defaults to false.
+	DisableAccountKeyRegistration bool `json:"disableAccountKeyRegistration"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -659,6 +659,7 @@ func autoConvert_v1_ACMEExternalAccountBinding_To_acme_ACMEExternalAccountBindin
 		return err
 	}
 	out.KeyAlgorithm = acme.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 
@@ -674,6 +675,7 @@ func autoConvert_acme_ACMEExternalAccountBinding_To_v1_ACMEExternalAccountBindin
 		return err
 	}
 	out.KeyAlgorithm = v1.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -659,6 +659,7 @@ func autoConvert_v1alpha2_ACMEExternalAccountBinding_To_acme_ACMEExternalAccount
 		return err
 	}
 	out.KeyAlgorithm = acme.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 
@@ -674,6 +675,7 @@ func autoConvert_acme_ACMEExternalAccountBinding_To_v1alpha2_ACMEExternalAccount
 		return err
 	}
 	out.KeyAlgorithm = v1alpha2.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -659,6 +659,7 @@ func autoConvert_v1alpha3_ACMEExternalAccountBinding_To_acme_ACMEExternalAccount
 		return err
 	}
 	out.KeyAlgorithm = acme.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 
@@ -674,6 +675,7 @@ func autoConvert_acme_ACMEExternalAccountBinding_To_v1alpha3_ACMEExternalAccount
 		return err
 	}
 	out.KeyAlgorithm = v1alpha3.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -659,6 +659,7 @@ func autoConvert_v1beta1_ACMEExternalAccountBinding_To_acme_ACMEExternalAccountB
 		return err
 	}
 	out.KeyAlgorithm = acme.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 
@@ -674,6 +675,7 @@ func autoConvert_acme_ACMEExternalAccountBinding_To_v1beta1_ACMEExternalAccountB
 		return err
 	}
 	out.KeyAlgorithm = v1beta1.HMACKeyAlgorithm(in.KeyAlgorithm)
+	out.DisableAccountKeyRegistration = in.DisableAccountKeyRegistration
 	return nil
 }
 

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -324,8 +324,8 @@ func (a *Acme) registerAccount(ctx context.Context, cl client.Interface, eabAcco
 	}
 
 	acc, err := cl.Register(ctx, acc, acmeapi.AcceptTOS)
-	// If the account already exists, fetch the Account object and return.
-	if err == acmeapi.ErrAccountAlreadyExists {
+	// If the account already exists or account key generation is disabled, fetch the Account object and return.
+	if err == acmeapi.ErrAccountAlreadyExists || a.issuer.GetSpec().ACME.DisableAccountKeyGeneration {
 		return cl.GetReg(ctx, "")
 	}
 	if err != nil {


### PR DESCRIPTION
**What this PR does / why we need it**:
When using EAB with a certificate provider (i.e. ZeroSSL or Sectigo), the ClusterIssuer will register an account successfully only with fresh EAB credentials. If the ClusterIssuer is ever re-provisioned, the existing EAB credentials (EAB KID, EAB HMAC Key, EAB Private Key) will not successfully link the account. 

Even with DisableAccountKeyGeneration set to true, cert-manager will attempt to call [acme.Register](https://pkg.go.dev/golang.org/x/crypto/acme#Client.Register) which for whatever reason does not return ErrAccountAlreadyExists even if the account does exist.  

I added this fix under the assumption that if DisableAccountKeyGeneration is true, it's likely that an Account exists and we should atleast try to call [acme.GetReg](https://pkg.go.dev/golang.org/x/crypto/acme#Client.GetReg). Full disclosure, I'm not entirely sure if we can assume that an account exists if DisableAccountKeyGeneration is set to true. If there's a scenario where that could happen, I still think we should attempt to call [acme.GetReg](https://pkg.go.dev/golang.org/x/crypto/acme#Client.GetReg) in a separate if statement when DisableAccountKeyGeneration is set to true. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #2882 
