### PR TITLE
selfsigned: warn when certs are issued with empty issuer DNs 

### DIFF
--- a/pkg/controller/certificaterequests/selfsigned/BUILD.bazel
+++ b/pkg/controller/certificaterequests/selfsigned/BUILD.bazel
@@ -16,8 +16,10 @@ go_library(
         "//pkg/util/errors:go_default_library",
         "//pkg/util/kube:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
+        "@io_k8s_client_go//tools/record:go_default_library",
     ],
 )
 

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -312,13 +312,6 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ing *networkingv1beta1.Ingr
 	}
 }
 
-func setCommonName(crt *cmapi.Certificate, ing *networkingv1beta1.Ingress) {
-	// if annotation is set use that as CN
-	if ing.Annotations != nil && ing.Annotations[cmapi.CommonNameAnnotationKey] != "" {
-		crt.Spec.CommonName = ing.Annotations[cmapi.CommonNameAnnotationKey]
-	}
-}
-
 // shouldSync returns true if this ingress should have a Certificate resource
 // created for it
 func shouldSync(ing *networkingv1beta1.Ingress, autoCertificateAnnotations []string) bool {

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -388,8 +388,8 @@ func GenerateTemplateFromCSRPEMWithUsages(csrPEM []byte, duration time.Duration,
 	}, nil
 }
 
-// SignCertificate returns a signed x509.Certificate object for the given
-// *v1.Certificate crt.
+// SignCertificate returns a signed *x509.Certificate given a template
+// *x509.Certificate crt and an issuer.
 // publicKey is the public key of the signee, and signerKey is the private
 // key of the signer.
 // It returns a PEM encoded copy of the Certificate as well as a *x509.Certificate

--- a/pkg/util/pki/generate.go
+++ b/pkg/util/pki/generate.go
@@ -38,11 +38,11 @@ const (
 	// generator functions in this package.
 	MaxRSAKeySize = 8192
 
-	// ECCurve256 represents a 256bit ECDSA key.
+	// ECCurve256 represents a secp256r1 / prime256v1 / NIST P-256 ECDSA key.
 	ECCurve256 = 256
-	// ECCurve384 represents a 384bit ECDSA key.
+	// ECCurve384 represents a secp384r1 / NIST P-384 ECDSA key.
 	ECCurve384 = 384
-	// ECCurve521 represents a 521bit ECDSA key.
+	// ECCurve521 represents a secp521r1 / NIST P-521 ECDSA key.
 	ECCurve521 = 521
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: RFC 5280 states that the issuer field cannot be empty, but this is effectively the default for selfsigned certs where the user doesn't specify any part of the subject DN (and with selfsigned certs, the subject becomes the issuer).

There are also some smaller tweaks to comments I discovered as part of this work.

/kind bug

**Which issue this PR fixes**: fixes #3634 (sort of)

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
selfsigned issuer: warn when certs have empty issuer DNs, in violation of TLS RFC 5280
```
