### PR TITLE
Add support for accessing the webhook from outside of the cluster

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -148,6 +148,9 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.securityContext` | Security context for webhook pod assignment | `{}` |
 | `webhook.containerSecurityContext` | Security context to be set on the webhook component container | `{}` |
 | `webhook.hostNetwork` | If `true`, run the Webhook on the host network. | `false` |
+| `webhook.serviceType` | The type of the `Service`. | `ClusterIP` |
+| `webhook.loadBalancerIP` | The specific load balancer IP to use (when `serviceType` is `LoadBalancer`). |  |
+| `webhook.url.host` | The host to use to reach the webhook, instead of using internal cluster DNS for the service. |  |
 | `webhook.livenessProbe.failureThreshold` | The liveness probe failure threshold | `3` |
 | `webhook.livenessProbe.initialDelaySeconds` | The liveness probe initial delay (in seconds) | `60` |
 | `webhook.livenessProbe.periodSeconds` | The liveness probe period (in seconds) | `10` |

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -66,7 +66,7 @@ spec:
           - --secure-port={{ .Values.webhook.securePort }}
           - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
           - --dynamic-serving-ca-secret-name={{ template "webhook.fullname" . }}-ca
-          - --dynamic-serving-dns-names={{ template "webhook.fullname" . }},{{ template "webhook.fullname" . }}.{{ .Release.Namespace }},{{ template "webhook.fullname" . }}.{{ .Release.Namespace }}.svc
+          - --dynamic-serving-dns-names={{ template "webhook.fullname" . }},{{ template "webhook.fullname" . }}.{{ .Release.Namespace }},{{ template "webhook.fullname" . }}.{{ .Release.Namespace }}.svc{{ if .Values.webhook.url.host }},{{ .Values.webhook.url.host }}{{ end }}
         {{- if .Values.webhook.extraArgs }}
 {{ toYaml .Values.webhook.extraArgs | indent 10 }}
         {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -33,7 +33,11 @@ webhooks:
     # Only include 'sideEffects' field in Kubernetes 1.12+
     sideEffects: None
     clientConfig:
+      {{- if .Values.webhook.url.host }}
+      url: https://{{ .Values.webhook.url.host }}/mutate
+      {{- else }}
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace | quote }}
         path: /mutate
+      {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -11,7 +11,10 @@ metadata:
     app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
 spec:
-  type: ClusterIP
+  type: {{ .Values.webhook.serviceType }}
+  {{- if .Values.webhook.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.webhook.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: https
     port: 443

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -42,7 +42,11 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     clientConfig:
+      {{- if .Values.webhook.url.host }}
+      url: https://{{ .Values.webhook.url.host }}/validate
+      {{- else }}
       service:
         name: {{ template "webhook.fullname" . }}
         namespace: {{ .Release.Namespace | quote }}
         path: /validate
+      {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -305,6 +305,17 @@ webhook:
   # running in hostNetwork mode.
   hostNetwork: false
 
+  # Specifies how the service should be handled. Useful if you want to expose the
+  # webhook to outside of the cluster. In some cases, the control plane cannot
+  # reach internal services.
+  serviceType: ClusterIP
+  # loadBalancerIP:
+
+  # Overrides the mutating webhook and validating webhook so they reach the webhook
+  # service using the `url` field instead of a service.
+  url: {}
+    # host:
+
 cainjector:
   enabled: true
   replicaCount: 1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR adds support for configuring a way of reaching the webhook from "outside" of the cluster. This is useful if your control plane is configured in a way where it does not
know anything about the internal cluster network.

See discussion in Slack:
https://kubernetes.slack.com/archives/C4NV3DWUC/p1617873731232000

**Special notes for your reviewer**:

I wasn't sure if the Helm chart is tested somehow. If it is, please let me know and I'll look into test coverage.

I currently only tested this in my local `0.15` Cert-manager installation, by modifying the manifests after installing the Helm chart.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
The webhook can now be configured to be accessible from outside of the cluster.
```
