### PR TITLE
Add automountServiceAccountToken field to ca service accounts

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -95,6 +95,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `serviceAccount.create` | If `true`, create a new service account | `true` |
 | `serviceAccount.name` | Service account to be used. If not set and `serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `serviceAccount.annotations` | Annotations to add to the service account |  |
+| `serviceAccount.automountServiceAccountToken` | Automount API credentials for the Service Account | `true` |
 | `volumes` | Optional volumes for cert-manager | `[]` |
 | `volumeMounts` | Optional volume mounts for cert-manager | `[]` |
 | `resources` | CPU/memory resource requests/limits | `{}` |
@@ -135,6 +136,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.serviceAccount.create` | If `true`, create a new service account for the webhook component | `true` |
 | `webhook.serviceAccount.name` | Service account for the webhook component to be used. If not set and `webhook.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `webhook.serviceAccount.annotations` | Annotations to add to the service account for the webhook component |  |
+| `webhook.serviceAccount.automountServiceAccountToken` | Automount API credentials for the webhook Service Account |  |
 | `webhook.resources` | CPU/memory resource requests/limits for the webhook pods | `{}` |
 | `webhook.nodeSelector` | Node labels for webhook pod assignment | `{}` |
 | `webhook.affinity` | Node affinity for webhook pod assignment | `{}` |
@@ -165,6 +167,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.serviceAccount.create` | If `true`, create a new service account for the cainjector component | `true` |
 | `cainjector.serviceAccount.name` | Service account for the cainjector component to be used. If not set and `cainjector.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
 | `cainjector.serviceAccount.annotations` | Annotations to add to the service account for the cainjector component |  |
+| `cainjector.serviceAccount.automountServiceAccountToken` | Automount API credentials for the cainjector Service Account | `true` |
 | `cainjector.resources` | CPU/memory resource requests/limits for the cainjector pods | `{}` |
 | `cainjector.nodeSelector` | Node labels for cainjector pod assignment | `{}` |
 | `cainjector.affinity` | Node affinity for cainjector pod assignment | `{}` |

--- a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -2,6 +2,7 @@
 {{- if .Values.cainjector.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.cainjector.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "cainjector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/serviceaccount.yaml
@@ -4,6 +4,7 @@ kind: ServiceAccount
 {{- if .Values.global.imagePullSecrets }}
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "cert-manager.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.webhook.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -80,6 +80,8 @@ serviceAccount:
   # name: ""
   # Optional additional annotations to add to the controller's ServiceAccount
   # annotations: {}
+  # Automount API credentials for a Service Account.
+  automountServiceAccountToken: true
 
 # Optional additional arguments
 extraArgs: []
@@ -280,6 +282,8 @@ webhook:
     # name: ""
     # Optional additional annotations to add to the controller's ServiceAccount
     # annotations: {}
+    # Automount API credentials for a Service Account.
+    automountServiceAccountToken: true
 
   # The port that the webhook should listen on for requests.
   # In GKE private clusters, by default kubernetes apiservers are allowed to
@@ -367,3 +371,5 @@ cainjector:
     # name: ""
     # Optional additional annotations to add to the controller's ServiceAccount
     # annotations: {}
+    # Automount API credentials for a Service Account.
+    automountServiceAccountToken: true


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds ability to specify the `automountServiceAccountToken` field on the cert-manager service accounts.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
Add automountServiceAccountToken field to service accounts in helm chart
```
