### PR TITLE
chore: used constants for string literals when recording new events

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -39,6 +39,7 @@ import (
 
 const (
 	reasonDomainVerified = "DomainVerified"
+	CleanUpError         = "CleanUpError"
 )
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -100,7 +101,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 
 			err = solver.CleanUp(ctx, genericIssuer, ch)
 			if err != nil {
-				c.recorder.Eventf(ch, corev1.EventTypeWarning, "CleanUpError", "Error cleaning up challenge: %v", err)
+				c.recorder.Eventf(ch, corev1.EventTypeWarning, CleanUpError, "Error cleaning up challenge: %v", err)
 				ch.Status.Reason = err.Error()
 				log.Error(err, "error cleaning up challenge")
 				return err
@@ -279,7 +280,7 @@ func (c *controller) handleFinalizer(ctx context.Context, ch *cmacme.Challenge) 
 
 	err = solver.CleanUp(ctx, genericIssuer, ch)
 	if err != nil {
-		c.recorder.Eventf(ch, corev1.EventTypeWarning, "CleanUpError", "Error cleaning up challenge: %v", err)
+		c.recorder.Eventf(ch, corev1.EventTypeWarning, CleanUpError, "Error cleaning up challenge: %v", err)
 		ch.Status.Reason = err.Error()
 		log.Error(err, "error cleaning up challenge")
 		return nil

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -40,6 +40,9 @@ import (
 const (
 	reasonDomainVerified = "DomainVerified"
 	CleanUpError         = "CleanUpError"
+	PresentError         = "PresentError"
+	Presented            = "Presented"
+	Failed               = "Failed"
 )
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -168,13 +171,13 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	if !ch.Status.Presented {
 		err := solver.Present(ctx, genericIssuer, ch)
 		if err != nil {
-			c.recorder.Eventf(ch, corev1.EventTypeWarning, "PresentError", "Error presenting challenge: %v", err)
+			c.recorder.Eventf(ch, corev1.EventTypeWarning, PresentError, "Error presenting challenge: %v", err)
 			ch.Status.Reason = err.Error()
 			return err
 		}
 
 		ch.Status.Presented = true
-		c.recorder.Eventf(ch, corev1.EventTypeNormal, "Presented", "Presented challenge using %s challenge mechanism", ch.Spec.Type)
+		c.recorder.Eventf(ch, corev1.EventTypeNormal, Presented, "Presented challenge using %s challenge mechanism", ch.Spec.Type)
 	}
 
 	err = solver.Check(ctx, genericIssuer, ch)
@@ -376,7 +379,7 @@ func (c *controller) handleAuthorizationError(ch *cmacme.Challenge, err error) e
 	//   if the returned state is 'invalid'
 	ch.Status.State = cmacme.Invalid
 	ch.Status.Reason = fmt.Sprintf("Error accepting authorization: %v", authErr)
-	c.recorder.Eventf(ch, corev1.EventTypeWarning, "Failed", "Accepting challenge authorization failed: %v", authErr)
+	c.recorder.Eventf(ch, corev1.EventTypeWarning, Failed, "Accepting challenge authorization failed: %v", authErr)
 
 	// return nil here, as accepting the challenge did not error, the challenge
 	// simply failed

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -38,11 +38,11 @@ import (
 )
 
 const (
-	reasonDomainVerified  = "DomainVerified"
-	challengeCleanUpError = "CleanUpError"
-	challengePresentError = "PresentError"
-	statusPresented       = "Presented"
-	statusFailed          = "Failed"
+	reasonDomainVerified = "DomainVerified"
+	reasonCleanUpError   = "CleanUpError"
+	reasonPresentError   = "PresentError"
+	reasonPresented      = "Presented"
+	reasonFailed         = "Failed"
 )
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -104,7 +104,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 
 			err = solver.CleanUp(ctx, genericIssuer, ch)
 			if err != nil {
-				c.recorder.Eventf(ch, corev1.EventTypeWarning, challengeCleanUpError, "Error cleaning up challenge: %v", err)
+				c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonCleanUpError, "Error cleaning up challenge: %v", err)
 				ch.Status.Reason = err.Error()
 				log.Error(err, "error cleaning up challenge")
 				return err
@@ -171,13 +171,13 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	if !ch.Status.Presented {
 		err := solver.Present(ctx, genericIssuer, ch)
 		if err != nil {
-			c.recorder.Eventf(ch, corev1.EventTypeWarning, challengePresentError, "Error presenting challenge: %v", err)
+			c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonPresentError, "Error presenting challenge: %v", err)
 			ch.Status.Reason = err.Error()
 			return err
 		}
 
 		ch.Status.Presented = true
-		c.recorder.Eventf(ch, corev1.EventTypeNormal, statusPresented, "Presented challenge using %s challenge mechanism", ch.Spec.Type)
+		c.recorder.Eventf(ch, corev1.EventTypeNormal, reasonPresented, "Presented challenge using %s challenge mechanism", ch.Spec.Type)
 	}
 
 	err = solver.Check(ctx, genericIssuer, ch)
@@ -283,7 +283,7 @@ func (c *controller) handleFinalizer(ctx context.Context, ch *cmacme.Challenge) 
 
 	err = solver.CleanUp(ctx, genericIssuer, ch)
 	if err != nil {
-		c.recorder.Eventf(ch, corev1.EventTypeWarning, challengeCleanUpError, "Error cleaning up challenge: %v", err)
+		c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonCleanUpError, "Error cleaning up challenge: %v", err)
 		ch.Status.Reason = err.Error()
 		log.Error(err, "error cleaning up challenge")
 		return nil
@@ -379,7 +379,7 @@ func (c *controller) handleAuthorizationError(ch *cmacme.Challenge, err error) e
 	//   if the returned state is 'invalid'
 	ch.Status.State = cmacme.Invalid
 	ch.Status.Reason = fmt.Sprintf("Error accepting authorization: %v", authErr)
-	c.recorder.Eventf(ch, corev1.EventTypeWarning, statusFailed, "Accepting challenge authorization failed: %v", authErr)
+	c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonFailed, "Accepting challenge authorization failed: %v", authErr)
 
 	// return nil here, as accepting the challenge did not error, the challenge
 	// simply failed

--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -38,11 +38,11 @@ import (
 )
 
 const (
-	reasonDomainVerified = "DomainVerified"
-	CleanUpError         = "CleanUpError"
-	PresentError         = "PresentError"
-	Presented            = "Presented"
-	Failed               = "Failed"
+	reasonDomainVerified  = "DomainVerified"
+	challengeCleanUpError = "CleanUpError"
+	challengePresentError = "PresentError"
+	statusPresented       = "Presented"
+	statusFailed          = "Failed"
 )
 
 // solver solves ACME challenges by presenting the given token and key in an
@@ -83,7 +83,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 
 	// bail out early on if processing=false, as this challenge has not been
 	// scheduled yet.
-	if ch.Status.Processing == false {
+	if !ch.Status.Processing {
 		return nil
 	}
 
@@ -104,7 +104,7 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 
 			err = solver.CleanUp(ctx, genericIssuer, ch)
 			if err != nil {
-				c.recorder.Eventf(ch, corev1.EventTypeWarning, CleanUpError, "Error cleaning up challenge: %v", err)
+				c.recorder.Eventf(ch, corev1.EventTypeWarning, challengeCleanUpError, "Error cleaning up challenge: %v", err)
 				ch.Status.Reason = err.Error()
 				log.Error(err, "error cleaning up challenge")
 				return err
@@ -171,13 +171,13 @@ func (c *controller) Sync(ctx context.Context, ch *cmacme.Challenge) (err error)
 	if !ch.Status.Presented {
 		err := solver.Present(ctx, genericIssuer, ch)
 		if err != nil {
-			c.recorder.Eventf(ch, corev1.EventTypeWarning, PresentError, "Error presenting challenge: %v", err)
+			c.recorder.Eventf(ch, corev1.EventTypeWarning, challengePresentError, "Error presenting challenge: %v", err)
 			ch.Status.Reason = err.Error()
 			return err
 		}
 
 		ch.Status.Presented = true
-		c.recorder.Eventf(ch, corev1.EventTypeNormal, Presented, "Presented challenge using %s challenge mechanism", ch.Spec.Type)
+		c.recorder.Eventf(ch, corev1.EventTypeNormal, statusPresented, "Presented challenge using %s challenge mechanism", ch.Spec.Type)
 	}
 
 	err = solver.Check(ctx, genericIssuer, ch)
@@ -283,7 +283,7 @@ func (c *controller) handleFinalizer(ctx context.Context, ch *cmacme.Challenge) 
 
 	err = solver.CleanUp(ctx, genericIssuer, ch)
 	if err != nil {
-		c.recorder.Eventf(ch, corev1.EventTypeWarning, CleanUpError, "Error cleaning up challenge: %v", err)
+		c.recorder.Eventf(ch, corev1.EventTypeWarning, challengeCleanUpError, "Error cleaning up challenge: %v", err)
 		ch.Status.Reason = err.Error()
 		log.Error(err, "error cleaning up challenge")
 		return nil
@@ -379,7 +379,7 @@ func (c *controller) handleAuthorizationError(ch *cmacme.Challenge, err error) e
 	//   if the returned state is 'invalid'
 	ch.Status.State = cmacme.Invalid
 	ch.Status.Reason = fmt.Sprintf("Error accepting authorization: %v", authErr)
-	c.recorder.Eventf(ch, corev1.EventTypeWarning, Failed, "Accepting challenge authorization failed: %v", authErr)
+	c.recorder.Eventf(ch, corev1.EventTypeWarning, statusFailed, "Accepting challenge authorization failed: %v", authErr)
 
 	// return nil here, as accepting the challenge did not error, the challenge
 	// simply failed

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -39,6 +39,11 @@ import (
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 )
 
+const (
+	Solver  = "Solver"
+	Created = "Created"
+)
+
 func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
@@ -107,7 +112,7 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 	requiredChallenges, err := buildRequiredChallenges(ctx, cl, genericIssuer, o)
 	if err != nil {
 		log.Error(err, "Failed to determine the list of Challenge resources needed for the Order")
-		c.recorder.Eventf(o, corev1.EventTypeWarning, "Solver", "Failed to determine a valid solver configuration for the set of domains on the Order: %v", err)
+		c.recorder.Eventf(o, corev1.EventTypeWarning, Solver, "Failed to determine a valid solver configuration for the set of domains on the Order: %v", err)
 		return nil
 	}
 
@@ -348,7 +353,7 @@ func (c *controller) createRequiredChallenges(o *cmacme.Order, requiredChallenge
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(o, corev1.EventTypeNormal, "Created", "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
+		c.recorder.Eventf(o, corev1.EventTypeNormal, Created, "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
 	}
 	return nil
 }

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	statusSolver  = "Solver"
-	statusCreated = "Created"
+	reasonSolver  = "Solver"
+	reasonCreated = "Created"
 )
 
 func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
@@ -112,7 +112,7 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 	requiredChallenges, err := buildRequiredChallenges(ctx, cl, genericIssuer, o)
 	if err != nil {
 		log.Error(err, "Failed to determine the list of Challenge resources needed for the Order")
-		c.recorder.Eventf(o, corev1.EventTypeWarning, statusSolver, "Failed to determine a valid solver configuration for the set of domains on the Order: %v", err)
+		c.recorder.Eventf(o, corev1.EventTypeWarning, reasonSolver, "Failed to determine a valid solver configuration for the set of domains on the Order: %v", err)
 		return nil
 	}
 
@@ -353,7 +353,7 @@ func (c *controller) createRequiredChallenges(o *cmacme.Order, requiredChallenge
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(o, corev1.EventTypeNormal, statusCreated, "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
+		c.recorder.Eventf(o, corev1.EventTypeNormal, reasonCreated, "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
 	}
 	return nil
 }

--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	Solver  = "Solver"
-	Created = "Created"
+	statusSolver  = "Solver"
+	statusCreated = "Created"
 )
 
 func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
@@ -112,7 +112,7 @@ func (c *controller) Sync(ctx context.Context, o *cmacme.Order) (err error) {
 	requiredChallenges, err := buildRequiredChallenges(ctx, cl, genericIssuer, o)
 	if err != nil {
 		log.Error(err, "Failed to determine the list of Challenge resources needed for the Order")
-		c.recorder.Eventf(o, corev1.EventTypeWarning, Solver, "Failed to determine a valid solver configuration for the set of domains on the Order: %v", err)
+		c.recorder.Eventf(o, corev1.EventTypeWarning, statusSolver, "Failed to determine a valid solver configuration for the set of domains on the Order: %v", err)
 		return nil
 	}
 
@@ -353,7 +353,7 @@ func (c *controller) createRequiredChallenges(o *cmacme.Order, requiredChallenge
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(o, corev1.EventTypeNormal, Created, "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
+		c.recorder.Eventf(o, corev1.EventTypeNormal, statusCreated, "Created Challenge resource %q for domain %q", ch.Name, ch.Spec.DNSName)
 	}
 	return nil
 }

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -50,6 +50,7 @@ import (
 
 const (
 	ControllerName = "certificates-key-manager"
+	DecodeFailed   = "DecodeFailed"
 )
 
 var (
@@ -238,16 +239,16 @@ func (c *controller) createNextPrivateKeyRotationPolicyNever(ctx context.Context
 	existingPKData := s.Data[corev1.TLSPrivateKeyKey]
 	pk, err := pki.DecodePrivateKeyBytes(existingPKData)
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, "DecodeFailed", "Failed to decode private key stored in Secret %q - generating new key", crt.Spec.SecretName)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, DecodeFailed, "Failed to decode private key stored in Secret %q - generating new key", crt.Spec.SecretName)
 		return c.createAndSetNextPrivateKey(ctx, crt)
 	}
 	violations, err := certificates.PrivateKeyMatchesSpec(pk, crt.Spec)
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, "DecodeFailed", "Failed to check if private key stored in Secret %q is up to date - generating new key", crt.Spec.SecretName)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, DecodeFailed, "Failed to check if private key stored in Secret %q is up to date - generating new key", crt.Spec.SecretName)
 		return c.createAndSetNextPrivateKey(ctx, crt)
 	}
 	if len(violations) > 0 {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, "DecodeFailed", "Existing private key in Secret %q does not match requirements on Certificate resource, mismatching fields: %v", crt.Spec.SecretName, violations)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, DecodeFailed, "Existing private key in Secret %q does not match requirements on Certificate resource, mismatching fields: %v", crt.Spec.SecretName, violations)
 		return nil
 	}
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -51,6 +51,7 @@ import (
 const (
 	ControllerName = "certificates-key-manager"
 	DecodeFailed   = "DecodeFailed"
+	Deleted        = "Deleted"
 )
 
 var (
@@ -215,7 +216,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 	if len(violations) > 0 {
 		log.V(logf.DebugLevel).Info("Regenerating private key due to change in fields", "violations", violations)
-		c.recorder.Eventf(crt, corev1.EventTypeNormal, "Deleted", "Regenerating private key due to change in fields: %v", violations)
+		c.recorder.Eventf(crt, corev1.EventTypeNormal, Deleted, "Regenerating private key due to change in fields: %v", violations)
 		return c.deleteSecretResources(ctx, secrets)
 	}
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -49,9 +49,9 @@ import (
 )
 
 const (
-	ControllerName = "certificates-key-manager"
-	DecodeFailed   = "DecodeFailed"
-	Deleted        = "Deleted"
+	ControllerName    = "certificates-key-manager"
+	errorDecodeFailed = "DecodeFailed"
+	responseDeleted   = "Deleted"
 )
 
 var (
@@ -216,7 +216,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 	if len(violations) > 0 {
 		log.V(logf.DebugLevel).Info("Regenerating private key due to change in fields", "violations", violations)
-		c.recorder.Eventf(crt, corev1.EventTypeNormal, Deleted, "Regenerating private key due to change in fields: %v", violations)
+		c.recorder.Eventf(crt, corev1.EventTypeNormal, responseDeleted, "Regenerating private key due to change in fields: %v", violations)
 		return c.deleteSecretResources(ctx, secrets)
 	}
 
@@ -240,16 +240,16 @@ func (c *controller) createNextPrivateKeyRotationPolicyNever(ctx context.Context
 	existingPKData := s.Data[corev1.TLSPrivateKeyKey]
 	pk, err := pki.DecodePrivateKeyBytes(existingPKData)
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, DecodeFailed, "Failed to decode private key stored in Secret %q - generating new key", crt.Spec.SecretName)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, errorDecodeFailed, "Failed to decode private key stored in Secret %q - generating new key", crt.Spec.SecretName)
 		return c.createAndSetNextPrivateKey(ctx, crt)
 	}
 	violations, err := certificates.PrivateKeyMatchesSpec(pk, crt.Spec)
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, DecodeFailed, "Failed to check if private key stored in Secret %q is up to date - generating new key", crt.Spec.SecretName)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, errorDecodeFailed, "Failed to check if private key stored in Secret %q is up to date - generating new key", crt.Spec.SecretName)
 		return c.createAndSetNextPrivateKey(ctx, crt)
 	}
 	if len(violations) > 0 {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, DecodeFailed, "Existing private key in Secret %q does not match requirements on Certificate resource, mismatching fields: %v", crt.Spec.SecretName, violations)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, errorDecodeFailed, "Existing private key in Secret %q does not match requirements on Certificate resource, mismatching fields: %v", crt.Spec.SecretName, violations)
 		return nil
 	}
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -49,9 +49,9 @@ import (
 )
 
 const (
-	ControllerName    = "certificates-key-manager"
-	errorDecodeFailed = "DecodeFailed"
-	responseDeleted   = "Deleted"
+	ControllerName     = "certificates-key-manager"
+	reasonDecodeFailed = "DecodeFailed"
+	reasonDeleted      = "Deleted"
 )
 
 var (
@@ -216,7 +216,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	}
 	if len(violations) > 0 {
 		log.V(logf.DebugLevel).Info("Regenerating private key due to change in fields", "violations", violations)
-		c.recorder.Eventf(crt, corev1.EventTypeNormal, responseDeleted, "Regenerating private key due to change in fields: %v", violations)
+		c.recorder.Eventf(crt, corev1.EventTypeNormal, reasonDeleted, "Regenerating private key due to change in fields: %v", violations)
 		return c.deleteSecretResources(ctx, secrets)
 	}
 
