### PR TITLE
Skips invalid Ingress tls entries instead of invalidating the Ingress

### DIFF
--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -513,11 +513,14 @@ func TestSync(t *testing.T) {
 			},
 		},
 		{
-			Name:           "should return an error when no TLS hosts are specified",
-			Issuer:         acmeIssuer,
-			IssuerLister:   []runtime.Object{acmeIssuer},
-			Err:            true,
-			ExpectedEvents: []string{`Warning BadConfig Secret "example-com-tls" for ingress TLS has no hosts specified`},
+			Name:         "should skip an invalid TLS entry (no TLS hosts specified)",
+			Issuer:       acmeIssuer,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			Err:          true,
+			ExpectedEvents: []string{
+				`Warning BadConfig TLS entry 0 is invalid: secret "example-com-tls-invalid" for ingress TLS has no hosts specified`,
+				`Normal CreateCertificate Successfully created Certificate "example-com-tls"`,
+			},
 			Ingress: &networkingv1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-name",
@@ -530,17 +533,43 @@ func TestSync(t *testing.T) {
 				Spec: networkingv1beta1.IngressSpec{
 					TLS: []networkingv1beta1.IngressTLS{
 						{
+							SecretName: "example-com-tls-invalid",
+						},
+						{
 							SecretName: "example-com-tls",
+							Hosts:      []string{"example.com", "www.example.com"},
+						},
+					},
+				},
+			},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com", "www.example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
 						},
 					},
 				},
 			},
 		},
+
 		{
-			Name:           "should return an error when no TLS secret name is specified",
-			Issuer:         acmeIssuer,
-			Err:            true,
-			ExpectedEvents: []string{`Warning BadConfig TLS entry 0 for hosts [example.com] must specify a secretName`},
+			Name:         "should skip an invalid TLS entry (no TLS secret name specified)",
+			Issuer:       acmeIssuer,
+			Err:          true,
+			IssuerLister: []runtime.Object{acmeIssuer},
+			ExpectedEvents: []string{
+				`Warning BadConfig TLS entry 0 is invalid: TLS entry for hosts [example.com] must specify a secretName`,
+				`Normal CreateCertificate Successfully created Certificate "example-com-tls"`,
+			},
 			Ingress: &networkingv1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-name",
@@ -555,10 +584,30 @@ func TestSync(t *testing.T) {
 						{
 							Hosts: []string{"example.com"},
 						},
+						{
+							Hosts:      []string{"example.com", "www.example.com"},
+							SecretName: "example-com-tls",
+						},
 					},
 				},
 			},
-			IssuerLister: []runtime.Object{acmeIssuer},
+			ExpectedCreate: []*cmapi.Certificate{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "example-com-tls",
+						Namespace:       gen.DefaultTestNamespace,
+						OwnerReferences: buildOwnerReferences("ingress-name", gen.DefaultTestNamespace),
+					},
+					Spec: cmapi.CertificateSpec{
+						DNSNames:   []string{"example.com", "www.example.com"},
+						SecretName: "example-com-tls",
+						IssuerRef: cmmeta.ObjectReference{
+							Name: "issuer-name",
+							Kind: "Issuer",
+						},
+					},
+				},
+			},
 		},
 		{
 			Name: "should error if the specified issuer is not found",

--- a/pkg/controller/ingress-shim/sync_test.go
+++ b/pkg/controller/ingress-shim/sync_test.go
@@ -428,7 +428,6 @@ func TestSync(t *testing.T) {
 		{
 			Name:   "return a single DNS01 Certificate for an ingress with a single valid TLS entry",
 			Issuer: acmeClusterIssuer,
-			Err:    true,
 			Ingress: &networkingv1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-name",
@@ -516,7 +515,6 @@ func TestSync(t *testing.T) {
 			Name:         "should skip an invalid TLS entry (no TLS hosts specified)",
 			Issuer:       acmeIssuer,
 			IssuerLister: []runtime.Object{acmeIssuer},
-			Err:          true,
 			ExpectedEvents: []string{
 				`Warning BadConfig TLS entry 0 is invalid: secret "example-com-tls-invalid" for ingress TLS has no hosts specified`,
 				`Normal CreateCertificate Successfully created Certificate "example-com-tls"`,
@@ -564,7 +562,6 @@ func TestSync(t *testing.T) {
 		{
 			Name:         "should skip an invalid TLS entry (no TLS secret name specified)",
 			Issuer:       acmeIssuer,
-			Err:          true,
 			IssuerLister: []runtime.Object{acmeIssuer},
 			ExpectedEvents: []string{
 				`Warning BadConfig TLS entry 0 is invalid: TLS entry for hosts [example.com] must specify a secretName`,
@@ -611,7 +608,6 @@ func TestSync(t *testing.T) {
 		},
 		{
 			Name: "should error if the specified issuer is not found",
-			Err:  true,
 			Ingress: &networkingv1beta1.Ingress{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "ingress-name",
@@ -1095,8 +1091,10 @@ func TestSync(t *testing.T) {
 			b.Start()
 
 			err := c.Sync(context.Background(), test.Ingress)
-			if err != nil && !test.Err {
-				t.Errorf("Expected no error, but got: %s", err)
+
+			// If test.Err == true, err should not be nil and vice versa
+			if test.Err == (err == nil) {
+				t.Errorf("Expected error: %v, but got: %v", test.Err, err)
 			}
 
 			if err := b.AllEventsCalled(); err != nil {


### PR DESCRIPTION
Signed-off-by: irbekrm <irbekrm@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Allows for certificates to be created/updated for valid `Ingress.spec.tls` entries even if there are some invalid ones (missing a secret name of hosts array) in the same spec.


**Which issue this PR fixes**:

 fixes #2009 


**Special notes for your reviewer**:

There would now be a `BadConfig` Ingress event for each invalid TLS entry rather than once for the whole Ingress and the TLS block validation happens [separately for each entry](https://github.com/irbekrm/cert-manager/blob/2009_skip_invalid_ingress_tls_entries/pkg/controller/ingress-shim/sync.go#L144)

I have manually tested (with nginx ingress) that if either a new Ingress resource with some invalid TLS entries is created or an existing one is updated with invalid entries, the valid entries will still have Certificates created. I am not aware of any other corner cases that should be checked.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Relaxes Ingress validation rules to allow for Certificates to be created/updated for valid Ingress TLS entries even if the same Ingress contains some invalid TLS entries
```