### PR TITLE
integration test for readiness controller

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -51,20 +51,20 @@ const (
 )
 
 type controller struct {
-	// the policies to use to define readiness - named here to make testing simpler
+	// The policies to use to define readiness - named here to make testing simpler.
 	policyChain              policies.Chain
 	certificateLister        cmlisters.CertificateLister
 	certificateRequestLister cmlisters.CertificateRequestLister
 	secretLister             corelisters.SecretLister
 	client                   cmclient.Interface
 	gatherer                 *policies.Gatherer
-	// policyEvaluator builds Ready condition of a Certificate based on policy evaluation
+	// policyEvaluator builds Ready condition of a Certificate based on policy evaluation.
 	policyEvaluator policyEvaluatorFunc
-	// renewalTimeCalculator calculates renewal time of a certificate
+	// renewalTimeCalculator calculates renewal time of a certificate.
 	renewalTimeCalculator certificates.RenewalTimeFunc
 }
 
-// readyConditionFunc is custom function type that builds certificate's Ready condition
+// policyEvaluatorFunc is custom function type that builds certificate's Ready condition.
 type policyEvaluatorFunc func(policies.Chain, policies.Input) cmapi.CertificateCondition
 
 func NewController(
@@ -163,7 +163,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		notAfter := metav1.NewTime(x509cert.NotAfter)
 		renewalTime := c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, crt)
 
-		//update Certificate's Status
+		// update Certificate's Status
 		crt.Status.NotBefore = &notBefore
 		crt.Status.NotAfter = &notAfter
 		crt.Status.RenewalTime = renewalTime
@@ -182,8 +182,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	return nil
 }
 
