### PR TITLE
Adds kubectl cert-manager [approve|deny] CLI commands

### DIFF
--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -33,8 +33,10 @@ filegroup(
     srcs = [
         ":package-srcs",
         "//cmd/ctl/cmd:all-srcs",
+        "//cmd/ctl/pkg/approve:all-srcs",
         "//cmd/ctl/pkg/convert:all-srcs",
         "//cmd/ctl/pkg/create:all-srcs",
+        "//cmd/ctl/pkg/deny:all-srcs",
         "//cmd/ctl/pkg/inspect:all-srcs",
         "//cmd/ctl/pkg/renew:all-srcs",
         "//cmd/ctl/pkg/status:all-srcs",

--- a/cmd/ctl/cmd/BUILD.bazel
+++ b/cmd/ctl/cmd/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/ctl/cmd",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/ctl/pkg/approve:go_default_library",
         "//cmd/ctl/pkg/convert:go_default_library",
         "//cmd/ctl/pkg/create:go_default_library",
+        "//cmd/ctl/pkg/deny:go_default_library",
         "//cmd/ctl/pkg/inspect:go_default_library",
         "//cmd/ctl/pkg/renew:go_default_library",
         "//cmd/ctl/pkg/status:go_default_library",

--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -25,14 +25,15 @@ import (
 
 	"github.com/spf13/cobra"
 	"k8s.io/cli-runtime/pkg/genericclioptions"
-
 	// Load all auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	"k8s.io/klog/v2"
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/approve"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/convert"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/create"
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/deny"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/inspect"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/renew"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/status"
@@ -70,6 +71,8 @@ kubectl cert-manager is a CLI tool manage and configure cert-manager resources f
 	cmds.AddCommand(renew.NewCmdRenew(ctx, ioStreams, factory))
 	cmds.AddCommand(status.NewCmdStatus(ctx, ioStreams, factory))
 	cmds.AddCommand(inspect.NewCmdInspect(ctx, ioStreams, factory))
+	cmds.AddCommand(approve.NewCmdApprove(ctx, ioStreams, factory))
+	cmds.AddCommand(deny.NewCmdDeny(ctx, ioStreams, factory))
 
 	return cmds
 }

--- a/cmd/ctl/pkg/approve/BUILD.bazel
+++ b/cmd/ctl/pkg/approve/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["approve.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/approve",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+        "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
+        "@io_k8s_kubectl//pkg/util/templates:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["approve_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ctl/pkg/approve/approve.go
+++ b/cmd/ctl/pkg/approve/approve.go
@@ -58,9 +58,11 @@ type Options struct {
 	// boolean indicating if there was an Override in determining CmdNamespace
 	EnforceNamespace bool
 
-	// TODO:
+	// Reason is the string that will be set on the Reason field of the Approved
+	// condition.
 	Reason string
-	// TODO:
+	// Message is the string that will be set on the Message field of the
+	// Approved condition.
 	Message string
 
 	genericclioptions.IOStreams

--- a/cmd/ctl/pkg/approve/approve.go
+++ b/cmd/ctl/pkg/approve/approve.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package approve
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	restclient "k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+)
+
+var (
+	example = templates.Examples(i18n.T(`
+# Approve a CertificateRequest with the name 'my-cr'
+kubectl cert-manager approve my-cr
+
+# Approve a CertificateRequest in namespace default
+kubectl cert-manager approve my-cr --namespace default
+
+# Approve a CertificateRequest giving a custom reason and message
+kubectl cert-manager approve my-cr --reason "ManualApproval" --reason "Approved by PKI department"
+`))
+)
+
+// Options is a struct to support create certificaterequest command
+type Options struct {
+	CMClient   cmclient.Interface
+	RESTConfig *restclient.Config
+	// Namespace resulting from the merged result of all overrides
+	// since namespace can be specified in file, as flag and in kube config
+	CmdNamespace string
+	// boolean indicating if there was an Override in determining CmdNamespace
+	EnforceNamespace bool
+
+	// TODO:
+	Reason string
+	// TODO:
+	Message string
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns initialized Options
+func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: ioStreams,
+	}
+}
+
+func NewCmdApprove(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+	o := NewOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:     "approve",
+		Short:   "Approve a CertificateRequest",
+		Long:    `Mark a CertificateRequest as Approved, so it may be signed by a configured Issuer.`,
+		Example: example,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Validate(args))
+			cmdutil.CheckErr(o.Complete(factory))
+			cmdutil.CheckErr(o.Run(ctx, args))
+		},
+	}
+
+	cmd.Flags().StringVar(&o.Reason, "reason", "KubectlCertManager",
+		"The reason to give as to what approved this CertificateRequest.")
+	cmd.Flags().StringVar(&o.Message, "message", `manually approved by "kubectl cert-manager"`,
+		"The message to give as to why this CertificateRequest was approved.")
+
+	return cmd
+}
+
+// Validate validates the provided options
+func (o *Options) Validate(args []string) error {
+	if len(args) < 1 {
+		return errors.New("the name of the CertificateRequest to approve has to be provided as an argument")
+	}
+	if len(args) > 1 {
+		return errors.New("only one argument can be passed: the name of the CertificateRequest")
+	}
+
+	if len(o.Reason) == 0 {
+		return errors.New("a reason must be given as to who approved this CertificateRequest")
+	}
+
+	if len(o.Message) == 0 {
+		return errors.New("a message must be given as to why this CertificateRequest is approved")
+	}
+
+	return nil
+}
+
+// Complete takes the command arguments and factory and infers any remaining options.
+func (o *Options) Complete(f cmdutil.Factory) error {
+	var err error
+
+	o.CmdNamespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.RESTConfig, err = f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	o.CMClient, err = cmclient.NewForConfig(o.RESTConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run executes create certificaterequest command
+func (o *Options) Run(ctx context.Context, args []string) error {
+	cr, err := o.CMClient.CertmanagerV1().CertificateRequests(o.CmdNamespace).Get(ctx, args[0], metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if apiutil.CertificateRequestIsApproved(cr) {
+		return errors.New("CertificateRequest is already approved")
+	}
+
+	if apiutil.CertificateRequestIsDenied(cr) {
+		return errors.New("CertificateRequest is already denied")
+	}
+
+	apiutil.SetCertificateRequestCondition(cr, cmapi.CertificateRequestConditionApproved,
+		cmmeta.ConditionTrue, o.Reason, o.Message)
+
+	_, err = o.CMClient.CertmanagerV1().CertificateRequests(o.CmdNamespace).UpdateStatus(ctx, cr, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "Approved CertificateRequest '%s/%s'\n", cr.Namespace, cr.Name)
+
+	return nil
+}

--- a/cmd/ctl/pkg/approve/approve.go
+++ b/cmd/ctl/pkg/approve/approve.go
@@ -139,7 +139,7 @@ func (o *Options) Complete(f cmdutil.Factory) error {
 	return nil
 }
 
-// Run executes create certificaterequest command
+// Run executes approve command
 func (o *Options) Run(ctx context.Context, args []string) error {
 	cr, err := o.CMClient.CertmanagerV1().CertificateRequests(o.CmdNamespace).Get(ctx, args[0], metav1.GetOptions{})
 	if err != nil {

--- a/cmd/ctl/pkg/approve/approve_test.go
+++ b/cmd/ctl/pkg/approve/approve_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package approve
+
+import (
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		args            []string
+		reason, message string
+		expErr          bool
+		expErrMsg       string
+	}{
+		"CR name not passed as arg throws error": {
+			args:      []string{},
+			reason:    "",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "the name of the CertificateRequest to approve has to be provided as an argument",
+		},
+		"multiple CR names passed as arg throws error": {
+			args:      []string{"cr-1", "cr-1"},
+			reason:    "",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "only one argument can be passed: the name of the CertificateRequest",
+		},
+		"empty reason given should throw error": {
+			args:      []string{"cr-1"},
+			reason:    "",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "a reason must be given as to who approved this CertificateRequest",
+		},
+		"empty message given should throw error": {
+			args:      []string{"cr-1"},
+			reason:    "foo",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "a message must be given as to why this CertificateRequest is approved",
+		},
+		"all fields populated should not error": {
+			args:    []string{"cr-1"},
+			reason:  "foo",
+			message: "bar",
+			expErr:  false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := &Options{
+				Reason:  test.reason,
+				Message: test.message,
+			}
+
+			// Validating args and flags
+			err := opts.Validate(test.args)
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v",
+					test.expErr, err)
+			}
+			if err != nil && err.Error() != test.expErrMsg {
+				t.Errorf("got unexpected error when validating args and flags, expected: %v; actual: %v", test.expErrMsg, err)
+			}
+		})
+	}
+}

--- a/cmd/ctl/pkg/deny/BUILD.bazel
+++ b/cmd/ctl/pkg/deny/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["deny.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/deny",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/client/clientset/versioned:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+        "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
+        "@io_k8s_kubectl//pkg/util/templates:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["deny_test.go"],
+    embed = [":go_default_library"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ctl/pkg/deny/deny.go
+++ b/cmd/ctl/pkg/deny/deny.go
@@ -139,7 +139,7 @@ func (o *Options) Complete(f cmdutil.Factory) error {
 	return nil
 }
 
-// Run executes create certificaterequest command
+// Run executes deny command
 func (o *Options) Run(ctx context.Context, args []string) error {
 	cr, err := o.CMClient.CertmanagerV1().CertificateRequests(o.CmdNamespace).Get(ctx, args[0], metav1.GetOptions{})
 	if err != nil {

--- a/cmd/ctl/pkg/deny/deny.go
+++ b/cmd/ctl/pkg/deny/deny.go
@@ -1,0 +1,166 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deny
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	restclient "k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+	"k8s.io/kubectl/pkg/util/i18n"
+	"k8s.io/kubectl/pkg/util/templates"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+)
+
+var (
+	example = templates.Examples(i18n.T(`
+# Deny a CertificateRequest with the name 'my-cr'
+kubectl cert-manager deny my-cr
+
+# Deny a CertificateRequest in namespace default
+kubectl cert-manager deny my-cr --namespace default
+
+# Deny a CertificateRequest giving a custom reason and message
+kubectl cert-manager deny my-cr --reason "ManualDenial" --reason "Denied by PKI department"
+`))
+)
+
+// Options is a struct to support create certificaterequest command
+type Options struct {
+	CMClient   cmclient.Interface
+	RESTConfig *restclient.Config
+	// Namespace resulting from the merged result of all overrides
+	// since namespace can be specified in file, as flag and in kube config
+	CmdNamespace string
+	// boolean indicating if there was an Override in determining CmdNamespace
+	EnforceNamespace bool
+
+	// TODO:
+	Reason string
+	// TODO:
+	Message string
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns initialized Options
+func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: ioStreams,
+	}
+}
+
+func NewCmdDeny(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+	o := NewOptions(ioStreams)
+	cmd := &cobra.Command{
+		Use:     "deny",
+		Short:   "Deny a CertificateRequest",
+		Long:    `Mark a CertificateRequest as Denied, so it may never be signed by a configured Issuer.`,
+		Example: example,
+		Run: func(cmd *cobra.Command, args []string) {
+			cmdutil.CheckErr(o.Validate(args))
+			cmdutil.CheckErr(o.Complete(factory))
+			cmdutil.CheckErr(o.Run(ctx, args))
+		},
+	}
+
+	cmd.Flags().StringVar(&o.Reason, "reason", "KubectlCertManager",
+		"The reason to give as to what denied this CertificateRequest.")
+	cmd.Flags().StringVar(&o.Message, "message", `manually denied by "kubectl cert-manager"`,
+		"The message to give as to why this CertificateRequest was denied.")
+
+	return cmd
+}
+
+// Validate validates the provided options
+func (o *Options) Validate(args []string) error {
+	if len(args) < 1 {
+		return errors.New("the name of the CertificateRequest to deny has to be provided as an argument")
+	}
+	if len(args) > 1 {
+		return errors.New("only one argument can be passed: the name of the CertificateRequest")
+	}
+
+	if len(o.Reason) == 0 {
+		return errors.New("a reason must be given as to who denied this CertificateRequest")
+	}
+
+	if len(o.Message) == 0 {
+		return errors.New("a message must be given as to why this CertificateRequest is denied")
+	}
+
+	return nil
+}
+
+// Complete takes the command arguments and factory and infers any remaining options.
+func (o *Options) Complete(f cmdutil.Factory) error {
+	var err error
+
+	o.CmdNamespace, o.EnforceNamespace, err = f.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.RESTConfig, err = f.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	o.CMClient, err = cmclient.NewForConfig(o.RESTConfig)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Run executes create certificaterequest command
+func (o *Options) Run(ctx context.Context, args []string) error {
+	cr, err := o.CMClient.CertmanagerV1().CertificateRequests(o.CmdNamespace).Get(ctx, args[0], metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	if apiutil.CertificateRequestIsApproved(cr) {
+		return errors.New("CertificateRequest is already approved")
+	}
+
+	if apiutil.CertificateRequestIsDenied(cr) {
+		return errors.New("CertificateRequest is already denied")
+	}
+
+	apiutil.SetCertificateRequestCondition(cr, cmapi.CertificateRequestConditionDenied,
+		cmmeta.ConditionTrue, o.Reason, o.Message)
+
+	_, err = o.CMClient.CertmanagerV1().CertificateRequests(o.CmdNamespace).UpdateStatus(ctx, cr, metav1.UpdateOptions{})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintf(o.Out, "Denied CertificateRequest '%s/%s'\n", cr.Namespace, cr.Name)
+
+	return nil
+}

--- a/cmd/ctl/pkg/deny/deny.go
+++ b/cmd/ctl/pkg/deny/deny.go
@@ -58,9 +58,11 @@ type Options struct {
 	// boolean indicating if there was an Override in determining CmdNamespace
 	EnforceNamespace bool
 
-	// TODO:
+	// Reason is the string that will be set on the Reason field of the Denied
+	// condition.
 	Reason string
-	// TODO:
+	// Message is the string that will be set on the Message field of the
+	// Denied condition.
 	Message string
 
 	genericclioptions.IOStreams

--- a/cmd/ctl/pkg/deny/deny_test.go
+++ b/cmd/ctl/pkg/deny/deny_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deny
+
+import (
+	"testing"
+)
+
+func TestValidate(t *testing.T) {
+	tests := map[string]struct {
+		args            []string
+		reason, message string
+		expErr          bool
+		expErrMsg       string
+	}{
+		"CR name not passed as arg throws error": {
+			args:      []string{},
+			reason:    "",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "the name of the CertificateRequest to deny has to be provided as an argument",
+		},
+		"multiple CR names passed as arg throws error": {
+			args:      []string{"cr-1", "cr-1"},
+			reason:    "",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "only one argument can be passed: the name of the CertificateRequest",
+		},
+		"empty reason given should throw error": {
+			args:      []string{"cr-1"},
+			reason:    "",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "a reason must be given as to who denied this CertificateRequest",
+		},
+		"empty message given should throw error": {
+			args:      []string{"cr-1"},
+			reason:    "foo",
+			message:   "",
+			expErr:    true,
+			expErrMsg: "a message must be given as to why this CertificateRequest is denied",
+		},
+		"all fields populated should not error": {
+			args:    []string{"cr-1"},
+			reason:  "foo",
+			message: "bar",
+			expErr:  false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts := &Options{
+				Reason:  test.reason,
+				Message: test.message,
+			}
+
+			// Validating args and flags
+			err := opts.Validate(test.args)
+			if (err != nil) != test.expErr {
+				t.Errorf("unexpected error, exp=%t got=%v",
+					test.expErr, err)
+			}
+			if err != nil && err.Error() != test.expErrMsg {
+				t.Errorf("got unexpected error when validating args and flags, expected: %v; actual: %v", test.expErrMsg, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
/kind feature

/assign @jakexks @irbekrm @maelvls 

```release-note
Adds `kubectl cert-manager [approve|deny] CLI commands to manually approve or deny CertificateRequests
```