@@ -240,16 +240,16 @@ func (c *controller) createNextPrivateKeyRotationPolicyNever(ctx context.Context
 	existingPKData := s.Data[corev1.TLSPrivateKeyKey]
 	pk, err := pki.DecodePrivateKeyBytes(existingPKData)
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, errorDecodeFailed, "Failed to decode private key stored in Secret %q - generating new key", crt.Spec.SecretName)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonDecodeFailed, "Failed to decode private key stored in Secret %q - generating new key", crt.Spec.SecretName)
 		return c.createAndSetNextPrivateKey(ctx, crt)
 	}
 	violations, err := certificates.PrivateKeyMatchesSpec(pk, crt.Spec)
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, errorDecodeFailed, "Failed to check if private key stored in Secret %q is up to date - generating new key", crt.Spec.SecretName)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonDecodeFailed, "Failed to check if private key stored in Secret %q is up to date - generating new key", crt.Spec.SecretName)
 		return c.createAndSetNextPrivateKey(ctx, crt)
 	}
 	if len(violations) > 0 {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, errorDecodeFailed, "Existing private key in Secret %q does not match requirements on Certificate resource, mismatching fields: %v", crt.Spec.SecretName, violations)
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonDecodeFailed, "Existing private key in Secret %q does not match requirements on Certificate resource, mismatching fields: %v", crt.Spec.SecretName, violations)
 		return nil
 	}
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -52,8 +52,8 @@ import (
 
 const (
 	ControllerName      = "certificates-request-manager"
-	statusRequestFailed = "RequestFailed"
-	statusRequested     = "Requested"
+	reasonRequestFailed = "RequestFailed"
+	reasonRequested     = "Requested"
 )
 
 var (
@@ -340,10 +340,10 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 
 	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{})
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, statusRequestFailed, "Failed to create CertificateRequest: "+err.Error())
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, reasonRequestFailed, "Failed to create CertificateRequest: "+err.Error())
 		return err
 	}
