### PR TITLE
Fix verify-codegen.sh to ignore Copyright lines

### DIFF
--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -53,7 +53,9 @@ tmpfiles=$TEST_TMPDIR/files
   rm -rf {.,"$tmpfiles"}/{"$gazelle","$kazel"}
 )
 # Avoid diff -N so we handle empty files correctly
+# Ignoring Copyright to not trigger a CI fail avery new year
 diff=$(diff -upr \
+  -I '^Copyright.*' \
   "./pkg" "$tmpfiles/pkg" 2>/dev/null || true)
 
 if [[ -n "${diff}" ]]; then


### PR DESCRIPTION
**What this PR does / why we need it**:
Added a regex to the diff to ignore Copyright lines for changes to avoid a new year making our testing go red. 

**Which issue this PR fixes**
fixes https://github.com/jetstack/cert-manager/issues/3554

**Special notes for your reviewer**:

Happy 2021

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
