### PR TITLE
Fix multiple Certificate Requests issue

### DIFF
--- a/pkg/controller/certificates/trigger/policies/BUILD.bazel
+++ b/pkg/controller/certificates/trigger/policies/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/util/predicate:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_utils//clock:go_default_library",

--- a/pkg/controller/certificates/trigger/policies/policies.go
+++ b/pkg/controller/certificates/trigger/policies/policies.go
@@ -202,9 +202,9 @@ func CurrentCertificateNearingExpiry(c clock.Clock, defaultRenewBeforeExpiryDura
 	return func(input Input) (string, string, bool) {
 
 		// Determine if the certificate is nearing expiry solely by looking at
-		// the actual cert if it exists. We assume that at this point we have
+		// the actual cert, if it exists. We assume that at this point we have
 		// called policy functions that check that input.Secret and
-		// input.Secret.Data exists (SecretDoesNotExist and SecretHasData).
+		// input.Secret.Data exists (SecretDoesNotExist and SecretIsMissingData).
 		x509cert, err := pki.DecodeX509CertificateBytes(input.Secret.Data[corev1.TLSCertKey])
 		if err != nil {
 			// This case should never happen as it should always be caught by the

--- a/pkg/controller/certificates/trigger/policies/policies.go
+++ b/pkg/controller/certificates/trigger/policies/policies.go
@@ -194,15 +194,17 @@ func currentSecretValidForSpec(input Input) (string, string, bool) {
 	return "", "", false
 }
 
-// CurrentCertificateNearingExpiry returns a policy function that can be used to check whether
-// an x509 cert currently issued for a Certificate should be renewed
+// CurrentCertificateNearingExpiry returns a policy function that can be used to
+// check whether an X.509 cert currently issued for a Certificate should be
+// renewed.
 func CurrentCertificateNearingExpiry(c clock.Clock, defaultRenewBeforeExpiryDuration time.Duration) Func {
 
 	return func(input Input) (string, string, bool) {
 
-		// Determine if certificate is nearing expiry solely by looking at the actual cert if it exists
-		// We assume that at this point we have called policy functions that check that
-		// input.Secret and input.Secret.Data exists (SecretDoesNotExist and SecretHasData)
+		// Determine if the certificate is nearing expiry solely by looking at
+		// the actual cert if it exists. We assume that at this point we have
+		// called policy functions that check that input.Secret and
+		// input.Secret.Data exists (SecretDoesNotExist and SecretHasData).
 		x509cert, err := pki.DecodeX509CertificateBytes(input.Secret.Data[corev1.TLSCertKey])
 		if err != nil {
 			// This case should never happen as it should always be caught by the

--- a/pkg/controller/certificates/trigger/policies/policies_test.go
+++ b/pkg/controller/certificates/trigger/policies/policies_test.go
@@ -441,7 +441,7 @@ func TestDefaultPolicyChain(t *testing.T) {
 				},
 				Data: map[string][]byte{
 					corev1.TLSPrivateKeyKey: staticFixedPrivateKey,
-					corev1.TLSCertKey: selfSignCertificateWithNotBeforeAfter(t, staticFixedPrivateKey,
+					corev1.TLSCertKey: internaltest.MustCreateCertWithNotBeforeAfter(t, staticFixedPrivateKey,
 						&cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.com"}},
 						clock.Now(),
 						// expires in 30 minutes time

--- a/pkg/controller/certificates/trigger/policies/policies_test.go
+++ b/pkg/controller/certificates/trigger/policies/policies_test.go
@@ -416,6 +416,40 @@ func TestDefaultPolicyChain(t *testing.T) {
 			message: "Renewing certificate as renewal was scheduled at 0000-12-31 23:59:00 +0000 UTC",
 			reissue: true,
 		},
+		"does not trigger renewal if the x509 cert has been re-issued, but Certificate's renewal time has not been updated yet": {
+			certificate: &cmapi.Certificate{
+				Spec: cmapi.CertificateSpec{
+					CommonName: "example.com",
+					IssuerRef: cmmeta.ObjectReference{
+						Name:  "testissuer",
+						Kind:  "IssuerKind",
+						Group: "group.example.com",
+					},
+					RenewBefore: &metav1.Duration{Duration: time.Minute * 1},
+				},
+				Status: cmapi.CertificateStatus{
+					RenewalTime: &metav1.Time{Time: clock.Now()},
+				},
+			},
+			secret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "something",
+					Annotations: map[string]string{
+						cmapi.IssuerNameAnnotationKey:  "testissuer",
+						cmapi.IssuerKindAnnotationKey:  "IssuerKind",
+						cmapi.IssuerGroupAnnotationKey: "group.example.com",
+					},
+				},
+				Data: map[string][]byte{
+					corev1.TLSPrivateKeyKey: staticFixedPrivateKey,
+					corev1.TLSCertKey: selfSignCertificateWithNotBeforeAfter(t, staticFixedPrivateKey,
+						&cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.com"}},
+						clock.Now(),
+						// expires in 30 minutes time
+						clock.Now().Add(time.Minute*30),
+					),
+				},
+			},
+		},
 		"does not trigger renewal if renewal time is in 1 minute": {
 			certificate: &cmapi.Certificate{
 				Spec: cmapi.CertificateSpec{
@@ -451,7 +485,9 @@ func TestDefaultPolicyChain(t *testing.T) {
 			},
 		},
 	}
-	policyChain := NewTriggerPolicyChain(clock)
+	// we don't really test default renewal time here, it's just passed through
+	someDefaultRenewalTime := time.Hour * 5
+	policyChain := NewTriggerPolicyChain(clock, someDefaultRenewalTime)
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			reason, message, reissue := policyChain.Evaluate(Input{

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -244,7 +244,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.SharedInformerFactory,
 		ctx.Recorder,
 		ctx.Clock,
-		policies.NewTriggerPolicyChain(ctx.Clock, ctx.CertificateOptions.RenewBeforeExpiryDuration),
+		policies.NewTriggerPolicyChain(ctx.Clock, cmapi.DefaultRenewBefore),
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -244,7 +244,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.SharedInformerFactory,
 		ctx.Recorder,
 		ctx.Clock,
-		policies.NewTriggerPolicyChain(ctx.Clock),
+		policies.NewTriggerPolicyChain(ctx.Clock, ctx.CertificateOptions.RenewBeforeExpiryDuration),
 	)
 	c.controller = ctrl
 

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -36,6 +36,8 @@ import (
 	"github.com/jetstack/cert-manager/pkg/controller/certificates/trigger/policies"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 	"github.com/jetstack/cert-manager/pkg/metrics"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	utilpki "github.com/jetstack/cert-manager/pkg/util/pki"
 	"github.com/jetstack/cert-manager/test/integration/framework"
 )
 
@@ -63,8 +65,9 @@ func TestTriggerController(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), fakeClock, policies.NewTriggerPolicyChain(fakeClock))
+	// default certificate renewBefore period
+	defaultRenewBefore := time.Hour * 24
+	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), fakeClock, policies.NewTriggerPolicyChain(fakeClock, defaultRenewBefore))
 	c := controllerpkg.NewController(
 		context.Background(),
 		"trigger_test",
@@ -117,22 +120,67 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
 	defer cancel()
 
+	// default certificate renewBefore period
+	defaultRenewBefore := time.Hour * 24
+
 	fakeClock := &fakeclock.FakeClock{}
 	// only use the 'current certificate nearing expiry' policy chain during the test
-	// as we want to test the very specific case of triggering due to a renewal being
-	// required
-	policyChain := policies.Chain{policies.CurrentCertificateNearingExpiry(fakeClock)}
+	// as we want to test the very specific cases of triggering/not triggering depending on whether a renewal is required
+	policyChain := policies.Chain{policies.CurrentCertificateNearingExpiry(fakeClock, defaultRenewBefore)}
 	// Build, instantiate and run the trigger controller.
 	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
 
 	namespace := "testns"
+	secretName := "example"
+	certName := "testcrt"
 
+	now := fakeClock.Now()
+	notBefore := metav1.NewTime(now)
+	notAfter := metav1.NewTime(now.Add(time.Hour * 3))
+	renewBefore := &metav1.Duration{Duration: time.Hour}
+
+	// Create namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
 	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	// Create Certificate template
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{Name: certName, Namespace: namespace},
+		Spec: cmapi.CertificateSpec{
+			SecretName:  secretName,
+			CommonName:  "example.com",
+			RenewBefore: renewBefore,
+			IssuerRef:   cmmeta.ObjectReference{Name: "testissuer"}, // doesn't need to exist
+		},
+	}
+
+	// Create a private key for x509 cert
+	sk, err := utilpki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	skBytes := utilpki.EncodePKCS1PrivateKey(sk)
+	// Create an x509 cert
+	x509CertBytes := selfSignCertificateWithNotBeforeAfter(t, skBytes, cert, notBefore.Time, notAfter.Time)
+	// Create a Secret with the x509 cert
+	_, err = kubeClient.CoreV1().Secrets(namespace).Create(ctx, &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		Data: map[string][]byte{
+			corev1.TLSCertKey: x509CertBytes,
+		},
+	}, metav1.CreateOptions{})
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Start the trigger controller
 	ctrl, queue, mustSync := trigger.NewController(logf.Log, cmCl, factory, cmFactory, framework.NewEventRecorder(t), fakeClock, policyChain)
 	c := controllerpkg.NewController(
 		logf.NewContext(context.Background(), logf.Log, "trigger_controller_RenewNearExpiry"),
@@ -146,41 +194,30 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 	stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
 	defer stopController()
 
-	// Create a Certificate resource and wait for it to have the 'Issuing' condition.
-	cert, err := cmCl.CertmanagerV1().Certificates(namespace).Create(ctx, &cmapi.Certificate{
-		ObjectMeta: metav1.ObjectMeta{Name: "testcrt", Namespace: namespace},
-		Spec: cmapi.CertificateSpec{
-			SecretName: "example",
-			CommonName: "example.com",
-			IssuerRef:  cmmeta.ObjectReference{Name: "testissuer"}, // doesn't need to exist
-		},
-	}, metav1.CreateOptions{})
+	// Create a Certificate
+	cert, err = cmCl.CertmanagerV1().Certificates(namespace).Create(ctx, cert, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// Ensure that the Certificate does *not* get the Triggered status condition
-	// if the status.renewalTime is not set.
+	// 1. Test that Certificate's Issuing condition is not set to True when the x509 cert is not approaching expiry
 	// Wait for 2s, polling every 200ms to ensure that the controller does not set
 	// the condition.
-	ensureCertificateDoesNotHaveIssuingCondition(ctx, t, cmCl, cert.Namespace, cert.Name)
-
-	t.Logf("Setting status.renewalTime in the future on Certificate resource")
-	renewalTime := metav1.NewTime(fakeClock.Now().Add(time.Second))
-	cert.Status.RenewalTime = &renewalTime
-	cert, err = cmCl.CertmanagerV1().Certificates(cert.Namespace).UpdateStatus(ctx, cert, metav1.UpdateOptions{})
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	t.Log("Ensuring Certificate does not have Issuing condition for 2s...")
-	ensureCertificateDoesNotHaveIssuingCondition(ctx, t, cmCl, cert.Namespace, cert.Name)
+	ensureCertificateDoesNotHaveIssuingCondition(ctx, t, cmCl, namespace, certName)
 
+	// 2. Test that a Certificate does get the Issuing status condition set to True when the x509 cert is nearing expiry
 	t.Log("Advancing the clock forward to renewal time")
-	// advance the clock to a millisecond after the renewal time, as the
-	// fakeclock implementation uses .After when checking whether to
-	// trigger timers.
-	fakeClock.SetTime(renewalTime.Time.Add(time.Millisecond))
+	// advance the clock to a millisecond after renewal time
+	// fakeclock implementation uses .After when checking whether to trigger timers.
+	// renewalTime = notAfter - renewBefore
+	renewalTime := notAfter.Add(renewBefore.Duration * -1)
+	fakeClock.SetTime(renewalTime.Add(time.Millisecond * 2))
+
+	// Certificate's status.RenewalTime does not determine renewal, but we need to update some field to trigger a reconcile
+	someRenewalTime := metav1.NewTime(now)
+	cert.Status.RenewalTime = &someRenewalTime
+	cert, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, cert, metav1.UpdateOptions{})
 
 	err = wait.Poll(time.Millisecond*200, time.Second*2, func() (done bool, err error) {
 		c, err := cmCl.CertmanagerV1().Certificates(cert.Namespace).Get(ctx, cert.Name, metav1.GetOptions{})
@@ -217,10 +254,32 @@ func ensureCertificateDoesNotHaveIssuingCondition(ctx context.Context, t *testin
 	})
 	switch {
 	case err == nil:
-		t.Fatal("expected Certificate to not have the Issuing condition after test initialisation")
+		t.Fatal("expected Certificate to not have the Issuing condition")
 	case err == wait.ErrWaitTimeout:
 		// this is the expected 'happy case'
 	default:
 		t.Fatal(err)
 	}
+}
+
+func selfSignCertificateWithNotBeforeAfter(t *testing.T, pkData []byte, spec *cmapi.Certificate, notBefore, notAfter time.Time) []byte {
+	pk, err := pki.DecodePrivateKeyBytes(pkData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template, err := pki.GenerateTemplate(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// override the NotAfter, NotBefore fields that by default are set based on time.Now
+	template.NotBefore = notBefore
+	template.NotAfter = notAfter
+
+	certData, _, err := pki.SignCertificate(template, template, pk.Public(), pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return certData
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

See #3603 for context.
When a `Certificate` is being renewed, after a `CertificateRequest` succeeds, `CertificateIssuing` controller updates the `Certficate` including [removing `status.Issuing` condition](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/issuing/issuing_controller.go#L338). After this, there are 2 possible paths:
1. `CertificateReadiness` controller syncs the updated `Certificate`, updates it including [setting new `status.RenewalTime` value](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/readiness/readiness_controller.go#L169), then `CertificateTrigger` controller syncs the updated `Certificate` and requeues the `Certificate` to be re-synced at renewal time.
2. `CertificateTrigger` controller syncs the `Certificate` before the `ReadinessController` has updated renewal time- in this case, the `Certificate` is evaluated as [not currently issuing](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/trigger_controller.go#L148) and [nearing expiry](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/policies/policies.go#L181) (as it still has the old `status.RenewalTime`). In this scenario, `Certificate` is [marked as `Issuing` again](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/trigger_controller.go#L183) and we end up with duplicate `CertificateRequests`.

**Special notes for your reviewer**:
I have changed [CertificateNearingExpiry policy](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/policies/policies.go#L181) to look at the actual x509 cert in order to determine if re-issuing is needed. 
We still use status.RenewalTime when [deciding if a Certificate should be re-queued](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/trigger_controller.go#L170)

I also considered:
1. Adding another field `Certificate.Status.LastIssuedTime`  and adding a check to [CertificateNearingExpiry policy](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/policies/policies.go#L181) to check whether the certificate has already been issued since the renewal time. This field would be set by issuing controller at a time a new certificate is successfully issued. I previously implemented a fix using this approach, however this would involve an API change and there is an argument that we should, when reconciling an object, look at the cluster state rather than the status of the object itself.
2. Setting `status.RenewalTime` to nil in `TriggerController` when the `Certificate` is set to `Issuing` and add an extra check in `ReadinessController` to only update the `status.RenewalTime` when the `Certificate` condition `Issuing` is not true. However, at the moment `ReadinessController` is only concerned about `Certificate`s Readiness condition and not `Issuing` - it seems like making it concerned about the `Issuing` condition too would potentially make it brittle.

Testing:
- I have updated unit tests for `CertificateNearingExpiry` and the integration test for trigger controller.
- I have manually tested certificate renewal and did not observe any more duplication.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixes multiple Certificate Requests issue - see #3603 
```
fixes #3603 
/kind bug
Signed-off-by: irbekrm <irbekrm@gmail.com>