### PR TITLE
WIP: Resync Issuers and ClusterIssuers every 30 seconds

### DIFF
--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -85,7 +85,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.secretLister = secretInformer.Lister()
 
 	// register handler functions
-	clusterIssuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue})
+	clusterIssuerInformer.Informer().AddEventHandlerWithResyncPeriod(&controllerpkg.QueuingEventHandler{Queue: c.queue}, issuer.ResyncPeriod)
 	secretInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: c.secretDeleted})
 
 	// instantiate additional helpers used by this controller

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -81,7 +81,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.secretLister = secretInformer.Lister()
 
 	// register handler functions
-	issuerInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue})
+	issuerInformer.Informer().AddEventHandlerWithResyncPeriod(&controllerpkg.QueuingEventHandler{Queue: c.queue}, issuer.ResyncPeriod)
 	secretInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{WorkFunc: c.secretDeleted})
 
 	// instantiate additional helpers used by this controller

--- a/pkg/controller/util.go
+++ b/pkg/controller/util.go
@@ -102,9 +102,6 @@ func (q *QueuingEventHandler) OnAdd(obj interface{}) {
 }
 
 func (q *QueuingEventHandler) OnUpdate(old, new interface{}) {
-	if reflect.DeepEqual(old, new) {
-		return
-	}
 	q.Enqueue(new)
 }
 

--- a/pkg/issuer/issuer.go
+++ b/pkg/issuer/issuer.go
@@ -18,6 +18,15 @@ package issuer
 
 import (
 	"context"
+	"time"
+)
+
+const (
+	// ResyncPeriod defines how frequently Issuers and ClusterIssuers will be
+	// reconciled.
+	// This ensures that Issuer.Status (in particular the Ready condition) is
+	// kept up-to-date.
+	ResyncPeriod = time.Second * 30
 )
 
 type Interface interface {

--- a/test/e2e/suite/issuers/venafi/tpp/BUILD.bazel
+++ b/test/e2e/suite/issuers/venafi/tpp/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//test/e2e/util:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],
 )


### PR DESCRIPTION
cert-manager used to resync every resource every 30 seconds, which was wasteful so we changed it in https://github.com/jetstack/cert-manager/pull/3403

But that regular resyncing had the side-effect of ensuring that all the Issuer and ClusterIssuer resources were regularly rechecked.

For example, the Venafi Issuer would regularly check that its credentials were valid and that the Venafi server was reachable.
That no longer happens.

This PR re-instates the 30 second recheck behaviour.

I need this for #3140  so that the access-token can be refreshed before it expires.

/kind bug

```release-note
Issuers and ClusterIssuers are now re-synced every 30 seconds.
```
