### PR TITLE
Standardise the name of controllers so there is consistency across the project

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -51,7 +51,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateIssuing"
+	ControllerName = "certificates-issuing"
 )
 
 type localTemporarySignerFn func(crt *cmapi.Certificate, pk []byte) ([]byte, error)

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -49,7 +49,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateKeyManager"
+	ControllerName = "certificates-key-manager"
 )
 
 var (

--- a/pkg/controller/certificates/metrics/controller.go
+++ b/pkg/controller/certificates/metrics/controller.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateMetrics"
+	ControllerName = "certificates-metrics"
 )
 
 // controllerWrapper wraps the `controller` structure to make it implement

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -46,7 +46,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateReadiness"
+	ControllerName = "certificates-readiness"
 	ReadyReason    = "Ready"
 )
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -51,7 +51,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateRequestManager"
+	ControllerName = "certificates-request-manager"
 )
 
 var (

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -47,7 +47,7 @@ import (
 )
 
 const (
-	ControllerName = "CertificateTrigger"
+	ControllerName = "certificates-trigger"
 
 	// the amount of time after the LastFailureTime of a Certificate
 	// before the request should be retried.


### PR DESCRIPTION
/kind cleanup

/assign @irbekrm @jakexks 

This is a small PR to change the names of the Certificate controllers so that they are consistent with the naming elsewhere in the project.

```release-note
Standardise controller names across the project
```
