### PR TITLE
tests: allow setting DNSName and ChallengeKey for webhook integration tests

### DIFF
--- a/test/acme/dns/fixture.go
+++ b/test/acme/dns/fixture.go
@@ -62,6 +62,16 @@ type fixture struct {
 	// Default: 8.8.8.8:53
 	testDNSServer string
 
+	// dnsName is the domain name used in the request in tests.
+	// This field can be set using the SetDNSName Option.
+	// Default: "example.com"
+	dnsName string
+
+	// dnsChallengeKey is the value of TXT record in tests.
+	// This field can be set using the SetDNSChallengeKey Option.
+	// Default: "123d=="
+	dnsChallengeKey string
+
 	// controlPlane is a reference to the control plane that is used to run the
 	// test suite.
 	// It is constructed when a Run* method is called.

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -52,6 +52,12 @@ func applyDefaults(f *fixture) {
 	if f.resolvedFQDN == "" {
 		f.resolvedFQDN = "cert-manager-dns01-tests." + f.resolvedZone
 	}
+	if f.dnsName == "" {
+		f.dnsName = "example.com"
+	}
+	if f.dnsChallengeKey == "" {
+		f.dnsChallengeKey = "123d=="
+	}
 	runfiles := os.Getenv("TEST_SRCDIR")
 	if f.binariesPath == "" {
 		if runfiles != "" {
@@ -168,5 +174,20 @@ func SetPollInterval(d time.Duration) Option {
 func SetPropagationLimit(d time.Duration) Option {
 	return func(f *fixture) {
 		f.propagationLimit = d
+	}
+}
+
+// SetDNSChallengeKey defines the value of the acme challenge string.
+func SetDNSChallengeKey(s string) Option {
+	return func(f *fixture) {
+		f.dnsChallengeKey = s
+	}
+}
+
+// SetDNSName defines the domain name to be used in the webhook
+// integration tests.
+func SetDNSName(s string) Option {
+	return func(f *fixture) {
+		f.dnsName = s
 	}
 }

--- a/test/acme/dns/util.go
+++ b/test/acme/dns/util.go
@@ -87,9 +87,8 @@ func (f *fixture) buildChallengeRequest(t *testing.T, ns string) *whapi.Challeng
 		ResolvedZone:            f.resolvedZone,
 		AllowAmbientCredentials: f.allowAmbientCredentials,
 		Config:                  f.jsonConfig,
-		// TODO
-		DNSName: "example.com",
-		Key:     "123d==",
+		DNSName:                 f.dnsName,
+		Key:                     f.dnsChallengeKey,
 	}
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

[Custom webhooks](https://github.com/cert-manager/webhook-example) provide a relatively easy approach to extend cert-manager acme-challenge to other DNS providers. Some in-house developed DNS providers/integrations may have restrictions, allowing just a few domains to be validated, and often example.com is not one of them.

This PR allows the base DNS name to be set using the new `SetDNSName()` and `SetDNSChallangeKey()` methods **in tests only**. If not set, the default value _"example.com"_ will be used, without changing the original behavior. 

```release-note
NONE
```