### PR TITLE
Handle CA issuer working as intermediate correctly 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+*.iml
 /acmesolver
 /controller
 /ingress-shim

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -424,9 +424,9 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 		return nil, nil, errors.New("no CA certificates given to sign CSR template")
 	}
 
-	caCert := caCerts[0]
+	issuingCACert := caCerts[0]
 
-	certPem, _, err := SignCertificate(template, caCert, template.PublicKey, caKey)
+	certPem, _, err := SignCertificate(template, issuingCACert, template.PublicKey, caKey)
 	if err != nil {
 		return nil, nil, err
 
@@ -440,7 +440,8 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 	certPem = append(certPem, chainPem...)
 
 	// encode the CA certificate to be bundled in the output
-	caPem, err := EncodeX509(caCerts[0])
+	caCert := caCerts[len(caCerts)-1]
+	caPem, err := EncodeX509(caCert)
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This patch fixes the CA issuer in case it is working as intermediate, and _the root CA certificate is available_ (best effort).

The current behavior is to assume that the CA issuer is the root CA, and return the issuing CA certificate as CA certificate to clients. This is not optimal when the CA issuer is an intermediate CA.

The wanted behavior in intermediate CA case is described in https://github.com/jetstack/cert-manager/issues/3619#issuecomment-808159467. Fix suggested in this PR uses the last certificate in the CA chain when signing as CA certificate supplied to clients. This should handle the intermediate case more correctly if the CA issuer is configured with the full CA certificate chain: starting with the issuing/signing CA certificate, any other intermediate CA certificates, ending with the root (self-signed) certificate.

This appears to be a non-breaking change.

**Which issue this PR fixes**: fixes #3619 

**Special notes for your reviewer**:

I would love to add some tests for this, both to test that this is actually a non-breaking change (which I presume) and ofc that the patch is effective. But being my first PR to cert-manager, I find it a bit hard to figure out how to test this properly - without introducing a bunch of new code. Any hints/tips would be greatly appreciated!

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Handle CA issuer working as intermediate correctly
```

Related:
- https://github.com/cert-manager/website/pull/498
- https://github.com/cert-manager/website/pull/499
