### PR TITLE
Add CRD categories

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -20,6 +20,9 @@ spec:
       - cr
       - crs
     singular: certificaterequest
+    categories:
+      - all
+      - cert-manager
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -21,7 +21,6 @@ spec:
       - crs
     singular: certificaterequest
     categories:
-      - all
       - cert-manager
   scope: Namespaced
   conversion:

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -21,7 +21,6 @@ spec:
       - certs
     singular: certificate
     categories:
-      - all
       - cert-manager
   scope: Namespaced
   conversion:

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -20,6 +20,9 @@ spec:
       - cert
       - certs
     singular: certificate
+    categories:
+      - all
+      - cert-manager
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -18,9 +18,8 @@ spec:
     plural: challenges
     singular: challenge
     categories:
-      - all
       - cert-manager
-      - acme
+      - cert-manager-acme
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -17,6 +17,10 @@ spec:
     listKind: ChallengeList
     plural: challenges
     singular: challenge
+    categories:
+      - all
+      - cert-manager
+      - acme
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -18,7 +18,6 @@ spec:
     plural: clusterissuers
     singular: clusterissuer
     categories:
-      - all
       - cert-manager
   scope: Cluster
   conversion:

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -17,6 +17,9 @@ spec:
     listKind: ClusterIssuerList
     plural: clusterissuers
     singular: clusterissuer
+    categories:
+      - all
+      - cert-manager
   scope: Cluster
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -18,7 +18,6 @@ spec:
     plural: issuers
     singular: issuer
     categories:
-      - all
       - cert-manager
   scope: Namespaced
   conversion:

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -17,6 +17,9 @@ spec:
     listKind: IssuerList
     plural: issuers
     singular: issuer
+    categories:
+      - all
+      - cert-manager
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -18,9 +18,8 @@ spec:
     plural: orders
     singular: order
     categories:
-      - all
       - cert-manager
-      - acme
+      - cert-manager-acme
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -17,6 +17,10 @@ spec:
     listKind: OrderList
     plural: orders
     singular: order
+    categories:
+      - all
+      - cert-manager
+      - acme
   scope: Namespaced
   conversion:
     # a Webhook strategy instruct API server to call an external webhook for any conversion between custom resources.


### PR DESCRIPTION
**What this PR does / why we need it**:go

This 1dda category names to our CRDs to they appear in `kubectl get all` and `kubectl get cert-manager` which is quite easy for debugging issues!

```
user@mect-l001 ~/g/s/g/m/c/acme> k get cert-manager
NAME                                                      STATE     AGE
order.acme.cert-manager.io/local-test2-896bh-2961499243   errored   3s

NAME                            READY   AGE
issuer.cert-manager.io/pebble   True    3s

NAME                                                   READY   AGE
certificaterequest.cert-manager.io/local-test2-896bh   False   6s

NAME                                      READY   SECRET      AGE
certificate.cert-manager.io/local-test2   False   localtls2   6s
user@mect-l001 ~/g/s/g/m/c/acme> k get acme
NAME                                                      STATE     AGE
order.acme.cert-manager.io/local-test2-896bh-2961499243   errored   7s
```

**Which issue this PR fixes**:
fixes https://github.com/jetstack/cert-manager/issues/3577


**Special notes for your reviewer**:

Category names are up for discussion!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add category names to our CRDs to they appear in `kubectl get cert-manager` and `kubectl get cert-manager-acme`
```
