### PR TITLE
Pass the key before hash and the token to the dns webhook solvers

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -71,6 +71,7 @@ spec:
                 - dnsName
                 - issuerRef
                 - key
+                - preHashKey
                 - solver
                 - token
                 - type
@@ -99,6 +100,9 @@ spec:
                       type: string
                 key:
                   description: 'Key is the ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                preHashKey:
+                  description: 'The ACME challenge key for this challenge, before hash. For both challenges, this is the key in the format : `<private key JWK thumbprint>.<key from acme server for challenge>`. without any hash or transformation. For HTTP01, this field correspond to the Key field.'
                   type: string
                 solver:
                   description: Solver contains the domain solving configuration that should be used to solve this challenge resource.
@@ -896,6 +900,7 @@ spec:
                 - dnsName
                 - issuerRef
                 - key
+                - preHashKey
                 - solver
                 - token
                 - type
@@ -924,6 +929,9 @@ spec:
                       type: string
                 key:
                   description: 'Key is the ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                preHashKey:
+                  description: 'The ACME challenge key for this challenge, before hash. For both challenges, this is the key in the format : `<private key JWK thumbprint>.<key from acme server for challenge>`. without any hash or transformation. For HTTP01, this field correspond to the Key field.'
                   type: string
                 solver:
                   description: Solver contains the domain solving configuration that should be used to solve this challenge resource.
@@ -1722,6 +1730,7 @@ spec:
                 - dnsName
                 - issuerRef
                 - key
+                - preHashKey
                 - solver
                 - token
                 - type
@@ -1750,6 +1759,9 @@ spec:
                       type: string
                 key:
                   description: 'The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                preHashKey:
+                  description: 'The ACME challenge key for this challenge, before hash. For both challenges, this is the key in the format : `<private key JWK thumbprint>.<key from acme server for challenge>`. without any hash or transformation. For HTTP01, this field correspond to the Key field.'
                   type: string
                 solver:
                   description: Contains the domain solving configuration that should be used to solve this challenge resource.
@@ -2576,6 +2588,9 @@ spec:
                       type: string
                 key:
                   description: 'The ACME challenge key for this challenge For HTTP01 challenges, this is the value that must be responded with to complete the HTTP01 challenge in the format: `<private key JWK thumbprint>.<key from acme server for challenge>`. For DNS01 challenges, this is the base64 encoded SHA256 sum of the `<private key JWK thumbprint>.<key from acme server for challenge>` text that must be set as the TXT record content.'
+                  type: string
+                preHashKey:
+                  description: 'The ACME challenge key for this challenge, before hash. For both challenges, this is the key in the format : `<private key JWK thumbprint>.<key from acme server for challenge>`. without any hash or transformation. For HTTP01, this field correspond to the Key field.'
                   type: string
                 solver:
                   description: Contains the domain solving configuration that should be used to solve this challenge resource.