-	c.recorder.Eventf(crt, corev1.EventTypeNormal, statusRequested, "Created new CertificateRequest resource %q", cr.Name)
+	c.recorder.Eventf(crt, corev1.EventTypeNormal, reasonRequested, "Created new CertificateRequest resource %q", cr.Name)
 	if err := c.waitForCertificateRequestToExist(cr.Namespace, cr.Name); err != nil {
 		return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried")
 	}

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -52,6 +52,8 @@ import (
 
 const (
 	ControllerName = "certificates-request-manager"
+	RequestFailed  = "RequestFailed"
+	Requested      = "Requested"
 )
 
 var (
@@ -338,10 +340,10 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 
 	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{})
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, "RequestFailed", "Failed to create CertificateRequest: "+err.Error())
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, RequestFailed, "Failed to create CertificateRequest: "+err.Error())
 		return err
 	}
-	c.recorder.Eventf(crt, corev1.EventTypeNormal, "Requested", "Created new CertificateRequest resource %q", cr.Name)
+	c.recorder.Eventf(crt, corev1.EventTypeNormal, Requested, "Created new CertificateRequest resource %q", cr.Name)
 	if err := c.waitForCertificateRequestToExist(cr.Namespace, cr.Name); err != nil {
 		return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried")
 	}

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -51,9 +51,9 @@ import (
 )
 
 const (
-	ControllerName = "certificates-request-manager"
-	RequestFailed  = "RequestFailed"
-	Requested      = "Requested"
+	ControllerName      = "certificates-request-manager"
+	statusRequestFailed = "RequestFailed"
+	statusRequested     = "Requested"
 )
 
 var (
@@ -340,10 +340,10 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 
 	cr, err = c.client.CertmanagerV1().CertificateRequests(cr.Namespace).Create(ctx, cr, metav1.CreateOptions{})
 	if err != nil {
-		c.recorder.Eventf(crt, corev1.EventTypeWarning, RequestFailed, "Failed to create CertificateRequest: "+err.Error())
+		c.recorder.Eventf(crt, corev1.EventTypeWarning, statusRequestFailed, "Failed to create CertificateRequest: "+err.Error())
 		return err
 	}
-	c.recorder.Eventf(crt, corev1.EventTypeNormal, Requested, "Created new CertificateRequest resource %q", cr.Name)
+	c.recorder.Eventf(crt, corev1.EventTypeNormal, statusRequested, "Created new CertificateRequest resource %q", cr.Name)
 	if err := c.waitForCertificateRequestToExist(cr.Namespace, cr.Name); err != nil {
 		return fmt.Errorf("failed whilst waiting for CertificateRequest to exist - this may indicate an apiserver running slowly. Request will be retried")
 	}

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -39,7 +39,10 @@ import (
 )
 
 const (
-	BadConfig = "BadConfig"
+	BadConfig         = "BadConfig"
+	CreateCertificate = "CreateCertificate"
+	UpdateCertificate = "UpdateCertificate"
+	DeleteCertificate = "DeleteCertificate"
 )
 
 var ingressGVK = networkingv1beta1.SchemeGroupVersion.WithKind("Ingress")
@@ -82,7 +85,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, "CreateCertificate", "Successfully created Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, CreateCertificate, "Successfully created Certificate %q", crt.Name)
 	}
 
 	for _, crt := range updateCrts {
@@ -90,7 +93,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, "UpdateCertificate", "Successfully updated Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, UpdateCertificate, "Successfully updated Certificate %q", crt.Name)
 	}
 
 	unrequiredCrts, err := c.findUnrequiredCertificates(ing)
