### PR TITLE
test/e2e/suite/conformance/certificates: fix dropped error

### DIFF
--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -566,6 +566,7 @@ func (s *Suite) Define() {
 					return nil
 				},
 			)
+			Expect(err).NotTo(HaveOccurred())
 
 			// Verify that the issuer has preserved all the Certificate values
 			// in the signed certificate


### PR DESCRIPTION
Signed-off-by: Lars Lehtonen <lars.lehtonen@gmail.com>

This fixes a dropped error in `test/e2e/suite/conformance/certificates`.

```release-note
NONE
```
