### PR TITLE
Handle CA issuer working as intermediate correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .idea
+*.iml
 /acmesolver
 /controller
 /ingress-shim

--- a/pkg/util/pki/BUILD.bazel
+++ b/pkg/util/pki/BUILD.bazel
@@ -28,6 +28,8 @@ go_test(
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/util:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
     ],
 )
 

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -424,9 +424,9 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 		return nil, nil, errors.New("no CA certificates given to sign CSR template")
 	}
 
-	caCert := caCerts[0]
+	issuingCACert := caCerts[0]
 
-	certPem, _, err := SignCertificate(template, caCert, template.PublicKey, caKey)
+	certPem, _, err := SignCertificate(template, issuingCACert, template.PublicKey, caKey)
 	if err != nil {
 		return nil, nil, err
 
@@ -440,7 +440,8 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 	certPem = append(certPem, chainPem...)
 
 	// encode the CA certificate to be bundled in the output
-	caPem, err := EncodeX509(caCerts[0])
+	caCert := caCerts[len(caCerts)-1]
+	caPem, err := EncodeX509(caCert)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/test/e2e/framework/helper/featureset/featureset.go
+++ b/test/e2e/framework/helper/featureset/featureset.go
@@ -128,6 +128,10 @@ const (
 	OnlySAN = "OnlySAN"
 
 	// SaveCAToSecret denotes whether the target issuer returns a CA
-	// certificate which can be stored in the CA.crt field of the Secret.
+	// certificate which can be stored in the ca.crt field of the Secret.
 	SaveCAToSecret = "SaveCAToSecret"
+
+	// SaveRootCAToSecret denotes whether the CA certificate is expected to
+	// represent a root CA (sub-feature of SaveCAToSecret)
+	SaveRootCAToSecret = "SaveRootCAToSecret"
 )

--- a/test/e2e/framework/helper/validate.go
+++ b/test/e2e/framework/helper/validate.go
@@ -37,6 +37,7 @@ func (h *Helper) DefaultValidationSet() []ValidationFunc {
 		validations.ExpectCertificateOrganizationToMatch,
 		validations.ExpectCertificateURIsToMatch,
 		validations.ExpectCorrectTrustChain,
+		validations.ExpectCARootCertificate,
 		validations.ExpectEmailsToMatch,
 		validations.ExpectValidAnnotations,
 		validations.ExpectValidCertificate,
@@ -71,6 +72,7 @@ func (h *Helper) ValidationSetForUnsupportedFeatureSet(fs featureset.FeatureSet)
 
 	if !fs.Contains(featureset.SaveCAToSecret) {
 		out = append(out, validations.ExpectCorrectTrustChain)
+		out = append(out, validations.ExpectCARootCertificate)
 	}
 
 	return out

--- a/test/e2e/framework/helper/validate.go
+++ b/test/e2e/framework/helper/validate.go
@@ -72,7 +72,9 @@ func (h *Helper) ValidationSetForUnsupportedFeatureSet(fs featureset.FeatureSet)
 
 	if !fs.Contains(featureset.SaveCAToSecret) {
 		out = append(out, validations.ExpectCorrectTrustChain)
-		out = append(out, validations.ExpectCARootCertificate)
+		if !fs.Contains(featureset.SaveRootCAToSecret) {
+			out = append(out, validations.ExpectCARootCertificate)
+		}
 	}
 
 	return out

--- a/test/e2e/framework/helper/validations/certificates.go
+++ b/test/e2e/framework/helper/validations/certificates.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validations
 
 import (
+	"bytes"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -307,6 +308,19 @@ func ExpectCorrectTrustChain(certificate *cmapi.Certificate, secret *corev1.Secr
 			pretty.Sprint(intermediateCertPool),
 			err,
 		)
+	}
+
+	return nil
+}
+
+// ExpectCARootCertificate checks if the CA cert is root CA if one is provided
+func ExpectCARootCertificate(certificate *cmapi.Certificate, secret *corev1.Secret) error {
+	caCert, err := pki.DecodeX509CertificateBytes(secret.Data[cmmeta.TLSCAKey])
+	if err != nil {
+		return err
+	}
+	if !bytes.Equal(caCert.RawSubject, caCert.RawIssuer) {
+		return fmt.Errorf("expected CA certificate to be root CA; want Issuer %v, but got %v", caCert.Subject, caCert.Issuer)
 	}
 
 	return nil

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -43,6 +43,7 @@ const (
 var _ = framework.ConformanceDescribe("Certificates", func() {
 	var unsupportedFeatures = featureset.NewFeatureSet(
 		featureset.KeyUsagesFeature,
+		featureset.SaveRootCAToSecret,
 	)
 
 	provisioner := new(vaultAppRoleProvisioner)

--- a/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
+++ b/test/e2e/suite/issuers/vault/certificate/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/addon:go_default_library",
         "//test/e2e/framework/addon/vault:go_default_library",
+        "//test/e2e/framework/helper/featureset:go_default_library",
         "//test/e2e/util:go_default_library",
         "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",

--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -31,6 +31,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
+	"github.com/jetstack/cert-manager/test/e2e/framework/helper/featureset"
 	"github.com/jetstack/cert-manager/test/e2e/util"
 	"github.com/jetstack/cert-manager/test/unit/gen"
 )
@@ -171,7 +172,8 @@ func runVaultAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName)
+		unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)...)
 		Expect(err).NotTo(HaveOccurred())
 
 	})
