### PR TITLE
Webhook validation request context passthrough

### DIFF
--- a/pkg/internal/apis/certmanager/validation/plugins/approval_test.go
+++ b/pkg/internal/apis/certmanager/validation/plugins/approval_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package plugins
 
 import (
+	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -280,7 +281,7 @@ func TestValidate(t *testing.T) {
 				discoverclient: test.discoverclient(t),
 			}
 
-			err := a.Validate(test.req, test.oldCR, test.newCR)
+			err := a.Validate(context.TODO(), test.req, test.oldCR, test.newCR)
 			if !reflect.DeepEqual(test.expErr, err) {
 				t.Errorf("unexpected error, exp=%#+v got=%#+v",
 					test.expErr, err)
@@ -435,7 +436,7 @@ func TestReviewRequest(t *testing.T) {
 			}
 
 			req := &admissionv1.AdmissionRequest{UserInfo: userInfo}
-			ok, err := a.reviewRequest(req, test.names)
+			ok, err := a.reviewRequest(context.TODO(), req, test.names)
 			if (err != nil) != test.expErr {
 				t.Errorf("unexpected error, exp=%t got=%v",
 					test.expErr, err)

--- a/pkg/internal/apis/certmanager/validation/plugins/plugins.go
+++ b/pkg/internal/apis/certmanager/validation/plugins/plugins.go
@@ -17,6 +17,8 @@ limitations under the License.
 package plugins
 
 import (
+	"context"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -26,7 +28,7 @@ import (
 // Plugin is an admission plugin that will run during admission webhook events.
 type Plugin interface {
 	Init(client kubernetes.Interface)
-	Validate(admissionSpec *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) *field.Error
+	Validate(ctx context.Context, admissionSpec *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) *field.Error
 }
 
 func All(scheme *runtime.Scheme) []Plugin {

--- a/pkg/webhook/handlers/interfaces.go
+++ b/pkg/webhook/handlers/interfaces.go
@@ -17,6 +17,8 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
+
 	admissionv1 "k8s.io/api/admission/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
@@ -26,7 +28,7 @@ import (
 type ValidatingAdmissionHook interface {
 	// Validate is called to decide whether to accept the admission request. The returned AdmissionResponse
 	// must not use the Patch field.
-	Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
+	Validate(ctx context.Context, admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
 
 	// InitPlugins will initialise all plugins which are registered for this
 	// validating admission hook.
@@ -36,7 +38,7 @@ type ValidatingAdmissionHook interface {
 type MutatingAdmissionHook interface {
 	// Admit is called to decide whether to accept the admission request. The returned AdmissionResponse may
 	// use the Patch field to mutate the object from the passed AdmissionRequest.
-	Mutate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
+	Mutate(ctx context.Context, admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
 }
 
 type ConversionHook interface {

--- a/pkg/webhook/handlers/mutation.go
+++ b/pkg/webhook/handlers/mutation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -45,7 +46,7 @@ func NewRegistryBackedMutator(log logr.Logger, scheme *runtime.Scheme, registry 
 	}
 }
 
-func (c *RegistryBackedMutator) Mutate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+func (c *RegistryBackedMutator) Mutate(_ context.Context, admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	status := &admissionv1.AdmissionResponse{}
 	status.UID = admissionSpec.UID
 

--- a/pkg/webhook/handlers/mutation_test.go
+++ b/pkg/webhook/handlers/mutation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"encoding/json"
 	"reflect"
 	"testing"
@@ -114,10 +115,10 @@ type admissionTestT struct {
 	expectedResponse admissionv1.AdmissionResponse
 }
 
-type admissionFn func(request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
+type admissionFn func(ctx context.Context, request *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse
 
 func runAdmissionTest(t *testing.T, fn admissionFn, test admissionTestT) {
-	resp := fn(&test.inputRequest)
+	resp := fn(context.TODO(), &test.inputRequest)
 	if !reflect.DeepEqual(&test.expectedResponse, resp) {
 		t.Errorf("Response was not as expected: %v", diff.ObjectGoPrintSideBySide(&test.expectedResponse, resp))
 	}

--- a/pkg/webhook/handlers/validation.go
+++ b/pkg/webhook/handlers/validation.go
@@ -17,6 +17,7 @@ limitations under the License.
 package handlers
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/go-logr/logr"
@@ -56,7 +57,7 @@ func (r *registryBackedValidator) InitPlugins(client kubernetes.Interface) {
 	}
 }
 
-func (r *registryBackedValidator) Validate(admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
+func (r *registryBackedValidator) Validate(ctx context.Context, admissionSpec *admissionv1.AdmissionRequest) *admissionv1.AdmissionResponse {
 	status := &admissionv1.AdmissionResponse{}
 	status.UID = admissionSpec.UID
 
@@ -112,7 +113,7 @@ func (r *registryBackedValidator) Validate(admissionSpec *admissionv1.AdmissionR
 	// If no validation errors occurred, perform plugin checks.
 	if len(errs) == 0 {
 		for _, plugin := range r.plugins {
-			if err := plugin.Validate(admissionSpec, oldObj, obj); err != nil {
+			if err := plugin.Validate(ctx, admissionSpec, oldObj, obj); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/pkg/webhook/server/server_test.go
+++ b/pkg/webhook/server/server_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -72,7 +73,7 @@ func TestConvert(t *testing.T) {
 				ConversionWebhook: handlers.NewSchemeBackedConverter(log, defaultScheme),
 				Log:               log,
 			}
-			out, err := s.convert(tc.in)
+			out, err := s.convert(context.TODO(), tc.in)
 			if tc.err != "" {
 				assert.EqualError(t, err, tc.err)
 				assert.Nil(t, out)


### PR DESCRIPTION
/kind cleanup
/hold

This PR is rebased on #3785

This PR passes through the request context of the webhook server to admission functions. This is primarily for the approval plugin.

```release-note
NONE
```