@@ -103,7 +106,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, "DeleteCertificate", "Successfully deleted unrequired Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, DeleteCertificate, "Successfully deleted unrequired Certificate %q", crt.Name)
 	}
 
 	return nil

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -39,10 +39,10 @@ import (
 )
 
 const (
-	BadConfig         = "BadConfig"
-	CreateCertificate = "CreateCertificate"
-	UpdateCertificate = "UpdateCertificate"
-	DeleteCertificate = "DeleteCertificate"
+	errorBadConfig           = "BadConfig"
+	successCreateCertificate = "CreateCertificate"
+	successUpdateCertificate = "UpdateCertificate"
+	successDeleteCertificate = "DeleteCertificate"
 )
 
 var ingressGVK = networkingv1beta1.SchemeGroupVersion.WithKind("Ingress")
@@ -60,7 +60,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 	issuerName, issuerKind, issuerGroup, err := c.issuerForIngress(ing)
 	if err != nil {
 		log.Error(err, "failed to determine issuer to be used for ingress resource")
-		c.recorder.Eventf(ing, corev1.EventTypeWarning, BadConfig, "Could not determine issuer for ingress due to bad annotations: %s",
+		c.recorder.Eventf(ing, corev1.EventTypeWarning, errorBadConfig, "Could not determine issuer for ingress due to bad annotations: %s",
 			err)
 		return nil
 	}
@@ -71,7 +71,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if len(errs) > 1 {
 			errMsg = utilerrors.NewAggregate(errs).Error()
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeWarning, BadConfig, errMsg)
+		c.recorder.Eventf(ing, corev1.EventTypeWarning, errorBadConfig, errMsg)
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, CreateCertificate, "Successfully created Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, successCreateCertificate, "Successfully created Certificate %q", crt.Name)
 	}
 
 	for _, crt := range updateCrts {
@@ -93,7 +93,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, UpdateCertificate, "Successfully updated Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, successUpdateCertificate, "Successfully updated Certificate %q", crt.Name)
 	}
 
 	unrequiredCrts, err := c.findUnrequiredCertificates(ing)
