### PR TITLE
Certificate Readiness controller only updates certificate's status if there is a change

### DIFF
--- a/pkg/controller/certificates/readiness/BUILD.bazel
+++ b/pkg/controller/certificates/readiness/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/predicate:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/equality:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/labels:go_default_library",

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -216,7 +216,6 @@ func TestProcessItem(t *testing.T) {
 					Message: "ready message",
 				})),
 		},
-		// TODO: this is the current behaviour, but we might want to actually not do unnecessary updates https://github.com/jetstack/cert-manager/issues/3663
 		"update status for a Certificate that has a Ready conditon and the policy evaluates to True- should remain True": {
 			condition: cmapi.CertificateCondition{
 				Type:               cmapi.CertificateConditionReady,
@@ -234,7 +233,7 @@ func TestProcessItem(t *testing.T) {
 					LastTransitionTime: &metaNow,
 				})),
 			secretShouldExist: true,
-			certShouldUpdate:  true,
+			certShouldUpdate:  false,
 		},
 	}
 	for name, test := range tests {


### PR DESCRIPTION
Signed-off-by: OmairK <omairkhan064@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Certificate readiness controller was updating the the status of the certificate even if there was no change. This PR will reduce the unnecessary Certificate updates.

**Which issue this PR fixes**
Fixes #3663

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```
None
```
