### PR TITLE
Certificate condition observed generation

### DIFF
--- a/cmd/ctl/pkg/renew/renew.go
+++ b/cmd/ctl/pkg/renew/renew.go
@@ -202,7 +202,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 }
 
 func (o *Options) renewCertificate(ctx context.Context, crt *cmapi.Certificate) error {
-	apiutil.SetCertificateCondition(crt, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "ManuallyTriggered", "Certificate re-issuance manually triggered")
+	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "ManuallyTriggered", "Certificate re-issuance manually triggered")
 	_, err := o.CMClient.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to trigger issuance of Certificate %s/%s: %v", crt.Namespace, crt.Name, err)

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -293,6 +293,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -588,6 +592,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -885,6 +893,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -1182,6 +1194,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Certificate.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -134,9 +134,12 @@ func GetCertificateRequestCondition(req *cmapi.CertificateRequest, conditionType
 // - If a condition of the same type and state already exists, the condition
 //   will be updated but the LastTransitionTime will not be modified.
 // - If a condition of the same type and different state already exists, the
-//   condition will be updated and the LastTransitionTime set to the current
+//   condition will be updated with the LastTransitionTime set to the current
 //   time.
-func SetCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.CertificateConditionType, status cmmeta.ConditionStatus, reason, message string) {
+// The given ObservedGeneration will always set on the condition, whether the
+// lastTransitionTime is modified or not.
+func SetCertificateCondition(crt *cmapi.Certificate, observedGeneration int64, conditionType cmapi.CertificateConditionType,
+	status cmmeta.ConditionStatus, reason, message string) {
 	newCondition := cmapi.CertificateCondition{
 		Type:    conditionType,
 		Status:  status,
@@ -147,6 +150,9 @@ func SetCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.Certifi
 	nowTime := metav1.NewTime(Clock.Now())
 	newCondition.LastTransitionTime = &nowTime
 
+	// Set the condition generation
+	newCondition.ObservedGeneration = observedGeneration
+
 	// Search through existing conditions
 	for idx, cond := range crt.Status.Conditions {
 		// Skip unrelated conditions
@@ -154,8 +160,8 @@ func SetCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.Certifi
 			continue
 		}
 
-		// If this update doesn't contain a state transition, we don't update
-		// the conditions LastTransitionTime to Now()
+		// If this update doesn't contain a state transition, we don't update the
+		// conditions LastTransitionTime to Now()
 		if cond.Status == status {
 			newCondition.LastTransitionTime = cond.LastTransitionTime
 		} else {
@@ -173,7 +179,7 @@ func SetCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.Certifi
 	logf.V(logf.InfoLevel).Infof("Setting lastTransitionTime for Certificate %q condition %q to %v", crt.Name, conditionType, nowTime.Time)
 }
 
-// RemoteCertificateCondition will remove any condition with this condition type
+// RemoveCertificateCondition will remove any condition with this condition type
 func RemoveCertificateCondition(crt *cmapi.Certificate, conditionType cmapi.CertificateConditionType) {
 	var updatedConditions []cmapi.CertificateCondition
 

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -383,6 +383,14 @@ type CertificateCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -371,6 +371,14 @@ type CertificateCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -378,6 +378,14 @@ type CertificateCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -376,6 +376,14 @@ type CertificateCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -295,7 +295,7 @@ func (c *controller) failIssueCertificate(ctx context.Context, log logr.Logger, 
 		condition.Message)
 
 	crt = crt.DeepCopy()
-	apiutil.SetCertificateCondition(crt, cmapi.CertificateConditionIssuing, cmmeta.ConditionFalse, reason, message)
+	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionFalse, reason, message)
 
 	_, err := c.client.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 	if err != nil {

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -60,6 +60,7 @@ func TestIssuingController(t *testing.T) {
 
 	baseCert := gen.Certificate("test",
 		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "ca-issuer", Kind: "Issuer", Group: "foo.io"}),
+		gen.SetCertificateGeneration(3),
 		gen.SetCertificateSecretName("output"),
 		gen.SetCertificateRenewBefore(time.Hour*36),
 		gen.SetCertificateDNSNames("example.com"),
@@ -72,8 +73,9 @@ func TestIssuingController(t *testing.T) {
 
 	issuingCert := gen.CertificateFrom(baseCert.DeepCopy(),
 		gen.SetCertificateStatusCondition(cmapi.CertificateCondition{
-			Type:   cmapi.CertificateConditionIssuing,
-			Status: cmmeta.ConditionTrue,
+			Type:               cmapi.CertificateConditionIssuing,
+			Status:             cmmeta.ConditionTrue,
+			ObservedGeneration: 3,
 		}),
 	)
 
@@ -250,6 +252,7 @@ func TestIssuingController(t *testing.T) {
 								Reason:             "Failed",
 								Message:            "The certificate request has failed to complete and will be retried: The certificate request failed because of reasons",
 								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
 							}),
 							gen.SetCertificateLastFailureTime(metaFixedClockStart),
 						),
@@ -923,6 +926,7 @@ func TestIssuingController(t *testing.T) {
 								Reason:             "Failed",
 								Message:            "The certificate request has failed to complete and will be retried: The certificate request failed because of reasons",
 								LastTransitionTime: &metaFixedClockStart,
+								ObservedGeneration: 3,
 							}),
 							gen.SetCertificateLastFailureTime(metaFixedClockStart),
 						),

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -147,7 +147,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	condition := c.policyEvaluator(c.policyChain, input)
 
 	crt = crt.DeepCopy()
-	apiutil.SetCertificateCondition(crt, condition.Type, condition.Status, condition.Reason, condition.Message)
+	apiutil.SetCertificateCondition(crt, crt.Generation, condition.Type, condition.Status, condition.Reason, condition.Message)
+
 	switch {
 	case input.Secret != nil && input.Secret.Data != nil:
 		x509cert, err := pki.DecodeX509CertificateBytes(input.Secret.Data[corev1.TLSCertKey])

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -180,7 +180,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 
 	crt = crt.DeepCopy()
-	apiutil.SetCertificateCondition(crt, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, reason, message)
+	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, reason, message)
 	_, err = c.client.CertmanagerV1().Certificates(crt.Namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 	if err != nil {
 		return err

--- a/pkg/controller/certificates/trigger/trigger_controller_test.go
+++ b/pkg/controller/certificates/trigger/trigger_controller_test.go
@@ -99,12 +99,13 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"do nothing if Certificate already has 'Issuing' condition": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Status: cmapi.CertificateStatus{
 					Conditions: []cmapi.CertificateCondition{
 						{
-							Type:   cmapi.CertificateConditionIssuing,
-							Status: cmmeta.ConditionTrue,
+							Type:               cmapi.CertificateConditionIssuing,
+							Status:             cmmeta.ConditionTrue,
+							ObservedGeneration: 3,
 						},
 					},
 				},
@@ -112,7 +113,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"evaluate policy chain with only the Certificate if no Request or Secret exists": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 			},
 			chainShouldEvaluate: true,
 			policyFuncs: []policyFuncBuilder{
@@ -136,7 +137,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"evaluate policy chain with the Certificate and Secret if no Request exists": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Spec: cmapi.CertificateSpec{
 					SecretName: "test-secret",
 				},
@@ -166,7 +167,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"evaluate policy chain with the Certificate, Secret and Request if one exists": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Spec: cmapi.CertificateSpec{
 					SecretName: "test-secret",
 				},
@@ -213,7 +214,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"error if multiple owned CertificateRequest resources exist and have the same revision": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Spec: cmapi.CertificateSpec{
 					SecretName: "test-secret",
 				},
@@ -255,7 +256,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"should evaluate policy if no certificaterequest resource exists for the current revision": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Spec: cmapi.CertificateSpec{
 					SecretName: "test-secret",
 				},
@@ -270,7 +271,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"should set the 'Issuing' status condition if the chain indicates an issuance is required": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 			},
 			chainShouldEvaluate:        true,
 			chainShouldTriggerIssuance: true,
@@ -282,12 +283,13 @@ func Test_controller_ProcessItem(t *testing.T) {
 					Reason:             forceTriggeredReason,
 					Message:            forceTriggeredMessage,
 					LastTransitionTime: &metaNow,
+					ObservedGeneration: 3,
 				},
 			},
 		},
 		"should not set the 'Issuing' status condition if the chain indicates an issuance is required if the last failure time is within the last hour": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Status: cmapi.CertificateStatus{
 					LastFailureTime: func(m metav1.Time) *metav1.Time { return &m }(metav1.NewTime(now.Add(-59 * time.Minute))),
 				},
