### PR TITLE
Add SECURITY.md documenting vuln report process

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,18 @@ project.
 Please take a look at our [issue tracker](https://github.com/jetstack/cert-manager/issues)
 if you are unsure where to start with getting involved!
 
-We also use the #cert-manager channel on kubernetes.slack.com for chat relating to
-the project.
+We also use the #cert-manager and #cert-manager-dev channels on [Kubernetes Slack](https://kubernetes.slack.com)
+for chat relating to the project.
 
 Developer documentation is available in the [official documentation](https://cert-manager.io/docs/contributing/).
+
+## Security Reporting
+
+Security is the number one priority for cert-manager. If you think you've found
+a security vulnerability, we'd love to hear from you.
+
+Please follow the instructions in [SECURITY.md](./SECURITY.md) to report a
+vulnerability to the team.
 
 ## Changelog
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,55 @@
+# Vulnerability Reporting Process
+
+Security is the number one priority for cert-manager. If you think you've found a
+security vulnerability in a cert-manager project, you're in the right place.
+
+Our reporting procedure is a work-in-progress, and will evolve over time. We
+welcome advice, feedback and pull requests for improving our security
+reporting processes.
+
+## Covered Repositories and Issues
+
+When we say "a security vulnerability in cert-manager" we mean a security issue
+in any repository under the [cert-manger GitHub organization](https://github.com/cert-manager/)
+or in the main [cert-manager repo](https://github.com/jetstack/cert-manager).
+
+This reporting process is intended only for security issues in the cert-manager
+project itself, and doesn't apply to applications _using_ cert-manager or to
+issues which do not affect security.
+
+Broadly speaking, if the issue cannot be fixed by a change to one of the covered
+repositories above, then it might not be appropriate to use this reporting
+mechanism and a GitHub issue in the appropriate repo or a question in Slack
+might be a better choice.
+
+All that said, **if you're unsure** please reach out using this process before
+raising your issue through another channel. We'd rather err on the side of
+caution!
+
+## Security Contacts
+
+The people who should have access to read your security report are listed in
+[`SECURITY_CONTACTS.md`](./SECURITY_CONTACTS.md)
+
+## Reporting Process
+
+1. Describe the issue in English, ideally with some example configuration or
+   code which allows the issue to be reproduced. Explain why you believe this
+   to be a security issue in cert-manager, if that's not obvious.
+2. Put that information into an email. Use a descriptive title.
+3. Send the email to [`cert-manager-security@googlegroups.com`](mailto:cert-manager-security@googlegroups.com)
+
+## Response
+
+Response times could be affected by weekends, holidays, breaks or time zone
+differences. That said, the security response team will endeavour to reply as
+soon as possible, ideally within 3 working days.
+
+If the team concludes that the reported issue is indeed a security
+vulnerability in a cert-manager project, at least two members of the security
+response team will discuss the next steps together as soon as possible, ideally
+within 24 hours.
+
+As soon as the team decides that the report is of a genuine vulnerability,
+one of the team will respond to the reporter acknowledging the issue and
+establishing a disclosure timeline, which should be as soon as possible.

--- a/SECURITY_CONTACTS.md
+++ b/SECURITY_CONTACTS.md
@@ -1,0 +1,15 @@
+# Security Contacts
+
+This file lists people who (should) have access to read security reports
+made via the cert-manager vulnerability reporting process.
+
+If you think you've found a security issue in cert-manager, don't reach
+out to any of these people individually - follow the details in
+SECURITY.md and report your vulnerability via e-mail.
+
+- [irbekrm](https://github.com/irbekrm)
+- [SgtCoDFish](https://github.com/SgtCoDFish)
+- [jakexks](https://github.com/jakexks)
+- [JoshVanL](https://github.com/JoshVanL)
+- [maelvls](https://github.com/maelvls)
+- [wallrj](https://github.com/wallrj)


### PR DESCRIPTION
Ideally, `SECURITY.md` will be the central source of truth to answer the
question "How do I report a security vulnerability in a cert-manager project?"

See also #3761 

```release-note
Add a vulnerability reporting process in SECURITY.md
```