### PR TITLE
Fix comments for docs on types_certificate.go

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -54,7 +54,7 @@ spec:
           type: date
       schema:
         openAPIV3Schema:
-          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a 'one-shot' resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
+          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
           type: object
           properties:
             apiVersion:
@@ -83,7 +83,7 @@ spec:
                   description: IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to 'cert-manager.io' if empty.
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.
                   type: object
                   required:
                     - name
@@ -160,14 +160,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', 'InvalidRequest').
+                        description: Type of the condition, known values are (`Ready`, `InvalidRequest`).
                         type: string
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
@@ -196,7 +196,7 @@ spec:
           type: date
       schema:
         openAPIV3Schema:
-          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a 'one-shot' resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
+          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
           type: object
           properties:
             apiVersion:
@@ -225,7 +225,7 @@ spec:
                   description: IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to 'cert-manager.io' if empty.
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.
                   type: object
                   required:
                     - name
@@ -302,14 +302,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', 'InvalidRequest').
+                        description: Type of the condition, known values are (`Ready`, `InvalidRequest`).
                         type: string
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
@@ -338,7 +338,7 @@ spec:
           type: date
       schema:
         openAPIV3Schema:
-          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a 'one-shot' resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
+          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
           type: object
           required:
             - spec
@@ -365,7 +365,7 @@ spec:
                   description: IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to 'cert-manager.io' if empty.
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.
                   type: object
                   required:
                     - name
@@ -446,14 +446,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', 'InvalidRequest').
+                        description: Type of the condition, known values are (`Ready`, `InvalidRequest`).
                         type: string
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.
@@ -482,7 +482,7 @@ spec:
           type: date
       schema:
         openAPIV3Schema:
-          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a 'one-shot' resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
+          description: "A CertificateRequest is used to request a signed certificate from one of the configured issuers. \n All fields within the CertificateRequest's `spec` are immutable after creation. A CertificateRequest will either succeed or fail, as denoted by its `status.state` field. \n A CertificateRequest is a one-shot resource, meaning it represents a single point in time request for a certificate and cannot be re-used."
           type: object
           required:
             - spec
@@ -509,7 +509,7 @@ spec:
                   description: IsCA will request to mark the certificate as valid for certificate signing when submitting to the issuer. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to 'cert-manager.io' if empty.
+                  description: IssuerRef is a reference to the issuer for this CertificateRequest.  If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the CertificateRequest will be used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times. The group field refers to the API group of the issuer which defaults to `cert-manager.io` if empty.
                   type: object
                   required:
                     - name
@@ -590,14 +590,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', 'InvalidRequest').
+                        description: Type of the condition, known values are (`Ready`, `InvalidRequest`).
                         type: string
                 failureTime:
                   description: FailureTime stores the time that this CertificateRequest failed. This is used to influence garbage collection and back-off.

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -103,7 +103,7 @@ spec:
                   description: IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this certificate. If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the Certificate will be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times.
+                  description: IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.
                   type: object
                   required:
                     - name
