### PR TITLE
Remove invalid warning about "kubectl cert-manager status" not supported for third party issuers

### DIFF
--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -376,11 +376,7 @@ func getGenericIssuer(cmClient cmclient.Interface, ctx context.Context, crt *cma
 		issuerKind = "Issuer"
 	}
 
-	if crt.Spec.IssuerRef.Group != "cert-manager.io" && crt.Spec.IssuerRef.Group != "" {
-		// TODO: Support Issuers/ClusterIssuers from other groups as well
-		return nil, "", fmt.Errorf("The %s %q is not of the group cert-manager.io, this command currently does not support third party issuers.\nTo get more information about %q, try 'kubectl describe'\n",
-			issuerKind, crt.Spec.IssuerRef.Name, crt.Spec.IssuerRef.Name)
-	} else if issuerKind == "Issuer" {
+	if issuerKind == "Issuer" {
 		issuer, issuerErr := cmClient.CertmanagerV1().Issuers(crt.Namespace).Get(ctx, crt.Spec.IssuerRef.Name, metav1.GetOptions{})
 		if issuerErr != nil {
 			issuerErr = fmt.Errorf("error when getting Issuer: %v\n", issuerErr)


### PR DESCRIPTION
**What this PR does / why we need it:**

The `kubectl cert-manager status` warns,

> The ExternalClusterIssuer "default" is not of the group cert-manager.io, this command currently does not support third party issuers.

However, we've not found that to be true; we can view `Certificate` details without issue.

Additionally, the warning implies the external issuer isn't supported in `kubectl cert-manager renew`, misleading our customers.

Since it no longer appears correct, and is confusing our customers, can we remove the warning?

/kind bug

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
