### PR TITLE
Spelling

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -146,11 +146,11 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.securityContext` | Security context for webhook pod assignment | `{}` |
 | `webhook.containerSecurityContext` | Security context to be set on the webhook component container | `{}` |
 | `webhook.hostNetwork` | If `true`, run the Webhook on the host network. | `false` |
-| `webhook.livenessProbe.failureThreshold` | The livneness probe failure threshold | `3` |
-| `webhook.livenessProbe.initialDelaySeconds` | The livneness probe initial delay (in seconds) | `60` |
-| `webhook.livenessProbe.periodSeconds` | The livneness probe period (in seconds) | `10` |
-| `webhook.livenessProbe.successThreshold` | The livneness probe success threshold | `1` |
-| `webhook.livenessProbe.timeoutSeconds` | The livneness probe timeout (in seconds) | `1` |
+| `webhook.livenessProbe.failureThreshold` | The liveness probe failure threshold | `3` |
+| `webhook.livenessProbe.initialDelaySeconds` | The liveness probe initial delay (in seconds) | `60` |
+| `webhook.livenessProbe.periodSeconds` | The liveness probe period (in seconds) | `10` |
+| `webhook.livenessProbe.successThreshold` | The liveness probe success threshold | `1` |
+| `webhook.livenessProbe.timeoutSeconds` | The liveness probe timeout (in seconds) | `1` |
 | `webhook.readinessProbe.failureThreshold` | The readiness probe failure threshold | `3` |
 | `webhook.readinessProbe.initialDelaySeconds` | The readiness probe initial delay (in seconds) | `5` |
 | `webhook.readinessProbe.periodSeconds` | The readiness probe period (in seconds) | `5` |

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -863,7 +863,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string
@@ -1897,7 +1897,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string
@@ -2933,7 +2933,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string
@@ -3969,7 +3969,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -863,7 +863,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string
@@ -1897,7 +1897,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string
@@ -2933,7 +2933,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string
@@ -3969,7 +3969,7 @@ spec:
                       items:
                         type: string
                     ocspServers:
-                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate wil be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
+                      description: The OCSP server list is an X.509 v3 extension that defines a list of URLs of OCSP responders. The OCSP responders can be queried for the revocation status of an issued certificate. If not set, the certificate will be issued with no OCSP servers set. For example, an OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
                       type: array
                       items:
                         type: string

--- a/design/20200326.extensible-certificate-controller.md
+++ b/design/20200326.extensible-certificate-controller.md
@@ -367,7 +367,7 @@ These conditions will cause a request to be triggered:
 * Issuer name/kind annotations on Secret resource do not match current `spec.issuerRef`.
 * The public key of the `tls.key` and `tls.crt` do not match.
 * A CertificateRequest for the current `status.revision` exists and the
-  current requested `certificaate.spec` does not match the options on the CSR.
+  current requested `certificate.spec` does not match the options on the CSR.
 * If the stored x509 certificate's `NotAfter` is within `spec.renewBefore` of
   the current time.
 

--- a/hack/verify-codegen.sh
+++ b/hack/verify-codegen.sh
@@ -53,7 +53,7 @@ tmpfiles=$TEST_TMPDIR/files
   rm -rf {.,"$tmpfiles"}/{"$gazelle","$kazel"}
 )
 # Avoid diff -N so we handle empty files correctly
-# Ignoring Copyright to not trigger a CI fail avery new year
+# Ignoring Copyright to not trigger a CI fail every new year
 diff=$(diff -upr \
   -I '^Copyright.*' \
   "./pkg" "$tmpfiles/pkg" 2>/dev/null || true)

--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -43,7 +43,7 @@ func NewClient(client *http.Client, config cmacme.ACMEIssuer, privateKey *rsa.Pr
 	}
 }
 
-// BuildHTTPClient returns a instramented HTTP client to be used by the ACME
+// BuildHTTPClient returns a instrumented HTTP client to be used by the ACME
 // client.
 // For the time being, we construct a new HTTP client on each invocation.
 // This is because we need to set the 'skipTLSVerify' flag on the HTTP client

--- a/pkg/acme/client/http.go
+++ b/pkg/acme/client/http.go
@@ -69,7 +69,7 @@ func (it *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// Remember the current time.
 	start := time.Now()
 
-	// Make the request using the wrappd RoundTripper.
+	// Make the request using the wrapped RoundTripper.
 	resp, err := it.wrappedRT.RoundTrip(req)
 	if resp != nil {
 		statusCode = resp.StatusCode

--- a/pkg/acme/util/util_test.go
+++ b/pkg/acme/util/util_test.go
@@ -29,9 +29,9 @@ func TestRetryBackoff(t *testing.T) {
 		resp *http.Response
 	}
 	tests := []struct {
-		name            string
-		args            args
-		validdateOutput func(time.Duration) bool
+		name           string
+		args           args
+		validateOutput func(time.Duration) bool
 	}{
 		{
 			name: "Do not retry a non 400 error",
@@ -40,7 +40,7 @@ func TestRetryBackoff(t *testing.T) {
 				r:    &http.Request{},
 				resp: &http.Response{StatusCode: http.StatusUnauthorized},
 			},
-			validdateOutput: func(duration time.Duration) bool {
+			validateOutput: func(duration time.Duration) bool {
 				return duration == -1
 			},
 		},
@@ -51,7 +51,7 @@ func TestRetryBackoff(t *testing.T) {
 				r:    &http.Request{},
 				resp: &http.Response{StatusCode: http.StatusBadRequest},
 			},
-			validdateOutput: func(duration time.Duration) bool {
+			validateOutput: func(duration time.Duration) bool {
 				return duration > 0
 			},
 		},
@@ -62,7 +62,7 @@ func TestRetryBackoff(t *testing.T) {
 				r:    &http.Request{},
 				resp: &http.Response{StatusCode: http.StatusBadRequest},
 			},
-			validdateOutput: func(duration time.Duration) bool {
+			validateOutput: func(duration time.Duration) bool {
 				return duration > 5
 			},
 		},
@@ -73,15 +73,15 @@ func TestRetryBackoff(t *testing.T) {
 				r:    &http.Request{},
 				resp: &http.Response{StatusCode: http.StatusBadRequest},
 			},
-			validdateOutput: func(duration time.Duration) bool {
+			validateOutput: func(duration time.Duration) bool {
 				return duration == -1
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := RetryBackoff(tt.args.n, tt.args.r, tt.args.resp); !tt.validdateOutput(got) {
-				t.Errorf("RetryBackoff() = %v which is not valid according to the validdateOutput()", got)
+			if got := RetryBackoff(tt.args.n, tt.args.r, tt.args.resp); !tt.validateOutput(got) {
+				t.Errorf("RetryBackoff() = %v which is not valid according to the validateOutput()", got)
 			}
 		})
 	}

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -281,7 +281,7 @@ type CAIssuer struct {
 	// The OCSP server list is an X.509 v3 extension that defines a list of
 	// URLs of OCSP responders. The OCSP responders can be queried for the
 	// revocation status of an issued certificate. If not set, the
-	// certificate wil be issued with no OCSP servers set. For example, an
+	// certificate will be issued with no OCSP servers set. For example, an
 	// OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
 	// +optional
 	OCSPServers []string `json:"ocspServers,omitempty"`

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -277,7 +277,7 @@ type CAIssuer struct {
 	// The OCSP server list is an X.509 v3 extension that defines a list of
 	// URLs of OCSP responders. The OCSP responders can be queried for the
 	// revocation status of an issued certificate. If not set, the
-	// certificate wil be issued with no OCSP servers set. For example, an
+	// certificate will be issued with no OCSP servers set. For example, an
 	// OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
 	// +optional
 	OCSPServers []string `json:"ocspServers,omitempty"`

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -277,7 +277,7 @@ type CAIssuer struct {
 	// The OCSP server list is an X.509 v3 extension that defines a list of
 	// URLs of OCSP responders. The OCSP responders can be queried for the
 	// revocation status of an issued certificate. If not set, the
-	// certificate wil be issued with no OCSP servers set. For example, an
+	// certificate will be issued with no OCSP servers set. For example, an
 	// OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
 	// +optional
 	OCSPServers []string `json:"ocspServers,omitempty"`

--- a/pkg/apis/certmanager/v1beta1/types_issuer.go
+++ b/pkg/apis/certmanager/v1beta1/types_issuer.go
@@ -279,7 +279,7 @@ type CAIssuer struct {
 	// The OCSP server list is an X.509 v3 extension that defines a list of
 	// URLs of OCSP responders. The OCSP responders can be queried for the
 	// revocation status of an issued certificate. If not set, the
-	// certificate wil be issued with no OCSP servers set. For example, an
+	// certificate will be issued with no OCSP servers set. For example, an
 	// OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
 	// +optional
 	OCSPServers []string `json:"ocspServers,omitempty"`

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -66,7 +66,7 @@ func TestSyncHappyPath(t *testing.T) {
 		},
 	}))
 
-	testIssuerHTTP01TestComPrefferedChain := gen.Issuer("testissuer", gen.SetIssuerACME(cmacme.ACMEIssuer{
+	testIssuerHTTP01TestComPreferredChain := gen.Issuer("testissuer", gen.SetIssuerACME(cmacme.ACMEIssuer{
 		PreferredChain: "ISRG Root X1",
 		Solvers: []cmacme.ACMEChallengeSolver{
 			{
@@ -508,7 +508,7 @@ rUCGwbCUDI0mxadJ3Bz4WxR6fyNpBK2yAinWEsikxqEt
 		"call FinalizeOrder fetch alternate cert chain": {
 			order: testOrderReady.DeepCopy(),
 			builder: &testpkg.Builder{
-				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestComPrefferedChain, testOrderReady, testAuthorizationChallengeValid},
+				CertManagerObjects: []runtime.Object{testIssuerHTTP01TestComPreferredChain, testOrderReady, testAuthorizationChallengeValid},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("orders"),
 						"status",

--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -177,7 +177,7 @@ func challengeSpecForAuthorization(ctx context.Context, cl acmecl.Interface, iss
 		dbg.Info("determining whether this match is more significant than last")
 
 		// because we don't count multiple dnsName matches as extra 'weight'
-		// in the selection process, we normalise the numDNSNamesMatch vars
+		// in the selection process, we normalize the numDNSNamesMatch vars
 		// to be either 1 or 0 (i.e. true or false)
 		selectedHasMatchingDNSNames := selectedNumDNSNamesMatch > 0
 		hasMatchingDNSNames := numDNSNamesMatch > 0

--- a/pkg/controller/certificates/internal/secretsmanager/secret.go
+++ b/pkg/controller/certificates/internal/secretsmanager/secret.go
@@ -82,7 +82,7 @@ func (s *SecretsManager) UpdateData(ctx context.Context, crt *cmapi.Certificate,
 	}
 	secretExists := (secret != nil)
 
-	// If the seret does not exist yet, then we need to create one
+	// If the secret does not exist yet, then we need to create one
 	if !secretExists {
 		secret = &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -193,12 +193,12 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		logf.WithResource(log, nextPrivateKeySecret).Error(err, "failed to parse next private key, waiting for keymanager controller")
 		return nil
 	}
-	pkVioations, err := certificates.PrivateKeyMatchesSpec(pk, crt.Spec)
+	pkViolations, err := certificates.PrivateKeyMatchesSpec(pk, crt.Spec)
 	if err != nil {
 		return err
 	}
-	if len(pkVioations) > 0 {
-		logf.WithResource(log, nextPrivateKeySecret).Info("stored next private key does not match requirements on Certificate resource, waiting for keymanager controller", "violations", pkVioations)
+	if len(pkViolations) > 0 {
+		logf.WithResource(log, nextPrivateKeySecret).Info("stored next private key does not match requirements on Certificate resource, waiting for keymanager controller", "violations", pkViolations)
 		return nil
 	}
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller_test.go
@@ -221,7 +221,7 @@ func TestProcessItem(t *testing.T) {
 		},
 		// TODO: in this case we should adapt the controller behaviour to unset the nextPrivateKeySecretName to
 		//  gracefully recover
-		"error if an existing Secret exists and is named as status.nextPrivateKeySecretName but it is not owned by the Certificte": {
+		"error if an existing Secret exists and is named as status.nextPrivateKeySecretName but it is not owned by the Certificate": {
 			certificate: &cmapi.Certificate{
 				ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "test"},
 				Status: cmapi.CertificateStatus{

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -97,7 +97,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	return c.queue, mustSync, nil
 }
 
-// TODO: replace with generic handleObjet function (like Navigator)
+// TODO: replace with generic handleObject function (like Navigator)
 func (c *controller) secretDeleted(obj interface{}) {
 	log := c.log.WithName("secretDeleted")
 

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -92,7 +92,7 @@ func (c *controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	return c.queue, mustSync, nil
 }
 
-// TODO: replace with generic handleObjet function (like Navigator)
+// TODO: replace with generic handleObject function (like Navigator)
 func (c *controller) secretDeleted(obj interface{}) {
 	log := c.log.WithName("secretDeleted")
 

--- a/pkg/internal/apis/certmanager/types_issuer.go
+++ b/pkg/internal/apis/certmanager/types_issuer.go
@@ -253,7 +253,7 @@ type CAIssuer struct {
 	// The OCSP server list is an X.509 v3 extension that defines a list of
 	// URLs of OCSP responders. The OCSP responders can be queried for the
 	// revocation status of an issued certificate. If not set, the
-	// certificate wil be issued with no OCSP servers set. For example, an
+	// certificate will be issued with no OCSP servers set. For example, an
 	// OCSP server URL could be "http://ocsp.int-x3.letsencrypt.org".
 	OCSPServers []string
 }

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -143,8 +143,8 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, ambient, util.RecursiveNameservers)
 			return nil, nil
 		},
-		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool) (*azuredns.DNSProvider, error) {
-			f.call("azuredns", clientID, clientSecret, subscriptionID, tenentID, resourceGroupName, hostedZoneName, util.RecursiveNameservers, ambient)
+		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool) (*azuredns.DNSProvider, error) {
+			f.call("azuredns", clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName, util.RecursiveNameservers, ambient)
 			return nil, nil
 		},
 		acmeDNS: func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -134,7 +134,7 @@ func New(log logr.Logger) *Metrics {
 	return m
 }
 
-// Start will register the Prometheu metrics, and start the Prometheus server
+// Start will register the Prometheus metrics, and start the Prometheus server
 func (m *Metrics) Start(listenAddress string, enablePprof bool) (*http.Server, error) {
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -67,7 +67,7 @@ func TestBuildUsages(t *testing.T) {
 			expectedError:    false,
 		},
 		{
-			name:          "nonexisting keyusage error",
+			name:          "nonexistent keyusage error",
 			usages:        []cmapi.KeyUsage{"nonexistent"},
 			expectedError: true,
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR corrects misspellings identified by the [check-spelling action](https://github.com/marketplace/actions/check-spelling).

The misspellings have been reported at https://github.com/jsoref/cert-manager/commit/bca1c47eeb1b7436891479def2835dfb3fa78ef0#commitcomment-47820545

The action reports that the changes in this PR would make it happy: https://github.com/jsoref/cert-manager/commit/3aed6e91b3b9690584ebdefad6b06ad26fa44ec1

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
Previous round #2624

Note: this PR does not include the action. If you're interested in running a spell check on every PR and push, that can be offered separately.

The CRD changes would probably trigger a bump to a chart.

The changes to `UsageContentCommittment` probably can't be made at all, as they're probably API breaks. If that's correct, let me know and I can trivially drop them.

This is an example of where having an action that runs on PRs could catch things and prevent poor APIs from sneaking in.

@maelvls 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
