### PR TITLE
Certificate revision history limit

### DIFF
--- a/cmd/controller/app/options/BUILD.bazel
+++ b/cmd/controller/app/options/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/controller/certificates/metrics:go_default_library",
         "//pkg/controller/certificates/readiness:go_default_library",
         "//pkg/controller/certificates/requestmanager:go_default_library",
+        "//pkg/controller/certificates/revisionmanager:go_default_library",
         "//pkg/controller/certificates/trigger:go_default_library",
         "//pkg/controller/clusterissuers:go_default_library",
         "//pkg/controller/ingress-shim:go_default_library",

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -36,6 +36,7 @@ import (
 	certificatesmetricscontroller "github.com/jetstack/cert-manager/pkg/controller/certificates/metrics"
 	"github.com/jetstack/cert-manager/pkg/controller/certificates/readiness"
 	"github.com/jetstack/cert-manager/pkg/controller/certificates/requestmanager"
+	"github.com/jetstack/cert-manager/pkg/controller/certificates/revisionmanager"
 	"github.com/jetstack/cert-manager/pkg/controller/certificates/trigger"
 	clusterissuerscontroller "github.com/jetstack/cert-manager/pkg/controller/clusterissuers"
 	ingressshimcontroller "github.com/jetstack/cert-manager/pkg/controller/ingress-shim"
@@ -154,6 +155,7 @@ var (
 		keymanager.ControllerName,
 		requestmanager.ControllerName,
 		readiness.ControllerName,
+		revisionmanager.ControllerName,
 	}
 )
 

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -201,6 +201,7 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
+                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -499,6 +500,7 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
+                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -804,6 +806,7 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
+                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -1109,6 +1112,7 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
+                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -197,6 +197,10 @@ spec:
                 renewBefore:
                   description: The amount of time before the currently issued certificate's `notAfter` time that cert-manager will begin to attempt to renew the certificate. If this value is greater than the total duration of the certificate (i.e. notAfter - notBefore), it will be automatically renewed 2/3rds of the way through the certificate's duration.
                   type: string
+                revisionHistoryLimit:
+                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
+                  type: integer
+                  format: int32
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -491,6 +495,10 @@ spec:
                 renewBefore:
                   description: The amount of time before the currently issued certificate's `notAfter` time that cert-manager will begin to attempt to renew the certificate. If this value is greater than the total duration of the certificate (i.e. notAfter - notBefore), it will be automatically renewed 2/3rds of the way through the certificate's duration.
                   type: string
+                revisionHistoryLimit:
+                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
+                  type: integer
+                  format: int32
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -792,6 +800,10 @@ spec:
                 renewBefore:
                   description: The amount of time before the currently issued certificate's `notAfter` time that cert-manager will begin to attempt to renew the certificate. If this value is greater than the total duration of the certificate (i.e. notAfter - notBefore), it will be automatically renewed 2/3rds of the way through the certificate's duration.
                   type: string
+                revisionHistoryLimit:
+                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
+                  type: integer
+                  format: int32
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -1093,6 +1105,10 @@ spec:
                 renewBefore:
                   description: The amount of time before the currently issued certificate's `notAfter` time that cert-manager will begin to attempt to renew the certificate. If this value is greater than the total duration of the certificate (i.e. notAfter - notBefore), it will be automatically renewed 2/3rds of the way through the certificate's duration.
                   type: string
