### PR TITLE
Pass context through to client calls in controllers and acme issuer

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -170,7 +170,7 @@ func (c *controller) runScheduler(ctx context.Context) {
 		ch = ch.DeepCopy()
 		ch.Status.Processing = true
 
-		_, err := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(context.TODO(), ch, metav1.UpdateOptions{})
+		_, err := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(ctx, ch, metav1.UpdateOptions{})
 		if err != nil {
 			log.Error(err, "error scheduling challenge for processing")
 			return

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -71,7 +71,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 		if apiequality.Semantic.DeepEqual(oldChal.Status, ch.Status) && len(oldChal.Finalizers) == len(ch.Finalizers) {
 			return
 		}
-		_, updateErr := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(context.TODO(), ch, metav1.UpdateOptions{})
+		_, updateErr := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(ctx, ch, metav1.UpdateOptions{})
 		if updateErr != nil {
 			err = utilerrors.NewAggregate([]error{err, updateErr})
 		}
@@ -248,14 +248,14 @@ func (c *controller) handleFinalizer(ctx context.Context, ch *cmacme.Challenge) 
 
 	defer func() {
 		// call UpdateStatus first as we may have updated the challenge.status.reason field
-		ch, updateErr := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(context.TODO(), ch, metav1.UpdateOptions{})
+		ch, updateErr := c.cmClient.AcmeV1().Challenges(ch.Namespace).UpdateStatus(ctx, ch, metav1.UpdateOptions{})
 		if updateErr != nil {
 			err = utilerrors.NewAggregate([]error{err, updateErr})
 			return
 		}
 		// call Update to remove the metadata.finalizers entry
 		ch.Finalizers = ch.Finalizers[1:]
-		_, updateErr = c.cmClient.AcmeV1().Challenges(ch.Namespace).Update(context.TODO(), ch, metav1.UpdateOptions{})
+		_, updateErr = c.cmClient.AcmeV1().Challenges(ch.Namespace).Update(ctx, ch, metav1.UpdateOptions{})
 		if updateErr != nil {
 			err = utilerrors.NewAggregate([]error{err, updateErr})
 			return

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -79,7 +79,7 @@ var (
 func registerAllInjectors(ctx context.Context, groupName string, mgr ctrl.Manager, sources []caDataSource, client client.Client, ca cache.Cache) error {
 	controllers := make([]controller.Controller, len(injectorSetups))
 	for i, setup := range injectorSetups {
-		controller, err := newGenericInjectionController(groupName, mgr, setup, sources, ca, client)
+		controller, err := newGenericInjectionController(ctx, groupName, mgr, setup, sources, ca, client)
 		if err != nil {
 			if !meta.IsNoMatchError(err) || !setup.injector.IsAlpha() {
 				return err
@@ -123,7 +123,9 @@ func registerAllInjectors(ctx context.Context, groupName string, mgr ctrl.Manage
 // indexes and event sources. Keep checking new controller-runtime releases for
 // improvements which might make this easier:
 // * https://github.com/kubernetes-sigs/controller-runtime/issues/764
-func newGenericInjectionController(groupName string, mgr ctrl.Manager, setup injectorSetup, sources []caDataSource, ca cache.Cache, client client.Client) (controller.Controller, error) {
+func newGenericInjectionController(ctx context.Context, groupName string, mgr ctrl.Manager,
+	setup injectorSetup, sources []caDataSource, ca cache.Cache,
+	client client.Client) (controller.Controller, error) {
 	log := ctrl.Log.WithName(groupName).WithName(setup.resourceName)
 	typ := setup.injector.NewTarget().AsObject()
 
@@ -148,7 +150,7 @@ func newGenericInjectionController(groupName string, mgr ctrl.Manager, setup inj
 	}
 
 	for _, s := range sources {
-		if err := s.ApplyTo(mgr, setup, c, ca); err != nil {
+		if err := s.ApplyTo(ctx, mgr, setup, c, ca); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/controller/certificaterequests/acme/acme.go
+++ b/pkg/controller/certificaterequests/acme/acme.go
@@ -118,7 +118,7 @@ func (a *ACME) Sign(ctx context.Context, cr *v1.CertificateRequest, issuer v1.Ge
 	if k8sErrors.IsNotFound(err) {
 		// Failing to create the order here is most likely network related.
 		// We should backoff and keep trying.
-		_, err = a.acmeClientV.Orders(expectedOrder.Namespace).Create(context.TODO(), expectedOrder, metav1.CreateOptions{})
+		_, err = a.acmeClientV.Orders(expectedOrder.Namespace).Create(ctx, expectedOrder, metav1.CreateOptions{})
 		if err != nil {
 			message := fmt.Sprintf("Failed create new order resource %s/%s", expectedOrder.Namespace, expectedOrder.Name)
 
@@ -187,12 +187,12 @@ func (a *ACME) Sign(ctx context.Context, cr *v1.CertificateRequest, issuer v1.Ge
 	x509Cert, err := pki.DecodeX509CertificateBytes(order.Status.Certificate)
 	if err != nil {
 		log.Error(err, "failed to decode x509 certificate data on Order resource.")
-		return nil, a.acmeClientV.Orders(order.Namespace).Delete(context.TODO(), order.Name, metav1.DeleteOptions{})
+		return nil, a.acmeClientV.Orders(order.Namespace).Delete(ctx, order.Name, metav1.DeleteOptions{})
 	}
 
 	if ok, err := pki.PublicKeyMatchesCertificate(csr.PublicKey, x509Cert); err != nil || !ok {
 		log.Error(err, "The public key in Order.Status.Certificate does not match the public key in CertificateRequest.Spec.Request. Deleting the order.")
-		return nil, a.acmeClientV.Orders(order.Namespace).Delete(context.TODO(), order.Name, metav1.DeleteOptions{})
+		return nil, a.acmeClientV.Orders(order.Namespace).Delete(ctx, order.Name, metav1.DeleteOptions{})
 	}
 
 	log.V(logf.InfoLevel).Info("certificate issued")

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -160,7 +160,7 @@ func (c *Controller) updateCertificateRequestStatusAndAnnotations(ctx context.Co
 	// if annotations changed we have to call .Update() and not .UpdateStatus()
 	if !reflect.DeepEqual(old.Annotations, new.Annotations) {
 		log.V(logf.DebugLevel).Info("updating resource due to change in annotations", "diff", pretty.Diff(old.Annotations, new.Annotations))
-		return c.cmClient.CertmanagerV1().CertificateRequests(new.Namespace).Update(context.TODO(), new, metav1.UpdateOptions{})
+		return c.cmClient.CertmanagerV1().CertificateRequests(new.Namespace).Update(ctx, new, metav1.UpdateOptions{})
 	}
 
 	if apiequality.Semantic.DeepEqual(old.Status, new.Status) {
@@ -168,5 +168,5 @@ func (c *Controller) updateCertificateRequestStatusAndAnnotations(ctx context.Co
 	}
 
 	log.V(logf.DebugLevel).Info("updating resource due to change in status", "diff", pretty.Diff(old.Status, new.Status))
-	return c.cmClient.CertmanagerV1().CertificateRequests(new.Namespace).UpdateStatus(context.TODO(), new, metav1.UpdateOptions{})
+	return c.cmClient.CertmanagerV1().CertificateRequests(new.Namespace).UpdateStatus(ctx, new, metav1.UpdateOptions{})
 }

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -40,7 +40,7 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.ClusterIssuer) (err er
 
 	issuerCopy := iss.DeepCopy()
 	defer func() {
-		if _, saveErr := c.updateIssuerStatus(iss, issuerCopy); saveErr != nil {
+		if _, saveErr := c.updateIssuerStatus(ctx, iss, issuerCopy); saveErr != nil {
 			err = errors.NewAggregate([]error{saveErr, err})
 		}
 	}()
@@ -64,9 +64,9 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.ClusterIssuer) (err er
 	return nil
 }
 
-func (c *controller) updateIssuerStatus(old, new *cmapi.ClusterIssuer) (*cmapi.ClusterIssuer, error) {
+func (c *controller) updateIssuerStatus(ctx context.Context, old, new *cmapi.ClusterIssuer) (*cmapi.ClusterIssuer, error) {
 	if apiequality.Semantic.DeepEqual(old.Status, new.Status) {
 		return nil, nil
 	}
-	return c.cmClient.CertmanagerV1().ClusterIssuers().UpdateStatus(context.TODO(), new, metav1.UpdateOptions{})
+	return c.cmClient.CertmanagerV1().ClusterIssuers().UpdateStatus(ctx, new, metav1.UpdateOptions{})
 }

--- a/pkg/controller/clusterissuers/sync_test.go
+++ b/pkg/controller/clusterissuers/sync_test.go
@@ -76,7 +76,7 @@ func TestUpdateIssuerStatus(t *testing.T) {
 
 	issuerCopy := issuer.DeepCopy()
 	issuerCopy.Status = newStatus
-	_, err = c.updateIssuerStatus(issuer, issuerCopy)
+	_, err = c.updateIssuerStatus(context.TODO(), issuer, issuerCopy)
 	assertErrIsNil(t, fatalf, err)
 
 	actions := filter(fakeClient.Actions())

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -74,7 +74,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 	}
 
 	for _, crt := range newCrts {
-		_, err := c.cmClient.CertmanagerV1().Certificates(crt.Namespace).Create(context.TODO(), crt, metav1.CreateOptions{})
+		_, err := c.cmClient.CertmanagerV1().Certificates(crt.Namespace).Create(ctx, crt, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
@@ -82,7 +82,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 	}
 
 	for _, crt := range updateCrts {
-		_, err := c.cmClient.CertmanagerV1().Certificates(crt.Namespace).Update(context.TODO(), crt, metav1.UpdateOptions{})
+		_, err := c.cmClient.CertmanagerV1().Certificates(crt.Namespace).Update(ctx, crt, metav1.UpdateOptions{})
 		if err != nil {
 			return err
 		}
@@ -95,7 +95,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 	}
 
 	for _, crt := range unrequiredCrts {
-		err = c.cmClient.CertmanagerV1().Certificates(crt.Namespace).Delete(context.TODO(), crt.Name, metav1.DeleteOptions{})
+		err = c.cmClient.CertmanagerV1().Certificates(crt.Namespace).Delete(ctx, crt.Name, metav1.DeleteOptions{})
 		if err != nil {
 			return err
 		}

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -40,7 +40,7 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.Issuer) (err error) {
 
 	issuerCopy := iss.DeepCopy()
 	defer func() {
-		if _, saveErr := c.updateIssuerStatus(iss, issuerCopy); saveErr != nil {
+		if _, saveErr := c.updateIssuerStatus(ctx, iss, issuerCopy); saveErr != nil {
 			err = errors.NewAggregate([]error{saveErr, err})
 		}
 	}()
@@ -64,9 +64,9 @@ func (c *controller) Sync(ctx context.Context, iss *cmapi.Issuer) (err error) {
 	return nil
 }
 
-func (c *controller) updateIssuerStatus(old, new *cmapi.Issuer) (*cmapi.Issuer, error) {
+func (c *controller) updateIssuerStatus(ctx context.Context, old, new *cmapi.Issuer) (*cmapi.Issuer, error) {
 	if apiequality.Semantic.DeepEqual(old.Status, new.Status) {
 		return nil, nil
 	}
-	return c.cmClient.CertmanagerV1().Issuers(new.Namespace).UpdateStatus(context.TODO(), new, metav1.UpdateOptions{})
+	return c.cmClient.CertmanagerV1().Issuers(new.Namespace).UpdateStatus(ctx, new, metav1.UpdateOptions{})
 }

--- a/pkg/controller/issuers/sync_test.go
+++ b/pkg/controller/issuers/sync_test.go
@@ -76,7 +76,7 @@ func TestUpdateIssuerStatus(t *testing.T) {
 
 	issuerCopy := issuer.DeepCopy()
 	issuerCopy.Status = newStatus
-	_, err = c.updateIssuerStatus(issuer, issuerCopy)
+	_, err = c.updateIssuerStatus(context.TODO(), issuer, issuerCopy)
 	assertErrIsNil(t, fatalf, err)
 
 	actions := filter(cmClient.Actions())

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -50,7 +50,7 @@ func TestGetIngressesForChallenge(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createIngress(s.Challenge, "fakeservice")
+				ing, err := s.Solver.createIngress(context.TODO(), s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -83,7 +83,7 @@ func TestGetIngressesForChallenge(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createIngress(s.Challenge, "fakeservice")
+				ing, err := s.Solver.createIngress(context.TODO(), s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -118,7 +118,7 @@ func TestGetIngressesForChallenge(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				differentChallenge := s.Challenge.DeepCopy()
 				differentChallenge.Spec.DNSName = "notexample.com"
-				_, err := s.Solver.createIngress(differentChallenge, "fakeservice")
+				_, err := s.Solver.createIngress(context.TODO(), differentChallenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -168,7 +168,7 @@ func TestCleanupIngresses(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createIngress(s.Challenge, "fakeservice")
+				ing, err := s.Solver.createIngress(context.TODO(), s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -203,7 +203,7 @@ func TestCleanupIngresses(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				differentChallenge := s.Challenge.DeepCopy()
 				differentChallenge.Spec.DNSName = "notexample.com"
-				ing, err := s.Solver.createIngress(differentChallenge, "fakeservice")
+				ing, err := s.Solver.createIngress(context.TODO(), differentChallenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -397,7 +397,7 @@ func TestCleanupIngresses(t *testing.T) {
 				s.Builder.FakeKubeClient().PrependReactor("delete", "ingresses", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
 					return true, nil, fmt.Errorf("simulated error")
 				})
-				ing, err := s.Solver.createIngress(s.Challenge, "fakeservice")
+				ing, err := s.Solver.createIngress(context.TODO(), s.Challenge, "fakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -436,7 +436,7 @@ func TestEnsureIngress(t *testing.T) {
 			},
 			Err: true,
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createIngress(s.Challenge, "anotherfakeservice")
+				_, err := s.Solver.createIngress(context.TODO(), s.Challenge, "anotherfakeservice")
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -542,7 +542,7 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			test.Setup(t)
-			resp, err := test.Solver.createIngress(test.Challenge, "fakeservice")
+			resp, err := test.Solver.createIngress(context.TODO(), test.Challenge, "fakeservice")
 			test.Finish(t, resp, err)
 		})
 	}

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -69,7 +69,7 @@ func (s *Solver) ensurePod(ctx context.Context, ch *cmacme.Challenge) (*corev1.P
 
 	log.V(logf.InfoLevel).Info("creating HTTP01 challenge solver pod")
 
-	return s.createPod(ch)
+	return s.createPod(ctx, ch)
 }
 
 // getPodsForChallenge returns a list of pods that were created to solve
@@ -117,7 +117,7 @@ func (s *Solver) cleanupPods(ctx context.Context, ch *cmacme.Challenge) error {
 		log := logf.WithRelatedResource(log, pod).V(logf.DebugLevel)
 		log.V(logf.InfoLevel).Info("deleting pod resource")
 
-		err := s.Client.CoreV1().Pods(pod.Namespace).Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+		err := s.Client.CoreV1().Pods(pod.Namespace).Delete(ctx, pod.Name, metav1.DeleteOptions{})
 		if err != nil {
 			log.V(logf.WarnLevel).Info("failed to delete pod resource", "error", err)
 			errs = append(errs, err)
@@ -131,9 +131,9 @@ func (s *Solver) cleanupPods(ctx context.Context, ch *cmacme.Challenge) error {
 
 // createPod will create a challenge solving pod for the given certificate,
 // domain, token and key.
-func (s *Solver) createPod(ch *cmacme.Challenge) (*corev1.Pod, error) {
+func (s *Solver) createPod(ctx context.Context, ch *cmacme.Challenge) (*corev1.Pod, error) {
 	return s.Client.CoreV1().Pods(ch.Namespace).Create(
-		context.TODO(),
+		ctx,
 		s.buildPod(ch),
 		metav1.CreateOptions{})
 }

--- a/pkg/issuer/acme/http/pod_test.go
+++ b/pkg/issuer/acme/http/pod_test.go
@@ -46,7 +46,7 @@ func TestEnsurePod(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createPod(s.Challenge)
+				ing, err := s.Solver.createPod(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -142,11 +142,11 @@ func TestEnsurePod(t *testing.T) {
 			},
 			Err: true,
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createPod(s.Challenge)
+				_, err := s.Solver.createPod(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
-				_, err = s.Solver.createPod(s.Challenge)
+				_, err = s.Solver.createPod(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -196,7 +196,7 @@ func TestGetPodsForCertificate(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createPod(s.Challenge)
+				ing, err := s.Solver.createPod(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -231,7 +231,7 @@ func TestGetPodsForCertificate(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				differentChallenge := s.Challenge.DeepCopy()
 				differentChallenge.Spec.DNSName = "notexample.com"
-				_, err := s.Solver.createPod(differentChallenge)
+				_, err := s.Solver.createPod(context.TODO(), differentChallenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -53,7 +53,7 @@ func (s *Solver) ensureService(ctx context.Context, ch *cmacme.Challenge) (*core
 	}
 
 	log.V(logf.DebugLevel).Info("creating HTTP01 challenge solver service")
-	return s.createService(ch)
+	return s.createService(ctx, ch)
 }
 
 // getServicesForChallenge returns a list of services that were created to solve
@@ -91,12 +91,12 @@ func (s *Solver) getServicesForChallenge(ctx context.Context, ch *cmacme.Challen
 
 // createService will create the service required to solve this challenge
 // in the target API server.
-func (s *Solver) createService(ch *cmacme.Challenge) (*corev1.Service, error) {
+func (s *Solver) createService(ctx context.Context, ch *cmacme.Challenge) (*corev1.Service, error) {
 	svc, err := buildService(ch)
 	if err != nil {
 		return nil, err
 	}
-	return s.Client.CoreV1().Services(ch.Namespace).Create(context.TODO(), svc, metav1.CreateOptions{})
+	return s.Client.CoreV1().Services(ch.Namespace).Create(ctx, svc, metav1.CreateOptions{})
 }
 
 func buildService(ch *cmacme.Challenge) (*corev1.Service, error) {
@@ -148,7 +148,7 @@ func (s *Solver) cleanupServices(ctx context.Context, ch *cmacme.Challenge) erro
 		log := logf.WithRelatedResource(log, service).V(logf.DebugLevel)
 		log.V(logf.DebugLevel).Info("deleting service resource")
 
-		err := s.Client.CoreV1().Services(service.Namespace).Delete(context.TODO(), service.Name, metav1.DeleteOptions{})
+		err := s.Client.CoreV1().Services(service.Namespace).Delete(ctx, service.Name, metav1.DeleteOptions{})
 		if err != nil {
 			log.V(logf.WarnLevel).Info("failed to delete pod resource", "error", err)
 			errs = append(errs, err)

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -44,7 +44,7 @@ func TestEnsureService(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				svc, err := s.Solver.createService(s.Challenge)
+				svc, err := s.Solver.createService(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -139,11 +139,11 @@ func TestEnsureService(t *testing.T) {
 			},
 			Err: true,
 			PreFn: func(t *testing.T, s *solverFixture) {
-				_, err := s.Solver.createService(s.Challenge)
+				_, err := s.Solver.createService(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
-				_, err = s.Solver.createService(s.Challenge)
+				_, err = s.Solver.createService(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -193,7 +193,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 				},
 			},
 			PreFn: func(t *testing.T, s *solverFixture) {
-				ing, err := s.Solver.createService(s.Challenge)
+				ing, err := s.Solver.createService(context.TODO(), s.Challenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}
@@ -228,7 +228,7 @@ func TestGetServicesForChallenge(t *testing.T) {
 			PreFn: func(t *testing.T, s *solverFixture) {
 				differentChallenge := s.Challenge.DeepCopy()
 				differentChallenge.Spec.DNSName = "invaliddomain"
-				_, err := s.Solver.createService(differentChallenge)
+				_, err := s.Solver.createService(context.TODO(), differentChallenge)
 				if err != nil {
 					t.Errorf("error preparing test: %v", err)
 				}


### PR DESCRIPTION
/kind cleanup
/milestone v1.3

Uses passed through context, rather than `context.TODO`, in client calls in controllers and acme issuer.

```release-note
NONE
```