@@ -297,7 +299,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 		},
 		"should set the 'Issuing' status condition if the chain indicates an issuance is required if the last failure time is older than the last hour": {
 			certificate: &cmapi.Certificate{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test", Generation: 3},
 				Status: cmapi.CertificateStatus{
 					LastFailureTime: func(m metav1.Time) *metav1.Time { return &m }(metav1.NewTime(now.Add(-61 * time.Minute))),
 				},
@@ -312,6 +314,7 @@ func Test_controller_ProcessItem(t *testing.T) {
 					Reason:             forceTriggeredReason,
 					Message:            forceTriggeredMessage,
 					LastTransitionTime: &metaNow,
+					ObservedGeneration: 3,
 				},
 			},
 		},

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -334,6 +334,13 @@ type CertificateCondition struct {
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
 	Message string
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	ObservedGeneration int64
 }
 
 // CertificateConditionType represents an Certificate condition value.

--- a/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -426,6 +426,7 @@ func autoConvert_v1_CertificateCondition_To_certmanager_CertificateCondition(in 
 	out.LastTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -440,6 +441,7 @@ func autoConvert_certmanager_CertificateCondition_To_v1_CertificateCondition(in 
 	out.LastTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -426,6 +426,7 @@ func autoConvert_v1alpha2_CertificateCondition_To_certmanager_CertificateConditi
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -440,6 +441,7 @@ func autoConvert_certmanager_CertificateCondition_To_v1alpha2_CertificateConditi
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -426,6 +426,7 @@ func autoConvert_v1alpha3_CertificateCondition_To_certmanager_CertificateConditi
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -440,6 +441,7 @@ func autoConvert_certmanager_CertificateCondition_To_v1alpha3_CertificateConditi
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -426,6 +426,7 @@ func autoConvert_v1beta1_CertificateCondition_To_certmanager_CertificateConditio
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -440,6 +441,7 @@ func autoConvert_certmanager_CertificateCondition_To_v1beta1_CertificateConditio
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -248,6 +248,13 @@ func (h *Helper) ValidateIssuedCertificate(certificate *cmapi.Certificate, rootC
 		}
 	}
 
+	if cond := apiutil.GetCertificateCondition(certificate, cmapi.CertificateConditionReady); cond.Status != cmmeta.ConditionTrue ||
+		cond.ObservedGeneration != certificate.Generation {
+		return nil, fmt.Errorf(
+			"expected Certificate to have ready condition true, with an observedGeneration matching the Certificate generation, got=%+v",
+			cond)
+	}
+
 	return cert, nil
 }
 

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -248,11 +248,11 @@ func (h *Helper) ValidateIssuedCertificate(certificate *cmapi.Certificate, rootC
 		}
 	}
 
