### PR TITLE
Removes the deprecated renew-before-expiry flag

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -238,8 +238,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 			DefaultAutoCertificateAnnotations: opts.DefaultAutoCertificateAnnotations,
 		},
 		CertificateOptions: controller.CertificateOptions{
-			EnableOwnerRef:            opts.EnableCertificateOwnerRef,
-			RenewBeforeExpiryDuration: opts.RenewBeforeExpiryDuration,
+			EnableOwnerRef: opts.EnableCertificateOwnerRef,
 		},
 		SchedulerOptions: controller.SchedulerOptions{
 			MaxConcurrentChallenges: opts.MaxConcurrentChallenges,

--- a/cmd/controller/app/options/BUILD.bazel
+++ b/cmd/controller/app/options/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager:go_default_library",
-        "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/controller/acmechallenges:go_default_library",
         "//pkg/controller/acmeorders:go_default_library",
         "//pkg/controller/certificaterequests/acme:go_default_library",

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -24,7 +24,6 @@ import (
 	"github.com/spf13/pflag"
 
 	cm "github.com/jetstack/cert-manager/pkg/apis/certmanager"
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	challengescontroller "github.com/jetstack/cert-manager/pkg/controller/acmechallenges"
 	orderscontroller "github.com/jetstack/cert-manager/pkg/controller/acmeorders"
 	cracmecontroller "github.com/jetstack/cert-manager/pkg/controller/certificaterequests/acme"
@@ -69,7 +68,6 @@ type ControllerOptions struct {
 
 	ClusterIssuerAmbientCredentials bool
 	IssuerAmbientCredentials        bool
-	RenewBeforeExpiryDuration       time.Duration
 
 	// Default issuer/certificates details consumed by ingress-shim
 	DefaultIssuerName                 string
@@ -114,7 +112,6 @@ const (
 
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false
-	defaultRenewBeforeExpiryDuration       = cmapi.DefaultRenewBefore
 
 	defaultTLSACMEIssuerName         = ""
 	defaultTLSACMEIssuerKind         = "Issuer"
@@ -175,7 +172,6 @@ func NewControllerOptions() *ControllerOptions {
 		EnabledControllers:                defaultEnabledControllers,
 		ClusterIssuerAmbientCredentials:   defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:          defaultIssuerAmbientCredentials,
-		RenewBeforeExpiryDuration:         defaultRenewBeforeExpiryDuration,
 		DefaultIssuerName:                 defaultTLSACMEIssuerName,
 		DefaultIssuerKind:                 defaultTLSACMEIssuerKind,
 		DefaultIssuerGroup:                defaultTLSACMEIssuerGroup,
@@ -249,11 +245,6 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"Whether an issuer may make use of ambient credentials. 'Ambient Credentials' are credentials drawn from the environment, metadata services, or local files which are not explicitly configured in the Issuer API object. "+
 		"When this flag is enabled, the following sources for credentials are also used: "+
 		"AWS - All sources the Go SDK defaults to, notably including any EC2 IAM roles available via instance metadata.")
-	fs.DurationVar(&s.RenewBeforeExpiryDuration, "renew-before-expiry-duration", defaultRenewBeforeExpiryDuration, ""+
-		"The default 'renew before expiry' time for Certificates. "+
-		"Once a certificate is within this duration until expiry, a new Certificate "+
-		"will be attempted to be issued.")
-	fs.MarkDeprecated("renew-before-expiry-duration", "Deprecated. Please set the Certificate.Spec.RenewBefore field.")
 	fs.StringSliceVar(&s.DefaultAutoCertificateAnnotations, "auto-certificate-annotations", defaultAutoCertificateAnnotations, ""+
 		"The annotation consumed by the ingress-shim controller to indicate a ingress is requesting a certificate")
 

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -215,7 +215,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.KubeSharedInformerFactory,
 		ctx.SharedInformerFactory,
 		PolicyChain,
-		ctx.CertificateOptions.RenewBeforeExpiryDuration,
+		cmapi.DefaultRenewBefore,
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -138,10 +138,6 @@ type CertificateOptions struct {
 	// EnableOwnerRef controls whether the certificate is configured as an owner of
 	// secret where the effective TLS certificate is stored.
 	EnableOwnerRef bool
-	// RenewBeforeExpiryDuration is the default 'renew before expiry' time for Certificates.
-	// Once a certificate is within this duration until expiry, a new Certificate
-	// will be attempted to be issued.
-	RenewBeforeExpiryDuration time.Duration
 }
 
 type SchedulerOptions struct {


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Removes the `--renew-before-expiry` flag that was [deprecated](https://github.com/jetstack/cert-manager/blob/master/cmd/controller/app/options/options.go#L256) in v1.2.0

Users can specify how long before the real expiry a certificate should be renewed using `Certificate.spec.renewBefore` field and if they haven't set that, we use a [default value](https://github.com/jetstack/cert-manager/blob/master/pkg/apis/certmanager/v1/const.go#L32) at the time of [calculating renewal](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/readiness/readiness_controller.go#L167)- this is already the current behaviour, I have only removed the part that would overrwrite the default value with the one from the flag.

I think the calculation of renewal could be refactored a bit, but perhaps it would be better if before doing that there were some tests for the readiness controller, so I was going to add that to #3692 

Fixes #3683 

Signed-off-by: irbekrm <irbekrm@gmail.com>



```release-note
Removes --renew-before-expiry flag that was deprecated in release v1.2.0
```
/kind cleanup