### PR TITLE
Adding a new key `acme-http01-solver-service-account` to provide a se…

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -217,6 +217,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		Metrics:                   metrics.New(log),
 		ACMEOptions: controller.ACMEOptions{
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
+			HTTP01SolverServiceAccount:        opts.ACMEHTTP01SolverServiceAccount,
 			HTTP01SolverResourceRequestCPU:    HTTP01SolverResourceRequestCPU,
 			HTTP01SolverResourceRequestMemory: HTTP01SolverResourceRequestMemory,
 			HTTP01SolverResourceLimitsCPU:     HTTP01SolverResourceLimitsCPU,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -62,6 +62,7 @@ type ControllerOptions struct {
 	EnabledControllers []string
 
 	ACMEHTTP01SolverImage                 string
+	ACMEHTTP01SolverServiceAccount        string
 	ACMEHTTP01SolverResourceRequestCPU    string
 	ACMEHTTP01SolverResourceRequestMemory string
 	ACMEHTTP01SolverResourceLimitsCPU     string
@@ -132,6 +133,7 @@ const (
 
 var (
 	defaultACMEHTTP01SolverImage                 = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
+	defaultACMEHTTP01SolverServiceAccount        = ""
 	defaultACMEHTTP01SolverResourceRequestCPU    = "10m"
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"
@@ -228,6 +230,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.ACMEHTTP01SolverImage, "acme-http01-solver-image", defaultACMEHTTP01SolverImage, ""+
 		"The docker image to use to solve ACME HTTP01 challenges. You most likely will not "+
 		"need to change this parameter unless you are testing a new feature or developing cert-manager.")
+
+	fs.StringVar(&s.ACMEHTTP01SolverServiceAccount, "acme-http01-solver-service-account", defaultACMEHTTP01SolverServiceAccount, ""+
+		"The service account to use for the ACME HTTP01 solver pod.")
 
 	fs.StringVar(&s.ACMEHTTP01SolverResourceRequestCPU, "acme-http01-solver-resource-request-cpu", defaultACMEHTTP01SolverResourceRequestCPU, ""+
 		"Defines the resource request CPU size when spawning new ACME HTTP01 challenge solver pods.")

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -98,6 +98,10 @@ type ACMEOptions struct {
 	// challenges
 	HTTP01SolverImage string
 
+	// ACMEHTTP01SolverServiceAccount is the name of the service account to get
+	// the ACMEHTTP01SolverImage
+	HTTP01SolverServiceAccount string
+
 	// HTTP01SolverResourceRequestCPU defines the ACME pod's resource request CPU size
 	HTTP01SolverResourceRequestCPU resource.Quantity
 

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -167,7 +167,8 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(ch, challengeGvk)},
 		},
 		Spec: corev1.PodSpec{
-			RestartPolicy: corev1.RestartPolicyOnFailure,
+			RestartPolicy:      corev1.RestartPolicyOnFailure,
+			ServiceAccountName: s.ACMEOptions.HTTP01SolverServiceAccount,
 			Containers: []corev1.Container{
 				{
 					Name: "acmesolver",


### PR DESCRIPTION
…rvice account

Signed-off-by: Primaël Bruant <primael.bruant@gmail.com>

When deploying cert-manager using the Helm chart, we can specify the serviceAccount to use for:

the Webohook
the CA injector
the deployment
But we can't specify it for the HTTP01 ACME solver pod.

The problems with this are:

If the default serviceAccount is disabled, we need to provide a custom one
We can't use a serviceAccount with linked imagePullSecrets to be able to pull the solver image from private registries in air gapped environments
We can't apply PSPs to the solver pod.
To solve this, we propose to add a parameter --acme-http01-solver-service-account to cert-manager deployment to specify the serviceAccount to use in every namespace.

/kind feature