@@ -118,19 +118,19 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 keyAlgorithm:
-                  description: KeyAlgorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize` is not provided, key size of 256 will be used for "ecdsa" key algorithm and key size of 2048 will be used for "rsa" key algorithm.
+                  description: KeyAlgorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `rsa` or `ecdsa` If `keyAlgorithm` is specified and `keySize` is not provided, key size of 256 will be used for `ecdsa` key algorithm and key size of 2048 will be used for `rsa` key algorithm.
                   type: string
                   enum:
                     - rsa
                     - ecdsa
                 keyEncoding:
-                  description: KeyEncoding is the private key cryptography standards (PKCS) for this certificate's private key to be encoded in. If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively. If KeyEncoding is not specified, then PKCS#1 will be used by default.
+                  description: KeyEncoding is the private key cryptography standards (PKCS) for this certificate's private key to be encoded in. If provided, allowed values are `pkcs1` and `pkcs8` standing for PKCS#1 and PKCS#8, respectively. If KeyEncoding is not specified, then `pkcs1` will be used by default.
                   type: string
                   enum:
                     - pkcs1
                     - pkcs8
                 keySize:
-                  description: KeySize is the key bit size of the corresponding private key for this certificate. If `keyAlgorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `keyAlgorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. No other values are allowed.
+                  description: KeySize is the key bit size of the corresponding private key for this certificate. If `keyAlgorithm` is set to `rsa`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `keyAlgorithm` is set to `ecdsa`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. No other values are allowed.
                   type: integer
                   maximum: 8192
                   minimum: 0
@@ -297,14 +297,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', `Issuing`).
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
                         type: string
                 lastFailureTime:
                   description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
@@ -400,7 +400,7 @@ spec:
                   description: IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this certificate. If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the Certificate will be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times.
+                  description: IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.
                   type: object
                   required:
                     - name
@@ -415,19 +415,19 @@ spec:
                       description: Name of the resource being referred to.
                       type: string
                 keyAlgorithm:
-                  description: KeyAlgorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either "rsa" or "ecdsa" If `keyAlgorithm` is specified and `keySize` is not provided, key size of 256 will be used for "ecdsa" key algorithm and key size of 2048 will be used for "rsa" key algorithm.
+                  description: KeyAlgorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `rsa` or `ecdsa` If `keyAlgorithm` is specified and `keySize` is not provided, key size of 256 will be used for `ecdsa` key algorithm and key size of 2048 will be used for `rsa` key algorithm.
                   type: string
                   enum:
                     - rsa
                     - ecdsa
                 keyEncoding:
-                  description: KeyEncoding is the private key cryptography standards (PKCS) for this certificate's private key to be encoded in. If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively. If KeyEncoding is not specified, then PKCS#1 will be used by default.
+                  description: KeyEncoding is the private key cryptography standards (PKCS) for this certificate's private key to be encoded in. If provided, allowed values are `pkcs1` and `pkcs8` standing for PKCS#1 and PKCS#8, respectively. If KeyEncoding is not specified, then `pkcs1` will be used by default.
                   type: string
                   enum:
                     - pkcs1
                     - pkcs8
                 keySize:
-                  description: KeySize is the key bit size of the corresponding private key for this certificate. If `keyAlgorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `keyAlgorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. No other values are allowed.
+                  description: KeySize is the key bit size of the corresponding private key for this certificate. If `keyAlgorithm` is set to `rsa`, valid values are `2048`, `4096` or `8192`, and will default to `2048` if not specified. If `keyAlgorithm` is set to `ecdsa`, valid values are `256`, `384` or `521`, and will default to `256` if not specified. No other values are allowed.
                   type: integer
                   maximum: 8192
                   minimum: 0
@@ -594,14 +594,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', `Issuing`).
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
                         type: string
                 lastFailureTime:
                   description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
@@ -699,7 +699,7 @@ spec:
                   description: IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this certificate. If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the Certificate will be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times.
+                  description: IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.
                   type: object
                   required:
                     - name
@@ -766,13 +766,13 @@ spec:
                   type: object
                   properties:
                     algorithm:
-                      description: Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either "rsa" or "ecdsa" If `algorithm` is specified and `size` is not provided, key size of 256 will be used for "ecdsa" key algorithm and key size of 2048 will be used for "rsa" key algorithm.
+                      description: Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm.
                       type: string
                       enum:
                         - RSA
                         - ECDSA
                     encoding:
-                      description: The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified.
+                      description: The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.
                       type: string
                       enum:
                         - PKCS1
@@ -893,14 +893,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', `Issuing`).
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
                         type: string
                 lastFailureTime:
                   description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.
@@ -998,7 +998,7 @@ spec:
                   description: IsCA will mark this Certificate as valid for certificate signing. This will automatically add the `cert sign` usage to the list of `usages`.
                   type: boolean
                 issuerRef:
-                  description: IssuerRef is a reference to the issuer for this certificate. If the 'kind' field is not set, or set to 'Issuer', an Issuer resource with the given name in the same namespace as the Certificate will be used. If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the provided name will be used. The 'name' field in this stanza is required at all times.
+                  description: IssuerRef is a reference to the issuer for this certificate. If the `kind` field is not set, or set to `Issuer`, an Issuer resource with the given name in the same namespace as the Certificate will be used. If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the provided name will be used. The `name` field in this stanza is required at all times.
                   type: object
                   required:
                     - name
@@ -1065,13 +1065,13 @@ spec:
                   type: object
                   properties:
                     algorithm:
-                      description: Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either "rsa" or "ecdsa" If `algorithm` is specified and `size` is not provided, key size of 256 will be used for "ecdsa" key algorithm and key size of 2048 will be used for "rsa" key algorithm.
+                      description: Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either `RSA` or `ECDSA` If `algorithm` is specified and `size` is not provided, key size of 256 will be used for `ECDSA` key algorithm and key size of 2048 will be used for `RSA` key algorithm.
                       type: string
                       enum:
                         - RSA
                         - ECDSA
                     encoding:
-                      description: The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively. Defaults to PKCS#1 if not specified.
+                      description: The private key cryptography standards (PKCS) encoding for this certificate's private key to be encoded in. If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1 and PKCS#8, respectively. Defaults to `PKCS1` if not specified.
                       type: string
                       enum:
                         - PKCS1
@@ -1192,14 +1192,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready', `Issuing`).
+                        description: Type of the condition, known values are (`Ready`, `Issuing`).
                         type: string
                 lastFailureTime:
                   description: LastFailureTime is the time as recorded by the Certificate controller of the most recent failure to complete a CertificateRequest for this Certificate resource. If set, cert-manager will not re-request another Certificate until 1 hour has elapsed from this time.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1048,14 +1048,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: false
@@ -2077,14 +2077,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: false
@@ -3108,14 +3108,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: false
@@ -4139,14 +4139,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: true

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1048,14 +1048,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: false
@@ -2077,14 +2077,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: false
@@ -3108,14 +3108,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: false
@@ -4139,14 +4139,14 @@ spec:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
                       status:
-                        description: Status of the condition, one of ('True', 'False', 'Unknown').
+                        description: Status of the condition, one of (`True`, `False`, `Unknown`).
                         type: string
                         enum:
                           - "True"
                           - "False"
                           - Unknown
                       type:
-                        description: Type of the condition, known values are ('Ready').
+                        description: Type of the condition, known values are (`Ready`).
                         type: string
       served: true
       storage: true

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -69,12 +69,12 @@ type PrivateKeyEncoding string
 
 const (
 	// PKCS1 key encoding will produce PEM files that include the type of
-	// private key as part of the PEM header, e.g. "BEGIN RSA PRIVATE KEY".
+	// private key as part of the PEM header, e.g. `BEGIN RSA PRIVATE KEY`.
 	// If the keyAlgorithm is set to 'ECDSA', this will produce private keys
-	// that use the "BEGIN EC PRIVATE KEY" header.
+	// that use the `BEGIN EC PRIVATE KEY` header.
 	PKCS1 PrivateKeyEncoding = "PKCS1"
 
-	// PKCS8 key encoding will produce PEM files with the "BEGIN PRIVATE KEY"
+	// PKCS8 key encoding will produce PEM files with the `BEGIN PRIVATE KEY`
 	// header. It encodes the keyAlgorithm of the private key as part of the
 	// DER encoded PEM block.
 	PKCS8 PrivateKeyEncoding = "PKCS8"
@@ -140,11 +140,11 @@ type CertificateSpec struct {
 	Keystores *CertificateKeystores `json:"keystores,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this certificate.
