### PR TITLE
Replace reflect.DeepEqual with dedicated Equals methods

### DIFF
--- a/pkg/apis/acme/v1/types_challenge.go
+++ b/pkg/apis/acme/v1/types_challenge.go
@@ -144,3 +144,19 @@ type ChallengeStatus struct {
 	// +optional
 	State State `json:"state,omitempty"`
 }
+
+// Equals returns true if the provided ChallengeStatus value matches that of the ChallengeStatus being called.
+func (in ChallengeStatus) Equals(cmp ChallengeStatus) bool {
+	switch {
+	case in.Presented != cmp.Presented:
+		return false
+	case in.Processing != cmp.Processing:
+		return false
+	case in.State != cmp.State:
+		return false
+	case in.Reason != cmp.Reason:
+		return false
+	default:
+		return true
+	}
+}

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -19,8 +19,6 @@ package acmechallenges
 import (
 	"context"
 	"fmt"
-	"reflect"
-
 	acmeapi "golang.org/x/crypto/acme"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,8 +66,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	}
 
 	defer func() {
-		// TODO: replace with more efficient comparison
-		if reflect.DeepEqual(oldChal.Status, ch.Status) && len(oldChal.Finalizers) == len(ch.Finalizers) {
+		if oldChal.Status.Equals(ch.Status) && len(oldChal.Finalizers) == len(ch.Finalizers) {
 			return
 		}
 		_, updateErr := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(context.TODO(), ch, metav1.UpdateOptions{})

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -22,8 +22,6 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"reflect"
-
 	acmeapi "golang.org/x/crypto/acme"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -47,11 +45,11 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 	o = o.DeepCopy()
 
 	defer func() {
-		// TODO: replace with more efficient comparison
-		if reflect.DeepEqual(oldOrder.Status, o.Status) {
+		if oldOrder.Status.Equals(o.Status) {
 			dbg.Info("skipping updating resource as new status == existing status")
 			return
 		}
+
 		log.V(logf.DebugLevel).Info("updating Order resource status")
 		_, updateErr := c.cmClient.AcmeV1().Orders(o.Namespace).UpdateStatus(context.TODO(), o, metav1.UpdateOptions{})
 		if updateErr != nil {


### PR DESCRIPTION
Signed-off-by: davidsbond <davidsbond93@gmail.com>

**What this PR does / why we need it**:

Found a `TODO` comment to remove a couple usages of `reflect.DeepEqual` for comparing some types. I've added `Equals` methods for `ChallengeStatus`, `OrderStatus`, `ACMEAuthorization` and `ACMEChallenge` and switched the commented code to use those instead.
 
**Release note**:

```release-note
NONE
```
