### PR TITLE
Minor log message clarification

### DIFF
--- a/pkg/controller/cainjector/sources.go
+++ b/pkg/controller/cainjector/sources.go
@@ -104,7 +104,7 @@ func (c *certificateDataSource) ReadCA(ctx context.Context, log logr.Logger, met
 	certName := splitNamespacedName(certNameRaw)
 	log = log.WithValues("certificate", certName)
 	if certName.Namespace == "" {
-		log.Error(nil, "invalid certificate name")
+		log.Error(nil, "invalid certificate name; needs a namespace/ prefix")
 		// don't return an error, requeuing won't help till this is changed
 		return nil, nil
 	}


### PR DESCRIPTION
Supplying just a name, rather than a namespace/name, for a cainjector
source reference, results in the generic error message "invalid
certificate name". This condition is detected on its own branch so we
can be more specific.

```release-note
NONE
```
