### PR TITLE
Fix build on go1.16

### DIFF
--- a/pkg/util/coverage/faketestdeps.go
+++ b/pkg/util/coverage/faketestdeps.go
@@ -52,3 +52,5 @@ func (fakeTestDeps) WriteHeapProfile(io.Writer) error {
 func (fakeTestDeps) WriteProfileTo(string, io.Writer, int) error {
 	return nil
 }
+
+func (fakeTestDeps) SetPanicOnExit0(bool) {}


### PR DESCRIPTION
Signed-off-by: Mitsuo Heijo <mitsuo.heijo@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Since go1.16, `SetPanicOnExit0` has been added to `testdeps`.
https://github.com/golang/go/commit/4f76fe86756841befb6574ce4bf04113d14389d4

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
