### PR TITLE
WIP: Refresh access-tokens when they expire

### DIFF
--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -46,6 +46,21 @@ func IssuerHasCondition(i cmapi.GenericIssuer, c cmapi.IssuerCondition) bool {
 	return false
 }
 
+// GetIssuerCondition will return a condition if there is one with the sepcified type,
+// else it will return nil.
+func GetIssuerCondition(i cmapi.GenericIssuer, conditionType cmapi.IssuerConditionType) *cmapi.IssuerCondition {
+	if i == nil {
+		return nil
+	}
+	existingConditions := i.GetStatus().Conditions
+	for _, cond := range existingConditions {
+		if conditionType == cond.Type {
+			return &cond
+		}
+	}
+	return nil
+}
+
 // SetIssuerCondition will set a 'condition' on the given GenericIssuer.
 // - If no condition of the same type already exists, the condition will be
 //   inserted with the LastTransitionTime set to the current time.

--- a/pkg/issuer/venafi/BUILD.bazel
+++ b/pkg/issuer/venafi/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/test:go_default_library",
         "//pkg/issuer/venafi/client:go_default_library",

--- a/pkg/issuer/venafi/client/fake/venafi.go
+++ b/pkg/issuer/venafi/client/fake/venafi.go
@@ -25,6 +25,8 @@ import (
 )
 
 type Venafi struct {
+	AuthenticateFn          func() error
+	RotateCredentialsFn     func() error
 	PingFn                  func() error
 	RequestCertificateFn    func(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
 	RetrieveCertificateFn   func(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
@@ -33,6 +35,14 @@ type Venafi struct {
 
 func (v *Venafi) Ping() error {
 	return v.PingFn()
+}
+
+func (v *Venafi) Authenticate() error {
+	return v.AuthenticateFn()
+}
+
+func (v *Venafi) RotateCredentials() error {
+	return v.RotateCredentialsFn()
 }
 
 func (v *Venafi) RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error) {

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -17,6 +17,7 @@ limitations under the License.
 package client
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -37,11 +38,18 @@ const (
 	defaultAPIKeyKey = "api-key"
 )
 
+var (
+	ErrAccessTokenExpired = errors.New("access-token expired")
+	ErrAccessTokenMissing = errors.New("access-token missing")
+)
+
 type VenafiClientBuilder func(namespace string, secretsLister corelisters.SecretLister,
 	issuer cmapi.GenericIssuer) (Interface, error)
 
 // Interface implements a Venafi client
 type Interface interface {
+	Authenticate() error
+	RotateCredentials() error
 	RequestCertificate(csrPEM []byte, duration time.Duration, customFields []api.CustomField) (string, error)
 	RetrieveCertificate(pickupID string, csrPEM []byte, duration time.Duration, customFields []api.CustomField) ([]byte, error)
 	Ping() error
@@ -157,4 +165,12 @@ func (v *Venafi) ReadZoneConfiguration() (*endpoint.ZoneConfiguration, error) {
 
 func (v *Venafi) SetClient(client endpoint.Connector) {
 	v.vcertClient = client
+}
+
+func (v *Venafi) Authenticate() error {
+	return nil
+}
+
+func (v *Venafi) RotateCredentials() error {
+	return nil
 }


### PR DESCRIPTION
Allow Venafi Issuer to use refresh-token to get new access-token when it expires.

A smaller version of https://github.com/jetstack/cert-manager/pull/3412 without all the refactoring and moving  of the venafi issuer and client
 
Fixes: #3140

/kind feature

```release-note
Venafi Issuer now supports oauth refresh tokens
```