+                revisionHistoryLimit:
+                  description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
+                  type: integer
+                  format: int32
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -165,6 +165,16 @@ type CertificateSpec struct {
 	// in the CertificateRequest
 	// +optional
 	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
+
+	// revisionHistoryLimit is the maximum number of CertificateRequest revisions
+	// that are maintained in the Certificate's history. Each revision represents
+	// a single `CertificateRequest` created by this Certificate, either when it
+	// was created, renewed, or Spec was changed. Revisions will be removed by
+	// oldest first if the number of revisions exceeds this number. If set,
+	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+	// revisions will not be garbage collected. Default value is `nil`.
+	// +optional
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -173,6 +173,8 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -405,6 +405,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -197,6 +197,8 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -189,6 +189,16 @@ type CertificateSpec struct {
 	// in the CertificateRequest
 	// +optional
 	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
+
+	// revisionHistoryLimit is the maximum number of CertificateRequest revisions
+	// that are maintained in the Certificate's history. Each revision represents
+	// a single `CertificateRequest` created by this Certificate, either when it
+	// was created, renewed, or Spec was changed. Revisions will be removed by
+	// oldest first if the number of revisions exceeds this number. If set,
+	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+	// revisions will not be garbage collected. Default value is `nil`.
+	// +optional
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -410,6 +410,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -187,6 +187,16 @@ type CertificateSpec struct {
 	// in the CertificateRequest
 	// +optional
 	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
+
+	// revisionHistoryLimit is the maximum number of CertificateRequest revisions
+	// that are maintained in the Certificate's history. Each revision represents
+	// a single `CertificateRequest` created by this Certificate, either when it
+	// was created, renewed, or Spec was changed. Revisions will be removed by
+	// oldest first if the number of revisions exceeds this number. If set,
+	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+	// revisions will not be garbage collected. Default value is `nil`.
+	// +optional
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -195,6 +195,8 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }

--- a/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
@@ -405,6 +405,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -164,6 +164,16 @@ type CertificateSpec struct {
 	// in the CertificateRequest
 	// +optional
 	EncodeUsagesInRequest *bool `json:"encodeUsagesInRequest,omitempty"`
+
+	// revisionHistoryLimit is the maximum number of CertificateRequest revisions
+	// that are maintained in the Certificate's history. Each revision represents
+	// a single `CertificateRequest` created by this Certificate, either when it
+	// was created, renewed, or Spec was changed. Revisions will be removed by
+	// oldest first if the number of revisions exceeds this number. If set,
+	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+	// revisions will not be garbage collected. Default value is `nil`.
+	// +optional
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -172,6 +172,8 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
+	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
 	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
 }

--- a/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
@@ -405,6 +405,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/certificates/BUILD.bazel
+++ b/pkg/controller/certificates/BUILD.bazel
@@ -46,6 +46,7 @@ filegroup(
         "//pkg/controller/certificates/metrics:all-srcs",
         "//pkg/controller/certificates/readiness:all-srcs",
         "//pkg/controller/certificates/requestmanager:all-srcs",
+        "//pkg/controller/certificates/revisionmanager:all-srcs",
         "//pkg/controller/certificates/trigger:all-srcs",
     ],
     tags = ["automanaged"],

--- a/pkg/controller/certificates/revisionmanager/BUILD.bazel
+++ b/pkg/controller/certificates/revisionmanager/BUILD.bazel
@@ -1,0 +1,57 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["revisionmanager_controller.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/controller/certificates/revisionmanager",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/client/informers/externalversions:go_default_library",
+        "//pkg/client/listers/certmanager/v1:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/controller/certificates:go_default_library",
+        "//pkg/logs:go_default_library",
+        "//pkg/util/predicate:go_default_library",
+        "@com_github_go_logr_logr//:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_client_go//tools/cache:go_default_library",
+        "@io_k8s_client_go//util/workqueue:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["revisionmanager_controller_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller:go_default_library",
+        "//pkg/controller/test:go_default_library",
+        "//pkg/logs/testing:go_default_library",
+        "//test/unit/gen:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_client_go//testing:go_default_library",
+    ],
+)

--- a/pkg/controller/certificates/revisionmanager/BUILD.bazel
+++ b/pkg/controller/certificates/revisionmanager/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_k8s_client_go//util/workqueue:go_default_library",
     ],
