### PR TITLE
Add unit tests around IPAddressesForCertificate

### DIFF
--- a/pkg/util/pki/BUILD.bazel
+++ b/pkg/util/pki/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/util:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
     ],
 )
 


### PR DESCRIPTION
While working on https://github.com/jetstack/cert-manager/pull/3475, I found out that `IPAddressesForCertificate` was left alone untested. So I figured I would test it! 😅

```release-note
NONE
```

Still 10 untested functions that contain non-obvious logic in the [pki](https://github.com/jetstack/cert-manager/blob/33a9cbfd36acda31e9117d9879973b7f951c7ee4/pkg/util/pki/csr.go) package (❌ = untested):

- ✅ `IPAddressesForCertificate` (in #3737)
- ~~`URIsForCertificate`~~ (no logic)
- ~~`DNSNamesForCertificate`~~ (no logic)
- ✅ `buildCertificate`
- ❌ `URLsFromStrings`
- ~~IPAddressesToString~~ (no logic)
- ❌ `URLsToString`
- ✅ `removeDuplicates`
- ~~`OrganizationForCertificate`~~ (no logic)
- ~~`SubjectForCertificate`~~ (no logic)
- ✅ `BuildKeyUsages`
- ~~`BuildCertManagerKeyUsages`~~ (not much logic)
- ❌ `GenerateCSR` (a ton of logic!)
- ✅ `buildKeyUsagesExtensionsForCertificate`
- ❌ `GenerateTemplate`
- ❌ `GenerateTemplateFromCertificateRequest`
- ❌ `GenerateTemplateFromCSRPEM`
- ❌ `GenerateTemplateFromCSRPEMWithUsages`
- ❌ `SignCertificate`
- ❌ `SignCSRTemplate`
- ~~`EncodeCSR`~~ (no logic)
- ~~`EncodeX509`~~ (no logic)
- ❌ `EncodeX509Chain`
- ✅ `SignatureAlgorithm`

Hmmm we might want to test all that

