### PR TITLE
Issuer observed generation

### DIFF
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1051,6 +1051,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -2085,6 +2089,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -3121,6 +3129,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -4157,6 +4169,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1051,6 +1051,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -2085,6 +2089,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -3121,6 +3129,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string
@@ -4157,6 +4169,10 @@ spec:
                       message:
                         description: Message is a human readable description of the details of the last transition, complementing reason.
                         type: string
+                      observedGeneration:
+                        description: If set, this represents the .metadata.generation that the condition was set based upon. For instance, if .metadata.generation is currently 12, but the .status.condition[x].observedGeneration is 9, the condition is out of date with respect to the current state of the Issuer.
+                        type: integer
+                        format: int64
                       reason:
                         description: Reason is a brief machine readable explanation for the condition's last transition.
                         type: string

--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -55,7 +55,7 @@ func IssuerHasCondition(i cmapi.GenericIssuer, c cmapi.IssuerCondition) bool {
 //   condition will be updated and the LastTransitionTime set to the current
 //   time.
 // This function works with both Issuer and ClusterIssuer resources.
-func SetIssuerCondition(i cmapi.GenericIssuer, conditionType cmapi.IssuerConditionType, status cmmeta.ConditionStatus, reason, message string) {
+func SetIssuerCondition(i cmapi.GenericIssuer, observedGeneration int64, conditionType cmapi.IssuerConditionType, status cmmeta.ConditionStatus, reason, message string) {
 	newCondition := cmapi.IssuerCondition{
 		Type:    conditionType,
 		Status:  status,
@@ -65,6 +65,9 @@ func SetIssuerCondition(i cmapi.GenericIssuer, conditionType cmapi.IssuerConditi
 
 	nowTime := metav1.NewTime(Clock.Now())
 	newCondition.LastTransitionTime = &nowTime
+
+	// Set the condition generation
+	newCondition.ObservedGeneration = observedGeneration
 
 	// Search through existing conditions
 	for idx, cond := range i.GetStatus().Conditions {

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -323,6 +323,14 @@ type IssuerCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Issuer.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // IssuerConditionType represents an Issuer condition value.

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -319,6 +319,14 @@ type IssuerCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Issuer.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // IssuerConditionType represents an Issuer condition value.

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -319,6 +319,14 @@ type IssuerCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // IssuerConditionType represents an Issuer condition value.

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -324,7 +324,7 @@ type IssuerCondition struct {
 	// set based upon.
 	// For instance, if .metadata.generation is currently 12, but the
 	// .status.condition[x].observedGeneration is 9, the condition is out of date
-	// with respect to the current state of the Certificate.
+	// with respect to the current state of the Issuer.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/pkg/apis/certmanager/v1beta1/types_issuer.go
+++ b/pkg/apis/certmanager/v1beta1/types_issuer.go
@@ -321,6 +321,14 @@ type IssuerCondition struct {
 	// transition, complementing reason.
 	// +optional
 	Message string `json:"message,omitempty"`
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Certificate.
+	// +optional
+	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }
 
 // IssuerConditionType represents an Issuer condition value.

--- a/pkg/apis/certmanager/v1beta1/types_issuer.go
+++ b/pkg/apis/certmanager/v1beta1/types_issuer.go
@@ -326,7 +326,7 @@ type IssuerCondition struct {
 	// set based upon.
 	// For instance, if .metadata.generation is currently 12, but the
 	// .status.condition[x].observedGeneration is 9, the condition is out of date
-	// with respect to the current state of the Certificate.
+	// with respect to the current state of the Issuer.
 	// +optional
 	ObservedGeneration int64 `json:"observedGeneration,omitempty"`
 }

--- a/pkg/internal/apis/certmanager/types_issuer.go
+++ b/pkg/internal/apis/certmanager/types_issuer.go
@@ -289,6 +289,13 @@ type IssuerCondition struct {
 	// Message is a human readable description of the details of the last
 	// transition, complementing reason.
 	Message string
+
+	// If set, this represents the .metadata.generation that the condition was
+	// set based upon.
+	// For instance, if .metadata.generation is currently 12, but the
+	// .status.condition[x].observedGeneration is 9, the condition is out of date
+	// with respect to the current state of the Issuer.
+	ObservedGeneration int64
 }
 
 // IssuerConditionType represents an Issuer condition value.

--- a/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -858,6 +858,7 @@ func autoConvert_v1_IssuerCondition_To_certmanager_IssuerCondition(in *v1.Issuer
 	out.LastTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -872,6 +873,7 @@ func autoConvert_certmanager_IssuerCondition_To_v1_IssuerCondition(in *certmanag
 	out.LastTransitionTime = (*metav1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -896,6 +896,7 @@ func autoConvert_v1alpha2_IssuerCondition_To_certmanager_IssuerCondition(in *v1a
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -910,6 +911,7 @@ func autoConvert_certmanager_IssuerCondition_To_v1alpha2_IssuerCondition(in *cer
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -895,6 +895,7 @@ func autoConvert_v1alpha3_IssuerCondition_To_certmanager_IssuerCondition(in *v1a
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -909,6 +910,7 @@ func autoConvert_certmanager_IssuerCondition_To_v1alpha3_IssuerCondition(in *cer
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -848,6 +848,7 @@ func autoConvert_v1beta1_IssuerCondition_To_certmanager_IssuerCondition(in *v1be
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 
@@ -862,6 +863,7 @@ func autoConvert_certmanager_IssuerCondition_To_v1beta1_IssuerCondition(in *cert
 	out.LastTransitionTime = (*v1.Time)(unsafe.Pointer(in.LastTransitionTime))
 	out.Reason = in.Reason
 	out.Message = in.Message
+	out.ObservedGeneration = in.ObservedGeneration
 	return nil
 }
 

--- a/pkg/issuer/ca/setup.go
+++ b/pkg/issuer/ca/setup.go
@@ -48,7 +48,7 @@ func (c *CA) Setup(ctx context.Context) error {
 		log.Error(err, "error getting signing CA TLS certificate")
 		s := messageErrorGetKeyPair + err.Error()
 		c.Recorder.Event(c.issuer, corev1.EventTypeWarning, errorGetKeyPair, s)
-		apiutil.SetIssuerCondition(c.issuer, v1.IssuerConditionReady, cmmeta.ConditionFalse, errorGetKeyPair, s)
+		apiutil.SetIssuerCondition(c.issuer, c.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorGetKeyPair, s)
 		return err
 	}
 
@@ -57,7 +57,7 @@ func (c *CA) Setup(ctx context.Context) error {
 		log.Error(err, "error getting signing CA private key")
 		s := messageErrorGetKeyPair + err.Error()
 		c.Recorder.Event(c.issuer, corev1.EventTypeWarning, errorGetKeyPair, s)
-		apiutil.SetIssuerCondition(c.issuer, v1.IssuerConditionReady, cmmeta.ConditionFalse, errorGetKeyPair, s)
+		apiutil.SetIssuerCondition(c.issuer, c.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorGetKeyPair, s)
 		return err
 	}
 
@@ -66,14 +66,14 @@ func (c *CA) Setup(ctx context.Context) error {
 		s := messageErrorGetKeyPair + "certificate is not a CA"
 		log.Error(nil, "signing certificate is not a CA")
 		c.Recorder.Event(c.issuer, corev1.EventTypeWarning, errorInvalidKeyPair, s)
-		apiutil.SetIssuerCondition(c.issuer, v1.IssuerConditionReady, cmmeta.ConditionFalse, errorInvalidKeyPair, s)
+		apiutil.SetIssuerCondition(c.issuer, c.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionFalse, errorInvalidKeyPair, s)
 		// Don't return an error here as there is nothing more we can do
 		return nil
 	}
 
 	log.V(logf.DebugLevel).Info("signing CA verified")
 	c.Recorder.Event(c.issuer, corev1.EventTypeNormal, successKeyPairVerified, messageKeyPairVerified)
-	apiutil.SetIssuerCondition(c.issuer, v1.IssuerConditionReady, cmmeta.ConditionTrue, successKeyPairVerified, messageKeyPairVerified)
+	apiutil.SetIssuerCondition(c.issuer, c.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionTrue, successKeyPairVerified, messageKeyPairVerified)
 
 	return nil
 }

--- a/pkg/issuer/selfsigned/setup.go
+++ b/pkg/issuer/selfsigned/setup.go
@@ -29,6 +29,6 @@ const (
 )
 
 func (c *SelfSigned) Setup(ctx context.Context) error {
-	apiutil.SetIssuerCondition(c.issuer, v1.IssuerConditionReady, cmmeta.ConditionTrue, successReady, "")
+	apiutil.SetIssuerCondition(c.issuer, c.issuer.GetGeneration(), v1.IssuerConditionReady, cmmeta.ConditionTrue, successReady, "")
 	return nil
 }

--- a/pkg/issuer/venafi/setup.go
+++ b/pkg/issuer/venafi/setup.go
@@ -32,7 +32,7 @@ func (v *Venafi) Setup(ctx context.Context) (err error) {
 		if err != nil {
 			errorMessage := "Failed to setup Venafi issuer"
 			v.log.Error(err, errorMessage)
-			apiutil.SetIssuerCondition(v.issuer, cmapi.IssuerConditionReady, cmmeta.ConditionFalse, "ErrorSetup", fmt.Sprintf("%s: %v", errorMessage, err))
+			apiutil.SetIssuerCondition(v.issuer, v.issuer.GetGeneration(), cmapi.IssuerConditionReady, cmmeta.ConditionFalse, "ErrorSetup", fmt.Sprintf("%s: %v", errorMessage, err))
 			err = fmt.Errorf("%s: %v", errorMessage, err)
 		}
 	}()
@@ -55,7 +55,7 @@ func (v *Venafi) Setup(ctx context.Context) (err error) {
 		v.Recorder.Eventf(v.issuer, corev1.EventTypeNormal, "Ready", "Verified issuer with Venafi server")
 	}
 	v.log.V(logf.DebugLevel).Info("Venafi issuer started")
-	apiutil.SetIssuerCondition(v.issuer, cmapi.IssuerConditionReady, cmmeta.ConditionTrue, "Venafi issuer started", "Venafi issuer started")
+	apiutil.SetIssuerCondition(v.issuer, v.issuer.GetGeneration(), cmapi.IssuerConditionReady, cmmeta.ConditionTrue, "Venafi issuer started", "Venafi issuer started")
 
 	return nil
 }


### PR DESCRIPTION
fixes #1551 

I haven't added this field to ACME resources since they don't follow the same condition pattern.

I also haven't added this field to the CertificateRequest since it the spec _shouldn't_, and soon _can't_ ever change once created.

```release-note
Adds ObservedGeneration field to all Issuer conditions
```