@@ -52,6 +53,7 @@ go_test(
         "//test/unit/gen:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
     ],
 )

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateRevisionManager"
+	ControllerName = "certificates-revision-manager"
 )
 
 var (

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revisionmanager
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/controller/certificates"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/util/predicate"
+)
+
+const (
+	ControllerName = "CertificateRevisionManager"
+)
+
+var (
+	certificateGvk = cmapi.SchemeGroupVersion.WithKind("Certificate")
+)
+
+type controller struct {
+	certificateLister        cmlisters.CertificateLister
+	certificateRequestLister cmlisters.CertificateRequestLister
+	client                   cmclient.Interface
+}
+
+type revision struct {
+	rev int
+	req *cmapi.CertificateRequest
+}
+
+func NewController(log logr.Logger, client cmclient.Interface, cmFactory cminformers.SharedInformerFactory) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
+	// create a queue used to queue up items to be processed
+	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
+
+	// obtain references to all the informers used by this controller
+	certificateInformer := cmFactory.Certmanager().V1().Certificates()
+	certificateRequestInformer := cmFactory.Certmanager().V1().CertificateRequests()
+
+	certificateInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: queue})
+	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.BlockingEventHandler{
+		// Trigger reconciles on changes to any 'owned' CertificateRequest resources
+		WorkFunc: certificates.EnqueueCertificatesForResourceUsingPredicates(log, queue, certificateInformer.Lister(), labels.Everything(),
+			predicate.ResourceOwnerOf,
+		),
+	})
+
+	// build a list of InformerSynced functions that will be returned by the Register method.
+	// the controller will only begin processing items once all of these informers have synced.
+	mustSync := []cache.InformerSynced{
+		certificateRequestInformer.Informer().HasSynced,
+		certificateInformer.Informer().HasSynced,
+	}
+
+	return &controller{
+		certificateLister:        certificateInformer.Lister(),
+		certificateRequestLister: certificateRequestInformer.Lister(),
+		client:                   client,
+	}, queue, mustSync
+}
+
+// ProcessItem will attempt to garbage collect old CertificateRequests based
+// upon `spec.revisionHistoryLimit`. This controller will only act on
+// Certificates which are in a Ready state and this value is set.
+func (c *controller) ProcessItem(ctx context.Context, key string) error {
+	log := logf.FromContext(ctx).WithValues("key", key)
+
+	ctx = logf.NewContext(ctx, log)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
+	if err != nil {
+		log.Error(err, "invalid resource key passed to ProcessItem")
+		return nil
+	}
+
+	crt, err := c.certificateLister.Certificates(namespace).Get(name)
+	if apierrors.IsNotFound(err) {
+		log.Error(err, "certificate not found for key")
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	log = logf.WithResource(log, crt)
+
+	// If RevisionHistoryLimit is nil, don't attempt to garbage collect old
+	// CertificateRequests
+	if crt.Spec.RevisionHistoryLimit == nil {
+		return nil
+	}
+
+	limit := int(*crt.Spec.RevisionHistoryLimit)
+
+	// Only garbage collect over Certificates that are in a Ready=True condition.
+	if !apiutil.CertificateHasCondition(crt, cmapi.CertificateCondition{
+		Type:   cmapi.CertificateConditionReady,
+		Status: cmmeta.ConditionTrue,
+	}) {
+		return nil
+	}
+
+	// Get all CertificateRequests that are owned by this Certificate
+	requests, err := certificates.ListCertificateRequestsMatchingPredicates(
+		c.certificateRequestLister.CertificateRequests(crt.Namespace), labels.Everything(), predicate.ResourceOwnedBy(crt))
+	if err != nil {
+		return err
+	}
+
+	// Prune and sort all CertificateRequests by their revision number.
+	revisions := pruneSortRequestsWithRevisions(log, requests)
+
+	// If the number of owned CertificateRequests with revisions is less than the
+	// revision limit, exit early.
+	if limit >= len(revisions) {
+		log.V(logf.DebugLevel).Info("request revisions within limit")
+		return nil
+	}
+
+	// Delete requests until we hit the revision limit, oldest first.
+	for i := 0; i < (len(revisions) - limit); i++ {
+		req := revisions[i].req
+		logf.WithRelatedResource(log, req).WithValues("revision", revisions[i].rev).Info("garbage collecting old certificate request revsion")
+
+		err = c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// pruneSortRequestsWithRevisions will prune the given CertificateRequests for
+// those that have a valid revision number set, and return a sorted slice by
+// oldest first.
+func pruneSortRequestsWithRevisions(log logr.Logger, reqs []*cmapi.CertificateRequest) []revision {
+	var revisions []revision
+
+	for _, req := range reqs {
+		log = logf.WithRelatedResource(log, req)
+
+		if req.Annotations == nil || req.Annotations[cmapi.CertificateRequestRevisionAnnotationKey] == "" {
+			log.V(logf.DebugLevel).Info("skipping processing request with missing revsion")
+			continue
+		}
+
+		rn, err := strconv.Atoi(req.Annotations[cmapi.CertificateRequestRevisionAnnotationKey])
+		if err != nil {
+			log.Error(err, "failed to parse request revsion")
+			continue
+		}
+
+		revisions = append(revisions, revision{rn, req})
+	}
+
+	sort.SliceStable(revisions, func(i, j int) bool {
+		return revisions[i].rev < revisions[j].rev
+	})
+
+	return revisions
+}
+
+// controllerWrapper wraps the `controller` structure to make it implement
+// the controllerpkg.queueingController interface
+type controllerWrapper struct {
+	*controller
+}
+
+func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.RateLimitingInterface, []cache.InformerSynced, error) {
+	// construct a new named logger to be reused throughout the controller
+	log := logf.FromContext(ctx.RootContext, ControllerName)
+
+	ctrl, queue, mustSync := NewController(log, ctx.CMClient, ctx.SharedInformerFactory)
+	c.controller = ctrl
+
+	return queue, mustSync, nil
+}
+
+func init() {
+	controllerpkg.Register(ControllerName, func(ctx *controllerpkg.Context) (controllerpkg.Interface, error) {
+		return controllerpkg.NewBuilder(ctx, ControllerName).
+			For(&controllerWrapper{}).
+			Complete()
+	})
+}

--- a/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
+++ b/pkg/controller/certificates/revisionmanager/revisionmanager_controller_test.go
@@ -1,0 +1,386 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package revisionmanager
+
+import (
+	"context"
+	"reflect"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	coretesting "k8s.io/client-go/testing"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
+	logtest "github.com/jetstack/cert-manager/pkg/logs/testing"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+func TestProcessItem(t *testing.T) {
+	baseCrt := gen.Certificate("test-cert",
+		gen.SetCertificateNamespace("testns"),
+		gen.SetCertificateUID("uid-1"),
+	)
+	baseCRNoOwner := gen.CertificateRequest("test-cr",
+		gen.SetCertificateRequestNamespace("testns"),
+	)
+	baseCR := gen.CertificateRequestFrom(baseCRNoOwner,
+		gen.AddCertificateRequestOwnerReferences(*metav1.NewControllerRef(
+			baseCrt, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+		),
+	)
+
+	tests := map[string]struct {
+		// key that should be passed to ProcessItem.
+		// if not set, the 'namespace/name' of the 'Certificate' field will be used.
+		// if neither is set, the key will be ""
+		key string
+
+		// Certificate to be synced for the test.
+		// if not set, the 'key' will be passed to ProcessItem instead.
+		certificate *cmapi.Certificate
+
+		// Request, if set, will exist in the apiserver before the test is run.
+		requests []runtime.Object
+
+		expectedActions []testpkg.Action
+
+		// err is the expected error text returned by the controller, if any.
+		err string
+	}{
+		"do nothing if an empty 'key' is used": {},
+		"do nothing if an invalid 'key' is used": {
+			key: "abc/def/ghi",
+		},
+		"do nothing if a key references a Certificate that does not exist": {
+			key: "namespace/name",
+		},
+		"do nothing if Certificate is not in a Ready=True state": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionIssuing, Status: cmmeta.ConditionFalse}),
+				gen.SetCertificateRevisionHistoryLimit(1),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("2"),
+				),
+			},
+		},
+		"do nothing if no requests exist": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(1),
+			),
+		},
+		"do nothing if requests don't have or bad revisions set": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(1),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("abc"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-2"),
+				),
+			},
+		},
+		"do nothing if requests aren't owned by this Certificate": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(1),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCRNoOwner,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+				gen.CertificateRequestFrom(baseCRNoOwner,
+					gen.SetCertificateRequestName("cr-2"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+			},
+		},
+		"do nothing if number of revisions matches that of the limit": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(2),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-2"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+			},
+		},
+		"do nothing if revision limit is not set": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-2"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+			},
+		},
+		"delete 1 request if limit is 1 and 2 requests exist": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(1),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-2"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "cr-1")),
+			},
+		},
+		"delete 3 requests if limit is 3 and 6 requests exist": {
+			certificate: gen.CertificateFrom(baseCrt,
+				gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady, Status: cmmeta.ConditionTrue}),
+				gen.SetCertificateRevisionHistoryLimit(3),
+			),
+			requests: []runtime.Object{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-2"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-3"),
+					gen.SetCertificateRequestRevision("3"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-1"),
+					gen.SetCertificateRequestRevision("1"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-4"),
+					gen.SetCertificateRequestRevision("11"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-5"),
+					gen.SetCertificateRequestRevision("11"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestName("cr-6"),
+					gen.SetCertificateRequestRevision("2"),
+				),
+			},
+			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "cr-1")),
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "cr-2")),
+				testpkg.NewAction(coretesting.NewDeleteAction(cmapi.SchemeGroupVersion.WithResource("certificaterequests"), "testns", "cr-6")),
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Create and initialise a new unit test builder
+			builder := &testpkg.Builder{
+				T:               t,
+				ExpectedEvents:  nil,
+				ExpectedActions: test.expectedActions,
+				StringGenerator: func(i int) string { return "notrandom" },
+			}
+			if test.certificate != nil {
+				builder.CertManagerObjects = append(builder.CertManagerObjects, test.certificate)
+			}
+			for _, req := range test.requests {
+				builder.CertManagerObjects = append(builder.CertManagerObjects, req)
+			}
+			builder.Init()
+
+			// Register informers used by the controller using the registration wrapper
+			w := &controllerWrapper{}
+			_, _, err := w.Register(builder.Context)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// Start the informers and begin processing updates
+			builder.Start()
+			defer builder.Stop()
+
+			key := test.key
+			if key == "" && test.certificate != nil {
+				key, err = controllerpkg.KeyFunc(test.certificate)
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Call ProcessItem
+			err = w.controller.ProcessItem(context.Background(), key)
+			switch {
+			case err != nil:
+				if test.err != err.Error() {
+					t.Errorf("error text did not match, got=%s, exp=%s", err.Error(), test.err)
+				}
+			default:
+				if test.err != "" {
+					t.Errorf("got no error but expected: %s", test.err)
+				}
+			}
+
+			if err := builder.AllEventsCalled(); err != nil {
+				builder.T.Error(err)
+			}
+			if err := builder.AllActionsExecuted(); err != nil {
+				builder.T.Error(err)
+			}
+			if err := builder.AllReactorsCalled(); err != nil {
+				builder.T.Error(err)
+			}
+		})
+	}
+}
+
+func TestPruneSortRequestsWithRevisions(t *testing.T) {
+	baseCR := gen.CertificateRequest("test")
+
+	tests := map[string]struct {
+		input []*cmapi.CertificateRequest
+		exp   []revision
+	}{
+		"an empty list of request should return empty": {
+			input: nil,
+			exp:   nil,
+		},
+		"a single request with no revision set should return empty": {
+			input: []*cmapi.CertificateRequest{
+				baseCR,
+			},
+			exp: nil,
+		},
+		"a single request with revision set should return single request": {
+			input: []*cmapi.CertificateRequest{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("123"),
+				),
+			},
+			exp: []revision{
+				{
+					rev: 123,
+					req: gen.CertificateRequestFrom(baseCR,
+						gen.SetCertificateRequestRevision("123"),
+					),
+				},
+			},
+		},
+		"two requests with one badly formed revision should return single request": {
+			input: []*cmapi.CertificateRequest{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("123"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("hello"),
+				),
+			},
+			exp: []revision{
+				{
+					rev: 123,
+					req: gen.CertificateRequestFrom(baseCR,
+						gen.SetCertificateRequestRevision("123"),
+					),
+				},
+			},
+		},
+		"multiple requests with some with good revsions should return list in order": {
+			input: []*cmapi.CertificateRequest{
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("123"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("hello"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("3"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("cert-manager"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("900"),
+				),
+				gen.CertificateRequestFrom(baseCR,
+					gen.SetCertificateRequestRevision("1"),
+				),
+			},
+			exp: []revision{
+				{
+					rev: 1,
+					req: gen.CertificateRequestFrom(baseCR,
+						gen.SetCertificateRequestRevision("1"),
+					),
+				},
+				{
+					rev: 3,
+					req: gen.CertificateRequestFrom(baseCR,
+						gen.SetCertificateRequestRevision("3"),
+					),
+				},
+				{
+					rev: 123,
+					req: gen.CertificateRequestFrom(baseCR,
+						gen.SetCertificateRequestRevision("123"),
+					),
+				},
+				{
+					rev: 900,
+					req: gen.CertificateRequestFrom(baseCR,
+						gen.SetCertificateRequestRevision("900"),
+					),
+				},
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			log := logtest.TestLogger{T: t}
+			output := pruneSortRequestsWithRevisions(log, test.input)
+			if !reflect.DeepEqual(test.exp, output) {
+				t.Errorf("unexpected prune sort response, exp=%v got=%v",
+					test.exp, output)
+			}
+		})
+	}
+}

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -146,6 +146,15 @@ type CertificateSpec struct {
 	// EncodeUsagesInRequest controls whether key usages should be present
 	// in the CertificateRequest
 	EncodeUsagesInRequest *bool
+
+	// revisionHistoryLimit is the maximum number of CertificateRequest revisions
+	// that are maintained in the Certificate's history. Each revision represents
+	// a single `CertificateRequest` created by this Certificate, either when it
+	// was created, renewed, or Spec was changed. Revisions will be removed by
+	// oldest first if the number of revisions exceeds this number. If set,
+	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
+	// revisions will not be garbage collected. Default value is `nil`.
+	RevisionHistoryLimit *int32
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -709,6 +709,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *v1.Certif
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 
@@ -731,6 +732,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
 	out.Usages = *(*[]v1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*v1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -731,6 +731,7 @@ func autoConvert_v1alpha2_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 		out.PrivateKey = nil
 	}
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 
@@ -769,6 +770,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha2_CertificateSpec(in *cer
 		out.PrivateKey = nil
 	}
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -730,6 +730,7 @@ func autoConvert_v1alpha3_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 		out.PrivateKey = nil
 	}
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 
@@ -768,6 +769,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha3_CertificateSpec(in *cer
 		out.PrivateKey = nil
 	}
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -689,6 +689,7 @@ func autoConvert_v1beta1_CertificateSpec_To_certmanager_CertificateSpec(in *v1be
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 
@@ -716,6 +717,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1beta1_CertificateSpec(in *cert
 	out.Usages = *(*[]v1beta1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*v1beta1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
+	out.RevisionHistoryLimit = (*int32)(unsafe.Pointer(in.RevisionHistoryLimit))
 	return nil
 }
 

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -80,10 +80,6 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 		el = append(el, validateUsages(crt, fldPath)...)
 	}
 
-	if crt.RevisionHistoryLimit != nil && *crt.RevisionHistoryLimit < 1 {
-		el = append(el, field.Invalid(fldPath.Child("revisionHistoryLimit"), *crt.RevisionHistoryLimit, "must be a value of 1 or greater"))
-	}
-
 	return el
 }
 

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -79,6 +79,11 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	if len(crt.Usages) > 0 {
 		el = append(el, validateUsages(crt, fldPath)...)
 	}
+
+	if crt.RevisionHistoryLimit != nil && *crt.RevisionHistoryLimit < 1 {
+		el = append(el, field.Invalid(fldPath.Child("revisionHistoryLimit"), *crt.RevisionHistoryLimit, "must be a value of 1 or greater"))
+	}
+
 	return el
 }
 

--- a/pkg/internal/apis/certmanager/validation/certificate_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_test.go
@@ -488,28 +488,6 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("emailAddresses").Index(0), "mailto:alice@example.com", "invalid email address: mail: expected comma"),
 			},
 		},
