### PR TITLE
Use upstream golang/crypto functionality for ACME External Account Binding

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -14132,6 +14132,41 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ================================================================================
+= vendor/golang.org/x/term licensed under: =
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+= vendor/golang.org/x/term/LICENSE 5d4950ecb7b26d2c5e4e7b4e0dd74707
+================================================================================
+
+
+================================================================================
 = vendor/golang.org/x/text licensed under: =
 
 Copyright (c) 2009 The Go Authors. All rights reserved.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -84,12 +84,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256
@@ -1122,12 +1121,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256
@@ -2162,12 +2160,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256
@@ -3202,12 +3199,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -84,12 +84,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256
@@ -1122,12 +1121,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256
@@ -2162,12 +2160,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256
@@ -3202,12 +3199,11 @@ spec:
                       description: ExternalAccountBinding is a reference to a CA external account of the ACME server. If set, upon registration cert-manager will attempt to associate the given external account credentials with the registered ACME account.
                       type: object
                       required:
-                        - keyAlgorithm
                         - keyID
                         - keySecretRef
                       properties:
                         keyAlgorithm:
-                          description: keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512".
+                          description: '(deprecated) keyAlgorithm is the MAC key algorithm that the key is used for. Valid values are "HS256", "HS384" and "HS512". Deprecation warning: this value is no longer used as golang/x/crypto/acme hardcodes the algorithm to HS256.'
                           type: string
                           enum:
                             - HS256

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.16
 
 // this if a fork to add EAB and alternative chains in ACME
 // to be replaced after https://github.com/golang/crypto/pull/109 merges
-replace golang.org/x/crypto => github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0
+replace golang.org/x/crypto => github.com/cert-manager/crypto v0.0.0-20210331051623-e6485987d0e4
 
 require (
 	github.com/Azure/azure-sdk-for-go v46.3.0+incompatible
@@ -40,7 +40,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.6.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
-	golang.org/x/net v0.0.0-20200822124328-c89045814202
+	golang.org/x/net v0.0.0-20210226172049-e18ecbb05110
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	google.golang.org/api v0.15.0

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jetstack/cert-manager
 go 1.16
 
 // this if a fork to add EAB and alternative chains in ACME
-// to be replaced after https://github.com/golang/crypto/pull/109 merges
+// to be replaced after https://go-review.googlesource.com/c/crypto/+/277294/ merges
 replace golang.org/x/crypto => github.com/cert-manager/crypto v0.0.0-20210331051623-e6485987d0e4
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,8 @@ github.com/blang/semver v3.5.0+incompatible h1:CGxCgetQ64DKk7rdZ++Vfnb1+ogGNnB17
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/census-instrumentation/opencensus-proto v0.2.1 h1:glEXhBS5PSLLv4IXzLA5yPRVX4bilULVyxxbrfOtDAk=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
+github.com/cert-manager/crypto v0.0.0-20210331051623-e6485987d0e4 h1:5Q/efCr8RAQPVg1LZbzWyB8XWBMQ4VkJ7mUBLN1BPbY=
+github.com/cert-manager/crypto v0.0.0-20210331051623-e6485987d0e4/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1 h1:6MnRN8NT7+YBpUIWxHtefFZOKTAPgGjpQSxqLNn0+qY=
@@ -512,8 +514,6 @@ github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369/go.mod h1:BSXmuO+STAnVfrANrmjBb36TMTDstsz7MSK+HVaYKv4=
-github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0 h1:09XQpCKCNW3zrjz4zvD/cYU3hqUEWW+bZrBwK8NwFW0=
-github.com/meyskens/crypto v0.0.0-20200821143559-6ca9aec645f0/go.mod h1:ihkquczjM7M0cZsn7H1TJ3ACXW1rCuAMKX9lZEWNU3U=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/miekg/dns v1.1.31 h1:sJFOl9BgwbYAWOGEwr61FU28pqsBNdpRBnhGXtO06Oo=
 github.com/miekg/dns v1.1.31/go.mod h1:KNUDUusw/aVsxyTYZM1oqvCicbwhgbNgztCETuNZ7xM=
@@ -796,8 +796,9 @@ golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20200707034311-ab3426394381/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/net v0.0.0-20200822124328-c89045814202 h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -848,8 +849,11 @@ golang.org/x/sys v0.0.0-20200202164722-d101bd2416d5/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4 h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=
 golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68 h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=
+golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20171227012246-e19ae1496984/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/hack/build/repos.bzl
+++ b/hack/build/repos.bzl
@@ -3380,9 +3380,9 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/crypto",
-        replace = "github.com/meyskens/crypto",
-        sum = "h1:09XQpCKCNW3zrjz4zvD/cYU3hqUEWW+bZrBwK8NwFW0=",
-        version = "v0.0.0-20200821143559-6ca9aec645f0",
+        replace = "github.com/cert-manager/crypto",
+        sum = "h1:5Q/efCr8RAQPVg1LZbzWyB8XWBMQ4VkJ7mUBLN1BPbY=",
+        version = "v0.0.0-20210331051623-e6485987d0e4",
     )
     go_repository(
         name = "org_golang_x_exp",
@@ -3430,8 +3430,8 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/net",
-        sum = "h1:VvcQYSHwXgi7W+TpUR6A9g6Up98WAHf3f/ulnJ62IyA=",
-        version = "v0.0.0-20200822124328-c89045814202",
+        sum = "h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=",
+        version = "v0.0.0-20210226172049-e18ecbb05110",
     )
     go_repository(
         name = "org_golang_x_oauth2",
@@ -3454,9 +3454,18 @@ def go_repositories():
         build_file_generation = "on",
         build_file_proto_mode = "disable",
         importpath = "golang.org/x/sys",
-        sum = "h1:5/PjkGUjvEU5Gl6BxmvKRPpqo2uNMv4rcHBMwzk/st8=",
-        version = "v0.0.0-20200622214017-ed371f2e16b4",
+        sum = "h1:nxC68pudNYkKU6jWhgrqdreuFiOQWj1Fs7T3VrH4Pjw=",
+        version = "v0.0.0-20201119102817-f84b799fce68",
     )
+    go_repository(
+        name = "org_golang_x_term",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "golang.org/x/term",
+        sum = "h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=",
+        version = "v0.0.0-20201126162022-7de9c90e9dd1",
+    )
+
     go_repository(
         name = "org_golang_x_text",
         build_file_generation = "on",

--- a/pkg/api/util/BUILD.bazel
+++ b/pkg/api/util/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "issuers.go",
         "names.go",
         "usages.go",
+        "warnings.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/api/util",
     visibility = ["//visibility:public"],

--- a/pkg/api/util/warnings.go
+++ b/pkg/api/util/warnings.go
@@ -1,0 +1,23 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+// Warning values thrown by validating webhook
+// https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/
+const (
+	DeprecatedACMEEABKeyAlgorithmField = "ACME issuer spec field 'externalAccount.keyAlgorithm' is deprecated. The value of this field will be ignored."
+)

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -118,9 +118,12 @@ type ACMEExternalAccountBinding struct {
 	// encoded data.
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
-	// keyAlgorithm is the MAC key algorithm that the key is used for.
-	// Valid values are "HS256", "HS384" and "HS512".
-	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+	// (deprecated) keyAlgorithm is the MAC key algorithm that the key is used
+	// for. Valid values are "HS256", "HS384" and "HS512".
+	// Deprecation warning: this value is no longer used as
+	// golang/x/crypto/acme hardcodes the algorithm to HS256.
+	// +optional
+	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm,omitempty"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -118,9 +118,12 @@ type ACMEExternalAccountBinding struct {
 	// encoded data.
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
-	// keyAlgorithm is the MAC key algorithm that the key is used for.
-	// Valid values are "HS256", "HS384" and "HS512".
-	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+	// (deprecated) keyAlgorithm is the MAC key algorithm that the key is used
+	// for. Valid values are "HS256", "HS384" and "HS512".
+	// Deprecation warning: this value is no longer used as
+	// golang/x/crypto/acme hardcodes the algorithm to HS256.
+	// +optional
+	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm,omitempty"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -118,9 +118,12 @@ type ACMEExternalAccountBinding struct {
 	// encoded data.
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
-	// keyAlgorithm is the MAC key algorithm that the key is used for.
-	// Valid values are "HS256", "HS384" and "HS512".
-	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+	// (deprecated) keyAlgorithm is the MAC key algorithm that the key is used
+	// for. Valid values are "HS256", "HS384" and "HS512".
+	// Deprecation warning: this value is no longer used as
+	// golang/x/crypto/acme hardcodes the algorithm to HS256.
+	// +optional
+	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm,omitempty"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -118,9 +118,12 @@ type ACMEExternalAccountBinding struct {
 	// encoded data.
 	Key cmmeta.SecretKeySelector `json:"keySecretRef"`
 
-	// keyAlgorithm is the MAC key algorithm that the key is used for.
-	// Valid values are "HS256", "HS384" and "HS512".
-	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm"`
+	// (deprecated) keyAlgorithm is the MAC key algorithm that the key is used
+	// for. Valid values are "HS256", "HS384" and "HS512".
+	// Deprecation warning: this value is no longer used as
+	// golang/x/crypto/acme hardcodes the algorithm to HS256.
+	// +optional
+	KeyAlgorithm HMACKeyAlgorithm `json:"keyAlgorithm,omitempty"`
 }
 
 // HMACKeyAlgorithm is the name of a key algorithm used for HMAC encryption

--- a/pkg/internal/api/validation/registry_test.go
+++ b/pkg/internal/api/validation/registry_test.go
@@ -18,6 +18,7 @@ package validation_test
 
 import (
 	"fmt"
+	"reflect"
 	"testing"
 
 	admissionv1 "k8s.io/api/admission/v1"
@@ -41,13 +42,16 @@ var (
 func TestValidateType(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
 	called := false
-	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
 		called = true
-		return nil
+		return nil, nil
 	}))
-	errs := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected no warnings but got: %+v", warnings)
 	}
 	if !called {
 		t.Errorf("expected registered validation function to run but it did not")
@@ -59,21 +63,24 @@ func TestValidateTypeMultiple(t *testing.T) {
 	called1 := false
 	called2 := false
 	calledInternal := false
-	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
 		called1 = true
-		return nil
+		return nil, nil
 	}))
-	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
 		called2 = true
-		return nil
+		return nil, nil
 	}))
