### PR TITLE
Adds Denied check to CertificateRequests in issuing controller to retry denied requests

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -238,6 +238,16 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 	cond := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
 	if cond == nil {
+		// If the certificate request has been denied, set the last failure time to
+		// now, and set the Issuing status condition to False with reason. We only
+		// perform this check if the request also doesn't have a Ready condition,
+		// since some issuers may not honor a Denied condition, and will sign and
+		// set the Ready condition to True anyway. We would still want to complete
+		// issuance for requests where the issuer doesn't respect approval.
+		if apiutil.CertificateRequestIsDenied(req) {
+			return c.failIssueCertificate(ctx, log, crt, req, cmapi.CertificateRequestConditionDenied)
+		}
+
 		log.V(logf.DebugLevel).Info("CertificateRequest does not have Ready condition, waiting...")
 		return nil
 	}
@@ -245,7 +255,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	// If the certificate request has failed, set the last failure time to now,
 	// and set the Issuing status condition to False with reason.
 	if cond.Reason == cmapi.CertificateRequestReasonFailed {
-		return c.failIssueCertificate(ctx, log, crt, req)
+		return c.failIssueCertificate(ctx, log, crt, req, cmapi.CertificateRequestConditionReady)
 	}
 
 	// If public key does not match, do nothing (requestmanager will handle this).
@@ -281,14 +291,15 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 }
 
 // failIssueCertificate will mark the condition Issuing of this Certificate as failed, and log an appropriate event
-func (c *controller) failIssueCertificate(ctx context.Context, log logr.Logger, crt *cmapi.Certificate, req *cmapi.CertificateRequest) error {
+func (c *controller) failIssueCertificate(ctx context.Context, log logr.Logger, crt *cmapi.Certificate, req *cmapi.CertificateRequest,
+	conType cmapi.CertificateRequestConditionType) error {
 	nowTime := metav1.NewTime(c.clock.Now())
 	crt.Status.LastFailureTime = &nowTime
 
 	log.V(logf.DebugLevel).Info("CertificateRequest in failed state so retrying issuance later")
 
 	var reason, message string
-	condition := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
+	condition := apiutil.GetCertificateRequestCondition(req, conType)
 
 	reason = condition.Reason
 	message = fmt.Sprintf("The certificate request has failed to complete and will be retried: %s",


### PR DESCRIPTION
This PR will mark the issuance of a certificate as failed if the CertificateRequest was denied. This means that denied requests will be retried after a period of time (1 hour), as if it had failed. We only check for the denied condition, if the Ready condition is also not present. This is because some issuers will ignore the Denied condition, and so we should still complete issuance for these issuers.

/kind feature
/assign @munnerz @jakexks @irbekrm @maelvls @wallrj 
/milestone v1.3

```release-note
Retry issuance of Denied CertificateRequests after 1 hour.
```