-	// If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+	// If the `kind` field is not set, or set to `Issuer`, an Issuer resource
 	// with the given name in the same namespace as the Certificate will be used.
-	// If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the
+	// If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
 	// provided name will be used.
-	// The 'name' field in this stanza is required at all times.
+	// The `name` field in this stanza is required at all times.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// IsCA will mark this Certificate as valid for certificate signing.
@@ -185,17 +185,17 @@ type CertificatePrivateKey struct {
 
 	// The private key cryptography standards (PKCS) encoding for this
 	// certificate's private key to be encoded in.
-	// If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1
+	// If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
 	// and PKCS#8, respectively.
-	// Defaults to PKCS#1 if not specified.
+	// Defaults to `PKCS1` if not specified.
 	// +optional
 	Encoding PrivateKeyEncoding `json:"encoding,omitempty"`
 
 	// Algorithm is the private key algorithm of the corresponding private key
-	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
+	// for this certificate. If provided, allowed values are either `RSA` or `ECDSA`
 	// If `algorithm` is specified and `size` is not provided,
-	// key size of 256 will be used for "ecdsa" key algorithm and
-	// key size of 2048 will be used for "rsa" key algorithm.
+	// key size of 256 will be used for `ECDSA` key algorithm and
+	// key size of 2048 will be used for `RSA` key algorithm.
 	// +optional
 	Algorithm PrivateKeyAlgorithm `json:"algorithm,omitempty"`
 
@@ -367,10 +367,10 @@ type CertificateStatus struct {
 
 // CertificateCondition contains condition information for an Certificate.
 type CertificateCondition struct {
-	// Type of the condition, known values are ('Ready', `Issuing`).
+	// Type of the condition, known values are (`Ready`, `Issuing`).
 	Type CertificateConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -46,7 +46,7 @@ const (
 // A CertificateRequest will either succeed or fail, as denoted by its `status.state`
 // field.
 //
-// A CertificateRequest is a 'one-shot' resource, meaning it represents a single
+// A CertificateRequest is a one-shot resource, meaning it represents a single
 // point in time request for a certificate and cannot be re-used.
 // +k8s:openapi-gen=true
 type CertificateRequest struct {
@@ -79,12 +79,12 @@ type CertificateRequestSpec struct {
 	Duration *metav1.Duration `json:"duration,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this CertificateRequest.  If
-	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
+	// the `kind` field is not set, or set to `Issuer`, an Issuer resource with
 	// the given name in the same namespace as the CertificateRequest will be
-	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
-	// the provided name will be used. The 'name' field in this stanza is
+	// used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with
+	// the provided name will be used. The `name` field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'cert-manager.io' if empty.
+	// issuer which defaults to `cert-manager.io` if empty.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
@@ -135,10 +135,10 @@ type CertificateRequestStatus struct {
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.
 type CertificateRequestCondition struct {
-	// Type of the condition, known values are ('Ready', 'InvalidRequest').
+	// Type of the condition, known values are (`Ready`, `InvalidRequest`).
 	Type CertificateRequestConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -295,10 +295,10 @@ type IssuerStatus struct {
 
 // IssuerCondition contains condition information for an Issuer.
 type IssuerCondition struct {
-	// Type of the condition, known values are ('Ready').
+	// Type of the condition, known values are (`Ready`).
 	Type IssuerConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -67,12 +67,12 @@ type KeyEncoding string
 
 const (
 	// PKCS1 key encoding will produce PEM files that include the type of
-	// private key as part of the PEM header, e.g. "BEGIN RSA PRIVATE KEY".
+	// private key as part of the PEM header, e.g. `BEGIN RSA PRIVATE KEY`.
 	// If the keyAlgorithm is set to 'ECDSA', this will produce private keys
-	// that use the "BEGIN EC PRIVATE KEY" header.
+	// that use the `BEGIN EC PRIVATE KEY` header.
 	PKCS1 KeyEncoding = "pkcs1"
 
-	// PKCS8 key encoding will produce PEM files with the "BEGIN PRIVATE KEY"
+	// PKCS8 key encoding will produce PEM files with the `BEGIN PRIVATE KEY`
 	// header. It encodes the keyAlgorithm of the private key as part of the
 	// DER encoded PEM block.
 	PKCS8 KeyEncoding = "pkcs8"
@@ -140,11 +140,11 @@ type CertificateSpec struct {
 	Keystores *CertificateKeystores `json:"keystores,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this certificate.
-	// If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+	// If the `kind` field is not set, or set to `Issuer`, an Issuer resource
 	// with the given name in the same namespace as the Certificate will be used.
-	// If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the
+	// If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
 	// provided name will be used.
-	// The 'name' field in this stanza is required at all times.
+	// The `name` field in this stanza is required at all times.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// IsCA will mark this Certificate as valid for certificate signing.
@@ -158,9 +158,9 @@ type CertificateSpec struct {
 	Usages []KeyUsage `json:"usages,omitempty"`
 
 	// KeySize is the key bit size of the corresponding private key for this certificate.
-	// If `keyAlgorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+	// If `keyAlgorithm` is set to `rsa`, valid values are `2048`, `4096` or `8192`,
 	// and will default to `2048` if not specified.
-	// If `keyAlgorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+	// If `keyAlgorithm` is set to `ecdsa`, valid values are `256`, `384` or `521`,
 	// and will default to `256` if not specified.
 	// No other values are allowed.
 	// +kubebuilder:validation:ExclusiveMaximum=false
@@ -171,17 +171,17 @@ type CertificateSpec struct {
 	KeySize int `json:"keySize,omitempty"`
 
 	// KeyAlgorithm is the private key algorithm of the corresponding private key
-	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
+	// for this certificate. If provided, allowed values are either `rsa` or `ecdsa`
 	// If `keyAlgorithm` is specified and `keySize` is not provided,
-	// key size of 256 will be used for "ecdsa" key algorithm and
-	// key size of 2048 will be used for "rsa" key algorithm.
+	// key size of 256 will be used for `ecdsa` key algorithm and
+	// key size of 2048 will be used for `rsa` key algorithm.
 	// +optional
 	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
 
 	// KeyEncoding is the private key cryptography standards (PKCS)
 	// for this certificate's private key to be encoded in. If provided, allowed
-	// values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively.
-	// If KeyEncoding is not specified, then PKCS#1 will be used by default.
+	// values are `pkcs1` and `pkcs8` standing for PKCS#1 and PKCS#8, respectively.
+	// If KeyEncoding is not specified, then `pkcs1` will be used by default.
 	// +optional
 	KeyEncoding KeyEncoding `json:"keyEncoding,omitempty"`
 
@@ -355,10 +355,10 @@ type CertificateStatus struct {
 
 // CertificateCondition contains condition information for an Certificate.
 type CertificateCondition struct {
-	// Type of the condition, known values are ('Ready', `Issuing`).
+	// Type of the condition, known values are (`Ready`, `Issuing`).
 	Type CertificateConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -45,7 +45,7 @@ const (
 // A CertificateRequest will either succeed or fail, as denoted by its `status.state`
 // field.
 //
-// A CertificateRequest is a 'one-shot' resource, meaning it represents a single
+// A CertificateRequest is a one-shot resource, meaning it represents a single
 // point in time request for a certificate and cannot be re-used.
 // +k8s:openapi-gen=true
 type CertificateRequest struct {
@@ -77,12 +77,12 @@ type CertificateRequestSpec struct {
 	Duration *metav1.Duration `json:"duration,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this CertificateRequest.  If
-	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
+	// the `kind` field is not set, or set to `Issuer`, an Issuer resource with
 	// the given name in the same namespace as the CertificateRequest will be
-	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
-	// the provided name will be used. The 'name' field in this stanza is
+	// used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with
+	// the provided name will be used. The `name` field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'cert-manager.io' if empty.
+	// issuer which defaults to `cert-manager.io` if empty.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
@@ -132,10 +132,10 @@ type CertificateRequestStatus struct {
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.
 type CertificateRequestCondition struct {
-	// Type of the condition, known values are ('Ready', 'InvalidRequest').
+	// Type of the condition, known values are (`Ready`, `InvalidRequest`).
 	Type CertificateRequestConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -291,10 +291,10 @@ type IssuerStatus struct {
 
 // IssuerCondition contains condition information for an Issuer.
 type IssuerCondition struct {
-	// Type of the condition, known values are ('Ready').
+	// Type of the condition, known values are (`Ready`).
 	Type IssuerConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -67,12 +67,12 @@ type KeyEncoding string
 
 const (
 	// PKCS1 key encoding will produce PEM files that include the type of
-	// private key as part of the PEM header, e.g. "BEGIN RSA PRIVATE KEY".
-	// If the keyAlgorithm is set to 'ECDSA', this will produce private keys
-	// that use the "BEGIN EC PRIVATE KEY" header.
+	// private key as part of the PEM header, e.g. `BEGIN RSA PRIVATE KEY`.
+	// If the keyAlgorithm is set to `ecdsa`, this will produce private keys
+	// that use the `BEGIN EC PRIVATE KEY` header.
 	PKCS1 KeyEncoding = "pkcs1"
 
-	// PKCS8 key encoding will produce PEM files with the "BEGIN PRIVATE KEY"
+	// PKCS8 key encoding will produce PEM files with the `BEGIN PRIVATE KEY`
 	// header. It encodes the keyAlgorithm of the private key as part of the
 	// DER encoded PEM block.
 	PKCS8 KeyEncoding = "pkcs8"
@@ -138,11 +138,11 @@ type CertificateSpec struct {
 	Keystores *CertificateKeystores `json:"keystores,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this certificate.
-	// If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+	// If the `kind` field is not set, or set to `Issuer`, an Issuer resource
 	// with the given name in the same namespace as the Certificate will be used.
-	// If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the
+	// If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
 	// provided name will be used.
-	// The 'name' field in this stanza is required at all times.
+	// The `name` field in this stanza is required at all times.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// IsCA will mark this Certificate as valid for certificate signing.
@@ -156,9 +156,9 @@ type CertificateSpec struct {
 	Usages []KeyUsage `json:"usages,omitempty"`
 
 	// KeySize is the key bit size of the corresponding private key for this certificate.
-	// If `keyAlgorithm` is set to `RSA`, valid values are `2048`, `4096` or `8192`,
+	// If `keyAlgorithm` is set to `rsa`, valid values are `2048`, `4096` or `8192`,
 	// and will default to `2048` if not specified.
-	// If `keyAlgorithm` is set to `ECDSA`, valid values are `256`, `384` or `521`,
+	// If `keyAlgorithm` is set to `ecdsa`, valid values are `256`, `384` or `521`,
 	// and will default to `256` if not specified.
 	// No other values are allowed.
 	// +kubebuilder:validation:ExclusiveMaximum=false
@@ -169,17 +169,17 @@ type CertificateSpec struct {
 	KeySize int `json:"keySize,omitempty"`
 
 	// KeyAlgorithm is the private key algorithm of the corresponding private key
-	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
+	// for this certificate. If provided, allowed values are either `rsa` or `ecdsa`
 	// If `keyAlgorithm` is specified and `keySize` is not provided,
-	// key size of 256 will be used for "ecdsa" key algorithm and
-	// key size of 2048 will be used for "rsa" key algorithm.
+	// key size of 256 will be used for `ecdsa` key algorithm and
+	// key size of 2048 will be used for `rsa` key algorithm.
 	// +optional
 	KeyAlgorithm KeyAlgorithm `json:"keyAlgorithm,omitempty"`
 
 	// KeyEncoding is the private key cryptography standards (PKCS)
 	// for this certificate's private key to be encoded in. If provided, allowed
-	// values are "pkcs1" and "pkcs8" standing for PKCS#1 and PKCS#8, respectively.
-	// If KeyEncoding is not specified, then PKCS#1 will be used by default.
+	// values are `pkcs1` and `pkcs8` standing for PKCS#1 and PKCS#8, respectively.
+	// If KeyEncoding is not specified, then `pkcs1` will be used by default.
 	// +optional
 	KeyEncoding KeyEncoding `json:"keyEncoding,omitempty"`
 
@@ -362,10 +362,10 @@ type CertificateStatus struct {
 
 // CertificateCondition contains condition information for an Certificate.
 type CertificateCondition struct {
-	// Type of the condition, known values are ('Ready', `Issuing`).
+	// Type of the condition, known values are (`Ready`, `Issuing`).
 	Type CertificateConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -45,7 +45,7 @@ const (
 // A CertificateRequest will either succeed or fail, as denoted by its `status.state`
 // field.
 //
-// A CertificateRequest is a 'one-shot' resource, meaning it represents a single
+// A CertificateRequest is a one-shot resource, meaning it represents a single
 // point in time request for a certificate and cannot be re-used.
 // +k8s:openapi-gen=true
 type CertificateRequest struct {
@@ -77,12 +77,12 @@ type CertificateRequestSpec struct {
 	Duration *metav1.Duration `json:"duration,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this CertificateRequest.  If
-	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
+	// the `kind` field is not set, or set to `Issuer`, an Issuer resource with
 	// the given name in the same namespace as the CertificateRequest will be
-	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
-	// the provided name will be used. The 'name' field in this stanza is
+	// used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with
+	// the provided name will be used. The `name` field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'cert-manager.io' if empty.
+	// issuer which defaults to `cert-manager.io` if empty.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
@@ -132,10 +132,10 @@ type CertificateRequestStatus struct {
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.
 type CertificateRequestCondition struct {
-	// Type of the condition, known values are ('Ready', 'InvalidRequest').
+	// Type of the condition, known values are (`Ready`, `InvalidRequest`).
 	Type CertificateRequestConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -291,10 +291,10 @@ type IssuerStatus struct {
 
 // IssuerCondition contains condition information for an Issuer.
 type IssuerCondition struct {
-	// Type of the condition, known values are ('Ready').
+	// Type of the condition, known values are (`Ready`).
 	Type IssuerConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -68,12 +68,12 @@ type PrivateKeyEncoding string
 
 const (
 	// PKCS1 key encoding will produce PEM files that include the type of
-	// private key as part of the PEM header, e.g. "BEGIN RSA PRIVATE KEY".
+	// private key as part of the PEM header, e.g. `BEGIN RSA PRIVATE KEY`.
 	// If the keyAlgorithm is set to 'ECDSA', this will produce private keys
-	// that use the "BEGIN EC PRIVATE KEY" header.
+	// that use the `BEGIN EC PRIVATE KEY` header.
 	PKCS1 PrivateKeyEncoding = "PKCS1"
 
-	// PKCS8 key encoding will produce PEM files with the "BEGIN PRIVATE KEY"
+	// PKCS8 key encoding will produce PEM files with the `BEGIN PRIVATE KEY`
 	// header. It encodes the keyAlgorithm of the private key as part of the
 	// DER encoded PEM block.
 	PKCS8 PrivateKeyEncoding = "PKCS8"
@@ -139,11 +139,11 @@ type CertificateSpec struct {
 	Keystores *CertificateKeystores `json:"keystores,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this certificate.
-	// If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+	// If the `kind` field is not set, or set to `Issuer`, an Issuer resource
 	// with the given name in the same namespace as the Certificate will be used.
-	// If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the
+	// If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
 	// provided name will be used.
-	// The 'name' field in this stanza is required at all times.
+	// The `name` field in this stanza is required at all times.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// IsCA will mark this Certificate as valid for certificate signing.
@@ -184,17 +184,17 @@ type CertificatePrivateKey struct {
 
 	// The private key cryptography standards (PKCS) encoding for this
 	// certificate's private key to be encoded in.
-	// If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1
+	// If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
 	// and PKCS#8, respectively.
-	// Defaults to PKCS#1 if not specified.
+	// Defaults to `PKCS1` if not specified.
 	// +optional
 	Encoding PrivateKeyEncoding `json:"encoding,omitempty"`
 
 	// Algorithm is the private key algorithm of the corresponding private key
-	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
+	// for this certificate. If provided, allowed values are either `RSA` or `ECDSA`
 	// If `algorithm` is specified and `size` is not provided,
-	// key size of 256 will be used for "ecdsa" key algorithm and
-	// key size of 2048 will be used for "rsa" key algorithm.
+	// key size of 256 will be used for `ECDSA` key algorithm and
+	// key size of 2048 will be used for `RSA` key algorithm.
 	// +optional
 	Algorithm PrivateKeyAlgorithm `json:"algorithm,omitempty"`
 
@@ -360,10 +360,10 @@ type CertificateStatus struct {
 
 // CertificateCondition contains condition information for an Certificate.
 type CertificateCondition struct {
-	// Type of the condition, known values are ('Ready', `Issuing`).
+	// Type of the condition, known values are (`Ready`, `Issuing`).
 	Type CertificateConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
@@ -45,7 +45,7 @@ const (
 // A CertificateRequest will either succeed or fail, as denoted by its `status.state`
 // field.
 //
-// A CertificateRequest is a 'one-shot' resource, meaning it represents a single
+// A CertificateRequest is a one-shot resource, meaning it represents a single
 // point in time request for a certificate and cannot be re-used.
 // +k8s:openapi-gen=true
 type CertificateRequest struct {
@@ -78,12 +78,12 @@ type CertificateRequestSpec struct {
 	Duration *metav1.Duration `json:"duration,omitempty"`
 
 	// IssuerRef is a reference to the issuer for this CertificateRequest.  If
-	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
+	// the `kind` field is not set, or set to `Issuer`, an Issuer resource with
 	// the given name in the same namespace as the CertificateRequest will be
-	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
-	// the provided name will be used. The 'name' field in this stanza is
+	// used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with
+	// the provided name will be used. The `name` field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'cert-manager.io' if empty.
+	// issuer which defaults to `cert-manager.io` if empty.
 	IssuerRef cmmeta.ObjectReference `json:"issuerRef"`
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
@@ -133,10 +133,10 @@ type CertificateRequestStatus struct {
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.
 type CertificateRequestCondition struct {
-	// Type of the condition, known values are ('Ready', 'InvalidRequest').
+	// Type of the condition, known values are (`Ready`, `InvalidRequest`).
 	Type CertificateRequestConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/apis/certmanager/v1beta1/types_issuer.go
+++ b/pkg/apis/certmanager/v1beta1/types_issuer.go
@@ -293,10 +293,10 @@ type IssuerStatus struct {
 
 // IssuerCondition contains condition information for an Issuer.
 type IssuerCondition struct {
-	// Type of the condition, known values are ('Ready').
+	// Type of the condition, known values are (`Ready`).
 	Type IssuerConditionType `json:"type"`
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus `json:"status"`
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -63,12 +63,12 @@ type PrivateKeyEncoding string
 
 const (
 	// PKCS1 key encoding will produce PEM files that include the type of
-	// private key as part of the PEM header, e.g. "BEGIN RSA PRIVATE KEY".
+	// private key as part of the PEM header, e.g. `BEGIN RSA PRIVATE KEY`.
 	// If the keyAlgorithm is set to 'ECDSA', this will produce private keys
-	// that use the "BEGIN EC PRIVATE KEY" header.
+	// that use the `BEGIN EC PRIVATE KEY` header.
 	PKCS1 PrivateKeyEncoding = "PKCS1"
 
-	// PKCS8 key encoding will produce PEM files with the "BEGIN PRIVATE KEY"
+	// PKCS8 key encoding will produce PEM files with the `BEGIN PRIVATE KEY`
 	// header. It encodes the keyAlgorithm of the private key as part of the
 	// DER encoded PEM block.
 	PKCS8 PrivateKeyEncoding = "PKCS8"
@@ -125,11 +125,11 @@ type CertificateSpec struct {
 	Keystores *CertificateKeystores
 
 	// IssuerRef is a reference to the issuer for this certificate.
-	// If the 'kind' field is not set, or set to 'Issuer', an Issuer resource
+	// If the `kind` field is not set, or set to `Issuer`, an Issuer resource
 	// with the given name in the same namespace as the Certificate will be used.
-	// If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with the
+	// If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with the
 	// provided name will be used.
-	// The 'name' field in this stanza is required at all times.
+	// The `name` field in this stanza is required at all times.
 	IssuerRef cmmeta.ObjectReference
 
 	// IsCA will mark this Certificate as valid for certificate signing.
@@ -154,27 +154,27 @@ type CertificateSpec struct {
 type CertificatePrivateKey struct {
 	// RotationPolicy controls how private keys should be regenerated when a
 	// re-issuance is being processed.
-	// If set to Never, a private key will only be generated if one does not
+	// If set to `Never`, a private key will only be generated if one does not
 	// already exist in the target `spec.secretName`. If one does exists but it
 	// does not have the correct algorithm or size, a warning will be raised
 	// to await user intervention.
-	// If set to Always, a private key matching the specified requirements
+	// If set to `Always`, a private key matching the specified requirements
 	// will be generated whenever a re-issuance occurs.
-	// Default is 'Never' for backward compatibility.
+	// Default is `Never` for backward compatibility.
 	RotationPolicy PrivateKeyRotationPolicy
 
 	// The private key cryptography standards (PKCS) encoding for this
 	// certificate's private key to be encoded in.
-	// If provided, allowed values are "pkcs1" and "pkcs8" standing for PKCS#1
+	// If provided, allowed values are `PKCS1` and `PKCS8` standing for PKCS#1
 	// and PKCS#8, respectively.
-	// Defaults to PKCS#1 if not specified.
+	// Defaults to `PKCS1` if not specified.
 	Encoding PrivateKeyEncoding
 
 	// Algorithm is the private key algorithm of the corresponding private key
-	// for this certificate. If provided, allowed values are either "rsa" or "ecdsa"
+	// for this certificate. If provided, allowed values are either `RSA` or `ECDSA`
 	// If `algorithm` is specified and `size` is not provided,
-	// key size of 256 will be used for "ecdsa" key algorithm and
-	// key size of 2048 will be used for "rsa" key algorithm.
+	// key size of `256` will be used for `ECDSA` key algorithm and
+	// key size of `2048` will be used for `RSA` key algorithm.
 	Algorithm PrivateKeyAlgorithm
 
 	// Size is the key bit size of the corresponding private key for this certificate.
@@ -317,10 +317,10 @@ type CertificateStatus struct {
 
 // CertificateCondition contains condition information for an Certificate.
 type CertificateCondition struct {
-	// Type of the condition, known values are ('Ready', `Issuing`).
+	// Type of the condition, known values are (`Ready`, `Issuing`).
 	Type CertificateConditionType
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/internal/apis/certmanager/types_certificaterequest.go
+++ b/pkg/internal/apis/certmanager/types_certificaterequest.go
@@ -44,7 +44,7 @@ const (
 // A CertificateRequest will either succeed or fail, as denoted by its `status.state`
 // field.
 //
-// A CertificateRequest is a 'one-shot' resource, meaning it represents a single
+// A CertificateRequest is a one-shot resource, meaning it represents a single
 // point in time request for a certificate and cannot be re-used.
 type CertificateRequest struct {
 	metav1.TypeMeta
@@ -74,12 +74,12 @@ type CertificateRequestSpec struct {
 	Duration *metav1.Duration
 
 	// IssuerRef is a reference to the issuer for this CertificateRequest.  If
-	// the 'kind' field is not set, or set to 'Issuer', an Issuer resource with
+	// the `kind` field is not set, or set to `Issuer`, an Issuer resource with
 	// the given name in the same namespace as the CertificateRequest will be
-	// used.  If the 'kind' field is set to 'ClusterIssuer', a ClusterIssuer with
-	// the provided name will be used. The 'name' field in this stanza is
+	// used.  If the `kind` field is set to `ClusterIssuer`, a ClusterIssuer with
+	// the provided name will be used. The `name` field in this stanza is
 	// required at all times. The group field refers to the API group of the
-	// issuer which defaults to 'cert-manager.io' if empty.
+	// issuer which defaults to `cert-manager.io` if empty.
 	IssuerRef cmmeta.ObjectReference
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
@@ -123,10 +123,10 @@ type CertificateRequestStatus struct {
 
 // CertificateRequestCondition contains condition information for a CertificateRequest.
 type CertificateRequestCondition struct {
-	// Type of the condition, known values are ('Ready', 'InvalidRequest').
+	// Type of the condition, known values are (`Ready`, `InvalidRequest`).
 	Type CertificateRequestConditionType
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus
 
 	// LastTransitionTime is the timestamp corresponding to the last status

--- a/pkg/internal/apis/certmanager/types_issuer.go
+++ b/pkg/internal/apis/certmanager/types_issuer.go
@@ -265,10 +265,10 @@ type IssuerStatus struct {
 
 // IssuerCondition contains condition information for an Issuer.
 type IssuerCondition struct {
-	// Type of the condition, known values are ('Ready').
+	// Type of the condition, known values are (`Ready`).
 	Type IssuerConditionType
 
-	// Status of the condition, one of ('True', 'False', 'Unknown').
+	// Status of the condition, one of (`True`, `False`, `Unknown`).
 	Status cmmeta.ConditionStatus
 
 	// LastTransitionTime is the timestamp corresponding to the last status


### PR DESCRIPTION
**What this PR does / why we need it**: fix the doc

 - Use backticks, not single/double quotes for enum values
 - Fix allowed values for encoding and key algorithm
 
At https://cert-manager.io/docs/reference/api-docs/#cert-manager.io/v1.CertificatePrivateKey

> algorithm: Algorithm is the private key algorithm of the corresponding private key for this certificate. If provided, allowed values are either “rsa” or “ecdsa” If algorithm is specified and size is not provided, key size of 256 will be used for “ecdsa” key algorithm and key size of 2048 will be used for “rsa” key algorithm.
> size: Size is the key bit size of the corresponding private key for this certificate. If algorithm is set to RSA, valid values are 2048, 4096 or 8192, and will default to 2048 if not specified. If algorithm is set to ECDSA, valid values are 256, 384 or 521, and will default to 256 if not specified. No other values are allowed.

From the source code, it seems like `RSA` / `ECDSA` are the correct values 

```go
const (
	// Denotes the RSA private key type.
	RSAKeyAlgorithm PrivateKeyAlgorithm = "RSA"

	// Denotes the ECDSA private key type.
	ECDSAKeyAlgorithm PrivateKeyAlgorithm = "ECDSA"
)
```

**Special notes for your reviewer**:

**Release note**:

```release-note
NONE
```
