### PR TITLE
fix(makefile): updated the docker_repo env var

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ generate:
 ################
 images:
 	APP_VERSION=$(APP_VERSION) \
-	DOCKER_REGISTRY=$(DOCKER_REPO) \
+	DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
 	bazel run \
 		--stamp \
 		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \


### PR DESCRIPTION
Signed-off-by: Arsh Sharma <arshsharma461@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Fixes the reference to the non-existent `DOCKER_REPO` env var in the makefile

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes (partly) #3648 

**Special notes for your reviewer**:
Verified manually by running:
```
make images DOCKER_REGISTRY=something.com/arsh
```
Got this in the final lines of the output:
```
Tagging 130518c203ce75a73173ed8238730033154a508d7f39edbe071d3b76f42db857 as something.com/arsh/cert-manager-acmesolver-amd64:v1.2.0-89-e1e8392d50d1e1
Tagging a41f59e78513c83f51d3d76e6c1bcb9b6e5524686b98b985816e2251dfab6b0b as something.com/arsh/cert-manager-cainjector-amd64:v1.2.0-89-e1e8392d50d1e1
Tagging e96030d48769734d51d906e0f1cde9454c293875359a3861d94fca447efd47ee as something.com/arsh/cert-manager-controller-amd64:v1.2.0-89-e1e8392d50d1e1
Tagging 28ddd1dd58b990628747f1227187ef22801cb1750717247f0336348fd10e44dc as something.com/arsh/cert-manager-webhook-amd64:v1.2.0-89-e1e8392d50d1e1
```
