### PR TITLE
[WIP] Adds ARM64 to test platforms

### DIFF
--- a/build/platforms.bzl
+++ b/build/platforms.bzl
@@ -45,8 +45,14 @@ CLIENT_PLATFORMS = {
 }
 
 TEST_PLATFORMS = {
-    "linux": ["amd64"],
-    "darwin": ["amd64"],
+    "linux": [
+        "amd64",
+        "arm64",
+    ],
+    "darwin": [
+        "amd64",
+        "arm64",
+    ],
 }
 
 # Helper which produces the ALL_PLATFORMS dictionary, currently composed of


### PR DESCRIPTION
Adds arm64 to test platforms.

This will help contributors using Apple Silicon to run `cert-manager` tests locally, see #3804 


```release-note
NONE
```

Closes #3804 
Signed-off-by: irbekrm <irbekrm@gmail.com>