### PR TITLE
Passes a singe context with cancel func to all the kubectl plugin com…

### DIFF
--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//cmd/cainjector/app:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/cmd:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
     ],

--- a/cmd/cainjector/main.go
+++ b/cmd/cainjector/main.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/jetstack/cert-manager/cmd/cainjector/app"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/util"
 	utilcmd "github.com/jetstack/cert-manager/pkg/util/cmd"
 )
 
@@ -37,12 +38,7 @@ func main() {
 	// Set up signal handlers and a cancellable context which gets cancelled on
 	// when either SIGINT or SIGTERM are received.
 	stopCh := utilcmd.SetupSignalHandler()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-	go func() {
-		<-stopCh
-		cancel()
-	}()
+	ctx := util.ContextWithStopCh(context.Background(), stopCh)
 
 	cmd := app.NewCommandStartInjectorController(ctx, os.Stdout, os.Stderr)
 	cmd.Flags().AddGoFlagSet(flag.CommandLine)

--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     visibility = ["//visibility:private"],
     deps = [
         "//cmd/ctl/cmd:go_default_library",
+        "//pkg/util:go_default_library",
         "//pkg/util/cmd:go_default_library",
     ],
 )

--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -17,6 +17,7 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"io"
@@ -38,7 +39,7 @@ import (
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/version"
 )
 
-func NewCertManagerCtlCommand(in io.Reader, out, err io.Writer, stopCh <-chan struct{}) *cobra.Command {
+func NewCertManagerCtlCommand(ctx context.Context, in io.Reader, out, err io.Writer) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "cert-manager",
 		Short: "cert-manager CLI tool to manage and configure cert-manager resources",
@@ -63,12 +64,12 @@ kubectl cert-manager is a CLI tool manage and configure cert-manager resources f
 	}
 
 	ioStreams := genericclioptions.IOStreams{In: in, Out: out, ErrOut: err}
