### PR TITLE
Revert "Handle CA issuer working as intermediate correctly"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .DS_Store
 .idea
-*.iml
 /acmesolver
 /controller
 /ingress-shim

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -424,9 +424,9 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 		return nil, nil, errors.New("no CA certificates given to sign CSR template")
 	}
 
-	issuingCACert := caCerts[0]
+	caCert := caCerts[0]
 
-	certPem, _, err := SignCertificate(template, issuingCACert, template.PublicKey, caKey)
+	certPem, _, err := SignCertificate(template, caCert, template.PublicKey, caKey)
 	if err != nil {
 		return nil, nil, err
 
@@ -440,8 +440,7 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 	certPem = append(certPem, chainPem...)
 
 	// encode the CA certificate to be bundled in the output
-	caCert := caCerts[len(caCerts)-1]
-	caPem, err := EncodeX509(caCert)
+	caPem, err := EncodeX509(caCerts[0])
 	if err != nil {
 		return nil, nil, err
 	}


### PR DESCRIPTION
This PR reverts jetstack/cert-manager#3847. As discussed in https://github.com/jetstack/cert-manager/pull/3847#issuecomment-814702622, I went too fast and `/lgtm` from my bed, which led to merging code that could potentially break people's cert-manager deployments.

Our plan is to have the same PR re-opened so that we can have it released for v1.4 (due on Friday 11 June 2021 as per [our timeline](https://docs.google.com/document/d/1Tc5t6ylY9dhXAan1OjOoldeaoys1Yh4Ir710ATfBa5U/edit#bookmark=kix.8a98ch6d7b)).

/cc @munnerz 

/kind cleanup
/area acme/http01
/priority important-soon

```release-note
NONE
```