@@ -266,7 +268,8 @@ func runVaultAppRoleTests(issuerKind string) {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Validating the issued Certificate...")
-			err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName)
+			unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+			err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)...)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Vault subtract 30 seconds to the NotBefore date.

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/addon"
 	vaultaddon "github.com/jetstack/cert-manager/test/e2e/framework/addon/vault"
+	"github.com/jetstack/cert-manager/test/e2e/framework/helper/featureset"
 	"github.com/jetstack/cert-manager/test/e2e/util"
 	"github.com/jetstack/cert-manager/test/unit/gen"
 )
@@ -169,7 +170,8 @@ func runVaultCustomAppRoleTests(issuerKind string) {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Validating the issued Certificate...")
-		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName)
+		unsupportedFeatures := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
+		err = f.Helper().ValidateCertificate(f.Namespace.Name, certificateName, f.Helper().ValidationSetForUnsupportedFeatureSet(unsupportedFeatures)...)
 		Expect(err).NotTo(HaveOccurred())
 	})
 }


### PR DESCRIPTION
This is a new PR to reapply the changes suggested in https://github.com/jetstack/cert-manager/pull/3847, that were reverted by https://github.com/jetstack/cert-manager/pull/3862. This time tests are added to test the wanted behavior - both unit tests and e2e-tests.

Copying in the PR description from https://github.com/jetstack/cert-manager/pull/3847.

**What this PR does / why we need it**:

This patch fixes the CA issuer in case it is working as intermediate, and _the root CA certificate is available_ (best effort).

The current behavior is to assume that the CA issuer is the root CA, and return the issuing CA certificate as CA certificate to clients. This is not optimal when the CA issuer is an intermediate CA.

The wanted behavior in intermediate CA case is described in https://github.com/jetstack/cert-manager/issues/3619#issuecomment-808159467. Fix suggested in this PR uses the last certificate in the CA chain when signing as CA certificate supplied to clients. This should handle the intermediate case more correctly if the CA issuer is configured with the full CA certificate chain: starting with the issuing/signing CA certificate, any other intermediate CA certificates, ending with the root (self-signed) certificate.

This appears to be a non-breaking change.

**Which issue this PR fixes**: fixes #3619 

**Special notes for your reviewer**:

When adding e2e-tests, tests for Vault issuer were failing - since the same test-helpers are used for multiple issuers. To limit the scope of this PR, I have added an unsupported feature and using it for the Vault issuer e2e-tests. As noted in https://github.com/jetstack/cert-manager/pull/3865#issuecomment-819720139, this can be avoided by a minor re-configuration of the Vault PKI mount used in the e2e-tests. But my suggestion is to leave this work for a follow-up PR.

```release-note
ACTION REQUIRED: CA issuer now stores root CA instead of issuing CA into CA bundle (`ca.crt`), from CA chain configured for CA issuer.
```

Related (add documentation): https://github.com/cert-manager/website/pull/499


/area ca
/kind bug