-// policyEvaluator builds Certificate's Ready condition using the result of policy chain evaluation
-func policyEvaluator(chain policies.Chain, input policies.Input) cmapi.CertificateCondition {
+// PolicyEvaluator builds Certificate's Ready condition using the result of policy chain evaluation.
+func PolicyEvaluator(chain policies.Chain, input policies.Input) cmapi.CertificateCondition {
 	reason, message, violationsFound := chain.Evaluate(input)
 	if !violationsFound {
 		return cmapi.CertificateCondition{
@@ -229,7 +229,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.SharedInformerFactory,
 		NewReadinessPolicyChain(ctx.Clock),
 		certificates.RenewalTimeWrapper(cmapi.DefaultRenewBefore),
-		policyEvaluator,
+		PolicyEvaluator,
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -274,10 +274,10 @@ func TestProcessItem(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			// Override controller's readyCondition func with a fake that returns test.condition.
+			// Override controller's policyEvaluator func with a fake that returns test.condition.
 			w.controller.policyEvaluator = policyEvaluatorBuilder(test.condition)
 
-			// Override controller's renewalTime func with a fake that returns test.renewalTime.
+			// Override controller's renewalTimeCalculator func with a fake that returns test.renewalTime.
 			w.controller.renewalTimeCalculator = renewalTimeBuilder(test.renewalTime)
 
 			// If Certificate's status should be updated,

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -1,20 +1,24 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_test(
     name = "go_default_test",
     srcs = [
         "issuing_controller_test.go",
         "metrics_controller_test.go",
+        "readiness_controller_test.go",
         "trigger_controller_test.go",
     ],
+    embed = [":go_default_library"],
     deps = [
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/controller/certificates:go_default_library",
         "//pkg/controller/certificates/issuing:go_default_library",
         "//pkg/controller/certificates/metrics:go_default_library",
+        "//pkg/controller/certificates/readiness:go_default_library",
         "//pkg/controller/certificates/trigger:go_default_library",
         "//pkg/controller/certificates/trigger/policies:go_default_library",
         "//pkg/logs:go_default_library",
@@ -22,6 +26,7 @@ go_test(
         "//pkg/util/pki:go_default_library",
         "//test/integration/framework:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
@@ -42,4 +47,19 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["util.go"],
+    importpath = "github.com/jetstack/cert-manager/test/integration/certificates",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+    ],
 )

--- a/test/integration/certificates/readiness_controller_test.go
+++ b/test/integration/certificates/readiness_controller_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/controller/certificates"
+	"github.com/jetstack/cert-manager/pkg/controller/certificates/readiness"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/metrics"
+	"github.com/jetstack/cert-manager/test/integration/framework"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+// TestReadinessController performs a basic test to ensure that
+// readiness controller sets the correct Ready condition on a Certificate.
+func TestReadinessController(t *testing.T) {
+	config, stopFn := framework.RunControlPlane(t)
+	defer stopFn()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+	defer cancel()
+
+	// Fix the time to be able to test expired certificate scenario.
+	fakeClock := &fakeclock.FakeClock{}
+	// Build, instantiate and run the trigger controller.
+	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
+
+	namespace := "testns"
+	certName := "test"
+	secretName := "test"
+	// notBefore value on the test certificate
+	notBefore := fakeClock.Now().UTC().Add(time.Hour).Truncate(time.Second)
+	// notAfter value on the test certificate
+	notAfter := notBefore.Add(time.Hour * 4).Truncate(time.Second)
+	// expected renewal time
+	renewalTime := notBefore.Add(time.Hour * 2).Truncate(time.Second)
+	issuer := cmmeta.ObjectReference{
+		Name:  "testissuer",
+		Kind:  "IssuerKind",
+		Group: "group.example.com",
+	}
+
+	// Create Namespace.
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctrl, queue, mustSync := readiness.NewController(logf.Log, cmCl, factory, cmFactory, readiness.NewReadinessPolicyChain(fakeClock), certificates.RenewalTimeWrapper(cmapi.DefaultRenewBefore), readiness.PolicyEvaluator)
+	c := controllerpkg.NewController(
+		context.Background(),
+		"readiness_test",
+		metrics.New(logf.Log),
+		ctrl.ProcessItem,
+		mustSync,
+		nil,
+		queue,
+	)
+	stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer stopController()
+
+	// 1. A newly created Certificate without a Secret should not be set to Ready.
+
+	// create the Certificate
+	cert, err := cmCl.CertmanagerV1().Certificates(namespace).Create(ctx,
+		gen.Certificate(certName,
+			gen.SetCertificateNamespace(namespace),
+			gen.SetCertificateSecretName(secretName),
+			gen.SetCertificateCommonName("example.com"),
+			gen.SetCertificateIssuer(issuer),
+			gen.SetCertificateRenewBefore(time.Hour*2)),
+		metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// ensure that Certificate does not have Ready conditon set to True
+	ensureConditionNotApplied(ctx, t, cmCl, cert, cmapi.CertificateCondition{
+		Type:   cmapi.CertificateConditionReady,
+		Status: cmmeta.ConditionTrue,
+	})
+
+	// 2. A Certificate with a valid Secret and CertificateRequest should have Ready condition set to True
+	// and updated status.RenewalTime, status.NotBefore, status.NotAfter fields
+
+	// Create private key
+	privKeyBytes := mustCreatePEMPrivateKey(t)
+	// Create x509 certificate
+	x509Cert := mustCreateCertWithNotBeforeAfter(t, privKeyBytes, cert, notBefore, notAfter)
+	// Create a Secret
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Create(ctx,
+		gen.Secret(secretName,
+			gen.SetSecretNamespace(namespace),
+			gen.SetSecretData(map[string][]byte{
+				corev1.TLSPrivateKeyKey: privKeyBytes,
+				corev1.TLSCertKey:       x509Cert,
+			}),
+			gen.SetSecretAnnotations(
+				map[string]string{
+					cmapi.IssuerNameAnnotationKey:  "testissuer",
+					cmapi.IssuerKindAnnotationKey:  "IssuerKind",
+					cmapi.IssuerGroupAnnotationKey: "group.example.com",
+				}),
+		),
+		metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create CertificateSigningRequest
+	csrBytes := mustGenerateCSRImpl(t, privKeyBytes, cert)
+	csr := gen.CertificateRequest("somerequest",
+		gen.SetCertificateRequestIssuer(issuer),
+		gen.SetCertificateRequestNamespace(namespace),
+		gen.SetCertificateRequestCSR(csrBytes))
+	// Create a CertificateRequest
+	_, err = cmCl.CertmanagerV1().CertificateRequests(namespace).Create(ctx, csr, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// build some assertions to check the status of the Certificate
+	assertions := []assertFunc{func(t *testing.T, c *cmapi.Certificate) {
+		// we expect change of condition and change of status as part of the same update
+		// assert.Equal(t, cert.Status.RenewalTime.Time, notBefore.Add(time.Hour*2))
+		assert.NotNil(t, c.Status.NotBefore)
+		assert.NotNil(t, c.Status.NotAfter)
+		// comparing unix time for more concise log messages in case of an error
+		assert.Equalf(t, c.Status.NotBefore.Unix(), notBefore.Unix(), "expected status.notBefore: %s, got: %s", notBefore, c.Status.NotBefore.String())
+		assert.Equalf(t, c.Status.NotAfter.Unix(), notAfter.Unix(), "expected status.notAfter: %s, got: %s", notAfter, c.Status.NotAfter.String())
+		assert.Equalf(t, c.Status.RenewalTime.Unix(), renewalTime.Unix(), "expected renewal time: %s, got: %s", renewalTime, c.Status.RenewalTime.String())
+
+	}}
+	// ensure that Ready conditon gets set to True
+	ensureConditionApplied(ctx, t, cmCl, cert, cmapi.CertificateCondition{
+		Type:   cmapi.CertificateConditionReady,
+		Status: cmmeta.ConditionTrue,
+	}, assertions...)
+
+	// 3. A Certificate that has expired gets it's Ready condition set to False
+
+	// advance the fake clock to after the certificate's expiry
+	fakeClock.SetTime(notAfter.Add(time.Minute))
+
+	// apply some change to Secret, to trigger reconcile of the Certificate
+	secret = gen.SecretFrom(secret,
+		gen.SetSecretAnnotations(map[string]string{
+			"somekey": "sometext",
+		}))
+	_, err = kubeClient.CoreV1().Secrets(namespace).Update(ctx, secret, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// ensure that Ready condition gets set to False
+	ensureConditionApplied(ctx, t, cmCl, cert, cmapi.CertificateCondition{
+		Type:   cmapi.CertificateConditionReady,
+		Status: cmmeta.ConditionFalse,
+	})
+}

--- a/test/integration/certificates/util.go
+++ b/test/integration/certificates/util.go
@@ -1,0 +1,173 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"encoding/pem"
+	"testing"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+)
+
+// ensureConditionNotApplied ensures that the provided condition is *not* applied to the certificate within 2 seconds.
+func ensureConditionNotApplied(ctx context.Context, t *testing.T, cmCl cmclient.Interface, cert *cmapi.Certificate, condition cmapi.CertificateCondition) {
+	err := wait.Poll(time.Millisecond*200, time.Second*2, func() (done bool, err error) {
+		c, err := cmCl.CertmanagerV1().Certificates(cert.Namespace).Get(ctx, cert.Name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		if apiutil.CertificateHasCondition(c, condition) {
+			return true, nil
+		}
+		return false, nil
+	})
+	switch {
+	case err == nil:
+		// condition was applied
+		t.Fatalf("expected Certificate to not have %v condition set to %v", condition.Type, condition.Status)
+	case err == wait.ErrWaitTimeout:
+		// success- condition has not been applied
+	default:
+		// some other erorr
+		t.Fatal(err)
+	}
+}
+
+// ensureConditionApplied ensures that a condition gets applied to a Certificate (within 5 seconds).
+// and once the condition has been applied, also runs any provided additional assertions.
+func ensureConditionApplied(ctx context.Context, t *testing.T, cmCl cmclient.Interface, cert *cmapi.Certificate, condition cmapi.CertificateCondition, assertions ...assertFunc) {
+	err := wait.Poll(time.Millisecond*100, time.Second*5, func() (done bool, err error) {
+		c, err := cmCl.CertmanagerV1().Certificates(cert.Namespace).Get(ctx, cert.Name, metav1.GetOptions{})
+		if err != nil {
+			// certificate not found
+			return false, err
+		}
+		if !apiutil.CertificateHasCondition(c, condition) {
+			t.Logf("Certificate does not have the expected %v conditon: %v, retrying", condition.Type, condition.Status)
+			return false, nil
+		}
+		//condition has been applied, run addition assertions
+		for _, a := range assertions {
+			a(t, c)
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Logf("expected Certificate to have %v condition set to %v", condition.Type, condition.Status)
+		t.Fatal(err)
+	}
+}
+
+type assertFunc func(*testing.T, *cmapi.Certificate)
+
+// mustGenerateCSRImpl returns PEM encoded certificate signing request.
+func mustGenerateCSRImpl(t *testing.T, pkData []byte, cert *cmapi.Certificate) []byte {
+	csrPEM, err := generateCSRImpl(cert, pkData)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return csrPEM
+}
+
+// mustCreatePEMPrivateKey returns a PEM encoded 2048 bit RSA private key.
+func mustCreatePEMPrivateKey(t *testing.T) []byte {
+	pk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkData, err := pki.EncodePrivateKey(pk, cmapi.PKCS8)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkData
+}
+
+// mustCreateCertWithNotBeforeAfter returns a self-signed X509 cert for Certificate
+// with the provided NotBefore, NotAfter values
+func mustCreateCertWithNotBeforeAfter(t *testing.T, pkData []byte, spec *cmapi.Certificate, notBefore, notAfter time.Time) []byte {
+	pk, err := pki.DecodePrivateKeyBytes(pkData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template, err := pki.GenerateTemplate(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template.NotBefore = notBefore
+	template.NotAfter = notAfter
+
+	certData, _, err := pki.SignCertificate(template, template, pk.Public(), pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return certData
+}
+
+// mustCreateCert returns a self-signed X509 certificate
+func mustCreateCert(t *testing.T, pkData []byte, spec *cmapi.Certificate) []byte {
+	pk, err := pki.DecodePrivateKeyBytes(pkData)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	template, err := pki.GenerateTemplate(spec)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	certData, _, err := pki.SignCertificate(template, template, pk.Public(), pk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return certData
+}
+
+// generateCSRImpl returns a PEM encoded certificate signing request for the certificate
+func generateCSRImpl(crt *cmapi.Certificate, pk []byte) ([]byte, error) {
+	csr, err := pki.GenerateCSR(crt)
+	if err != nil {
+		return nil, err
+	}
+
+	signer, err := pki.DecodePrivateKeyBytes(pk)
+	if err != nil {
+		return nil, err
+	}
+
+	csrDER, err := pki.EncodeCSR(csr, signer)
+	if err != nil {
+		return nil, err
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrDER,
+	})
+
+	return csrPEM, nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds basic integration tests for readiness controller.

I also tried to split out the functionality that could potentially be reused in other existing integration tests or ones that would be written later.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

fixes #3696 

/kind cleanup
