### PR TITLE
HTTP01 ACME solver pod: add imagePullSecret

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -217,6 +217,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		Metrics:                   metrics.New(log),
 		ACMEOptions: controller.ACMEOptions{
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
+			HTTP01SolverImagePullSecret:       opts.ACMEHTTP01SolverImagePullSecret,
 			HTTP01SolverResourceRequestCPU:    HTTP01SolverResourceRequestCPU,
 			HTTP01SolverResourceRequestMemory: HTTP01SolverResourceRequestMemory,
 			HTTP01SolverResourceLimitsCPU:     HTTP01SolverResourceLimitsCPU,

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -64,6 +64,7 @@ type ControllerOptions struct {
 	ACMEHTTP01SolverImage                 string
 	ACMEHTTP01SolverResourceRequestCPU    string
 	ACMEHTTP01SolverResourceRequestMemory string
+	ACMEHTTP01SolverImagePullSecret       string
 	ACMEHTTP01SolverResourceLimitsCPU     string
 	ACMEHTTP01SolverResourceLimitsMemory  string
 
@@ -133,6 +134,7 @@ const (
 var (
 	defaultACMEHTTP01SolverImage                 = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
 	defaultACMEHTTP01SolverResourceRequestCPU    = "10m"
+	defaultACMEHTTP01SolverImagePullSecret       = ""
 	defaultACMEHTTP01SolverResourceRequestMemory = "64Mi"
 	defaultACMEHTTP01SolverResourceLimitsCPU     = "100m"
 	defaultACMEHTTP01SolverResourceLimitsMemory  = "64Mi"
@@ -234,6 +236,10 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 
 	fs.StringVar(&s.ACMEHTTP01SolverResourceRequestMemory, "acme-http01-solver-resource-request-memory", defaultACMEHTTP01SolverResourceRequestMemory, ""+
 		"Defines the resource request Memory size when spawning new ACME HTTP01 challenge solver pods.")
+
+	fs.StringVar(&s.ACMEHTTP01SolverImagePullSecret, "acme-http01-solver-image-pull-secret", defaultACMEHTTP01SolverImagePullSecret, ""+
+		"The docker image to use to solve ACME HTTP01 challenges. You most likely will not "+
+		"need to change this parameter unless you are testing a new feature or developing cert-manager.")
 
 	fs.StringVar(&s.ACMEHTTP01SolverResourceLimitsCPU, "acme-http01-solver-resource-limits-cpu", defaultACMEHTTP01SolverResourceLimitsCPU, ""+
 		"Defines the resource limits CPU size when spawning new ACME HTTP01 challenge solver pods.")

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -101,6 +101,10 @@ type ACMEOptions struct {
 	// HTTP01SolverResourceRequestCPU defines the ACME pod's resource request CPU size
 	HTTP01SolverResourceRequestCPU resource.Quantity
 
+	// ACMEHTTP01SolverImagePullSecret is the name of the secret to get the ACMEHTTP01SolverImage
+	// from a private container registry
+	HTTP01SolverImagePullSecret string
+
 	// HTTP01SolverResourceRequestMemory defines the ACME pod's resource request Memory size
 	HTTP01SolverResourceRequestMemory resource.Quantity
 

--- a/pkg/issuer/acme/http/pod.go
+++ b/pkg/issuer/acme/http/pod.go
@@ -168,6 +168,9 @@ func (s *Solver) buildDefaultPod(ch *cmacme.Challenge) *corev1.Pod {
 		},
 		Spec: corev1.PodSpec{
 			RestartPolicy: corev1.RestartPolicyOnFailure,
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: s.ACMEOptions.HTTP01SolverImagePullSecret},
+			},
 			Containers: []corev1.Container{
 				{
 					Name: "acmesolver",


### PR DESCRIPTION
cert-manager create the HTTP01 ACME solver pod, when can specify:

The image: --acme-http01-solver-image
The serviceAccount (##3817): --acme-http01-solver-service-account
The resources
But we can't specify the imagePullSecret to use.

This is an issue for:

Air gapped environments with private registries
Docker Hub rate limits for anonymous pulls
It is currently possible to use the serviceAccount with an attached
imagePullSecret, but it is not always convenient because it requires to
update the serviceAccount of every namespace in the cluster to link the
imagePullsecret.

Signed-off-by: Primaël Bruant <primael.bruant@gmail.com>