@@ -106,7 +106,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, DeleteCertificate, "Successfully deleted unrequired Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, successDeleteCertificate, "Successfully deleted unrequired Certificate %q", crt.Name)
 	}
 
 	return nil
@@ -152,7 +152,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 		// if this tls entry is invalid, record an error event on Ingress object and continue to the next tls entry
 		if len(errs) > 0 {
 			errMsg := utilerrors.NewAggregate(errs).Error()
-			c.recorder.Eventf(ing, corev1.EventTypeWarning, BadConfig, fmt.Sprintf("TLS entry %d is invalid: %s", i, errMsg))
+			c.recorder.Eventf(ing, corev1.EventTypeWarning, errorBadConfig, fmt.Sprintf("TLS entry %d is invalid: %s", i, errMsg))
 			continue
 		}
 		existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(tls.SecretName)

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -38,6 +38,10 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
 
+const (
+	BadConfig = "BadConfig"
+)
+
 var ingressGVK = networkingv1beta1.SchemeGroupVersion.WithKind("Ingress")
 
 func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) error {
@@ -53,7 +57,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 	issuerName, issuerKind, issuerGroup, err := c.issuerForIngress(ing)
 	if err != nil {
 		log.Error(err, "failed to determine issuer to be used for ingress resource")
-		c.recorder.Eventf(ing, corev1.EventTypeWarning, "BadConfig", "Could not determine issuer for ingress due to bad annotations: %s",
+		c.recorder.Eventf(ing, corev1.EventTypeWarning, BadConfig, "Could not determine issuer for ingress due to bad annotations: %s",
 			err)
 		return nil
 	}
@@ -64,7 +68,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if len(errs) > 1 {
 			errMsg = utilerrors.NewAggregate(errs).Error()
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeWarning, "BadConfig", errMsg)
+		c.recorder.Eventf(ing, corev1.EventTypeWarning, BadConfig, errMsg)
 		return nil
 	}
 
@@ -145,7 +149,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 		// if this tls entry is invalid, record an error event on Ingress object and continue to the next tls entry
 		if len(errs) > 0 {
 			errMsg := utilerrors.NewAggregate(errs).Error()
-			c.recorder.Eventf(ing, corev1.EventTypeWarning, "BadConfig", fmt.Sprintf("TLS entry %d is invalid: %s", i, errMsg))
+			c.recorder.Eventf(ing, corev1.EventTypeWarning, BadConfig, fmt.Sprintf("TLS entry %d is invalid: %s", i, errMsg))
 			continue
 		}
 		existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(tls.SecretName)

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -39,10 +39,10 @@ import (
 )
 
 const (
-	errorBadConfig           = "BadConfig"
-	successCreateCertificate = "CreateCertificate"
-	successUpdateCertificate = "UpdateCertificate"
-	successDeleteCertificate = "DeleteCertificate"
+	reasonBadConfig         = "BadConfig"
+	reasonCreateCertificate = "CreateCertificate"
+	reasonUpdateCertificate = "UpdateCertificate"
+	reasonDeleteCertificate = "DeleteCertificate"
 )
 
 var ingressGVK = networkingv1beta1.SchemeGroupVersion.WithKind("Ingress")
@@ -60,7 +60,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 	issuerName, issuerKind, issuerGroup, err := c.issuerForIngress(ing)
 	if err != nil {
 		log.Error(err, "failed to determine issuer to be used for ingress resource")
-		c.recorder.Eventf(ing, corev1.EventTypeWarning, errorBadConfig, "Could not determine issuer for ingress due to bad annotations: %s",
+		c.recorder.Eventf(ing, corev1.EventTypeWarning, reasonBadConfig, "Could not determine issuer for ingress due to bad annotations: %s",
 			err)
 		return nil
 	}
@@ -71,7 +71,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if len(errs) > 1 {
 			errMsg = utilerrors.NewAggregate(errs).Error()
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeWarning, errorBadConfig, errMsg)
+		c.recorder.Eventf(ing, corev1.EventTypeWarning, reasonBadConfig, errMsg)
 		return nil
 	}
 
@@ -85,7 +85,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, successCreateCertificate, "Successfully created Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, reasonCreateCertificate, "Successfully created Certificate %q", crt.Name)
 	}
 
 	for _, crt := range updateCrts {
@@ -93,7 +93,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, successUpdateCertificate, "Successfully updated Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, reasonUpdateCertificate, "Successfully updated Certificate %q", crt.Name)
 	}
 
 	unrequiredCrts, err := c.findUnrequiredCertificates(ing)
