### PR TITLE
Log Info when a re-queue happens due to optimistic locking

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_apimachinery//pkg/util/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_apiserver//pkg/registry/generic/registry:go_default_library",
         "@io_k8s_client_go//dynamic:go_default_library",
         "@io_k8s_client_go//dynamic/dynamicinformer:go_default_library",
         "@io_k8s_client_go//informers:go_default_library",

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -19,10 +19,12 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/util/wait"
+	genericregistry "k8s.io/apiserver/pkg/registry/generic/registry"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/util/workqueue"
 
@@ -154,8 +156,14 @@ func (b *controller) worker(ctx context.Context) {
 			// Increase sync count for this controller
 			b.metrics.IncrementSyncCallCount(b.name)
 
-			if err := b.syncHandler(ctx, key); err != nil {
-				log.Error(err, "re-queuing item due to error processing")
+			err := b.syncHandler(ctx, key)
+			if err != nil {
+				if strings.Contains(err.Error(), genericregistry.OptimisticLockErrorMsg) {
+					log.V(logf.DebugLevel).Error(err, "re-queuing item due to optimistic locking")
+				} else {
+					log.Error(err, "re-queuing item due to error processing")
+				}
+
 				b.queue.AddRateLimited(obj)
 				return
 			}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -159,7 +159,7 @@ func (b *controller) worker(ctx context.Context) {
 			err := b.syncHandler(ctx, key)
 			if err != nil {
 				if strings.Contains(err.Error(), genericregistry.OptimisticLockErrorMsg) {
-					log.V(logf.DebugLevel).Error(err, "re-queuing item due to optimistic locking")
+					log.Info("re-queuing item due to optimistic locking on resource", "error", err.Error())
 				} else {
 					log.Error(err, "re-queuing item due to error processing")
 				}


### PR DESCRIPTION
This PR stops the pollution of cert-manager-controller logs with errors from multiple controllers attempting to update the same object version. Instead, we log to info, however we _still_ re-queue the object so has not functional change to any controller.

```
E0323 18:09:56.487221       1 controller.go:158] cert-manager/controller/CertificateReadiness "msg"="re-queuing item due to error processing" "error"="Operation cannot be fulfilled on certificates.cert-manager.io \"osm-ca\": the object has been modified; please apply your changes to the latest version and try again" "key"="default/osm-ca" 
```

/assign @irbekrm @jakexks @maelvls @wallrj 
/milestone v1.3
/cleanup
fixes #3667

```release-note
Optimistic locking messages (the object has been modified) are now logged at the Info level instead of the Error level, as cert-manager controllers will automatically retry until successful.
```