-		"valid certificate with revisionHistoryLimit less than 1 should error": {
-			cfg: &internalcmapi.Certificate{
-				Spec: internalcmapi.CertificateSpec{
-					EmailSANs:            []string{"alice@example.com"},
-					SecretName:           "abc",
-					IssuerRef:            validIssuerRef,
-					RevisionHistoryLimit: int32Ptr(-2),
-				},
-			},
-			errs: []*field.Error{field.Invalid(fldPath.Child("revisionHistoryLimit"), int32(-2), "must be a value of 1 or greater")},
-		},
-		"valid certificate with revisionHistoryLimit of 1 shouldn't error": {
-			cfg: &internalcmapi.Certificate{
-				Spec: internalcmapi.CertificateSpec{
-					EmailSANs:            []string{"alice@example.com"},
-					SecretName:           "abc",
-					IssuerRef:            validIssuerRef,
-					RevisionHistoryLimit: int32Ptr(1),
-				},
-			},
-			errs: []*field.Error{},
-		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {

--- a/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -405,6 +405,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.RevisionHistoryLimit != nil {
+		in, out := &in.RevisionHistoryLimit, &out.RevisionHistoryLimit
+		*out = new(int32)
+		**out = **in
+	}
 	return
 }
 

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -5,6 +5,7 @@ go_test(
     srcs = [
         "issuing_controller_test.go",
         "metrics_controller_test.go",
+        "revisionmanager_controller_test.go",
         "trigger_controller_test.go",
     ],
     deps = [
@@ -15,6 +16,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/controller/certificates/issuing:go_default_library",
         "//pkg/controller/certificates/metrics:go_default_library",
+        "//pkg/controller/certificates/revisionmanager:go_default_library",
         "//pkg/controller/certificates/trigger:go_default_library",
         "//pkg/controller/certificates/trigger/policies:go_default_library",
         "//pkg/logs:go_default_library",

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -53,7 +53,7 @@ func TestRevisionManagerController(t *testing.T) {
 
 	c := controllerpkg.NewController(
 		context.Background(),
-		"issuing_test",
+		"revisionmanager_controller_test",
 		metrics.New(logf.Log),
 		ctrl.ProcessItem,
 		mustSync,

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificates
+
+import (
+	"context"
+	"encoding/pem"
+	"strconv"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/controller/certificates/revisionmanager"
+	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"github.com/jetstack/cert-manager/pkg/metrics"
+	utilpki "github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/integration/framework"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+// TestRevisionManagerController will ensure that the revision manager
+// controller will delete old CertificateRequests occording to the
+// spec.revisionHistoryLimit value
+func TestRevisionManagerController(t *testing.T) {
+	config, stopFn := framework.RunControlPlane(t)
+	defer stopFn()
+
+	// Build, instantiate and run the revision manager controller.
+	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
+
+	ctrl, queue, mustSync := revisionmanager.NewController(logf.Log, cmCl, cmFactory)
+
+	c := controllerpkg.NewController(
+		context.Background(),
+		"issuing_test",
+		metrics.New(logf.Log),
+		ctrl.ProcessItem,
+		mustSync,
+		nil,
+		queue,
+	)
+	stopController := framework.StartInformersAndController(t, factory, cmFactory, c)
+	defer stopController()
+
+	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+	defer cancel()
+
+	var (
+		crtName    = "testcrt"
+		namespace  = "testns"
+		secretName = "test-crt-tls"
+	)
+
+	// Create Namespace
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
+	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create Certificate
+	crt := gen.Certificate(crtName,
+		gen.SetCertificateNamespace(namespace),
+		gen.SetCertificateCommonName("my-common-name"),
+		gen.SetCertificateSecretName(secretName),
+		gen.SetCertificateRevisionHistoryLimit(3),
+		gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: "testissuer", Group: "foo.io", Kind: "Issuer"}),
+	)
+
+	crt, err = cmCl.CertmanagerV1().Certificates(namespace).Create(ctx, crt, metav1.CreateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Set Certificate to Ready
+	apiutil.SetCertificateCondition(crt, crt.Generation,
+		cmapi.CertificateConditionReady, cmmeta.ConditionTrue, "Issued", "integration test")
+	crt, err = cmCl.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a new private key
+	sk, err := utilpki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csr, err := utilpki.GenerateCSR(crt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Encode CSR
+	csrDER, err := utilpki.EncodeCSR(csr, sk)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	csrPEM := pem.EncodeToMemory(&pem.Block{
+		Type: "CERTIFICATE REQUEST", Bytes: csrDER,
+	})
+
+	// Create 6 CertificateRequests which are owned by this Certificate
+	for i := 0; i < 6; i++ {
+		_, err = cmCl.CertmanagerV1().CertificateRequests(namespace).Create(ctx, &cmapi.CertificateRequest{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: crtName + "-",
+				Namespace:    namespace,
+				Annotations: map[string]string{
+					cmapi.CertificateRequestRevisionAnnotationKey: strconv.Itoa(i),
+				},
+				OwnerReferences: []metav1.OwnerReference{
+					*metav1.NewControllerRef(crt, cmapi.SchemeGroupVersion.WithKind("Certificate")),
+				},
+			},
+			Spec: cmapi.CertificateRequestSpec{
+				Request:   csrPEM,
+				IssuerRef: cmmeta.ObjectReference{Name: "testissuer", Group: "foo.io", Kind: "Issuer"},
+			},
+		}, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var crs []cmapi.CertificateRequest
+
+	// Wait for 3 CertificateRequests to be deleted, and that they have the correct revisions
+	err = wait.Poll(time.Millisecond*100, time.Second*5, func() (done bool, err error) {
+		requests, err := cmCl.CertmanagerV1().CertificateRequests(namespace).List(context.TODO(), metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
+
+		if len(requests.Items) != 3 {
+			t.Logf("waiting for 3 requests to be deleted, got=%d", len(requests.Items))
+			return false, nil
+		}
+
+		crs = requests.Items
+
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Expect that the remaining requests have the largest revisions (3, 4, 5)
+	for _, revision := range []string{"3", "4", "5"} {
+		var found bool
+		for _, cr := range crs {
+			if cr.Annotations[cmapi.CertificateRequestRevisionAnnotationKey] == revision {
+				found = true
+				break
+			}
+		}
+
+		if !found {
+			t.Errorf("failed to find a CertificateRequest with a revision=%s", revision)
+		}
+	}
+}

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -237,3 +237,9 @@ func CertificateRef(certName, ownedUID string) metav1.OwnerReference {
 		v1.SchemeGroupVersion.WithKind("Certificate"),
 	)
 }
+
+func SetCertificateRevisionHistoryLimit(limit int32) CertificateModifier {
+	return func(crt *v1.Certificate) {
+		crt.Spec.RevisionHistoryLimit = &limit
+	}
+}

--- a/test/unit/gen/certificaterequest.go
+++ b/test/unit/gen/certificaterequest.go
@@ -177,3 +177,13 @@ func SetCertificateRequestGroups(groups []string) CertificateRequestModifier {
 		cr.Spec.Groups = groups
 	}
 }
+
+func SetCertificateRequestRevision(rev string) CertificateRequestModifier {
+	return func(cr *v1.CertificateRequest) {
+		if cr.Annotations == nil {
+			cr.Annotations = make(map[string]string)
+		}
+
+		cr.Annotations[v1.CertificateRequestRevisionAnnotationKey] = rev
+	}
+}


### PR DESCRIPTION
fixes  #3458
/assign @jakexks 
/kind feature

This PR adds a new Certificate controller that is responsible for cleaning up old CertificateRequests using a new `RevisionHistoryLimit` field.

This optional field will ensure that only x number of old request revisions for a Certificate exist. The field is set to `nil` by default, which won't clean up any CRs. The controller will delete CRs from oldest first, and will ignore CRs if they don't have the annotation or have an invalid value (which shouldn't normally happen). The controller won't trigger if the Certificate isn't in a Ready state so as to not conflict with other processing. The value must be set to 1 or greater- this is to ensure we keep _some_ kind of visibility and doesn't cause potential issues for other controllers.

I'm not 100% about the "revisionmanager' name, so keen to hear suggestions :smile: 


```release-note
Adds RevisionHistoryLimit field to Certificates to optionally garbage collect old CertificateRequests
```