-	cmds.AddCommand(version.NewCmdVersion(ioStreams))
-	cmds.AddCommand(convert.NewCmdConvert(ioStreams))
-	cmds.AddCommand(create.NewCmdCreate(ioStreams, factory))
-	cmds.AddCommand(renew.NewCmdRenew(ioStreams, factory))
-	cmds.AddCommand(status.NewCmdStatus(ioStreams, factory))
-	cmds.AddCommand(inspect.NewCmdInspect(ioStreams, factory))
+	cmds.AddCommand(version.NewCmdVersion(ctx, ioStreams))
+	cmds.AddCommand(convert.NewCmdConvert(ctx, ioStreams))
+	cmds.AddCommand(create.NewCmdCreate(ctx, ioStreams, factory))
+	cmds.AddCommand(renew.NewCmdRenew(ctx, ioStreams, factory))
+	cmds.AddCommand(status.NewCmdStatus(ctx, ioStreams, factory))
+	cmds.AddCommand(inspect.NewCmdInspect(ctx, ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -17,16 +17,19 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 
 	ctlcmd "github.com/jetstack/cert-manager/cmd/ctl/cmd"
+	"github.com/jetstack/cert-manager/pkg/util"
 	utilcmd "github.com/jetstack/cert-manager/pkg/util/cmd"
 )
 
 func main() {
 	stopCh := utilcmd.SetupSignalHandler()
-	cmd := ctlcmd.NewCertManagerCtlCommand(os.Stdin, os.Stdout, os.Stderr, stopCh)
+	ctx := util.ContextWithStopCh(context.Background(), stopCh)
+	cmd := ctlcmd.NewCertManagerCtlCommand(ctx, os.Stdin, os.Stdout, os.Stderr)
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)

--- a/cmd/ctl/pkg/convert/convert.go
+++ b/cmd/ctl/pkg/convert/convert.go
@@ -17,6 +17,7 @@ limitations under the License.
 package convert
 
 import (
+	"context"
 	"fmt"
 
 	logf "github.com/jetstack/cert-manager/pkg/logs"
@@ -83,7 +84,7 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 }
 
 // NewCmdConvert returns a cobra command for converting cert-manager resources
-func NewCmdConvert(ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdConvert(ctx context.Context, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest_test.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package certificaterequest
 
 import (
+	"context"
 	"io/ioutil"
 	"os"
 	"testing"
@@ -225,7 +226,7 @@ spec:
 			}
 
 			// Create CR
-			err = opts.Run(test.inputArgs)
+			err = opts.Run(context.TODO(), test.inputArgs)
 			if err != nil {
 				if !test.expErr {
 					t.Fatalf("got unexpected error when trying to create CR: %v", err)

--- a/cmd/ctl/pkg/create/create.go
+++ b/cmd/ctl/pkg/create/create.go
@@ -17,6 +17,8 @@ limitations under the License.
 package create
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -24,14 +26,14 @@ import (
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/create/certificaterequest"
 )
 
-func NewCmdCreate(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+func NewCmdCreate(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "create",
 		Short: "Create cert-manager resources",
 		Long:  `Create cert-manager resources e.g. a CertificateRequest`,
 	}
 
-	cmds.AddCommand(certificaterequest.NewCmdCreateCR(ioStreams, factory))
+	cmds.AddCommand(certificaterequest.NewCmdCreateCR(ctx, ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/pkg/inspect/inspect.go
+++ b/cmd/ctl/pkg/inspect/inspect.go
@@ -17,6 +17,8 @@ limitations under the License.
 package inspect
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -24,14 +26,14 @@ import (
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/inspect/secret"
 )
 
-func NewCmdInspect(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+func NewCmdInspect(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "inspect",
 		Short: "Get details on certificate related resources",
 		Long:  `Get details on certificate related resources, e.g. secrets`,
 	}
 
-	cmds.AddCommand(secret.NewCmdInspectSecret(ioStreams, factory))
+	cmds.AddCommand(secret.NewCmdInspectSecret(ctx, ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/pkg/inspect/secret/secret.go
+++ b/cmd/ctl/pkg/inspect/secret/secret.go
@@ -111,7 +111,7 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 }
 
 // NewCmdInspectSecret returns a cobra command for status certificate
-func NewCmdInspectSecret(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+func NewCmdInspectSecret(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
 	o := NewOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:     "secret",
@@ -121,7 +121,7 @@ func NewCmdInspectSecret(ioStreams genericclioptions.IOStreams, factory cmdutil.
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Validate(args))
 			cmdutil.CheckErr(o.Complete(factory))
-			cmdutil.CheckErr(o.Run(args))
+			cmdutil.CheckErr(o.Run(ctx, args))
 		},
 	}
 	return cmd
@@ -161,9 +161,7 @@ func (o *Options) Complete(f cmdutil.Factory) error {
 }
 
 // Run executes status certificate command
-func (o *Options) Run(args []string) error {
-	ctx := context.TODO()
-
+func (o *Options) Run(ctx context.Context, args []string) error {
 	secret, err := o.clientSet.CoreV1().Secrets(o.Namespace).Get(ctx, args[0], metav1.GetOptions{})
 	if err != nil {
 		return fmt.Errorf("error when finding Secret %q: %w\n", args[0], err)

--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -75,7 +75,7 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 }
 
 // NewCmdRenew returns a cobra command for renewing Certificates
-func NewCmdRenew(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+func NewCmdRenew(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
 	o := NewOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:     "renew",
@@ -85,7 +85,7 @@ func NewCmdRenew(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory)
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Complete(factory))
 			cmdutil.CheckErr(o.Validate(cmd, args))
-			cmdutil.CheckErr(o.Run(args))
+			cmdutil.CheckErr(o.Run(ctx, args))
 		},
 	}
 
@@ -139,8 +139,7 @@ func (o *Options) Complete(f cmdutil.Factory) error {
 }
 
 // Run executes renew command
-func (o *Options) Run(args []string) error {
-	ctx := context.TODO()
+func (o *Options) Run(ctx context.Context, args []string) error {
 
 	nss := []corev1.Namespace{{ObjectMeta: metav1.ObjectMeta{Name: o.Namespace}}}
 

--- a/cmd/ctl/pkg/renew/renew_test.go
+++ b/cmd/ctl/pkg/renew/renew_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package renew
 
 import (
+	"context"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -75,7 +76,7 @@ func TestValidate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			cmd := NewCmdRenew(genericclioptions.IOStreams{}, nil)
+			cmd := NewCmdRenew(context.TODO(), genericclioptions.IOStreams{}, nil)
 
 			// This is normally registered in the main func. We add here to test
 			// against flags normally inherited.

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -89,7 +89,7 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 }
 
 // NewCmdStatusCert returns a cobra command for status certificate
-func NewCmdStatusCert(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+func NewCmdStatusCert(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
 	o := NewOptions(ioStreams)
 	cmd := &cobra.Command{
 		Use:     "certificate",
@@ -99,7 +99,7 @@ func NewCmdStatusCert(ioStreams genericclioptions.IOStreams, factory cmdutil.Fac
 		Run: func(cmd *cobra.Command, args []string) {
 			cmdutil.CheckErr(o.Validate(args))
 			cmdutil.CheckErr(o.Complete(factory))
-			cmdutil.CheckErr(o.Run(args))
+			cmdutil.CheckErr(o.Run(ctx, args))
 		},
 	}
 	return cmd
@@ -139,8 +139,8 @@ func (o *Options) Complete(f cmdutil.Factory) error {
 }
 
 // Run executes status certificate command
-func (o *Options) Run(args []string) error {
-	data, err := o.GetResources(args[0])
+func (o *Options) Run(ctx context.Context, args []string) error {
+	data, err := o.GetResources(ctx, args[0])
 	if err != nil {
 		return err
 	}
@@ -157,9 +157,7 @@ func (o *Options) Run(args []string) error {
 // in a Data struct and returns it.
 // Returns error if error occurs when finding Certificate resource or while preparing to find other resources,
 // e.g. when creating clientSet
-func (o *Options) GetResources(crtName string) (*Data, error) {
-	ctx := context.TODO()
-
+func (o *Options) GetResources(ctx context.Context, crtName string) (*Data, error) {
 	clientSet, err := kubernetes.NewForConfig(o.RESTConfig)
 	if err != nil {
 		return nil, err

--- a/cmd/ctl/pkg/status/status.go
+++ b/cmd/ctl/pkg/status/status.go
@@ -17,6 +17,8 @@ limitations under the License.
 package status
 
 import (
+	"context"
+
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
@@ -24,14 +26,14 @@ import (
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/status/certificate"
 )
 
-func NewCmdStatus(ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+func NewCmdStatus(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
 	cmds := &cobra.Command{
 		Use:   "status",
 		Short: "Get details on current status of cert-manager resources",
 		Long:  `Get details on current status of cert-manager resources, e.g. Certificate`,
 	}
 
-	cmds.AddCommand(certificate.NewCmdStatusCert(ioStreams, factory))
+	cmds.AddCommand(certificate.NewCmdStatusCert(ctx, ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/pkg/version/version.go
+++ b/cmd/ctl/pkg/version/version.go
@@ -17,6 +17,7 @@ limitations under the License.
 package version
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -49,7 +50,7 @@ func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
 }
 
 // NewCmdVersion returns a cobra command for fetching versions
-func NewCmdVersion(ioStreams genericclioptions.IOStreams) *cobra.Command {
+func NewCmdVersion(ctx context.Context, ioStreams genericclioptions.IOStreams) *cobra.Command {
 	o := NewOptions(ioStreams)
 
 	cmd := &cobra.Command{

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -75,9 +75,11 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 		ns1     = "testns-1"
 	)
 
+	ctx := context.TODO()
+
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1}}
-	_, err := kubernetesCl.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := kubernetesCl.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +113,7 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 				InputFilename:    test.inputFile,
 				CertFileName:     test.certFilename,
 			}
-			err := opts.Run(test.inputArgs)
+			err := opts.Run(ctx, test.inputArgs)
 			if err != nil {
 				t.Fatal("failed to set up test to fail after writing private key to file and during creating CR")
 			}
@@ -120,14 +122,14 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 			// Now we try to create another CR with the same name, but storing the private key somewhere else
 			// This should break after writing private key to file and during creating CR
 			opts.KeyFilename = test.keyFilename
-			// Validating args and flags
+			// Validating args and flagscontext.TODO()
 			err = opts.Validate(test.inputArgs)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			// Run ctl create cr command with input options
-			err = opts.Run(test.inputArgs)
+			err = opts.Run(ctx, test.inputArgs)
 			if err != nil {
 				if !test.expRunErr {
 					t.Errorf("got unexpected error when trying to create CR: %v", err)
@@ -314,7 +316,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 			}
 
 			// Run ctl create cr command with input options
-			err = opts.Run(test.inputArgs)
+			err = opts.Run(ctx, test.inputArgs)
 			if err != nil {
 				if !test.expRunErr {
 					t.Errorf("got unexpected error when trying to create CR: %v", err)

--- a/test/integration/ctl/ctl_renew_test.go
+++ b/test/integration/ctl/ctl_renew_test.go
@@ -172,7 +172,7 @@ func TestCtlRenew(t *testing.T) {
 				IOStreams:  streams,
 			}
 
-			if err := cmd.Run(test.inputArgs); err != nil {
+			if err := cmd.Run(ctx, test.inputArgs); err != nil {
 				t.Fatal(err)
 			}
 

--- a/test/integration/ctl/ctl_status_certificate_test.go
+++ b/test/integration/ctl/ctl_status_certificate_test.go
@@ -536,7 +536,7 @@ CertificateRequest:
 				Namespace:  test.inputNamespace,
 			}
 
-			err = opts.Run(test.inputArgs)
+			err = opts.Run(ctx, test.inputArgs)
 			if err != nil {
 				if !test.expErr {
 					t.Errorf("got unexpected error: %v", err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Passes a single context with a cancel function to all the `cert-manager` `kubectl` plugin commands.

The cancel function will be called when the process receives SIGTERM or SIGINT.

Uses the existing custom signal handling- there is a stop channel created [here](https://github.com/jetstack/cert-manager/blob/master/cmd/ctl/main.go#L28), when a value is sent into the channel, the cancel function will be called.

**Which issue this PR fixes**:
 fixes #3587 

/kind cleanup

**Release note:**
```
NONE
```