### PR TITLE
Make CNAME resolver recursive

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -94,7 +94,7 @@ func (s *Solver) Present(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 		return err
 	}
 
-	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, updateDomainWithCName(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
+	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, followCNAME(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (s *Solver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 		return err
 	}
 
-	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, updateDomainWithCName(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
+	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, followCNAME(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func (s *Solver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 	return slv.CleanUp(ch.Spec.DNSName, fqdn, ch.Spec.Key)
 }
 
-func updateDomainWithCName(strategy cmacme.CNAMEStrategy) bool {
+func followCNAME(strategy cmacme.CNAMEStrategy) bool {
 	if strategy == cmacme.FollowStrategy {
 		return true
 	}
@@ -390,7 +390,7 @@ func (s *Solver) prepareChallengeRequest(issuer v1.GenericIssuer, ch *cmacme.Cha
 		return nil, nil, err
 	}
 
-	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, updateDomainWithCName(dns01Config.CNAMEStrategy), s.DNS01Nameservers...)
+	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, followCNAME(dns01Config.CNAMEStrategy), s.DNS01Nameservers...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -94,7 +94,7 @@ func (s *Solver) Present(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 		return err
 	}
 
-	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, followCNAME(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
+	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, updateDomainWithCName(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
 	if err != nil {
 		return err
 	}
@@ -152,7 +152,7 @@ func (s *Solver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 		return err
 	}
 
-	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, followCNAME(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
+	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, updateDomainWithCName(providerConfig.CNAMEStrategy), s.DNS01Nameservers...)
 	if err != nil {
 		return err
 	}
@@ -160,7 +160,7 @@ func (s *Solver) CleanUp(ctx context.Context, issuer v1.GenericIssuer, ch *cmacm
 	return slv.CleanUp(ch.Spec.DNSName, fqdn, ch.Spec.Key)
 }
 
-func followCNAME(strategy cmacme.CNAMEStrategy) bool {
+func updateDomainWithCName(strategy cmacme.CNAMEStrategy) bool {
 	if strategy == cmacme.FollowStrategy {
 		return true
 	}
@@ -390,7 +390,7 @@ func (s *Solver) prepareChallengeRequest(issuer v1.GenericIssuer, ch *cmacme.Cha
 		return nil, nil, err
 	}
 
-	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, followCNAME(dns01Config.CNAMEStrategy), s.DNS01Nameservers...)
+	fqdn, err := util.DNS01LookupFQDN(ch.Spec.DNSName, updateDomainWithCName(dns01Config.CNAMEStrategy), s.DNS01Nameservers...)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -23,7 +23,7 @@ func DNS01LookupFQDN(domain string, followCNAME bool, nameservers ...string) (st
 	// Check if the domain has CNAME then return that
 	if followCNAME {
 		var err error
-		fqdn, err = updateDomainWithCName(fqdn, nameservers)
+		fqdn, err = followCNAMEs(fqdn, nameservers)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/issuer/acme/dns/util/dns.go
+++ b/pkg/issuer/acme/dns/util/dns.go
@@ -22,10 +22,8 @@ func DNS01LookupFQDN(domain string, followCNAME bool, nameservers ...string) (st
 
 	// Check if the domain has CNAME then return that
 	if followCNAME {
-		r, err := DNSQuery(fqdn, dns.TypeCNAME, nameservers, true)
-		if err == nil && r.Rcode == dns.RcodeSuccess {
-			fqdn = updateDomainWithCName(r, fqdn)
-		}
+		var err error
+		fqdn, err = updateDomainWithCName(fqdn, nameservers)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -72,7 +72,7 @@ func getNameservers(path string, defaults []string) []string {
 
 // Update FQDN with CNAME if any, it will follow CNAME records till it hits a non-CNAME.
 // this will error if there is a recursive CNAME in the chain
-func followCNAME(fqdn string, nameservers []string, fqdnChain ...string) (string, error) {
+func updateDomainWithCName(fqdn string, nameservers []string, fqdnChain ...string) (string, error) {
 	r, err := dnsQuery(fqdn, dns.TypeCNAME, nameservers, true)
 	if err == nil && r.Rcode == dns.RcodeSuccess {
 		for _, rr := range r.Answer {

--- a/pkg/issuer/acme/dns/util/wait.go
+++ b/pkg/issuer/acme/dns/util/wait.go
@@ -86,7 +86,7 @@ func updateDomainWithCName(fqdn string, nameservers []string, fqdnChain ...strin
 			continue
 		}
 		logf.V(logf.DebugLevel).Infof("Updating FQDN: %s with its CNAME: %s", fqdn, cn.Target)
-		// check if we were here before to prevent recursive records causing issues
+		// Check if we were here before to prevent loops in the chain of CNAME records.
 		for _, fqdnInChain := range fqdnChain {
 			if cn.Target != fqdnInChain {
 				continue

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -286,7 +286,7 @@ func TestValidateCAA(t *testing.T) {
 	}
 }
 
-func Test_updateDomainWithCName(t *testing.T) {
+func Test_followCNAMEs(t *testing.T) {
 	dnsQuery = func(fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error) {
 		msg := &dns.Msg{}
 		msg.Rcode = dns.RcodeSuccess
@@ -380,13 +380,13 @@ func Test_updateDomainWithCName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := updateDomainWithCName(tt.args.fqdn, tt.args.nameservers, tt.args.fqdnChain...)
+			got, err := followCNAMEs(tt.args.fqdn, tt.args.nameservers, tt.args.fqdnChain...)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("updateDomainWithCName() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("followCNAMEs() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("updateDomainWithCName() got = %v, want %v", got, tt.want)
+				t.Errorf("followCNAMEs() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/issuer/acme/dns/util/wait_test.go
+++ b/pkg/issuer/acme/dns/util/wait_test.go
@@ -9,6 +9,7 @@ this directory.
 package util
 
 import (
+	"fmt"
 	"reflect"
 	"sort"
 	"strings"
@@ -282,5 +283,111 @@ func TestValidateCAA(t *testing.T) {
 	err = ValidateCAA("www.example.org", []string{"daniel.homebrew.ca"}, false, RecursiveNameservers)
 	if err != nil {
 		t.Fatalf("expected err, got %s", err)
+	}
+}
+
+func Test_updateDomainWithCName(t *testing.T) {
+	dnsQuery = func(fqdn string, rtype uint16, nameservers []string, recursive bool) (in *dns.Msg, err error) {
+		msg := &dns.Msg{}
+		msg.Rcode = dns.RcodeSuccess
+		switch fqdn {
+		case "test1.example.com":
+			msg.Answer = []dns.RR{
+				&dns.CNAME{
+					Target: "test2.example.com",
+				},
+			}
+		case "test2.example.com":
+			msg.Answer = []dns.RR{
+				&dns.CNAME{
+
+					Target: "test3.example.com",
+				},
+			}
+		case "recursive.example.com":
+			msg.Answer = []dns.RR{
+				&dns.CNAME{
+
+					Target: "recursive1.example.com",
+				},
+			}
+		case "recursive1.example.com":
+			msg.Answer = []dns.RR{
+				&dns.CNAME{
+					Target: "recursive.example.com",
+				},
+			}
+		case "error.example.com":
+			return nil, fmt.Errorf("Error while mocking resolve for %q", fqdn)
+		}
+
+		// inject fqdn in headers
+		for _, rr := range msg.Answer {
+			if cn, ok := rr.(*dns.CNAME); ok {
+				cn.Hdr = dns.RR_Header{
+					Name: fqdn,
+				}
+			}
+		}
+
+		return msg, nil
+	}
+	defer func() {
+		// restore the mock
+		dnsQuery = DNSQuery
+	}()
+	type args struct {
+		fqdn        string
+		nameservers []string
+		fqdnChain   []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Resolve CNAME 3 down",
+			args: args{
+				fqdn: "test1.example.com",
+			},
+			want:    "test3.example.com",
+			wantErr: false,
+		},
+		{
+			name: "Resolve CNAME 1 down",
+			args: args{
+				fqdn: "test3.example.com",
+			},
+			want:    "test3.example.com",
+			wantErr: false,
+		},
+		{
+			name: "Error when DNS fails",
+			args: args{
+				fqdn: "error.example.com",
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error on recursive CNAME",
+			args: args{
+				fqdn: "recursive.example.com",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := updateDomainWithCName(tt.args.fqdn, tt.args.nameservers, tt.args.fqdnChain...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("updateDomainWithCName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("updateDomainWithCName() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
We always resolved 1 level of CNAME follows,. this changes that logic to keep looking for CNAMEs. If there is a potential recursive it will error out.

**Which issue this PR fixes**:
fixes https://github.com/jetstack/cert-manager/issues/3098

**Special notes for your reviewer**:

Needs some testing to be written as the functionality is sensitive to infinite loops.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Make CNAME Follow recursive in DNS01 checker
```
