### PR TITLE
Fix duplication of the CRD definitions in cert-manager.yaml

### DIFF
--- a/deploy/charts/cert-manager/templates/BUILD.bazel
+++ b/deploy/charts/cert-manager/templates/BUILD.bazel
@@ -1,10 +1,14 @@
 package(default_visibility = ["//visibility:public"])
 
-genrule(
+load("//build:files.bzl", "modify_file")
+
+modify_file(
     name = "crds",
-    srcs = ["//deploy/crds:templates"],
-    outs = ["crds.yaml"],
-    cmd = "cp $< $@",
+    src = "//deploy/crds:templates",
+    out = "crds.yaml",
+    prefix = """{{- if .Values.installCRDs }}""",
+    suffix = """{{- end }}""",
+    visibility = ["//visibility:private"],
 )
 
 filegroup(

--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -50,6 +50,7 @@ genrule(
     outs = ["unlicensed.yaml"],
     cmd = " ".join([
         "cat",
+        "$(location //deploy/crds:crds)",
         "$(location 01-namespace.yaml)",
         "$(location manifests.helm)",
         "> $@",

--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -50,7 +50,6 @@ genrule(
     outs = ["unlicensed.yaml"],
     cmd = " ".join([
         "cat",
-        "$(location //deploy/crds:crds)",
         "$(location 01-namespace.yaml)",
         "$(location manifests.helm)",
         "> $@",


### PR DESCRIPTION
We had inadvertently broken [the `installCRDs` mechanism ](https://cert-manager.io/next-docs/installation/kubernetes/#installing-with-helm), which works by  wrapping the whole `crds.yaml` content in an `{{ if }}` statement.

The `{{ if }}` block is added using a bazel `modify_file` rule.

This oversight was probably due to that `modify_file` rule also adding an  `{{ if }}` clause to test for legacy versions of Kubernetes.
I've re-instated it, without the test for Kubernetes versions.

Fixes: https://github.com/jetstack/cert-manager/issues/3627

```release-note
NONE
```