### PR TITLE
pkg/controller/certificaterequests/acme: fix dropped test error

### DIFF
--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -151,6 +151,9 @@ func TestSign(t *testing.T) {
 		t.Fatal(err)
 	}
 	template2, err := pki.GenerateTemplateFromCSRPEM(generateCSR(t, sk2, "example.com", "example.com", "foo.com"), time.Hour, false)
+	if err != nil {
+		t.Fatal(err)
+	}
 	certPEM2, _, err := pki.SignCSRTemplate([]*x509.Certificate{template}, sk, template2)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This fixes a dropped test error in `pkg/controller/certificaterequests/acme`.

```release-note
NONE
```