-	if cond := apiutil.GetCertificateCondition(certificate, cmapi.CertificateConditionReady); cond.Status != cmmeta.ConditionTrue ||
-		cond.ObservedGeneration != certificate.Generation {
+	readyCond := apiutil.GetCertificateCondition(certificate, cmapi.CertificateConditionReady)
+	if readyCond.Status != cmmeta.ConditionTrue || readyCond.ObservedGeneration != certificate.Generation {
 		return nil, fmt.Errorf(
 			"expected Certificate to have ready condition true, with an observedGeneration matching the Certificate generation, got=%+v",
-			cond)
+			readyCond)
 	}
 
 	return cert, nil

--- a/test/e2e/framework/helper/validate.go
+++ b/test/e2e/framework/helper/validate.go
@@ -43,6 +43,7 @@ func (h *Helper) DefaultValidationSet() []ValidationFunc {
 		validations.ExpectValidCommonName,
 		validations.ExpectValidNotAfterDate,
 		validations.ExpectValidPrivateKeyData,
+		validations.ExpectConditionReadyObservedGeneration,
 	}
 }
 
@@ -57,6 +58,7 @@ func (h *Helper) ValidationSetForUnsupportedFeatureSet(fs featureset.FeatureSet)
 		validations.ExpectValidCommonName,
 		validations.ExpectValidNotAfterDate,
 		validations.ExpectValidPrivateKeyData,