-	utilruntime.Must(reg.AddValidateFunc(&cmapiinternal.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateFunc(&cmapiinternal.Certificate{}, func(req *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
 		calledInternal = true
-		return nil
+		return nil, nil
 	}))
-	errs := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected to not get any warnings but got %+v", warnings)
 	}
 	if !called1 || !called2 {
 		t.Errorf("expected registered validation function to run but it did not")
@@ -88,21 +95,24 @@ func TestValidateUpdateTypeMultiple(t *testing.T) {
 	called1 := false
 	called2 := false
 	calledInternal := false
-	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, _, _ runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, _, _ runtime.Object) (field.ErrorList, []string) {
 		called1 = true
-		return nil
+		return nil, nil
 	}))
-	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, _, _ runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, _, _ runtime.Object) (field.ErrorList, []string) {
 		called2 = true
-		return nil
+		return nil, nil
 	}))
-	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapiinternal.Certificate{}, func(_ *admissionv1.AdmissionRequest, _, _ runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapiinternal.Certificate{}, func(_ *admissionv1.AdmissionRequest, _, _ runtime.Object) (field.ErrorList, []string) {
 		calledInternal = true
-		return nil
+		return nil, nil
 	}))
-	errs := reg.ValidateUpdate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.ValidateUpdate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected to not get any warnings but got: %v", warnings)
 	}
 	if !called1 || !called2 {
 		t.Errorf("expected registered validation function to run but it did not")
@@ -115,32 +125,39 @@ func TestValidateUpdateTypeMultiple(t *testing.T) {
 func TestValidateUpdateType(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
 	called := false
-	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateUpdateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (field.ErrorList, []string) {
 		called = true
-		return nil
+		return nil, nil
 	}))
-	errs := reg.ValidateUpdate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.ValidateUpdate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected to not get any warnings but got %+v", warnings)
 	}
 	if !called {
 		t.Errorf("expected registered validation function to run but it did not")
 	}
 }
 