--- a/pkg/acme/webhook/apis/acme/v1alpha1/types.go
+++ b/pkg/acme/webhook/apis/acme/v1alpha1/types.go
@@ -75,6 +75,9 @@ type ChallengeRequest struct {
 	// but some implementations hash the key themselves and need this version.
 	PreHashKey string `json:"preHashKey"`
 
+	// The ACME challenge token. Some implementations uses it.
+	Token string `json:"token"`
+
 	// ResourceNamespace is the namespace containing resources that are
 	// referenced in the providers config.
 	// If this request is solving for an Issuer resource, this will be the

--- a/pkg/acme/webhook/apis/acme/v1alpha1/types.go
+++ b/pkg/acme/webhook/apis/acme/v1alpha1/types.go
@@ -70,6 +70,11 @@ type ChallengeRequest struct {
 	// ResolveFQDN.
 	Key string `json:"key"`
 
+	// The ACME challenge Key before hash
+	// This key should not end up as is in the TXT record
+	// but some implementations hash the key themselves and need this version.
+	PreHashKey string `json:"preHashKey"`
+
 	// ResourceNamespace is the namespace containing resources that are
 	// referenced in the providers config.
 	// If this request is solving for an Issuer resource, this will be the

--- a/pkg/apis/acme/v1/types_challenge.go
+++ b/pkg/apis/acme/v1/types_challenge.go
@@ -89,6 +89,13 @@ type ChallengeSpec struct {
 	// text that must be set as the TXT record content.
 	Key string `json:"key"`
 
+	// The ACME challenge key for this challenge, before hash.
+	// For both challenges, this is the key in the format :
+	// `<private key JWK thumbprint>.<key from acme server for challenge>`.
+	// without any hash or transformation.
+	// For HTTP01, this field correspond to the Key field.
+	PreHashKey string `json:"preHashKey"`
+
 	// Contains the domain solving configuration that should be used to
 	// solve this challenge resource.
 	Solver ACMEChallengeSolver `json:"solver"`

--- a/pkg/apis/acme/v1alpha2/types_challenge.go
+++ b/pkg/apis/acme/v1alpha2/types_challenge.go
@@ -87,6 +87,13 @@ type ChallengeSpec struct {
 	// text that must be set as the TXT record content.
 	Key string `json:"key"`
 
+	// The ACME challenge key for this challenge, before hash.
+	// For both challenges, this is the key in the format :
+	// `<private key JWK thumbprint>.<key from acme server for challenge>`.
+	// without any hash or transformation.
+	// For HTTP01, this field correspond to the Key field.
+	PreHashKey string `json:"preHashKey"`
+
 	// Solver contains the domain solving configuration that should be used to
 	// solve this challenge resource.
 	Solver ACMEChallengeSolver `json:"solver"`

--- a/pkg/apis/acme/v1alpha3/types_challenge.go
+++ b/pkg/apis/acme/v1alpha3/types_challenge.go
@@ -87,6 +87,13 @@ type ChallengeSpec struct {
 	// text that must be set as the TXT record content.
 	Key string `json:"key"`
 
+	// The ACME challenge key for this challenge, before hash.
+	// For both challenges, this is the key in the format :
+	// `<private key JWK thumbprint>.<key from acme server for challenge>`.
+	// without any hash or transformation.
+	// For HTTP01, this field correspond to the Key field.
+	PreHashKey string `json:"preHashKey"`
+
 	// Solver contains the domain solving configuration that should be used to
 	// solve this challenge resource.
 	Solver ACMEChallengeSolver `json:"solver"`

--- a/pkg/apis/acme/v1beta1/types_challenge.go
+++ b/pkg/apis/acme/v1beta1/types_challenge.go
@@ -88,6 +88,13 @@ type ChallengeSpec struct {
 	// text that must be set as the TXT record content.
 	Key string `json:"key"`
 
+	// The ACME challenge key for this challenge, before hash.
+	// For both challenges, this is the key in the format :
+	// `<private key JWK thumbprint>.<key from acme server for challenge>`.
+	// without any hash or transformation.
+	// For HTTP01, this field correspond to the Key field.
+	PreHashKey string `json:"preHashKey"`
+
 	// Contains the domain solving configuration that should be used to
 	// solve this challenge resource.
 	Solver ACMEChallengeSolver `json:"solver"`

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -299,7 +299,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 					testpkg.NewAction(coretesting.NewCreateAction(cmacme.SchemeGroupVersion.WithResource("challenges"), testAuthorizationChallenge.Namespace, testAuthorizationChallenge)),
 				},
 				ExpectedEvents: []string{
-					`Normal Created Created Challenge resource "testorder-2179654896" for domain "test.com"`,
+					`Normal Created Created Challenge resource "testorder-2013108113" for domain "test.com"`,
 				},
 			},
 			acmeClient: &acmecl.FakeACME{

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -124,10 +124,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
@@ -163,10 +164,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
@@ -230,11 +232,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeDNS01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeDNS01,
-				DNSName: "example.com",
-				Token:   acmeChallengeDNS01.Token,
-				Key:     "dns01",
-				Solver:  emptySelectorSolverDNS01,
+				Type:       cmacme.ACMEChallengeTypeDNS01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeDNS01.Token,
+				Key:        "dns01",
+				PreHashKey: "http01",
+				Solver:     emptySelectorSolverDNS01,
 			},
 		},
 		"should use configured default solver when no others are present": {
@@ -258,11 +261,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  emptySelectorSolverHTTP01,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     emptySelectorSolverHTTP01,
 			},
 		},
 		"should use configured default solver when no others are present but selector is non-nil": {
@@ -295,10 +299,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{},
 					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
@@ -333,11 +338,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  emptySelectorSolverHTTP01,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     emptySelectorSolverHTTP01,
 			},
 		},
 		"should use DNS01 solver over HTTP01 if challenge is of type DNS01": {
@@ -364,11 +370,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeDNS01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeDNS01,
-				DNSName: "example.com",
-				Token:   acmeChallengeDNS01.Token,
-				Key:     "dns01",
-				Solver:  emptySelectorSolverDNS01,
+				Type:       cmacme.ACMEChallengeTypeDNS01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeDNS01.Token,
+				Key:        "dns01",
+				PreHashKey: "http01",
+				Solver:     emptySelectorSolverDNS01,
 			},
 		},
 		"should return an error if none match": {
@@ -419,11 +426,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 		"uses default solver if dnsName does not match": {
@@ -450,11 +458,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "notexample.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  emptySelectorSolverHTTP01,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "notexample.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     emptySelectorSolverHTTP01,
 			},
 		},
 		"if two solvers specify the same dnsName, the one with the most labels should be chosen": {
@@ -498,10 +507,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						MatchLabels: map[string]string{
@@ -557,11 +567,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 		// identical to the test above, but the solvers are listed in reverse
@@ -606,11 +617,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 		"if one solver matches with dnsNames, and the other solver matches with 2 labels, the dnsName solver should be chosen": {
@@ -655,11 +667,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 		"should choose the solver with the most labels matching if multiple match": {
@@ -715,10 +728,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						MatchLabels: map[string]string{
@@ -768,11 +782,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeDNS01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:     cmacme.ACMEChallengeTypeDNS01,
-				DNSName:  "example.com",
-				Wildcard: true,
-				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
+				Type:       cmacme.ACMEChallengeTypeDNS01,
+				DNSName:    "example.com",
+				Wildcard:   true,
+				Token:      acmeChallengeDNS01.Token,
+				Key:        "dns01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSNames: []string{"*.example.com"},
@@ -818,11 +833,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 		"dnsName selectors should take precedence over dnsZone selectors (reversed order)": {
@@ -858,11 +874,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 		"should allow matching with dnsZones": {
@@ -899,11 +916,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeDNS01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:     cmacme.ACMEChallengeTypeDNS01,
-				DNSName:  "www.example.com",
-				Wildcard: true,
-				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
+				Type:       cmacme.ACMEChallengeTypeDNS01,
+				DNSName:    "www.example.com",
+				Wildcard:   true,
+				Token:      acmeChallengeDNS01.Token,
+				Key:        "dns01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"example.com"},
@@ -959,11 +977,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeDNS01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:     cmacme.ACMEChallengeTypeDNS01,
-				DNSName:  "www.prod.example.com",
-				Wildcard: true,
-				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
+				Type:       cmacme.ACMEChallengeTypeDNS01,
+				DNSName:    "www.prod.example.com",
+				Wildcard:   true,
+				Token:      acmeChallengeDNS01.Token,
+				Key:        "dns01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"prod.example.com"},
@@ -1019,11 +1038,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeDNS01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:     cmacme.ACMEChallengeTypeDNS01,
-				DNSName:  "www.prod.example.com",
-				Wildcard: true,
-				Token:    acmeChallengeDNS01.Token,
-				Key:      "dns01",
+				Type:       cmacme.ACMEChallengeTypeDNS01,
+				DNSName:    "www.prod.example.com",
+				Wildcard:   true,
+				Token:      acmeChallengeDNS01.Token,
+				Key:        "dns01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"prod.example.com"},
@@ -1086,10 +1106,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "www.example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "www.example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						MatchLabels: map[string]string{
@@ -1148,10 +1169,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "www.example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "www.example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"example.com"},
@@ -1208,10 +1230,11 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "www.example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "www.example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
 				Solver: cmacme.ACMEChallengeSolver{
 					Selector: &cmacme.CertificateDNSNameSelector{
 						DNSZones: []string{"example.com"},
@@ -1249,11 +1272,12 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
 			},
 			expectedChallengeSpec: &cmacme.ChallengeSpec{
-				Type:    cmacme.ACMEChallengeTypeHTTP01,
-				DNSName: "example.com",
-				Token:   acmeChallengeHTTP01.Token,
-				Key:     "http01",
-				Solver:  exampleComDNSNameSelectorSolver,
+				Type:       cmacme.ACMEChallengeTypeHTTP01,
+				DNSName:    "example.com",
+				Token:      acmeChallengeHTTP01.Token,
+				Key:        "http01",
+				PreHashKey: "http01",
+				Solver:     exampleComDNSNameSelectorSolver,
 			},
 		},
 	}

--- a/pkg/internal/apis/acme/types_challenge.go
+++ b/pkg/internal/apis/acme/types_challenge.go
@@ -78,6 +78,13 @@ type ChallengeSpec struct {
 	// text that must be set as the TXT record content.
 	Key string
 
+	// The ACME challenge key for this challenge, before hash.
+	// For both challenges, this is the key in the format :
+	// `<private key JWK thumbprint>.<key from acme server for challenge>`.
+	// without any hash or transformation.
+	// For HTTP01, this field correspond to the Key field.
+	PreHashKey string
+
 	// Contains the domain solving configuration that should be used to
 	// solve this challenge resource.
 	Solver ACMEChallengeSolver

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1100,6 +1100,7 @@ func autoConvert_v1_ChallengeSpec_To_acme_ChallengeSpec(in *v1.ChallengeSpec, ou
 	out.Type = acme.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_v1_ACMEChallengeSolver_To_acme_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}
@@ -1123,6 +1124,7 @@ func autoConvert_acme_ChallengeSpec_To_v1_ChallengeSpec(in *acme.ChallengeSpec, 
 	out.Type = v1.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_acme_ACMEChallengeSolver_To_v1_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}

--- a/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha2/zz_generated.conversion.go
@@ -1120,6 +1120,7 @@ func autoConvert_v1alpha2_ChallengeSpec_To_acme_ChallengeSpec(in *v1alpha2.Chall
 	out.Type = acme.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_v1alpha2_ACMEChallengeSolver_To_acme_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}
@@ -1138,6 +1139,7 @@ func autoConvert_acme_ChallengeSpec_To_v1alpha2_ChallengeSpec(in *acme.Challenge
 	out.Type = v1alpha2.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_acme_ACMEChallengeSolver_To_v1alpha2_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}

--- a/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1alpha3/zz_generated.conversion.go
@@ -1120,6 +1120,7 @@ func autoConvert_v1alpha3_ChallengeSpec_To_acme_ChallengeSpec(in *v1alpha3.Chall
 	out.Type = acme.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_v1alpha3_ACMEChallengeSolver_To_acme_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}
@@ -1138,6 +1139,7 @@ func autoConvert_acme_ChallengeSpec_To_v1alpha3_ChallengeSpec(in *acme.Challenge
 	out.Type = v1alpha3.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_acme_ACMEChallengeSolver_To_v1alpha3_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}

--- a/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1beta1/zz_generated.conversion.go
@@ -1100,6 +1100,7 @@ func autoConvert_v1beta1_ChallengeSpec_To_acme_ChallengeSpec(in *v1beta1.Challen
 	out.Type = acme.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_v1beta1_ACMEChallengeSolver_To_acme_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}
@@ -1123,6 +1124,7 @@ func autoConvert_acme_ChallengeSpec_To_v1beta1_ChallengeSpec(in *acme.ChallengeS
 	out.Type = v1beta1.ACMEChallengeType(in.Type)
 	out.Token = in.Token
 	out.Key = in.Key
+	out.PreHashKey = in.PreHashKey
 	if err := Convert_acme_ACMEChallengeSolver_To_v1beta1_ACMEChallengeSolver(&in.Solver, &out.Solver, s); err != nil {
 		return err
 	}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -418,6 +418,8 @@ func (s *Solver) prepareChallengeRequest(issuer v1.GenericIssuer, ch *cmacme.Cha
 		AllowAmbientCredentials: canUseAmbientCredentials,
 		ResourceNamespace:       resourceNamespace,
 		Key:                     ch.Spec.Key,
+		PreHashKey:              ch.Spec.PreHashKey,
+		Token:                   ch.Spec.Token,
 		DNSName:                 ch.Spec.DNSName,
 		Config:                  &apiext.JSON{Raw: b},
 	}

--- a/test/acme/dns/util.go
+++ b/test/acme/dns/util.go
@@ -97,6 +97,7 @@ func (f *fixture) buildChallengeRequest(t *testing.T, ns string) *whapi.Challeng
 		DNSName:    "example.com",
 		Key:        key,
 		PreHashKey: preHashKey,
+		Token:      "some_token",
 	}
 }
 

--- a/test/acme/dns/util.go
+++ b/test/acme/dns/util.go
@@ -18,6 +18,8 @@ package dns
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -81,6 +83,10 @@ func (f *fixture) setupNamespace(t *testing.T, name string) (string, func()) {
 }
 
 func (f *fixture) buildChallengeRequest(t *testing.T, ns string) *whapi.ChallengeRequest {
+	preHashKey := "123d=="
+	keyBytes := sha256.Sum256([]byte(preHashKey))
+	key := base64.RawURLEncoding.EncodeToString(keyBytes[:sha256.Size])
+
 	return &whapi.ChallengeRequest{
 		ResourceNamespace:       ns,
 		ResolvedFQDN:            f.resolvedFQDN,
@@ -88,8 +94,9 @@ func (f *fixture) buildChallengeRequest(t *testing.T, ns string) *whapi.Challeng
 		AllowAmbientCredentials: f.allowAmbientCredentials,
 		Config:                  f.jsonConfig,
 		// TODO
-		DNSName: "example.com",
-		Key:     "123d==",
+		DNSName:    "example.com",
+		Key:        key,
+		PreHashKey: preHashKey,
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR add a PreHashKey field to the challenge objects so that acme dns solvers can use the before hash version of key.
See https://tools.ietf.org/html/rfc8555#section-8.4 and https://tools.ietf.org/html/rfc8555#section-8.3
The DNS01 key correspond to the hashed and base64encoded version of the HTTP01 key.

It also add the preHashKey and a token field to the challenge requests objects, so that the webhook solvers can use them. This required to use lego providers as final solvers. 

This is needed to use lego as a webhook solver (see https://github.com/TeoGoddet/cert-manager-webhook-example/blob/lego-solver/main.go)

**Which issue this PR fixes**

Linked to #3437 

**Special notes for your reviewer**:
I'm new to golang and cert-manager, so please forgive my mistakes. 
Normally generated all required files. 
It tested it as far as I can. 2 tests fails (seems normal) and did not run e2e tests.
I'm not sure about a change I made in a test, and it may lack of new tests.

Also i'm not sure about API versioning relative to the add of this feature.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Pass the ACME key before hash to the webhook DNS solvers (necessary to use lego to manage the dns)
```