+		validations.ExpectConditionReadyObservedGeneration,
 	}
 
 	if !fs.Contains(featureset.URISANsFeature) {

--- a/test/e2e/framework/helper/validations/BUILD.bazel
+++ b/test/e2e/framework/helper/validations/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/test/e2e/framework/helper/validations",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",

--- a/test/e2e/framework/helper/validations/certificates.go
+++ b/test/e2e/framework/helper/validations/certificates.go
@@ -25,6 +25,7 @@ import (
 	"github.com/kr/pretty"
 	corev1 "k8s.io/api/core/v1"
 
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/pkg/util"
@@ -306,6 +307,20 @@ func ExpectCorrectTrustChain(certificate *cmapi.Certificate, secret *corev1.Secr
 			pretty.Sprint(intermediateCertPool),
 			err,
 		)
+	}
+
+	return nil
+}
+
+// ExpectConditionReadyObservedGeneration checks that the ObservedGeneration
+// field on the Ready condition which must be true, is set to the Generation of
+// the Certificate.
+func ExpectConditionReadyObservedGeneration(certificate *cmapi.Certificate, secret *corev1.Secret) error {
+	cond := apiutil.GetCertificateCondition(certificate, cmapi.CertificateConditionReady)
+
+	if cond.Status != cmmeta.ConditionTrue || cond.ObservedGeneration != certificate.Generation {
+		return fmt.Errorf("expected Certificate to have ready condition true, observedGeneration matching the Certificate generation, got=%+v",
+			cond)
 	}
 
 	return nil

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -184,7 +184,7 @@ func TestIssuingController(t *testing.T) {
 	}
 
 	// Add Issuing condition to Certificate
-	apiutil.SetCertificateCondition(crt, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "", "")
+	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "", "")
 	crt.Status.NextPrivateKeySecretName = &nextPrivateKeySecretName
 	crt.Status.Revision = &revision
 	crt, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
@@ -395,7 +395,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 	}
 
 	// Add Issuing condition to Certificate
-	apiutil.SetCertificateCondition(crt, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "", "")
+	apiutil.SetCertificateCondition(crt, crt.Generation, cmapi.CertificateConditionIssuing, cmmeta.ConditionTrue, "", "")
 	crt.Status.NextPrivateKeySecretName = &nextPrivateKeySecretName
 	crt.Status.Revision = &revision
 	crt, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})

--- a/test/integration/ctl/ctl_status_certificate_test.go
+++ b/test/integration/ctl/ctl_status_certificate_test.go
@@ -566,7 +566,7 @@ CertificateRequest:
 func setCertificateStatus(cmCl versioned.Interface, crt *cmapi.Certificate,
 	status *cmapi.CertificateStatus, ctx context.Context) (*cmapi.Certificate, error) {
 	for _, cond := range status.Conditions {
-		apiutil.SetCertificateCondition(crt, cond.Type, cond.Status, cond.Reason, cond.Message)
+		apiutil.SetCertificateCondition(crt, crt.Generation, cond.Type, cond.Status, cond.Reason, cond.Message)
 	}
 	crt.Status.NotAfter = status.NotAfter
 	crt.Status.Revision = status.Revision

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -198,6 +198,12 @@ func SetCertificateUID(uid types.UID) CertificateModifier {
 	}
 }
 
+func SetCertificateGeneration(gen int64) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Generation = gen
+	}
+}
+
 func AddCertificateAnnotations(annotations map[string]string) CertificateModifier {
 	return func(crt *v1.Certificate) {
 		if crt.Annotations == nil {


### PR DESCRIPTION
fixes #3585 #1551

This PR adds the field `observedGeneration` to Certificate conditions. 

This does not make any functional changes to any of the Certificate controllers, but instead, exposes the Generation of the Certificate when adding/updating a condition. When adding a condition where one with the same type already exists, but the observed generation is different, that condition will be overwritten with the newer generation.

The e2e Certificate is valid func is updated to ensure we get an observed generation we are expecting.

```release-note
Adds an observedGeneration field to all Certificate conditions. This is set to the generation of that Certificate at the time of updating.
```

/assign @munnerz 