### PR TITLE
helm chart cert-manager-issuer

### DIFF
--- a/deploy/charts/cert-manager-issuer/Chart.yaml
+++ b/deploy/charts/cert-manager-issuer/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+appVersion: "v1.2.0"
+description: cert manager issuer
+home: https://github.com/jetstack/cert-manager
+icon: https://raw.githubusercontent.com/jetstack/cert-manager/master/logo/logo.png
+keywords:
+  - cert-manager
+  - kube-lego
+  - letsencrypt
+  - tls
+name: cert-manager-issuer
+sources:
+  - https://github.com/jetstack/cert-manager
+version: v1.2.0

--- a/deploy/charts/cert-manager-issuer/Chart.yaml
+++ b/deploy/charts/cert-manager-issuer/Chart.yaml
@@ -8,6 +8,10 @@ keywords:
   - kube-lego
   - letsencrypt
   - tls
+maintainers:
+  - name: eumel8 # Frank Kloeker
+    email: f.kloeker@telekom.de
+    url: https://www.telekom.com
 name: cert-manager-issuer
 sources:
   - https://github.com/jetstack/cert-manager

--- a/deploy/charts/cert-manager-issuer/README.md
+++ b/deploy/charts/cert-manager-issuer/README.md
@@ -1,0 +1,6 @@
+# cert-manager-issuer
+
+This helm chart contains the following cert-manager cluster issuers:
+
+ - letsencrypt-staging
+ - letsencrypt-prod

--- a/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-prod.yaml
+++ b/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-prod.yaml
@@ -1,0 +1,19 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: {{ .Values.letsencrypt.email }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-prod
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - selector: {}
+      http01:
+        ingress:
+          class: nginx

--- a/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-prod.yaml
+++ b/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-prod.yaml
@@ -16,4 +16,4 @@ spec:
     - selector: {}
       http01:
         ingress:
-          class: nginx
+          class: {{ .Values.letsencrypt.ingressClass | default "nginx" }}

--- a/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-staging.yaml
+++ b/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-staging.yaml
@@ -1,0 +1,18 @@
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    # The ACME server URL
+    server: https://acme-staging-v02.api.letsencrypt.org/directory
+    # Email address used for ACME registration
+    email: {{ .Values.letsencrypt.email }}
+    # Name of a secret used to store the ACME account private key
+    privateKeySecretRef:
+      name: letsencrypt-staging
+    # Enable the HTTP-01 challenge provider
+    solvers:
+    - http01:
+        ingress:
+          class: nginx

--- a/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-staging.yaml
+++ b/deploy/charts/cert-manager-issuer/templates/issuer_letsencrypt-staging.yaml
@@ -15,4 +15,4 @@ spec:
     solvers:
     - http01:
         ingress:
-          class: nginx
+          class: {{ .Values.letsencrypt.ingressClass | default "nginx" }}

--- a/deploy/charts/cert-manager-issuer/values.yaml
+++ b/deploy/charts/cert-manager-issuer/values.yaml
@@ -1,0 +1,2 @@
+letsencrypt:
+  email: nobody@example.com

--- a/deploy/charts/cert-manager-issuer/values.yaml
+++ b/deploy/charts/cert-manager-issuer/values.yaml
@@ -1,2 +1,6 @@
+# params for Let's Encrypt service
 letsencrypt:
+# e-mail contact address for certificates
   email: nobody@example.com
+# Ingress Class for ACME Solver (nginx, traefik...)
+  # ingressClass: nginx


### PR DESCRIPTION
**What this PR does / why we need it**:

This Helm chart will deploy two Cluster Issuer for Let's Encrypt ACME prod and staging, implemented with HTTP-01 response challenge. The only value for the chart is the contact e-mail address for Let's Encrypt service.

**Which issue this PR fixes** 
none

**Special notes for your reviewer**:
chart can be independly installed

**Release note**:
```release-note
Helm Chart for Let's Encrypt Cluster Issuer
```