-func TestValidateTypeReturnsErrors(t *testing.T) {
+func TestValidateTypeReturnsErrorsAndWarnings(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
 	called := false
 	expectedErr := field.InternalError(nil, fmt.Errorf("failed"))
-	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+	expectedWarnings := []string{"test warning"}
+	utilruntime.Must(reg.AddValidateFunc(&cmapi.Certificate{}, func(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
 		called = true
-		return field.ErrorList{expectedErr}
+		return field.ErrorList{expectedErr}, expectedWarnings
 	}))
-	errs := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) != 1 {
 		t.Error("expected to get an error but got none")
 	} else if err := errs[0]; err.Error() != expectedErr.Error() {
 		t.Errorf("expected error to be %q but got %q", expectedErr.Error(), err.Error())
+	}
+	if !reflect.DeepEqual(warnings, expectedWarnings) {
+		t.Errorf("expected warnings %+#v got %+#v", expectedWarnings, warnings)
 	}
 	if !called {
 		t.Errorf("expected registered validation function to run but it did not")
@@ -150,13 +167,16 @@ func TestValidateTypeReturnsErrors(t *testing.T) {
 func TestValidateInternalType(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
 	called := false
-	utilruntime.Must(reg.AddValidateFunc(&cmapiinternal.Certificate{}, func(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+	utilruntime.Must(reg.AddValidateFunc(&cmapiinternal.Certificate{}, func(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
 		called = true
-		return nil
+		return nil, nil
 	}))
-	errs := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected to not get any warnings but got %+v", warnings)
 	}
 	if !called {
 		t.Errorf("expected registered internal validation function to run for external type but it did not")
@@ -165,24 +185,30 @@ func TestValidateInternalType(t *testing.T) {
 
 func TestValidateNoErrorNoneRegistered(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
-	errs := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.Validate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("expected to not get any warnings but got: %+v", warnings)
 	}
 }
 
 func TestValidateUpdateNoErrorNoneRegistered(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
-	errs := reg.ValidateUpdate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
+	errs, warnings := reg.ValidateUpdate(&admissionv1.AdmissionRequest{}, &cmapi.Certificate{}, &cmapi.Certificate{}, cmapi.SchemeGroupVersion.WithKind("Certificate"))
 	if len(errs) > 0 {
 		t.Errorf("expected to not get an error but got: %v", errs.ToAggregate())
+	}
+	if len(warnings) > 0 {
+		t.Errorf("exptected to not get any warnings but got: %+v", warnings)
 	}
 }
 
 func TestValidateUnrecognisedType(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
-	err := reg.AddValidateFunc(&corev1.Pod{}, func(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
-		return nil
+	err := reg.AddValidateFunc(&corev1.Pod{}, func(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+		return nil, nil
 	})
 	if err == nil {
 		t.Errorf("expected to get an error but did not")
@@ -191,8 +217,8 @@ func TestValidateUnrecognisedType(t *testing.T) {
 
 func TestValidateUpdateUnrecognisedType(t *testing.T) {
 	reg := validation.NewRegistry(scheme)
-	err := reg.AddValidateUpdateFunc(&corev1.Pod{}, func(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) field.ErrorList {
-		return nil
+	err := reg.AddValidateUpdateFunc(&corev1.Pod{}, func(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (field.ErrorList, []string) {
+		return nil, nil
 	})
 	if err == nil {
 		t.Errorf("expected to get an error but did not")

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -108,8 +108,9 @@ type ACMEExternalAccountBinding struct {
 	// encoded data.
 	Key cmmeta.SecretKeySelector
 
-	// keyAlgorithm is the MAC key algorithm that the key is used for.
-	// Valid values are "HS256", "HS384" and "HS512".
+	// keyAlgorithm is deprecated. This value will not be used
+	// as golang/x/crypto/acme hardcodes the algorithm to HS256.
+	// See https://github.com/jetstack/cert-manager/issues/3220#issuecomment-809438314
 	KeyAlgorithm HMACKeyAlgorithm
 }
 

--- a/pkg/internal/apis/acme/validation/challenge.go
+++ b/pkg/internal/apis/acme/validation/challenge.go
@@ -26,12 +26,13 @@ import (
 	cmacme "github.com/jetstack/cert-manager/pkg/internal/apis/acme"
 )
 
-func ValidateChallengeUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) field.ErrorList {
+func ValidateChallengeUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	old, ok := oldObj.(*cmacme.Challenge)
 	new := newObj.(*cmacme.Challenge)
 	// if oldObj is not set, the Update operation is always valid.
 	if !ok || old == nil {
-		return nil
+		return nil, warnings
 	}
 
 	el := field.ErrorList{}
@@ -39,5 +40,5 @@ func ValidateChallengeUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj run
 		el = append(el, field.Forbidden(field.NewPath("spec"), "challenge spec is immutable after creation"))
 	}
 
-	return el
+	return el, warnings
 }

--- a/pkg/internal/apis/acme/validation/challenge_test.go
+++ b/pkg/internal/apis/acme/validation/challenge_test.go
@@ -29,6 +29,7 @@ func TestValidateChallengeUpdate(t *testing.T) {
 	scenarios := map[string]struct {
 		old, new *cmacme.Challenge
 		errs     []*field.Error
+		warnings []string
 	}{
 		"allows setting challenge spec for the first time": {
 			new: &cmacme.Challenge{
@@ -67,7 +68,7 @@ func TestValidateChallengeUpdate(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateChallengeUpdate(nil, s.old, s.new)
+			errs, warnings := ValidateChallengeUpdate(nil, s.old, s.new)
 			if len(errs) != len(s.errs) {
 				t.Errorf("Expected %v but got %v", s.errs, errs)
 				return
@@ -75,8 +76,11 @@ func TestValidateChallengeUpdate(t *testing.T) {
 			for i, e := range errs {
 				expectedErr := s.errs[i]
 				if !reflect.DeepEqual(e, expectedErr) {
-					t.Errorf("Expected %v but got %v", expectedErr, e)
+					t.Errorf("Expected errors %v but got %v", expectedErr, e)
 				}
+			}
+			if !reflect.DeepEqual(warnings, s.warnings) {
+				t.Errorf("Expected warnings %+#v but got %+#v", s.warnings, warnings)
 			}
 		})
 	}

--- a/pkg/internal/apis/acme/validation/order.go
+++ b/pkg/internal/apis/acme/validation/order.go
@@ -26,18 +26,19 @@ import (
 	cmacme "github.com/jetstack/cert-manager/pkg/internal/apis/acme"
 )
 
-func ValidateOrderUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) field.ErrorList {
+func ValidateOrderUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	old, ok := oldObj.(*cmacme.Order)
 	new := newObj.(*cmacme.Order)
 	// if oldObj is not set, the Update operation is always valid.
 	if !ok || old == nil {
-		return nil
+		return nil, warnings
 	}
 
 	el := field.ErrorList{}
 	el = append(el, ValidateOrderSpecUpdate(old.Spec, new.Spec, field.NewPath("spec"))...)
 	el = append(el, ValidateOrderStatusUpdate(old.Status, new.Status, field.NewPath("status"))...)
-	return el
+	return el, warnings
 }
 
 func ValidateOrderSpecUpdate(old, new cmacme.OrderSpec, fldPath *field.Path) field.ErrorList {

--- a/pkg/internal/apis/acme/validation/order_test.go
+++ b/pkg/internal/apis/acme/validation/order_test.go
@@ -43,38 +43,46 @@ func testImmutableOrderField(t *testing.T, fldPath *field.Path, setter func(*cma
 		expectedErrs := []*field.Error{
 			field.Forbidden(fldPath, "field is immutable once set"),
 		}
+		var expectedWarnings []string
 		old := &cmacme.Order{}
 		new := &cmacme.Order{}
 		setter(old, testValueOptionOne)
 		setter(new, testValueOptionTwo)
-		errs := ValidateOrderUpdate(nil, old, new)
+		errs, warnings := ValidateOrderUpdate(nil, old, new)
 		if len(errs) != len(expectedErrs) {
-			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
 			return
 		}
 		for i, e := range errs {
 			expectedErr := expectedErrs[i]
 			if !reflect.DeepEqual(e, expectedErr) {
-				t.Errorf("Expected %v but got %v", expectedErr, e)
+				t.Errorf("Expected error %v but got %v", expectedErr, e)
 			}
+		}
+		if !reflect.DeepEqual(warnings, expectedWarnings) {
+			t.Errorf("Expected warnings %+#v but got %+#v", expectedWarnings, warnings)
 		}
 	})
 	t.Run("should allow updates to "+fldPath.String()+" if not already set", func(t *testing.T) {
 		expectedErrs := []*field.Error{}
+		var expectedWarnings []string
 		old := &cmacme.Order{}
 		new := &cmacme.Order{}
 		setter(old, testValueNone)
 		setter(new, testValueOptionOne)
-		errs := ValidateOrderUpdate(nil, old, new)
+		errs, warnings := ValidateOrderUpdate(nil, old, new)
 		if len(errs) != len(expectedErrs) {
-			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
 			return
 		}
 		for i, e := range errs {
 			expectedErr := expectedErrs[i]
 			if !reflect.DeepEqual(e, expectedErr) {
-				t.Errorf("Expected %v but got %v", expectedErr, e)
+				t.Errorf("Expected error %v but got %v", expectedErr, e)
 			}
+		}
+		if !reflect.DeepEqual(warnings, expectedWarnings) {
+			t.Errorf("Expected warnings %+#v but got %+#v", expectedWarnings, warnings)
 		}
 	})
 }
@@ -200,6 +208,7 @@ func TestValidateCertificateUpdate(t *testing.T) {
 	scenarios := map[string]struct {
 		old, new *cmacme.Order
 		errs     []*field.Error
+		warnings []string
 	}{
 		"allows all updates if old is nil": {
 			new: &cmacme.Order{
@@ -211,7 +220,7 @@ func TestValidateCertificateUpdate(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateOrderUpdate(nil, s.old, s.new)
+			errs, warnings := ValidateOrderUpdate(nil, s.old, s.new)
 			if len(errs) != len(s.errs) {
 				t.Errorf("Expected %v but got %v", s.errs, errs)
 				return
@@ -219,8 +228,11 @@ func TestValidateCertificateUpdate(t *testing.T) {
 			for i, e := range errs {
 				expectedErr := s.errs[i]
 				if !reflect.DeepEqual(e, expectedErr) {
-					t.Errorf("Expected %v but got %v", expectedErr, e)
+					t.Errorf("Expected errors %v but got %v", expectedErr, e)
 				}
+			}
+			if !reflect.DeepEqual(warnings, s.warnings) {
+				t.Errorf("Expected warnings %+#v but got %+#v", s.warnings, warnings)
 			}
 		})
 	}

--- a/pkg/internal/apis/certmanager/identity/certificaterequests/certificaterequests.go
+++ b/pkg/internal/apis/certmanager/identity/certificaterequests/certificaterequests.go
@@ -30,7 +30,8 @@ import (
 	"github.com/jetstack/cert-manager/pkg/util"
 )
 
-func ValidateCreate(req *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateCreate(req *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	cr := obj.(*cmapi.CertificateRequest)
 	fldPath := field.NewPath("spec")
 
@@ -48,7 +49,7 @@ func ValidateCreate(req *admissionv1.AdmissionRequest, obj runtime.Object) field
 		el = append(el, field.Forbidden(fldPath.Child("extra"), "extra identity must be that of the requester"))
 	}
 
-	return el
+	return el, warnings
 }
 
 func extrasMatch(crExtra map[string][]string, reqExtra map[string]authenticationv1.ExtraValue) bool {
@@ -70,7 +71,8 @@ func extrasMatch(crExtra map[string][]string, reqExtra map[string]authentication
 	return true
 }
 
-func ValidateUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) field.ErrorList {
+func ValidateUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	oldCR, newCR := oldObj.(*cmapi.CertificateRequest), newObj.(*cmapi.CertificateRequest)
 	fldPath := field.NewPath("spec")
 
@@ -88,7 +90,7 @@ func ValidateUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Obje
 		el = append(el, field.Forbidden(fldPath.Child("extra"), "extra identity cannot be changed once set"))
 	}
 
-	return el
+	return el, warnings
 }
 
 func MutateCreate(req *admissionv1.AdmissionRequest, obj runtime.Object) {

--- a/pkg/internal/apis/certmanager/identity/certificaterequests/certificaterequests_test.go
+++ b/pkg/internal/apis/certmanager/identity/certificaterequests/certificaterequests_test.go
@@ -31,9 +31,10 @@ func TestValidateCreate(t *testing.T) {
 	fldPath := field.NewPath("spec")
 
 	tests := map[string]struct {
-		req  *admissionv1.AdmissionRequest
-		cr   *cmapi.CertificateRequest
-		want field.ErrorList
+		req   *admissionv1.AdmissionRequest
+		cr    *cmapi.CertificateRequest
+		wantE field.ErrorList
+		wantW []string
 	}{
 		"if identity fields don't match that of requester, should fail": {
 			req: &admissionv1.AdmissionRequest{
@@ -58,7 +59,7 @@ func TestValidateCreate(t *testing.T) {
 					},
 				},
 			},
-			want: field.ErrorList{
+			wantE: field.ErrorList{
 				field.Forbidden(fldPath.Child("uid"), "uid identity must be that of the requester"),
 				field.Forbidden(fldPath.Child("username"), "username identity must be that of the requester"),
 				field.Forbidden(fldPath.Child("groups"), "groups identity must be that of the requester"),
@@ -88,15 +89,18 @@ func TestValidateCreate(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			wantE: nil,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ValidateCreate(test.req, test.cr)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("ValidateCreate() = %v, want %v", got, test.want)
+			gotE, gotW := ValidateCreate(test.req, test.cr)
+			if !reflect.DeepEqual(gotE, test.wantE) {
+				t.Errorf("errors from ValidateCreate() = %v, want %v", gotE, test.wantE)
+			}
+			if !reflect.DeepEqual(gotW, test.wantW) {
+				t.Errorf("warnings from ValidateCreate() = %v, want %v", gotW, test.wantW)
 			}
 		})
 	}
@@ -107,7 +111,8 @@ func TestValidateUpdate(t *testing.T) {
 
 	tests := map[string]struct {
 		oldCR, newCR *cmapi.CertificateRequest
-		want         field.ErrorList
+		wantE        field.ErrorList
+		wantW        []string
 	}{
 		"if identity fields don't match that of the old CertificateRequest, should fail": {
 			oldCR: &cmapi.CertificateRequest{
@@ -132,7 +137,7 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: field.ErrorList{
+			wantE: field.ErrorList{
 				field.Forbidden(fldPath.Child("uid"), "uid identity cannot be changed once set"),
 				field.Forbidden(fldPath.Child("username"), "username identity cannot be changed once set"),
 				field.Forbidden(fldPath.Child("groups"), "groups identity cannot be changed once set"),
@@ -162,15 +167,18 @@ func TestValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			wantE: nil,
 		},
 	}
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ValidateUpdate(nil, test.newCR, test.oldCR)
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("ValidateUpdate() = %v, want %v", got, test.want)
+			gotE, gotW := ValidateUpdate(nil, test.newCR, test.oldCR)
+			if !reflect.DeepEqual(gotE, test.wantE) {
+				t.Errorf("errors from ValidateUpdate() = %v, want %v", gotE, test.wantE)
+			}
+			if !reflect.DeepEqual(gotW, test.wantW) {
+				t.Errorf("warnings from ValidateUpdate() = %v, want %v", gotW, test.wantW)
 			}
 		})
 	}

--- a/pkg/internal/apis/certmanager/validation/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/validation/BUILD.bazel
@@ -42,6 +42,7 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/internal/apis/acme:go_default_library",
         "//pkg/internal/apis/certmanager:go_default_library",

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -83,16 +83,18 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	return el
 }
 
-func ValidateCertificate(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateCertificate(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	crt := obj.(*internalcmapi.Certificate)
 	allErrs := ValidateCertificateSpec(&crt.Spec, field.NewPath("spec"))
-	return allErrs
+	return allErrs, warnings
 }
 
-func ValidateUpdateCertificate(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) field.ErrorList {
+func ValidateUpdateCertificate(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	crt := obj.(*internalcmapi.Certificate)
 	allErrs := ValidateCertificateSpec(&crt.Spec, field.NewPath("spec"))
-	return allErrs
+	return allErrs, warnings
 }
 
 func validateIssuerRef(issuerRef cmmeta.ObjectReference, fldPath *field.Path) field.ErrorList {

--- a/pkg/internal/apis/certmanager/validation/certificate_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_test.go
@@ -48,8 +48,9 @@ func int32Ptr(i int32) *int32 {
 func TestValidateCertificate(t *testing.T) {
 	fldPath := field.NewPath("spec")
 	scenarios := map[string]struct {
-		cfg  *internalcmapi.Certificate
-		errs []*field.Error
+		cfg      *internalcmapi.Certificate
+		errs     []*field.Error
+		warnings []string
 	}{
 		"valid basic certificate": {
 			cfg: &internalcmapi.Certificate{
@@ -491,15 +492,24 @@ func TestValidateCertificate(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateCertificate(nil, s.cfg)
+			errs, warnings := ValidateCertificate(nil, s.cfg)
 			if len(errs) != len(s.errs) {
-				t.Errorf("Expected %v but got %v", s.errs, errs)
+				t.Errorf("Expected errors %v but got %v", s.errs, errs)
 				return
+			}
+			if len(warnings) != len(s.warnings) {
+				t.Errorf("Expected warnings %v but got %v", s.warnings, warnings)
 			}
 			for i, e := range errs {
 				expectedErr := s.errs[i]
 				if !reflect.DeepEqual(e, expectedErr) {
-					t.Errorf("Expected %v but got %v", expectedErr, e)
+					t.Errorf("Expected error %v but got %v", expectedErr, e)
+				}
+			}
+			for i, w := range warnings {
+				expectedWarning := s.warnings[i]
+				if w != expectedWarning {
+					t.Errorf("Expected warning %q but got %q", expectedWarning, w)
 				}
 			}
 		})

--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -38,16 +38,18 @@ import (
 
 var defaultInternalKeyUsages = []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment}
 
-func ValidateCertificateRequest(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateCertificateRequest(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	cr := obj.(*cmapi.CertificateRequest)
 	allErrs := ValidateCertificateRequestSpec(&cr.Spec, field.NewPath("spec"), true)
 	allErrs = append(allErrs,
 		ValidateCertificateRequestApprovalCondition(cr.Status.Conditions, field.NewPath("status", "conditions"))...)
 
-	return allErrs
+	return allErrs, warnings
 }
 
-func ValidateUpdateCertificateRequest(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) field.ErrorList {
+func ValidateUpdateCertificateRequest(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	oldCR, newCR := oldObj.(*cmapi.CertificateRequest), newObj.(*cmapi.CertificateRequest)
 
 	var el field.ErrorList
@@ -66,7 +68,7 @@ func ValidateUpdateCertificateRequest(_ *admissionv1.AdmissionRequest, oldObj, n
 		el = append(el, field.Forbidden(field.NewPath("spec"), "cannot change spec after creation"))
 	}
 
-	return el
+	return el, warnings
 }
 
 func validateCertificateRequestAnnotations(objA, objB *cmapi.CertificateRequest, fieldPath *field.Path) field.ErrorList {

--- a/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest_test.go
@@ -62,7 +62,8 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 
 	tests := map[string]struct {
 		oldCR, newCR *cminternal.CertificateRequest
-		want         field.ErrorList
+		wantE        field.ErrorList
+		wantW        []string
 	}{
 		"if CertificateRequest spec and cert-manager.io annotations change, error": {
 			oldCR: baseCR.DeepCopy(),
@@ -77,7 +78,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					Request: mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"))),
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(field.NewPath("metadata", "annotations", "cert-manager.io/foo"), "cannot change cert-manager annotation after creation"),
 				field.Forbidden(field.NewPath("spec"), "cannot change spec after creation"),
 			},
@@ -95,7 +96,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					Request: mustGenerateCSR(t, gen.Certificate("test", gen.SetCertificateDNSNames("example.com"))),
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(field.NewPath("metadata", "annotations", "acme.cert-manager.io/bar"), "cannot change cert-manager annotation after creation"),
 				field.Forbidden(field.NewPath("spec"), "cannot change spec after creation"),
 			},
@@ -103,7 +104,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 		"if CertificateRequest spec and annotations do not change, don't error": {
 			oldCR: baseCR.DeepCopy(),
 			newCR: baseCR.DeepCopy(),
-			want:  nil,
+			wantE: nil,
 		},
 		"CertificateRequest with single Approved=true condition that doesn't change, shouldn't error": {
 			oldCR: &cminternal.CertificateRequest{
@@ -134,7 +135,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			wantE: nil,
 		},
 		"CertificateRequest with single Denied=true condition that doesn't change, shouldn't error": {
 			oldCR: &cminternal.CertificateRequest{
@@ -165,7 +166,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			wantE: nil,
 		},
 		"CertificateRequest with single Approved=false condition that changes, should error": {
 			oldCR: &cminternal.CertificateRequest{
@@ -198,7 +199,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "'Approved' condition may not be modified once set"),
 			},
 		},
@@ -233,7 +234,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "'Denied' condition may not be modified once set"),
 				field.Invalid(fldPathConditions.Child("Denied"), nil, `"Denied" condition may only be set to True`),
 			},
@@ -269,7 +270,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "'Denied' condition may not be modified once set"),
 			},
 		},
@@ -304,7 +305,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "'Approved' condition may not be modified once set"),
 			},
 		},
@@ -333,7 +334,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			wantE: nil,
 		},
 		"CertificateRequest with no condition that changes to Denied=true, shouldn't error": {
 			oldCR: &cminternal.CertificateRequest{
@@ -360,7 +361,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					},
 				},
 			},
-			want: nil,
+			wantE: nil,
 		},
 		"CertificateRequest with single Approved=true condition that is removed, should error": {
 			oldCR: &cminternal.CertificateRequest{
@@ -386,7 +387,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					Conditions: []cminternal.CertificateRequestCondition{},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "'Approved' condition may not be modified once set"),
 			},
 		},
@@ -414,7 +415,7 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 					Conditions: []cminternal.CertificateRequestCondition{},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "'Denied' condition may not be modified once set"),
 			},
 		},
@@ -422,16 +423,19 @@ func TestValidateCertificateRequestUpdate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ValidateUpdateCertificateRequest(nil, test.oldCR, test.newCR)
-			for i := range got {
-				if got[i].Type != field.ErrorTypeForbidden {
+			gotE, gotW := ValidateUpdateCertificateRequest(nil, test.oldCR, test.newCR)
+			for i := range gotE {
+				if gotE[i].Type != field.ErrorTypeForbidden {
 					// filter out the value so it does not print the full CSR in tests
-					got[i].BadValue = nil
+					gotE[i].BadValue = nil
 				}
 			}
 
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("ValidateUpdateCertificateRequest() = %v, want %v", got, test.want)
+			if !reflect.DeepEqual(gotE, test.wantE) {
+				t.Errorf("errors from ValidateUpdateCertificateRequest() = %v, want %v", gotE, test.wantE)
+			}
+			if !reflect.DeepEqual(gotW, test.wantW) {
+				t.Errorf("warnings from ValidateUpdateCertificateRequest() = %v, want %v", gotW, test.wantW)
 			}
 		})
 	}
@@ -442,8 +446,9 @@ func TestValidateCertificateRequest(t *testing.T) {
 	fldPathConditions := field.NewPath("status", "conditions")
 
 	tests := map[string]struct {
-		cr   *cminternal.CertificateRequest
-		want field.ErrorList
+		cr    *cminternal.CertificateRequest
+		wantE field.ErrorList
+		wantW []string
 	}{
 		"Test csr with no usages": {
 			cr: &cminternal.CertificateRequest{
@@ -453,7 +458,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    nil,
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"Test csr with double signature usages": {
 			cr: &cminternal.CertificateRequest{
@@ -463,7 +468,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"Test csr with double extended usages": {
 			cr: &cminternal.CertificateRequest{
@@ -473,7 +478,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment, cminternal.UsageServerAuth, cminternal.UsageClientAuth},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"Test csr with reordered usages": {
 			cr: &cminternal.CertificateRequest{
@@ -483,7 +488,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageServerAuth, cminternal.UsageClientAuth, cminternal.UsageKeyEncipherment, cminternal.UsageDigitalSignature},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"Test csr that is CA with usages set": {
 			cr: &cminternal.CertificateRequest{
@@ -494,7 +499,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageAny, cminternal.UsageDigitalSignature, cminternal.UsageKeyEncipherment, cminternal.UsageCertSign},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"Test csr that is CA but no cert sign in usages": {
 			cr: &cminternal.CertificateRequest{
@@ -505,7 +510,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageAny, cminternal.UsageDigitalSignature, cminternal.UsageKeyEncipherment, cminternal.UsageClientAuth, cminternal.UsageServerAuth},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"Error on csr not having all usages": {
 			cr: &cminternal.CertificateRequest{
@@ -515,7 +520,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment, cminternal.UsageServerAuth, cminternal.UsageClientAuth},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Invalid(fldPath.Child("request"), nil, "csr key usages do not match specified usages, these should match if both are set: [[]certmanager.KeyUsage[3] != []certmanager.KeyUsage[4]]"),
 			},
 		},
@@ -527,7 +532,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageSigning, cminternal.UsageKeyEncipherment},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Invalid(fldPath.Child("request"), nil, "csr key usages do not match specified usages, these should match if both are set: [[]certmanager.KeyUsage[4] != []certmanager.KeyUsage[2]]"),
 			},
 		},
@@ -540,7 +545,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					Usages:    []cminternal.KeyUsage{cminternal.UsageAny, cminternal.UsageSigning, cminternal.UsageKeyEncipherment, cminternal.UsageClientAuth, cminternal.UsageServerAuth},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"CertificateRequest with single Approved=true condition, shouldn't error": {
 			cr: &cminternal.CertificateRequest{
@@ -559,7 +564,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"CertificateRequest with single Denied=true condition, shouldn't error": {
 			cr: &cminternal.CertificateRequest{
@@ -578,7 +583,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{},
+			wantE: []*field.Error{},
 		},
 		"CertificateRequest with single Approved=false condition, should error": {
 			cr: &cminternal.CertificateRequest{
@@ -598,7 +603,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Invalid(fldPathConditions.Child("Approved"), nil,
 					`"Approved" condition may only be set to True`),
 			},
@@ -621,7 +626,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Invalid(fldPathConditions.Child("Denied"), nil,
 					`"Denied" condition may only be set to True`),
 			},
@@ -649,7 +654,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Invalid(field.NewPath("status", "conditions", "Approved"), nil,
 					`"Approved" condition may only be set to True`),
 				field.Invalid(field.NewPath("status", "conditions", "Denied"), nil,
@@ -680,7 +685,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, "both 'Denied' and 'Approved' conditions cannot coexist"),
 			},
 		},
@@ -707,7 +712,7 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, `multiple "Approved" conditions present`),
 			},
 		},
@@ -734,22 +739,25 @@ func TestValidateCertificateRequest(t *testing.T) {
 					},
 				},
 			},
-			want: []*field.Error{
+			wantE: []*field.Error{
 				field.Forbidden(fldPathConditions, `multiple "Denied" conditions present`),
 			},
 		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			got := ValidateCertificateRequest(nil, test.cr)
-			for i := range got {
-				if got[i].Type != field.ErrorTypeForbidden {
+			gotE, gotW := ValidateCertificateRequest(nil, test.cr)
+			for i := range gotE {
+				if gotE[i].Type != field.ErrorTypeForbidden {
 					// filter out the value so it does not print the full CSR in tests
-					got[i].BadValue = nil
+					gotE[i].BadValue = nil
 				}
 			}
-			if !reflect.DeepEqual(got, test.want) {
-				t.Errorf("ValidateCertificateRequest() = %v, want %v", got, test.want)
+			if !reflect.DeepEqual(gotE, test.wantE) {
+				t.Errorf("errors from ValidateCertificateRequest() = %v, want %v", gotE, test.wantE)
+			}
+			if !reflect.DeepEqual(test.wantW, gotW) {
+				t.Errorf("warnings from ValidateCertificateRequest() = %v, want  %v", gotW, test.wantW)
 			}
 		})
 	}

--- a/pkg/internal/apis/certmanager/validation/clusterissuer.go
+++ b/pkg/internal/apis/certmanager/validation/clusterissuer.go
@@ -24,16 +24,18 @@ import (
 	cmapi "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager"
 )
 
-// Validation functions for cert-manager v1alpha2 ClusterIssuer types
+// Validation functions for cert-manager ClusterIssuer types.
 
-func ValidateClusterIssuer(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateClusterIssuer(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	iss := obj.(*cmapi.ClusterIssuer)
-	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
-	return allErrs
+	allErrs, warnings := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
+	return allErrs, warnings
 }
 
-func ValidateUpdateClusterIssuer(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) field.ErrorList {
+func ValidateUpdateClusterIssuer(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	iss := obj.(*cmapi.ClusterIssuer)
-	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
-	return allErrs
+	allErrs, warnings := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
+	return allErrs, warnings
 }

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -32,7 +32,7 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/internal/apis/meta"
 )
 
-// Validation functions for cert-manager v1alpha2 Issuer types
+// Validation functions for cert-manager Issuer types.
 
 func ValidateIssuer(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
 	iss := obj.(*certmanager.Issuer)
@@ -116,10 +116,6 @@ func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) field
 		}
 
 		el = append(el, ValidateSecretKeySelector(&eab.Key, eabFldPath.Child("keySecretRef"))...)
-
-		if len(eab.KeyAlgorithm) == 0 {
-			el = append(el, field.Required(eabFldPath.Child("keyAlgorithm"), "the keyAlgorithm field is required when using externalAccountBinding"))
-		}
 	}
 
 	for i, sol := range iss.Solvers {

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -121,6 +121,10 @@ func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) (fiel
 		}
 
 		el = append(el, ValidateSecretKeySelector(&eab.Key, eabFldPath.Child("keySecretRef"))...)
+
+		if len(eab.KeyAlgorithm) != 0 {
+			warnings = append(warnings, apiutil.DeprecatedACMEEABKeyAlgorithmField)
+		}
 	}
 
 	for i, sol := range iss.Solvers {

--- a/pkg/internal/apis/certmanager/validation/issuer.go
+++ b/pkg/internal/apis/certmanager/validation/issuer.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmacme "github.com/jetstack/cert-manager/pkg/internal/apis/acme"
 	"github.com/jetstack/cert-manager/pkg/internal/apis/certmanager"
 	"github.com/jetstack/cert-manager/pkg/internal/apis/certmanager/validation/util"
@@ -34,23 +35,25 @@ import (
 
 // Validation functions for cert-manager Issuer types.
 
-func ValidateIssuer(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateIssuer(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	iss := obj.(*certmanager.Issuer)
-	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
-	return allErrs
+	allErrs, warnings := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
+	return allErrs, warnings
 }
 
-func ValidateUpdateIssuer(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) field.ErrorList {
+func ValidateUpdateIssuer(_ *admissionv1.AdmissionRequest, oldObj, obj runtime.Object) (field.ErrorList, []string) {
 	iss := obj.(*certmanager.Issuer)
-	allErrs := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
-	return allErrs
+	allErrs, warnings := ValidateIssuerSpec(&iss.Spec, field.NewPath("spec"))
+	return allErrs, warnings
 }
 
-func ValidateIssuerSpec(iss *certmanager.IssuerSpec, fldPath *field.Path) field.ErrorList {
+func ValidateIssuerSpec(iss *certmanager.IssuerSpec, fldPath *field.Path) (field.ErrorList, []string) {
 	return ValidateIssuerConfig(&iss.IssuerConfig, fldPath)
 }
 
-func ValidateIssuerConfig(iss *certmanager.IssuerConfig, fldPath *field.Path) field.ErrorList {
+func ValidateIssuerConfig(iss *certmanager.IssuerConfig, fldPath *field.Path) (field.ErrorList, []string) {
+	var warnings []string
 	numConfigs := 0
 	el := field.ErrorList{}
 	if iss.ACME != nil {
@@ -58,7 +61,8 @@ func ValidateIssuerConfig(iss *certmanager.IssuerConfig, fldPath *field.Path) fi
 			el = append(el, field.Forbidden(fldPath.Child("acme"), "may not specify more than one issuer type"))
 		} else {
 			numConfigs++
-			el = append(el, ValidateACMEIssuerConfig(iss.ACME, fldPath.Child("acme"))...)
+			e, w := ValidateACMEIssuerConfig(iss.ACME, fldPath.Child("acme"))
+			el, warnings = append(el, e...), append(warnings, w...)
 		}
 	}
 	if iss.CA != nil {
@@ -97,10 +101,11 @@ func ValidateIssuerConfig(iss *certmanager.IssuerConfig, fldPath *field.Path) fi
 		el = append(el, field.Required(fldPath, "at least one issuer must be configured"))
 	}
 
-	return el
+	return el, warnings
 }
 
-func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) field.ErrorList {
+func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) (field.ErrorList, []string) {
+	var warnings []string
 	el := field.ErrorList{}
 	if len(iss.PrivateKey.Name) == 0 {
 		el = append(el, field.Required(fldPath.Child("privateKeySecretRef", "name"), "private key secret name is a required field"))
@@ -122,7 +127,7 @@ func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) field
 		el = append(el, ValidateACMEIssuerChallengeSolverConfig(&sol, fldPath.Child("solvers").Index(i))...)
 	}
 
-	return el
+	return el, warnings
 }
 
 func ValidateACMEIssuerChallengeSolverConfig(sol *cmacme.ACMEChallengeSolver, fldPath *field.Path) field.ErrorList {

--- a/pkg/internal/apis/certmanager/validation/issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/issuer_test.go
@@ -106,8 +106,9 @@ func TestValidateVaultIssuerConfig(t *testing.T) {
 func TestValidateACMEIssuerConfig(t *testing.T) {
 	fldPath := field.NewPath("")
 	scenarios := map[string]struct {
-		spec *cmacme.ACMEIssuer
-		errs []*field.Error
+		spec     *cmacme.ACMEIssuer
+		errs     []*field.Error
+		warnings []string
 	}{
 		"valid acme issuer": {
 			spec: &validACMEIssuer,
@@ -316,7 +317,7 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateACMEIssuerConfig(s.spec, fldPath)
+			errs, warnings := ValidateACMEIssuerConfig(s.spec, fldPath)
 			if len(errs) != len(s.errs) {
 				t.Errorf("Expected %v but got %v", s.errs, errs)
 				return
@@ -327,6 +328,7 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 					t.Errorf("Expected %v but got %v", expectedErr, e)
 				}
 			}
+			assert.Equal(t, s.warnings, warnings)
 		})
 	}
 }
@@ -334,8 +336,9 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 func TestValidateIssuerSpec(t *testing.T) {
 	fldPath := field.NewPath("")
 	scenarios := map[string]struct {
-		spec *cmapi.IssuerSpec
-		errs field.ErrorList
+		spec     *cmapi.IssuerSpec
+		errs     field.ErrorList
+		warnings []string
 	}{
 		"valid ca issuer": {
 			spec: &cmapi.IssuerSpec{
@@ -427,8 +430,9 @@ func TestValidateIssuerSpec(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			gotErrs := ValidateIssuerSpec(s.spec, fldPath)
+			gotErrs, warnings := ValidateIssuerSpec(s.spec, fldPath)
 			assert.Equal(t, s.errs, gotErrs)
+			assert.Equal(t, s.warnings, warnings)
 		})
 	}
 }

--- a/pkg/internal/apis/certmanager/validation/issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/issuer_test.go
@@ -25,6 +25,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmacme "github.com/jetstack/cert-manager/pkg/internal/apis/acme"
 	cmapi "github.com/jetstack/cert-manager/pkg/internal/apis/certmanager"
 	cmmeta "github.com/jetstack/cert-manager/pkg/internal/apis/meta"
@@ -203,6 +204,7 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 					},
 				},
 			},
+			warnings: []string{apiutil.DeprecatedACMEEABKeyAlgorithmField},
 		},
 		"acme solver with missing http01 config type": {
 			spec: &cmacme.ACMEIssuer{

--- a/pkg/internal/apis/certmanager/validation/issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/issuer_test.go
@@ -146,7 +146,7 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 				},
 			},
 		},
-		"acme solver with empty external account binding fields": {
+		"acme solver with external account binding missing required fields": {
 			spec: &cmacme.ACMEIssuer{
 				Email:                  "valid-email",
 				Server:                 "valid-server",
@@ -164,7 +164,43 @@ func TestValidateACMEIssuerConfig(t *testing.T) {
 				field.Required(fldPath.Child("externalAccountBinding.keyID"), "the keyID field is required when using externalAccountBinding"),
 				field.Required(fldPath.Child("externalAccountBinding.keySecretRef.name"), "secret name is required"),
 				field.Required(fldPath.Child("externalAccountBinding.keySecretRef.key"), "secret key is required"),
-				field.Required(fldPath.Child("externalAccountBinding.keyAlgorithm"), "the keyAlgorithm field is required when using externalAccountBinding"),
+			},
+		},
+		"acme solver with a valid external account binding and keyAlgorithm not set": {
+			spec: &cmacme.ACMEIssuer{
+				Email:      "valid-email",
+				Server:     "valid-server",
+				PrivateKey: validSecretKeyRef,
+				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
+					KeyID: "test",
+					Key:   validSecretKeyRef,
+				},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							CloudDNS: &validCloudDNSProvider,
+						},
+					},
+				},
+			},
+		},
+		"acme solver with a valid external account binding and keyAlgorithm set": {
+			spec: &cmacme.ACMEIssuer{
+				Email:      "valid-email",
+				Server:     "valid-server",
+				PrivateKey: validSecretKeyRef,
+				ExternalAccountBinding: &cmacme.ACMEExternalAccountBinding{
+					KeyID:        "test",
+					Key:          validSecretKeyRef,
+					KeyAlgorithm: cmacme.HS384,
+				},
+				Solvers: []cmacme.ACMEChallengeSolver{
+					{
+						DNS01: &cmacme.ACMEChallengeSolverDNS01{
+							CloudDNS: &validCloudDNSProvider,
+						},
+					},
+				},
 			},
 		},
 		"acme solver with missing http01 config type": {

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -204,9 +204,8 @@ func (a *Acme) Setup(ctx context.Context) error {
 
 		// set the external account binding
 		eabAccount = &acmeapi.ExternalAccountBinding{
-			KID:          eabObj.KeyID,
-			Key:          eabKey,
-			KeyAlgorithm: string(eabObj.KeyAlgorithm),
+			KID: eabObj.KeyID,
+			Key: eabKey,
 		}
 	}
 

--- a/pkg/webhook/handlers/testdata/apis/testgroup/v2/validation.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/v2/validation.go
@@ -22,11 +22,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-func ValidateTestType(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateTestType(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	el := field.ErrorList{}
 	tt := obj.(*TestType)
 	if tt.TestField == DisallowedTestFieldValue {
 		el = append(el, field.Invalid(field.NewPath("testField"), tt.TestField, "value not allowed"))
 	}
-	return el
+	return el, warnings
 }

--- a/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation.go
@@ -25,25 +25,27 @@ import (
 	v1 "github.com/jetstack/cert-manager/pkg/webhook/handlers/testdata/apis/testgroup/v1"
 )
 
-func ValidateTestType(_ *admissionv1.AdmissionRequest, obj runtime.Object) field.ErrorList {
+func ValidateTestType(_ *admissionv1.AdmissionRequest, obj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	testType := obj.(*testgroup.TestType)
 	el := field.ErrorList{}
 	if testType.TestField == v1.TestFieldValueNotAllowed {
 		el = append(el, field.Invalid(field.NewPath("testField"), testType.TestField, "invalid value"))
 	}
-	return el
+	return el, warnings
 }
 
-func ValidateTestTypeUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) field.ErrorList {
+func ValidateTestTypeUpdate(_ *admissionv1.AdmissionRequest, oldObj, newObj runtime.Object) (field.ErrorList, []string) {
+	var warnings []string
 	old, ok := oldObj.(*testgroup.TestType)
 	new := newObj.(*testgroup.TestType)
 	// if oldObj is not set, the Update operation is always valid.
 	if !ok || old == nil {
-		return nil
+		return nil, warnings
 	}
 	el := field.ErrorList{}
 	if old.TestFieldImmutable != "" && old.TestFieldImmutable != new.TestFieldImmutable {
 		el = append(el, field.Forbidden(field.NewPath("testFieldImmutable"), "field is immutable once set"))
 	}
-	return el
+	return el, warnings
 }

--- a/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation_test.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation_test.go
@@ -28,8 +28,8 @@ import (
 
 func TestValidateTestType(t *testing.T) {
 	scenarios := map[string]struct {
-		obj  *testgroup.TestType
-		errs []*field.Error
+		obj      *testgroup.TestType
+		errs     []*field.Error
 		warnings []string
 	}{
 		"does not allow testField to be TestFieldValueNotAllowed": {

--- a/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation_test.go
+++ b/pkg/webhook/handlers/testdata/apis/testgroup/validation/validation_test.go
@@ -30,6 +30,7 @@ func TestValidateTestType(t *testing.T) {
 	scenarios := map[string]struct {
 		obj  *testgroup.TestType
 		errs []*field.Error
+		warnings []string
 	}{
 		"does not allow testField to be TestFieldValueNotAllowed": {
 			obj: &testgroup.TestType{
@@ -42,16 +43,19 @@ func TestValidateTestType(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateTestType(nil, s.obj)
+			errs, warnings := ValidateTestType(nil, s.obj)
 			if len(errs) != len(s.errs) {
-				t.Errorf("Expected %v but got %v", s.errs, errs)
+				t.Errorf("Expected errors %v but got %v", s.errs, errs)
 				return
 			}
 			for i, e := range errs {
 				expectedErr := s.errs[i]
 				if !reflect.DeepEqual(e, expectedErr) {
-					t.Errorf("Expected %v but got %v", expectedErr, e)
+					t.Errorf("Expected error %v but got %v", expectedErr, e)
 				}
+			}
+			if !reflect.DeepEqual(warnings, s.warnings) {
+				t.Errorf("Expected warnings %+#v but got %+#v", s.warnings, warnings)
 			}
 		})
 	}
@@ -65,6 +69,7 @@ func TestValidateTestTypeUpdate(t *testing.T) {
 	scenarios := map[string]struct {
 		old, new *testgroup.TestType
 		errs     []*field.Error
+		warnings []string
 	}{
 		"allows all updates if old is nil": {
 			new: &testgroup.TestType{
@@ -74,16 +79,19 @@ func TestValidateTestTypeUpdate(t *testing.T) {
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {
-			errs := ValidateTestTypeUpdate(nil, s.old, s.new)
+			errs, warnings := ValidateTestTypeUpdate(nil, s.old, s.new)
 			if len(errs) != len(s.errs) {
-				t.Errorf("Expected %v but got %v", s.errs, errs)
+				t.Errorf("Expected errors %v but got %v", s.errs, errs)
 				return
 			}
 			for i, e := range errs {
 				expectedErr := s.errs[i]
 				if !reflect.DeepEqual(e, expectedErr) {
-					t.Errorf("Expected %v but got %v", expectedErr, e)
+					t.Errorf("Expected error %v but got %v", expectedErr, e)
 				}
+			}
+			if !reflect.DeepEqual(warnings, s.warnings) {
+				t.Errorf("Expected warnings %+#v but got %+#v", s.warnings, warnings)
 			}
 		})
 	}
@@ -105,38 +113,46 @@ func testImmutableTestTypeField(t *testing.T, fldPath *field.Path, setter func(*
 		expectedErrs := []*field.Error{
 			field.Forbidden(fldPath, "field is immutable once set"),
 		}
+		var expectedWarnings []string
 		old := &testgroup.TestType{}
 		new := &testgroup.TestType{}
 		setter(old, testValueOptionOne)
 		setter(new, testValueOptionTwo)
-		errs := ValidateTestTypeUpdate(nil, old, new)
+		errs, warnings := ValidateTestTypeUpdate(nil, old, new)
 		if len(errs) != len(expectedErrs) {
-			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
 			return
 		}
 		for i, e := range errs {
 			expectedErr := expectedErrs[i]
 			if !reflect.DeepEqual(e, expectedErr) {
-				t.Errorf("Expected %v but got %v", expectedErr, e)
+				t.Errorf("Expected error %v but got %v", expectedErr, e)
 			}
+		}
+		if !reflect.DeepEqual(warnings, expectedWarnings) {
+			t.Errorf("Expected warnings %+#v got %+#v", expectedWarnings, warnings)
 		}
 	})
 	t.Run("should allow updates to "+fldPath.String()+" if not already set", func(t *testing.T) {
 		expectedErrs := []*field.Error{}
+		var expectedWarnings []string
 		old := &testgroup.TestType{}
 		new := &testgroup.TestType{}
 		setter(old, testValueNone)
 		setter(new, testValueOptionOne)
-		errs := ValidateTestTypeUpdate(nil, old, new)
+		errs, warnings := ValidateTestTypeUpdate(nil, old, new)
 		if len(errs) != len(expectedErrs) {
-			t.Errorf("Expected %v but got %v", expectedErrs, errs)
+			t.Errorf("Expected errors %v but got %v", expectedErrs, errs)
 			return
 		}
 		for i, e := range errs {
 			expectedErr := expectedErrs[i]
 			if !reflect.DeepEqual(e, expectedErr) {
-				t.Errorf("Expected %v but got %v", expectedErr, e)
+				t.Errorf("Expected error %v but got %v", expectedErr, e)
 			}
+		}
+		if !reflect.DeepEqual(warnings, expectedWarnings) {
+			t.Errorf("Expected warnings %+#v but got %+#v", expectedWarnings, warnings)
 		}
 	})
 }

--- a/pkg/webhook/handlers/validation.go
+++ b/pkg/webhook/handlers/validation.go
@@ -101,15 +101,19 @@ func (r *registryBackedValidator) Validate(ctx context.Context, admissionSpec *a
 		}
 	}
 	errs := field.ErrorList{}
+	var warnings []string
 
 	if admissionSpec.Operation == admissionv1.Create {
 		// perform validation on new version of resource
-		errs = append(errs, r.registry.Validate(admissionSpec, obj, gvk)...)
+		e, w := r.registry.Validate(admissionSpec, obj, gvk)
+		errs, warnings = append(errs, e...), append(warnings, w...)
 	} else if admissionSpec.Operation == admissionv1.Update {
 		// perform update validation on resource
-		errs = append(errs, r.registry.ValidateUpdate(admissionSpec, oldObj, obj, gvk)...)
+		e, w := r.registry.ValidateUpdate(admissionSpec, oldObj, obj, gvk)
+		errs, warnings = append(errs, e...), append(warnings, w...)
 	}
 
+	// TODO: implement warnings for Plugin interface
 	// If no validation errors occurred, perform plugin checks.
 	if len(errs) == 0 {
 		for _, plugin := range r.plugins {
@@ -118,6 +122,8 @@ func (r *registryBackedValidator) Validate(ctx context.Context, admissionSpec *a
 			}
 		}
 	}
+
+	status.Warnings = warnings
 
 	// return with allowed = false if any errors occurred
 	if err := errs.ToAggregate(); err != nil {

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -39,8 +39,7 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 })
 var _ = framework.ConformanceDescribe("Certificates with External Account Binding", func() {
 	runACMEIssuerTests(&cmacme.ACMEExternalAccountBinding{
-		KeyID:        "kid-1",
-		KeyAlgorithm: "HS256",
+		KeyID: "kid-1",
 	})
 })
 

--- a/test/e2e/suite/issuers/acme/BUILD.bazel
+++ b/test/e2e/suite/issuers/acme/BUILD.bazel
@@ -10,15 +10,19 @@ go_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/acme/v1:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/suite/issuers/acme/certificate:go_default_library",
         "//test/e2e/suite/issuers/acme/certificaterequest:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/issuers/acme/certificate/notafter.go
+++ b/test/e2e/suite/issuers/acme/certificate/notafter.go
@@ -56,10 +56,7 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 	validations := f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)
 
 	BeforeEach(func() {
-		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
-		// Enable Duration feature to set NotAfter
-		acmeIssuer.Spec.ACME.EnableDurationFeature = true
-		acmeIssuer.Spec.ACME.Solvers = []cmacme.ACMEChallengeSolver{
+		solvers := []cmacme.ACMEChallengeSolver{
 			{
 				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
@@ -80,6 +77,15 @@ var _ = framework.CertManagerDescribe("ACME Certificate (HTTP01 + Not After)", f
 				},
 			},
 		}
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			// Enable Duration feature to set NotAfter
+			gen.SetIssuerACMEDuration(true),
+			gen.SetIssuerACMESolvers(solvers))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/issuers/acme/certificaterequest/http01.go
+++ b/test/e2e/suite/issuers/acme/certificaterequest/http01.go
@@ -38,6 +38,7 @@ import (
 	. "github.com/jetstack/cert-manager/test/e2e/framework/matcher"
 	frameworkutil "github.com/jetstack/cert-manager/test/e2e/framework/util"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func() {
@@ -53,8 +54,7 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 	fixedIngressName := "testingress"
 
 	BeforeEach(func() {
-		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
-		acmeIssuer.Spec.ACME.Solvers = []cmacme.ACMEChallengeSolver{
+		solvers := []cmacme.ACMEChallengeSolver{
 			{
 				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
 					Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
@@ -75,6 +75,13 @@ var _ = framework.CertManagerDescribe("ACME CertificateRequest (HTTP01)", func()
 				},
 			},
 		}
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMESolvers(solvers))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -24,10 +24,13 @@ import (
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 const invalidACMEURL = "http://not-a-real-acme-url.com"
@@ -47,8 +50,12 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	})
 
 	It("should register ACME account", func() {
-		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
-
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -82,8 +89,12 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	})
 
 	It("should recover a lost ACME account URI", func() {
-		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
-
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -123,7 +134,12 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Recreating the Issuer")
-		acmeIssuer = util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
+		acmeIssuer = gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
 		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -153,7 +169,12 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	})
 
 	It("should fail to register an ACME account", func() {
-		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, invalidACMEURL, testingACMEEmail, testingACMEPrivateKey)
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(invalidACMEURL),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
 
 		By("Creating an Issuer with an invalid server")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
@@ -170,7 +191,12 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	})
 
 	It("should handle updates to the email field", func() {
-		acmeIssuer := util.NewCertManagerACMEIssuer(issuerName, f.Config.Addons.ACMEServer.URL, testingACMEEmail, testingACMEPrivateKey)
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
 
 		By("Creating an Issuer")
 		acmeIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -18,11 +18,15 @@ package acme
 
 import (
 	"context"
+	"encoding/base64"
+	"errors"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
@@ -268,5 +272,77 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 				return false, nil
 			})
 		Expect(err).NotTo(HaveOccurred())
+	})
+	It("ACME account with External Account Binding", func() {
+
+		By("providing the legacy keyAlgorithm value")
+
+		var (
+			secretName = "test-secret"
+			keyID      = "kid-1"
+			key        = "kid-secret-1"
+		)
+
+		// TODO: this value will get base64 encoded twice. Investigate why we need to do this.
+		keyBytes := []byte(base64.RawURLEncoding.EncodeToString([]byte(key)))
+		s := gen.Secret(secretName,
+			gen.SetSecretNamespace(f.Namespace.Name),
+			gen.SetSecretData(map[string][]byte{
+				"key": keyBytes,
+			}))
+		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), s, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		acmeIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
+			gen.SetIssuerACMESkipTLSVerify(true),
+			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey),
+			gen.SetIssuerACMEEABWithKeyAlgorithm(keyID, secretName, cmacme.HS256))
+
+		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(
+			context.TODO(), acmeIssuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			acmeIssuer.Name,
+			v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+
+		By("removing the legacy keyAlgorithm value")
+
+		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Get(context.TODO(), acmeIssuer.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		acmeIssuer = gen.IssuerFrom(acmeIssuer,
+			gen.SetIssuerACMEEAB(keyID, secretName))
+
+		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Update(context.TODO(), acmeIssuer, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		// TODO: we should use observedGeneration here, but currently it won't
+		// be incremented correctly in this scenario.
+		// Verify that Issuer's Ready condition remains True for 5 seconds.
+		err = wait.Poll(time.Millisecond*200, time.Second*5, func() (bool, error) {
+			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Get(
+				context.TODO(), issuerName, metav1.GetOptions{})
+			if err != nil {
+				return false, err
+			}
+			if !apiutil.IssuerHasCondition(iss, v1.IssuerCondition{
+				Type:   v1.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			}) {
+				return false, errors.New("expected Ready condition to be true, got false")
+			}
+			// keep polling
+			return false, nil
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(wait.ErrWaitTimeout))
 	})
 })

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -41,7 +41,10 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 
 	JustBeforeEach(func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerCAIssuer(issuerName, issuerSecretName), metav1.CreateOptions{})
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerCASecretName(issuerSecretName))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),

--- a/test/e2e/suite/issuers/ca/certificaterequest.go
+++ b/test/e2e/suite/issuers/ca/certificaterequest.go
@@ -58,7 +58,10 @@ var _ = framework.CertManagerDescribe("CA CertificateRequest", func() {
 
 	JustBeforeEach(func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerCAIssuer(issuerName, issuerSecretName), metav1.CreateOptions{})
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerCASecretName(issuerSecretName))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),

--- a/test/e2e/suite/issuers/ca/clusterissuer.go
+++ b/test/e2e/suite/issuers/ca/clusterissuer.go
@@ -28,6 +28,7 @@ import (
 	cmutil "github.com/jetstack/cert-manager/pkg/util"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {
@@ -50,7 +51,8 @@ var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {
 
 	It("should validate a signing keypair", func() {
 		By("Creating an Issuer")
-		clusterIssuer := util.NewCertManagerCAClusterIssuer(issuerName, secretName)
+		clusterIssuer := gen.ClusterIssuer(issuerName,
+			gen.SetIssuerCASecretName(secretName))
 		_, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), clusterIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")

--- a/test/e2e/suite/issuers/ca/issuer.go
+++ b/test/e2e/suite/issuers/ca/issuer.go
@@ -26,6 +26,7 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -48,7 +49,10 @@ var _ = framework.CertManagerDescribe("CA Issuer", func() {
 
 	It("should generate a signing keypair", func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerCAIssuer(issuerName, secretName), metav1.CreateOptions{})
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerCASecretName(secretName))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),

--- a/test/e2e/suite/issuers/selfsigned/certificate.go
+++ b/test/e2e/suite/issuers/selfsigned/certificate.go
@@ -28,6 +28,7 @@ import (
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -43,7 +44,10 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 
 		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerSelfSignedIssuer(issuerName), metav1.CreateOptions{})
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(v1.SelfSignedIssuer{}))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
@@ -91,7 +95,10 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 
 			By("Creating an Issuer")
 			issuerDurationName := fmt.Sprintf("%s-%d", issuerName, v.expectedDuration)
-			_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerSelfSignedIssuer(issuerDurationName), metav1.CreateOptions{})
+			issuer := gen.Issuer(issuerDurationName,
+				gen.SetIssuerNamespace(f.Namespace.Name),
+				gen.SetIssuerSelfSigned(v1.SelfSignedIssuer{}))
+			_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			By("Waiting for Issuer to become Ready")
 			err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
@@ -122,7 +129,10 @@ var _ = framework.CertManagerDescribe("Self Signed Certificate", func() {
 
 		certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerSelfSignedIssuer(issuerName), metav1.CreateOptions{})
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(v1.SelfSignedIssuer{}))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		crt := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil)

--- a/test/e2e/suite/issuers/selfsigned/certificaterequest.go
+++ b/test/e2e/suite/issuers/selfsigned/certificaterequest.go
@@ -43,7 +43,10 @@ var _ = framework.CertManagerDescribe("SelfSigned CertificateRequest", func() {
 
 	JustBeforeEach(func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerSelfSignedIssuer(issuerName), metav1.CreateOptions{})
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerSelfSigned(v1.SelfSignedIssuer{}))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),

--- a/test/e2e/suite/issuers/vault/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//test/e2e/suite/issuers/vault/certificate:go_default_library",
         "//test/e2e/suite/issuers/vault/certificaterequest:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole)", func() {
@@ -119,12 +120,23 @@ func runVaultAppRoleTests(issuerKind string) {
 
 		var err error
 		if issuerKind == cmapi.IssuerKind {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.IssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerNamespace(f.Namespace.Name),
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name
 		} else {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), util.NewCertManagerVaultClusterIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.ClusterIssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name
@@ -204,12 +216,23 @@ func runVaultAppRoleTests(issuerKind string) {
 
 			var err error
 			if issuerKind == cmapi.IssuerKind {
-				iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole("test-vault-issuer-", vault.Details().Host, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+				vaultIssuer := gen.IssuerWithRandomName("test-vault-issuer-",
+					gen.SetIssuerNamespace(f.Namespace.Name),
+					gen.SetIssuerVaultURL(vault.Details().Host),
+					gen.SetIssuerVaultPath(vaultPath),
+					gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+					gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+				iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				vaultIssuerName = iss.Name
 			} else {
-				iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), util.NewCertManagerVaultClusterIssuerAppRole("test-vault-issuer-", vault.Details().Host, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+				vaultIssuer := gen.ClusterIssuerWithRandomName("test-vault-issuer-",
+					gen.SetIssuerVaultURL(vault.Details().Host),
+					gen.SetIssuerVaultPath(vaultPath),
+					gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+					gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+				iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				vaultIssuerName = iss.Name

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole with a custom mount path)", func() {
@@ -118,12 +119,23 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 
 		var err error
 		if issuerKind == cmapi.IssuerKind {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.IssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerNamespace(f.Namespace.Name),
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name
 		} else {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), util.NewCertManagerVaultClusterIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.ClusterIssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name

--- a/test/e2e/suite/issuers/vault/certificaterequest/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/certificaterequest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer CertificateRequest (AppRole)", func() {
@@ -126,12 +127,23 @@ func runVaultAppRoleTests(issuerKind string) {
 
 		var err error
 		if issuerKind == cmapi.IssuerKind {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.IssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerNamespace(f.Namespace.Name),
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name
 		} else {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), util.NewCertManagerVaultClusterIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.ClusterIssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name
@@ -205,12 +217,23 @@ func runVaultAppRoleTests(issuerKind string) {
 
 			var err error
 			if issuerKind == cmapi.IssuerKind {
-				iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole("test-vault-issuer-", vault.Details().Host, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+				vaultIssuer := gen.IssuerWithRandomName("test-vault-issuer-",
+					gen.SetIssuerNamespace(f.Namespace.Name),
+					gen.SetIssuerVaultURL(vault.Details().Host),
+					gen.SetIssuerVaultPath(vaultPath),
+					gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+					gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+				iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				vaultIssuerName = iss.Name
 			} else {
-				iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), util.NewCertManagerVaultClusterIssuerAppRole("test-vault-issuer", vault.Details().Host, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+				vaultIssuer := gen.ClusterIssuerWithRandomName("test-vault-issuer-",
+					gen.SetIssuerVaultURL(vault.Details().Host),
+					gen.SetIssuerVaultPath(vaultPath),
+					gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+					gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+				iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				vaultIssuerName = iss.Name

--- a/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificaterequest/approle_custom_mount.go
@@ -33,6 +33,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer CertificateRequest (AppRole with a custom mount path)", func() {
@@ -128,12 +129,23 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 
 		var err error
 		if issuerKind == cmapi.IssuerKind {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.IssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerNamespace(f.Namespace.Name),
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name
 		} else {
-			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), util.NewCertManagerVaultClusterIssuerAppRole("test-vault-issuer-", vaultURL, vaultPath, roleId, vaultSecretName, authPath, vault.Details().VaultCA), metav1.CreateOptions{})
+			vaultIssuer := gen.ClusterIssuerWithRandomName("test-vault-issuer-",
+				gen.SetIssuerVaultURL(vaultURL),
+				gen.SetIssuerVaultPath(vaultPath),
+				gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+				gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, authPath))
+			iss, err := f.CertManagerClientSet.CertmanagerV1().ClusterIssuers().Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			vaultIssuerName = iss.Name

--- a/test/e2e/suite/issuers/vault/issuer.go
+++ b/test/e2e/suite/issuers/vault/issuer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer", func() {
@@ -115,7 +116,13 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 		vaultSecretName = sec.Name
 
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretName, appRoleAuthPath, vault.Details().VaultCA), metav1.CreateOptions{})
+		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(vault.Details().Host),
+			gen.SetIssuerVaultPath(vaultPath),
+			gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretName, roleId, appRoleAuthPath))
+		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
@@ -130,7 +137,13 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init with missing Vault AppRole", func() {
 		By("Creating an Issuer")
-		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerAppRole(issuerName, vault.Details().Host, vaultPath, roleId, vaultSecretAppRoleName, appRoleAuthPath, vault.Details().VaultCA), metav1.CreateOptions{})
+		vaultIssuer := gen.IssuerWithRandomName(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(vault.Details().Host),
+			gen.SetIssuerVaultPath(vaultPath),
+			gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+			gen.SetIssuerVaultAppRoleAuth("secretkey", vaultSecretAppRoleName, roleId, appRoleAuthPath))
+		iss, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
@@ -145,7 +158,13 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init with missing Vault Token", func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerToken(issuerName, vault.Details().Host, vaultPath, vaultSecretTokenName, appRoleAuthPath, vault.Details().VaultCA), metav1.CreateOptions{})
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(vault.Details().Host),
+			gen.SetIssuerVaultPath(vaultPath),
+			gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+			gen.SetIssuerVaultTokenAuth("secretkey", vaultSecretTokenName))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
@@ -162,7 +181,13 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 		_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), vaultaddon.NewVaultKubernetesSecret(vaultSecretServiceAccount, vaultSecretServiceAccount), metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerKubernetes(issuerName, vault.Details().Host, vaultPath, vaultSecretServiceAccount, vaultKubernetesRoleName, kubernetesAuthPath, vault.Details().VaultCA), metav1.CreateOptions{})
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(vault.Details().Host),
+			gen.SetIssuerVaultPath(vaultPath),
+			gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+			gen.SetIssuerVaultKubernetesAuth("token", vaultSecretServiceAccount, vaultKubernetesRoleName, kubernetesAuthPath))
+		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for Issuer to become Ready")
@@ -177,7 +202,13 @@ var _ = framework.CertManagerDescribe("Vault Issuer", func() {
 
 	It("should fail to init with missing Kubernetes Role", func() {
 		By("Creating an Issuer")
-		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), util.NewCertManagerVaultIssuerKubernetes(issuerName, vault.Details().Host, vaultPath, vaultSecretServiceAccount, vaultKubernetesRoleName, kubernetesAuthPath, vault.Details().VaultCA), metav1.CreateOptions{})
+		vaultIssuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerVaultURL(vault.Details().Host),
+			gen.SetIssuerVaultPath(vaultPath),
+			gen.SetIssuerVaultCABundle(vault.Details().VaultCA),
+			gen.SetIssuerVaultKubernetesAuth("token", vaultSecretServiceAccount, vaultKubernetesRoleName, kubernetesAuthPath))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), vaultIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		By("Waiting for Issuer to become Ready")
 		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),

--- a/test/e2e/suite/serving/BUILD.bazel
+++ b/test/e2e/suite/serving/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "//pkg/apis/meta/v1:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/util:go_default_library",
+        "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
         "@io_k8s_api//admissionregistration/v1:go_default_library",

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -32,9 +32,11 @@ import (
 	apireg "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
 
 	certmanager "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
 type injectableTest struct {
@@ -56,8 +58,9 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 
 			BeforeEach(func() {
 				By("creating a self-signing issuer")
-				issuer := util.NewCertManagerSelfSignedIssuer(issuerName)
-				issuer.Namespace = f.Namespace.Name
+				issuer := gen.Issuer(issuerName,
+					gen.SetIssuerNamespace(f.Namespace.Name),
+					gen.SetIssuerSelfSigned(v1.SelfSignedIssuer{}))
 				Expect(f.CRClient.Create(context.Background(), issuer)).To(Succeed())
 
 				By("Waiting for Issuer to become Ready")

--- a/test/e2e/util/BUILD.bazel
+++ b/test/e2e/util/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/api/util:go_default_library",
-        "//pkg/apis/acme/v1:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned/scheme:go_default_library",

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	intscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
@@ -243,21 +242,6 @@ func WaitForCRDToNotExist(client apiextcs.CustomResourceDefinitionInterface, nam
 	)
 }
 
-func NewCertManagerCAClusterIssuer(name, secretName string) *v1.ClusterIssuer {
-	return &v1.ClusterIssuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				CA: &v1.CAIssuer{
-					SecretName: secretName,
-				},
-			},
-		},
-	}
-}
-
 // Deprecated: use test/unit/gen/Certificate in future
 func NewCertManagerBasicCertificate(name, secretName, issuerName string, issuerKind string, duration, renewBefore *metav1.Duration, dnsNames ...string) *v1.Certificate {
 	cn := "test.domain.com"
@@ -406,152 +390,6 @@ func NewIngress(name, secretName string, annotations map[string]string, dnsNames
 									},
 								},
 							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func NewCertManagerACMEIssuer(name, acmeURL, acmeEmail, acmePrivateKey string) *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				ACME: &cmacme.ACMEIssuer{
-					Email:         acmeEmail,
-					Server:        acmeURL,
-					SkipTLSVerify: true,
-					PrivateKey: cmmeta.SecretKeySelector{
-						LocalObjectReference: cmmeta.LocalObjectReference{
-							Name: acmePrivateKey,
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func NewCertManagerCAIssuer(name, secretName string) *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				CA: &v1.CAIssuer{
-					SecretName: secretName,
-				},
-			},
-		},
-	}
-}
-
-func NewCertManagerSelfSignedIssuer(name string) *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				SelfSigned: &v1.SelfSignedIssuer{},
-			},
-		},
-	}
-}
-
-func NewCertManagerVaultIssuerToken(name, vaultURL, vaultPath, vaultSecretToken, authPath string, caBundle []byte) *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				Vault: &v1.VaultIssuer{
-					Server:   vaultURL,
-					Path:     vaultPath,
-					CABundle: caBundle,
-					Auth: v1.VaultAuth{
-						TokenSecretRef: &cmmeta.SecretKeySelector{
-							Key: "secretkey",
-							LocalObjectReference: cmmeta.LocalObjectReference{
-								Name: vaultSecretToken,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func NewCertManagerVaultIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: name,
-		},
-		Spec: newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole, authPath, caBundle),
-	}
-}
-
-func NewCertManagerVaultClusterIssuerAppRole(name, vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) *v1.ClusterIssuer {
-	return &v1.ClusterIssuer{
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: name,
-		},
-		Spec: newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole, authPath, caBundle),
-	}
-}
-
-func newCertManagerVaultIssuerSpecAppRole(vaultURL, vaultPath, roleId, vaultSecretAppRole string, authPath string, caBundle []byte) v1.IssuerSpec {
-	return v1.IssuerSpec{
-		IssuerConfig: v1.IssuerConfig{
-			Vault: &v1.VaultIssuer{
-				Server:   vaultURL,
-				Path:     vaultPath,
-				CABundle: caBundle,
-				Auth: v1.VaultAuth{
-					AppRole: &v1.VaultAppRole{
-						Path:   authPath,
-						RoleId: roleId,
-						SecretRef: cmmeta.SecretKeySelector{
-							Key: "secretkey",
-							LocalObjectReference: cmmeta.LocalObjectReference{
-								Name: vaultSecretAppRole,
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-}
-
-func NewCertManagerVaultIssuerKubernetes(name, vaultURL, vaultPath, vaultSecretServiceAccount string, role string, authPath string, caBundle []byte) *v1.Issuer {
-	return &v1.Issuer{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-		},
-		Spec: v1.IssuerSpec{
-			IssuerConfig: v1.IssuerConfig{
-				Vault: &v1.VaultIssuer{
-					Server:   vaultURL,
-					Path:     vaultPath,
-					CABundle: caBundle,
-					Auth: v1.VaultAuth{
-						Kubernetes: &v1.VaultKubernetesAuth{
-							Path: authPath,
-							SecretRef: cmmeta.SecretKeySelector{
-								Key: "token",
-								LocalObjectReference: cmmeta.LocalObjectReference{
-									Name: vaultSecretServiceAccount,
-								},
-							},
-							Role: role,
 						},
 					},
 				},


### PR DESCRIPTION
[Update] I will split this PR into multiple ones to make it easier to code review.

See #3220  for full context.

Up till now we used a fork of [`golang/crypto`](https://github.com/golang/crypto) with added support for ACME External Account Binding and fetching of ACME preferred certificate chains from @meyskens GitHub account.

This PR:
- uses upstream `golang/crypto` functionality for ACME External Account Binding instead of our own
- uses `golang/crypto` fork from `cert-manager` account instead of @meyskens  account


Notes:
- I have forked the latest `golang/crypto` [to `cert-manager` org](https://github.com/cert-manager/crypto) and cherry-picked @meyskens commit that implements fetching of alternative certificate chains on top of that. We can use this fork till the same functionality [gets implemented upstream](https://go-review.googlesource.com/c/crypto/+/277294/)

- The difference between the upstream implementation of ACME EAB and our own that we have used up till now is that in upstream the MAC algorithm value is hardcoded to `HS256`. This means that the [`issuer.spec.acme.externalAccountBinding.keyAlgorithm`](https://cert-manager.io/docs/reference/api-docs/#acme.cert-manager.io/v1.ACMEExternalAccountBinding) that has been 'required' so far becomes useless. This PR makes the field optional and the validating webhook now [returns a warning](https://kubernetes.io/blog/2020/09/03/warnings/) if it is set. It is now possible (we test for that) to 1) deploy with `issuer.spec.acme.externalAccountBinding.keyAlgorithm`  field set 2) deploy without the field 3) deploy with, then remove.

- I have removed a bunch of legacy functions for issuer generation from [`test/e2e/util/util.go`](https://github.com/jetstack/cert-manager/blob/master/test/e2e/util/util.go) as it partially duplicated the functionality in [`test/test/unit/gen/issuer.go`](https://github.com/jetstack/cert-manager/blob/master/test/unit/gen/issuer.go) and added some more specific issuer generation functions to `test/unit/gen/issuer.go`.
Can we assume that no-one has been importing the legacy functions from `test/e2e/util/util.go`? I did not find [external imports on `pkg.go.dev`](https://pkg.go.dev/github.com/jetstack/cert-manager/test/e2e/util?tab=importedby)

- In order for the webhook to be able to [return a warning](https://kubernetes.io/blog/2020/09/03/warnings/) I had to add it to the signature of most validating functions. I assume that this is a functionality that might potentially become useful? (i.e perhaps [the warning about empty hostname for self-signed issuer that @SgtCoDFish worked on](https://github.com/jetstack/cert-manager/pull/3760) could have been implemented as a warning)

- Would it make sense to eventually remove `issuer.spec.acme.externalAccountBinding.keyAlgorithm`? (In which case that should probabaly be added to the warning message).

This is what the warning looks like:
![Screenshot from 2021-04-07 12-38-25](https://user-images.githubusercontent.com/24879183/113887733-a81aba80-97b9-11eb-947b-985c6658dc37.png)



 fixes #3822 

```release-note
Deprecate Issuer.spec.acme.externalAccountBinding.keyAlgorithm field. EAB MAC algorithm is now hardcoded to HS256.
```
