### PR TITLE
Refactor the end-to-end ACME HTTP01 tests (follow-up to #3444)

### DIFF
--- a/pkg/controller/certificates/trigger/policies/gatherer.go
+++ b/pkg/controller/certificates/trigger/policies/gatherer.go
@@ -19,7 +19,7 @@ package policies
 // In order to decide whether or not to reissue a certificate, we want to gather
 // the "state of the world" regarding that particular certificate, which is the
 // entire purpose of DataForCertificate. Along with the certificate's secret,
-// DataForCertificate also returns two separate // certificate requests: the
+// DataForCertificate also returns two separate certificate requests: the
 // "current" one and the "next" one.
 //
 // To understand the roles of the "current" and "next" certificate requests, let
@@ -42,9 +42,9 @@ package policies
 //               |   - type: Issuing   |  |        |     cert-manager.io/certificate-revision: 1 |
 //               |     status: True    |  +------->| status:                                     |
 //               +---------------------+    "next" |   conditions:                               |
-//                         |                       |   - type: Ready                             |
-//                         |                       |     status: False                           |
-//                         v                       |     reason: Pending                         |
+//                         |                       |    - type: Ready                            |
+//                         |                       |      status: False                          |
+//                         v                       |      reason: Pending                        |
 //                        ...                      +---------------------------------------------+
 //
 // DIAGRAM (A2): the certificate in (A1) gets reconciled. Eventually, it becomes
@@ -58,8 +58,8 @@ package policies
 //               |   revision: 1 ---------+------->|     cert-manager.io/certificate-revision: 1 |
 //               |   conditions:       |  |        | status:                                     |
 //               |    - type: Issuing  |  |        |   conditions:                               |
-//               |      status: False  |  |        |     type: Ready                             |
-//               |      reason: Issued |  |        |     status: True                            |
+//               |      status: False  |  |        |    - type: Ready                            |
+//               |      reason: Issued |  |        |      status: True                           |
 //               |    - type: Ready    |  |        +---------------------------------------------+
 //               |      status: True   |  |
 //               +---------------------+  |
@@ -91,8 +91,8 @@ package policies
 //                         |                        |     cert-manager.io/certificate-revision: 7 |
 //                         |                        | status:                                     |
 //                         |               "current"|   conditions:                               |
-//                         v               +------->|     type: Ready                             |
-//                +--------------------+   |        |     status: True                            |
+//                         v               +------->|    - type: Ready                            |
+//                +--------------------+   |        |      status: True                           |
 //    CERTIFICATE | kind: Certificate  |   |        +-MISMATCH---------MISMATCH----------MISMATCH-+
 //       DOES NOT | status:            |   |
 //      MATCH THE |   revision: 7 ---------+
@@ -114,8 +114,8 @@ package policies
 //                         |                        |     cert-manager.io/certificate-revision: 7 |
 //                         |                        | status:                                     |
 //                         v                        |   conditions:                               |
-//                +---------------------+ "current" |     type: Ready                             |
-//   CERTIFICATE  | kind: Certificate   |  +------->|     status: True                            |
+//                +---------------------+ "current" |    - type: Ready                            |
+//   CERTIFICATE  | kind: Certificate   |  +------->|      status: True                           |
 //      IS BEING  | status:             |  |        +-MISMATCH---------MISMATCH----------MISMATCH-+
 //      REISSUED  |   revision: 7----------+
 //                |   conditions:       |  |        +---------------------------------------------+
@@ -125,9 +125,9 @@ package policies
 //                |    - type: Ready    |    "next" |     cert-manager.io/certificate-revision: 8 |
 //                |      status: False  |           | status:                                     |
 //                +---------------------+           |   conditions:                               |
-//                                                  |     type: Ready                             |
-//                                                  |     status: False                           |
-//                                                  |     reason: Pending                         |
+//                                                  |    - type: Ready                            |
+//                                                  |      status: False                          |
+//                                                  |      reason: Pending                        |
 //                                                  +---------------------------------------------+
 //
 //
@@ -149,8 +149,8 @@ package policies
 //    IS FAILING | status:             |   |        |     cert-manager.io/certificate-revision: 1 |
 //               |   revision: nil --------+        | status:                                     |
 //               |   conditions:       |   |        |   conditions:                               |
-//               |    - type: Issuing  |   +------->|     type: Failed                            |
-//               |      status: False  |     "next" |     status: True                            |
+//               |    - type: Issuing  |   +------->|    - type: Failed                           |
+//               |      status: False  |     "next" |      status: True                           |
 //               |      reason: Failed |            +---------------------------------------------+
 //               |   lastFailureTime: *|
 //               +---------------------+
@@ -176,8 +176,8 @@ package policies
 //     MISMATCH  |    - type: Issuing  |   |        |     cert-manager.io/certificate-revision: 1 |
 //               |      status: True   |   |        | status:                                     |
 //               |      reason: Pending|   |------->|   conditions:                               |
-//               |    - type: Ready    |     "next" |     type: Failed                            |
-//               |      status: False  |            |     status: True                            |
+//               |    - type: Ready    |     "next" |    - type: Failed                           |
+//               |      status: False  |            |      status: True                           |
 //               +---------------------+            +-MISMATCH---------MISMATCH----------MISMATCH-+
 //                         |
 //                         v
@@ -202,9 +202,9 @@ package policies
 //                |      status: False   |  |        |     cert-manager.io/certificate-revision: 1 |
 //                |    - type: Issuing   |  |------->| status:                                     |
 //                |      status: True    |    "next" |   conditions:                               |
-//                |      reason: Pending |           |     type: Ready                             |
-//                +----------------------+           |     status: False                           |
-//                                                   |     reason: Pending                         |
+//                |      reason: Pending |           |    - type: Ready                            |
+//                +----------------------+           |      status: False                          |
+//                                                   |      reason: Pending                        |
 //                                                   +-NEW---------------NEW-------------------NEW-+
 
 import (

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -246,17 +246,6 @@ func (h *Helper) deduplicateExtKeyUsages(us []x509.ExtKeyUsage) []x509.ExtKeyUsa
 	return us
 }
 
-func (h *Helper) WaitCertificateIssued(ns, name string, timeout time.Duration) error {
-	certificate, err := h.WaitForCertificateReady(ns, name, timeout)
-	if err != nil {
-		log.Logf("Error waiting for Certificate to become Ready: %v", err)
-		h.Kubectl(ns).DescribeResource("certificate", name)
-		h.Kubectl(ns).Describe("order", "challenge")
-		h.describeCertificateRequestFromCertificate(ns, certificate)
-	}
-	return err
-}
-
 func (h *Helper) defaultKeyUsagesToAdd(ns string, issuerRef *cmmeta.ObjectReference) (x509.KeyUsage, []x509.ExtKeyUsage, error) {
 	var issuerSpec *cmapi.IssuerSpec
 	switch issuerRef.Kind {

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -72,7 +72,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -125,7 +125,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -154,7 +154,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -186,7 +186,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -216,7 +216,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -294,7 +294,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -324,7 +324,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -354,7 +354,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -381,7 +381,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -409,7 +409,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -467,7 +467,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -494,7 +494,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -525,7 +525,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -559,7 +559,7 @@ func (s *Suite) Define() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, "testcert", time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -620,7 +620,7 @@ func (s *Suite) Define() {
 			)).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -656,7 +656,7 @@ func (s *Suite) Define() {
 			)).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Verify that the ingres-shim has translated all the supplied

--- a/test/e2e/suite/issuers/acme/certificate/dns01.go
+++ b/test/e2e/suite/issuers/acme/certificate/dns01.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
+	"github.com/jetstack/cert-manager/test/e2e/framework/helper/featureset"
+	"github.com/jetstack/cert-manager/test/e2e/suite/issuers/acme/dnsproviders"
+	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+type dns01Provider interface {
+	Details() *dnsproviders.Details
+	addon.Addon
+}
+
+var _ = framework.CertManagerDescribe("ACME Certificate (DNS01)", func() {
+	// TODO: add better logic to handle other DNS providers
+	testRFC2136DNSProvider()
+})
+
+func testRFC2136DNSProvider() bool {
+	name := "rfc2136"
+	return Context("With "+name+" credentials configured", func() {
+		f := framework.NewDefaultFramework("create-acme-certificate-dns01-" + name)
+
+		issuerName := "test-acme-issuer"
+		certificateName := "test-acme-certificate"
+		certificateSecretName := "test-acme-certificate"
+
+		p := &dnsproviders.RFC2136{}
+		f.RequireAddon(p)
+
+		dnsDomain := ""
+
+		// ACME Issuer does not return a ca.crt. See:
+		// https://github.com/jetstack/cert-manager/issues/1571
+		unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+		validations := f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)
+
+		BeforeEach(func() {
+			By("Creating an Issuer")
+			dnsDomain = p.Details().NewTestDomain()
+			issuer := gen.Issuer(issuerName,
+				gen.SetIssuerACME(cmacme.ACMEIssuer{
+					SkipTLSVerify: true,
+					Server:        f.Config.Addons.ACMEServer.URL,
+					Email:         testingACMEEmail,
+					PrivateKey: cmmeta.SecretKeySelector{
+						LocalObjectReference: cmmeta.LocalObjectReference{
+							Name: testingACMEPrivateKey,
+						},
+					},
+					Solvers: []cmacme.ACMEChallengeSolver{
+						{
+							DNS01: &p.Details().ProviderConfig,
+						},
+					},
+				}))
+			issuer.Namespace = f.Namespace.Name
+			issuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			By("Waiting for Issuer to become Ready")
+			err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+				issuerName,
+				v1.IssuerCondition{
+					Type:   v1.IssuerConditionReady,
+					Status: cmmeta.ConditionTrue,
+				})
+			Expect(err).NotTo(HaveOccurred())
+			By("Verifying the ACME account URI is set")
+			err = util.WaitForIssuerStatusFunc(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+				issuerName,
+				func(i *v1.Issuer) (bool, error) {
+					if i.GetStatus().ACMEStatus().URI == "" {
+						return false, nil
+					}
+					return true, nil
+				})
+			Expect(err).NotTo(HaveOccurred())
+			By("Verifying ACME account private key exists")
+			secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), testingACMEPrivateKey, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			if len(secret.Data) != 1 {
+				Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
+			}
+		})
+
+		AfterEach(func() {
+			By("Cleaning up")
+			f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), testingACMEPrivateKey, metav1.DeleteOptions{})
+			f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), certificateSecretName, metav1.DeleteOptions{})
+		})
+
+		It("should obtain a signed certificate for a regular domain", func() {
+			By("Creating a Certificate")
+
+			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+				gen.SetCertificateDNSNames(dnsDomain),
+			)
+			cert.Namespace = f.Namespace.Name
+
+			cert, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the Certificate to be issued...")
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Validating the issued Certificate...")
+			err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should obtain a signed certificate for a wildcard domain", func() {
+			By("Creating a Certificate")
+
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+				gen.SetCertificateDNSNames("*."+dnsDomain),
+			)
+			cert.Namespace = f.Namespace.Name
+
+			cert, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.TODO(), cert, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the Certificate to be issued...")
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Validating the issued Certificate...")
+			err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should obtain a signed certificate for a wildcard and apex domain", func() {
+			By("Creating a Certificate")
+
+			cert := gen.Certificate(certificateName,
+				gen.SetCertificateSecretName(certificateSecretName),
+				gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+				gen.SetCertificateDNSNames("*."+dnsDomain, dnsDomain),
+			)
+			cert.Namespace = f.Namespace.Name
+
+			cert, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.TODO(), cert, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			// use a longer timeout for this, as it requires performing 2 dns validations in serial
+			By("Waiting for the Certificate to be issued...")
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*10)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Validating the issued Certificate...")
+			err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+}

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -1,0 +1,677 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package certificate
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1beta1 "k8s.io/api/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	cmutil "github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework/helper/featureset"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
+	. "github.com/jetstack/cert-manager/test/e2e/framework/matcher"
+	frameworkutil "github.com/jetstack/cert-manager/test/e2e/framework/util"
+	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+const testingACMEEmail = "e2e@cert-manager.io"
+const testingACMEPrivateKey = "test-acme-private-key"
+const foreverTestTimeout = time.Second * 60
+
+var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
+	f := framework.NewDefaultFramework("create-acme-certificate-http01")
+	h := f.Helper()
+
+	var acmeIngressDomain string
+	issuerName := "test-acme-issuer"
+	certificateName := "test-acme-certificate"
+	certificateSecretName := "test-acme-certificate"
+	// fixedIngressName is the name of an ingress resource that is configured
+	// with a challenge solve.
+	// To utilise this solver, add the 'testing.cert-manager.io/fixed-ingress: "true"' label.
+	fixedIngressName := "testingress"
+
+	// ACME Issuer does not return a ca.crt. See:
+	// https://github.com/jetstack/cert-manager/issues/1571
+	unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+	validations := f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)
+
+	BeforeEach(func() {
+		solvers := []cmacme.ACMEChallengeSolver{
+			{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Class: &f.Config.Addons.IngressController.IngressClass,
+					},
+				},
+			},
+			{
+				Selector: &cmacme.CertificateDNSNameSelector{
+					MatchLabels: map[string]string{
+						"testing.cert-manager.io/fixed-ingress": "true",
+					},
+				},
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+						Name: fixedIngressName,
+					},
+				},
+			},
+		}
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMESolvers(solvers))
+		By("Creating an Issuer")
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying the ACME account URI is set")
+		err = util.WaitForIssuerStatusFunc(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			func(i *v1.Issuer) (bool, error) {
+				if i.GetStatus().ACMEStatus().URI == "" {
+					return false, nil
+				}
+				return true, nil
+			})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying ACME account private key exists")
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), testingACMEPrivateKey, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		if len(secret.Data) != 1 {
+			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
+		}
+	})
+
+	JustBeforeEach(func() {
+		acmeIngressDomain = frameworkutil.RandomSubdomain(f.Config.Addons.IngressController.Domain)
+	})
+
+	AfterEach(func() {
+		By("Cleaning up")
+		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), testingACMEPrivateKey, metav1.DeleteOptions{})
+	})
+
+	It("should obtain a signed certificate with a single CN from the ACME server", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(acmeIngressDomain),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should obtain a signed ecdsa certificate with a single CN from the ACME server", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{
+				Name: issuerName,
+			}),
+			gen.SetCertificateDNSNames(acmeIngressDomain),
+			gen.SetCertificateKeyAlgorithm(v1.ECDSAKeyAlgorithm),
+		)
+		cert.Namespace = f.Namespace.Name
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should obtain a signed certificate for a long domain using http01 validation", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		// the maximum length of a single segment of the domain being requested
+		const maxLengthOfDomainSegment = 63
+		By("Creating a Certificate")
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(acmeIngressDomain, fmt.Sprintf("%s.%s", cmutil.RandStringRunes(maxLengthOfDomainSegment), acmeIngressDomain)),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should obtain a signed certificate with a CN and single subdomain as dns name from the ACME server", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Verifying the Certificate is valid")
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow updating an existing certificate with a new dns name", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the Certificate is valid")
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Getting the latest version of the Certificate")
+		cert, err = certClient.Get(context.TODO(), certificateName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Adding an additional dnsName to the Certificate")
+		newDNSName := fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)
+		cert.Spec.DNSNames = append(cert.Spec.DNSNames, newDNSName)
+
+		By("Updating the Certificate in the apiserver")
+		cert, err = certClient.Update(context.TODO(), cert, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be not ready")
+		_, err = h.WaitForCertificateNotReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to become ready & valid")
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow updating the dns name of a failing certificate that had an incorrect dns name", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a failing Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames("google.com"),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Making sure the Order failed with a 400 since google.com is invalid")
+		order := &cmacme.Order{}
+		err = wait.PollImmediate(1*time.Second, 1*time.Minute, func() (done bool, err error) {
+			orders, err := listOwnedOrders(f.CertManagerClientSet, cert)
+			Expect(err).NotTo(HaveOccurred())
+
+			if len(orders) == 0 || len(orders) > 1 {
+				log.Logf("Waiting as one Order should exist, but we found %d", len(orders))
+				return false, nil
+			}
+			order = orders[0]
+
+			expected := `400 urn:ietf:params:acme:error:rejectedIdentifier`
+			if !strings.Contains(order.Status.Reason, expected) {
+				log.Logf("Waiting for Order's reason, current: %s, should contain: %s", order.Status.Reason, expected)
+				return false, nil
+			}
+
+			return true, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be not ready")
+		_, err = h.WaitForCertificateNotReady(f.Namespace.Name, certificateName, 30*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Getting the latest version of the Certificate")
+		cert, err = certClient.Get(context.TODO(), certificateName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Replacing dnsNames with a valid dns name")
+		cert.Spec.DNSNames = []string{fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)}
+		_, err = certClient.Update(context.TODO(), cert, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to have the Ready=True condition")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Sanity checking the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Checking that the secret contains this dns name")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, func(cert *v1.Certificate, secret *corev1.Secret) error {
+			dnsnames, err := findDNSNames(secret)
+			if err != nil {
+				return err
+			}
+			Expect(cert.Spec.DNSNames).To(ContainElements(dnsnames))
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should fail to obtain a certificate for an invalid ACME dns name", func() {
+		// create test fixture
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames("google.com"),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		cert, err := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name).Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		notReadyCondition := v1.CertificateCondition{
+			Type:   v1.CertificateConditionReady,
+			Status: cmmeta.ConditionFalse,
+		}
+		Eventually(cert, "30s", "1s").Should(HaveCondition(f, notReadyCondition))
+		Consistently(cert, "1m", "10s").Should(HaveCondition(f, notReadyCondition))
+	})
+
+	It("should obtain a signed certificate with a single CN from the ACME server when putting an annotation on an ingress resource", func() {
+		ingClient := f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace.Name)
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating an Ingress with the issuer name annotation set")
+		_, err := ingClient.Create(context.TODO(), util.NewIngress(certificateSecretName, certificateSecretName, map[string]string{
+			"cert-manager.io/issuer": issuerName,
+		}, acmeIngressDomain), metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for Certificate to exist")
+		err = util.WaitForCertificateToExist(certClient, certificateSecretName, foreverTestTimeout)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should obtain a signed certificate with a single CN from the ACME server when redirected", func() {
+
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		// force-ssl-redirect should make every request turn into a redirect,
+		// but I haven't been able to make this happen. Create a TLS cert via
+		// the self-sign issuer to make it have a "proper" TLS cert
+		// TODO: investigate if we still need to use the self-signed issuer here
+
+		issuer := gen.Issuer("selfsign",
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(v1.SelfSignedIssuer{}))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for (selfsign) Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		const dummycert = "dummy-tls"
+		const secretname = "dummy-tls-secret"
+
+		selfcert := util.NewCertManagerBasicCertificate("dummy-tls", secretname, "selfsign", v1.IssuerKind, nil, nil, acmeIngressDomain)
+		_, err = certClient.Create(context.TODO(), selfcert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, dummycert, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, dummycert, validations...)
+		Expect(err).NotTo(HaveOccurred())
+
+		// create an ingress that points at nothing, but has the TLS redirect annotation set
+		// using the TLS secret that we just got from the self-sign
+		ingress := f.KubeClientSet.NetworkingV1beta1().Ingresses(f.Namespace.Name)
+		_, err = ingress.Create(context.TODO(), &networkingv1beta1.Ingress{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fixedIngressName,
+				Annotations: map[string]string{
+					"nginx.ingress.kubernetes.io/force-ssl-redirect": "true",
+					"kubernetes.io/ingress.class":                    "nginx",
+				},
+			},
+			Spec: networkingv1beta1.IngressSpec{
+				TLS: []networkingv1beta1.IngressTLS{
+					{
+						Hosts:      []string{acmeIngressDomain},
+						SecretName: secretname,
+					},
+				},
+				Rules: []networkingv1beta1.IngressRule{
+					{
+						Host: acmeIngressDomain,
+						IngressRuleValue: networkingv1beta1.IngressRuleValue{
+							HTTP: &networkingv1beta1.HTTPIngressRuleValue{
+								Paths: []networkingv1beta1.HTTPIngressPath{
+									{
+										Path: "/",
+										Backend: networkingv1beta1.IngressBackend{
+											ServiceName: "doesnotexist",
+											ServicePort: intstr.FromInt(443),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating a Certificate")
+		// This is a special cert for the test suite, where we specify an ingress rather than a
+		// class
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(acmeIngressDomain),
+		)
+		cert.Namespace = f.Namespace.Name
+		cert.Labels = map[string]string{
+			"testing.cert-manager.io/fixed-ingress": "true",
+		}
+
+		_, err = certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should automatically recreate challenge pod and still obtain a certificate if it is manually deleted", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(acmeIngressDomain),
+		)
+		cert.Namespace = f.Namespace.Name
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("killing the solver pod")
+		podClient := f.KubeClientSet.CoreV1().Pods(f.Namespace.Name)
+		var pod corev1.Pod
+		err = wait.PollImmediate(1*time.Second, time.Minute,
+			func() (bool, error) {
+				log.Logf("Waiting for solver pod to exist")
+				podlist, err := podClient.List(context.TODO(), metav1.ListOptions{})
+				if err != nil {
+					return false, err
+				}
+
+				for _, p := range podlist.Items {
+					log.Logf("solver pod %s", p.Name)
+					// TODO(dmo): make this cleaner instead of just going by name
+					if strings.Contains(p.Name, "http-solver") {
+						pod = p
+						return true, nil
+					}
+				}
+				return false, nil
+
+			},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = podClient.Delete(context.TODO(), pod.Name, metav1.DeleteOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// The pod should get remade and the certificate should be made valid.
+		// Killing the pod could potentially make the validation invalid if pebble
+		// were to ask us for the challenge after the pod was killed, but because
+		// we kill it so early, we should always be in the self-check phase
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should obtain a signed certificate with a single IP Address from the ACME server", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateIPs(f.Config.Addons.ACMEServer.IngressIP),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should obtain a signed certificate with an IP and DNS names from the ACME server", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(fmt.Sprintf("%s.%s", cmutil.RandStringRunes(2), acmeIngressDomain)),
+			gen.SetCertificateIPs(f.Config.Addons.ACMEServer.IngressIP),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow updating an existing certificate with a new dns name", func() {
+		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
+
+		By("Creating a Certificate")
+		cert := gen.Certificate(certificateName,
+			gen.SetCertificateSecretName(certificateSecretName),
+			gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName}),
+			gen.SetCertificateDNSNames(fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)),
+		)
+		cert.Namespace = f.Namespace.Name
+
+		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Getting the latest version of the Certificate")
+		cert, err = certClient.Get(context.TODO(), certificateName, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Adding an additional dnsName to the Certificate")
+		newDNSName := fmt.Sprintf("%s.%s", cmutil.RandStringRunes(5), acmeIngressDomain)
+		cert.Spec.DNSNames = append(cert.Spec.DNSNames, newDNSName)
+
+		By("Updating the Certificate in the apiserver")
+		cert, err = certClient.Update(context.TODO(), cert, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be not ready")
+		_, err = h.WaitForCertificateNotReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Waiting for the Certificate to be issued...")
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validating the issued Certificate...")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+})
+
+// findDNSNames decodes and returns the dns names (SANs) contained in a
+// certificate secret.
+func findDNSNames(s *corev1.Secret) ([]string, error) {
+	if s.Data == nil {
+		return nil, fmt.Errorf("secret contains no data")
+	}
+	pkData := s.Data[corev1.TLSPrivateKeyKey]
+	certData := s.Data[corev1.TLSCertKey]
+	if len(pkData) == 0 || len(certData) == 0 {
+		return nil, fmt.Errorf("missing data in CA secret")
+	}
+	cert, err := tls.X509KeyPair(certData, pkData)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse data in CA secret: %w", err)
+	}
+
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		return nil, fmt.Errorf("internal error parsing x509 certificate: %w", err)
+	}
+
+	return x509Cert.DNSNames, nil
+}

--- a/test/e2e/suite/issuers/acme/certificate/http01.go
+++ b/test/e2e/suite/issuers/acme/certificate/http01.go
@@ -65,7 +65,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 	// ACME Issuer does not return a ca.crt. See:
 	// https://github.com/jetstack/cert-manager/issues/1571
 	unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveCAToSecret)
-	validations := f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)
+	sanityChecksWithoutx509Validation := f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)
 
 	BeforeEach(func() {
 		solvers := []cmacme.ACMEChallengeSolver{
@@ -149,12 +149,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -174,12 +174,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -201,12 +201,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be issued")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certific")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -225,12 +225,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		By("Verifying the Certificate is valid")
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be issued")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-checking the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -250,12 +250,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 
 		By("Verifying the Certificate is valid")
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be issued")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-checking the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Getting the latest version of the Certificate")
@@ -267,21 +267,19 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		cert.Spec.DNSNames = append(cert.Spec.DNSNames, newDNSName)
 
 		By("Updating the Certificate in the apiserver")
-		cert, err = certClient.Update(context.TODO(), cert, metav1.UpdateOptions{})
+		_, err = certClient.Update(context.TODO(), cert, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the Certificate to be not ready")
 		_, err = h.WaitForCertificateNotReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to become ready & valid")
-
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-checking the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -339,7 +337,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Sanity checking the issued Certificate")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Checking that the secret contains this dns name")
@@ -389,12 +387,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		err = util.WaitForCertificateToExist(certClient, certificateSecretName, foreverTestTimeout)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -428,12 +426,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err = certClient.Create(context.TODO(), selfcert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, dummycert, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, dummycert, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, dummycert, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 
 		// create an ingress that points at nothing, but has the TLS redirect annotation set
@@ -493,12 +491,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err = certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -547,12 +545,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		// Killing the pod could potentially make the validation invalid if pebble
 		// were to ask us for the challenge after the pod was killed, but because
 		// we kill it so early, we should always be in the self-check phase
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -570,12 +568,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -594,12 +592,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -617,12 +615,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err := certClient.Create(context.TODO(), cert, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Getting the latest version of the Certificate")
@@ -641,12 +639,12 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01)", func() {
 		_, err = h.WaitForCertificateNotReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Waiting for the Certificate to be issued...")
+		By("Waiting for the Certificate to be ready")
 		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, validations...)
+		By("Sanity-check the issued Certificate")
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, sanityChecksWithoutx509Validation...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -142,7 +142,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the Certificate to be issued...")
-		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -77,7 +77,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			Expect(err).NotTo(HaveOccurred())
 			By("Verifying the Certificate is valid")
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -97,7 +97,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -133,7 +133,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 				cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, v.inputDuration, v.inputRenewBefore), metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 				By("Waiting for the Certificate to be issued...")
-				err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+				err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 				Expect(err).NotTo(HaveOccurred())
 
 				By("Validating the issued Certificate...")
@@ -159,7 +159,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			_, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil), metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -182,7 +182,7 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 			_, err := certClient.Create(context.TODO(), gen.Certificate(certificateName, gen.SetCertificateNamespace(f.Namespace.Name), gen.SetCertificateCommonName("test.domain.com"), gen.SetCertificateSecretName(certificateSecretName), gen.SetCertificateIssuer(cmmeta.ObjectReference{Name: issuerName, Kind: v1.IssuerKind}), gen.SetCertificateKeyUsages(v1.UsageServerAuth, v1.UsageClientAuth)), metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -61,7 +61,7 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 		_, err = certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for the Certificate to be issued...")
-		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")
@@ -113,7 +113,7 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 			cert, err := certClient.Create(context.TODO(), util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerDurationName, v1.IssuerKind, v.inputDuration, v.inputRenewBefore), metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
@@ -143,7 +143,7 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the Certificate to be issued...")
-		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -168,7 +168,7 @@ func runVaultAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the Certificate to be issued...")
-		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")
@@ -264,7 +264,7 @@ func runVaultAppRoleTests(issuerKind string) {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for the Certificate to be issued...")
-			err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+			err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -166,7 +166,7 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the Certificate to be issued...")
-		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")

--- a/test/e2e/suite/issuers/venafi/tpp/certificate.go
+++ b/test/e2e/suite/issuers/venafi/tpp/certificate.go
@@ -83,7 +83,7 @@ var _ = TPPDescribe("Certificate with a properly configured Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for the Certificate to be issued...")
-		err = f.Helper().WaitCertificateIssued(f.Namespace.Name, certificateName, time.Minute*5)
+		err = f.Helper().WaitForCertificateReady(f.Namespace.Name, certificateName, time.Minute*5)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")


### PR DESCRIPTION
This is a follow-up PR to #3444. I struggled a lot understanding what we meant by "validation", so I propose a two changes that will hopefully help with this.

```release-note
NONE
```

**Update 3 May 2021:** I am trying to understand where `http01.go` and `dns01.go` went, see https://github.com/jetstack/cert-manager/pull/3724#discussion_r625108967 and https://github.com/jetstack/cert-manager/pull/3724#discussion_r625110854.