@@ -106,7 +106,7 @@ func (c *controller) Sync(ctx context.Context, ing *networkingv1beta1.Ingress) e
 		if err != nil {
 			return err
 		}
-		c.recorder.Eventf(ing, corev1.EventTypeNormal, successDeleteCertificate, "Successfully deleted unrequired Certificate %q", crt.Name)
+		c.recorder.Eventf(ing, corev1.EventTypeNormal, reasonDeleteCertificate, "Successfully deleted unrequired Certificate %q", crt.Name)
 	}
 
 	return nil
@@ -152,7 +152,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 		// if this tls entry is invalid, record an error event on Ingress object and continue to the next tls entry
 		if len(errs) > 0 {
 			errMsg := utilerrors.NewAggregate(errs).Error()
-			c.recorder.Eventf(ing, corev1.EventTypeWarning, errorBadConfig, fmt.Sprintf("TLS entry %d is invalid: %s", i, errMsg))
+			c.recorder.Eventf(ing, corev1.EventTypeWarning, reasonBadConfig, fmt.Sprintf("TLS entry %d is invalid: %s", i, errMsg))
 			continue
 		}
 		existingCrt, err := c.certificateLister.Certificates(ing.Namespace).Get(tls.SecretName)


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Uses constants for string literals which get repeated in as the `reason` argument in `k8s.io/client-go/tools/record.EventRecorder.Eventf` function calls.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #3620

**Special notes for your reviewer**:
Should I do this even for arguments which do not get repeated and are only used once @irbekrm?

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
