### PR TITLE
Fix release tar content of manifests

### DIFF
--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -36,7 +36,7 @@ helm_tmpl(
 )
 
 licensed_file(
-    name = "crds.yaml",
+    name = "cert-manager.crds.yaml",
     src = ":crds.nohelm.yaml",
 )
 
@@ -76,15 +76,15 @@ genrule(
 )
 
 licensed_file(
-    name = "manifests.yaml",
+    name = "cert-manager.yaml",
     src = "unlicensed.nohelm",
 )
 
 pkg_tar(
     name = "manifests",
     srcs = [
-        ":crds.yaml",
-        ":manifests.helm",
+        ":cert-manager.crds.yaml",
+        ":cert-manager.yaml",
     ],
     extension = "tar.gz",
     mode = "0644",


### PR DESCRIPTION
**What this PR does / why we need it**:

When releasing v1.2.0-alpha.0 we found a few file names had a bad name. This PR fixes the output for the static manifests which was caused in the cleanup of the legacy release.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
