### PR TITLE
Set the Ready condition to False when a CertificateRequest has been denied for all CertificateRequests that reference a cert-manager.io signer

### DIFF
--- a/pkg/api/util/conditions.go
+++ b/pkg/api/util/conditions.go
@@ -270,6 +270,7 @@ func CertificateRequestReadyReason(cr *cmapi.CertificateRequest) string {
 		cmapi.CertificateRequestReasonFailed,
 		cmapi.CertificateRequestReasonIssued,
 		cmapi.CertificateRequestReasonPending,
+		cmapi.CertificateRequestReasonDenied,
 	} {
 		for _, con := range cr.Status.Conditions {
 			if con.Type == cmapi.CertificateRequestConditionReady &&

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -33,6 +33,11 @@ const (
 	// Issued indicates that a CertificateRequest has been completed, and that
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
+
+	// RequestDenied is a Ready condition reason that indicates that a
+	// CertificateRequest has been denied, and the CertificateRequest will never
+	// be issued.
+	CertificateRequestReasonDenied = "RequestDenied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -34,10 +34,10 @@ const (
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
 
-	// RequestDenied is a Ready condition reason that indicates that a
+	// Denied is a Ready condition reason that indicates that a
 	// CertificateRequest has been denied, and the CertificateRequest will never
 	// be issued.
-	CertificateRequestReasonDenied = "RequestDenied"
+	CertificateRequestReasonDenied = "Denied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -33,6 +33,11 @@ const (
 	// Issued indicates that a CertificateRequest has been completed, and that
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
+
+	// RequestDenied is a Ready condition reason that indicates that a
+	// CertificateRequest has been denied, and the CertificateRequest will never
+	// be issued.
+	CertificateRequestReasonDenied = "RequestDenied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -34,10 +34,10 @@ const (
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
 
-	// RequestDenied is a Ready condition reason that indicates that a
+	// Denied is a Ready condition reason that indicates that a
 	// CertificateRequest has been denied, and the CertificateRequest will never
 	// be issued.
-	CertificateRequestReasonDenied = "RequestDenied"
+	CertificateRequestReasonDenied = "Denied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -33,6 +33,11 @@ const (
 	// Issued indicates that a CertificateRequest has been completed, and that
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
+
+	// RequestDenied is a Ready condition reason that indicates that a
+	// CertificateRequest has been denied, and the CertificateRequest will never
+	// be issued.
+	CertificateRequestReasonDenied = "RequestDenied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -34,10 +34,10 @@ const (
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
 
-	// RequestDenied is a Ready condition reason that indicates that a
+	// Denied is a Ready condition reason that indicates that a
 	// CertificateRequest has been denied, and the CertificateRequest will never
 	// be issued.
-	CertificateRequestReasonDenied = "RequestDenied"
+	CertificateRequestReasonDenied = "Denied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
@@ -33,6 +33,11 @@ const (
 	// Issued indicates that a CertificateRequest has been completed, and that
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
+
+	// RequestDenied is a Ready condition reason that indicates that a
+	// CertificateRequest has been denied, and the CertificateRequest will never
+	// be issued.
+	CertificateRequestReasonDenied = "RequestDenied"
 )
 
 // +genclient

--- a/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
@@ -34,10 +34,10 @@ const (
 	// the `status.certificate` field is set.
 	CertificateRequestReasonIssued = "Issued"
 
-	// RequestDenied is a Ready condition reason that indicates that a
+	// Denied is a Ready condition reason that indicates that a
 	// CertificateRequest has been denied, and the CertificateRequest will never
 	// be issued.
-	CertificateRequestReasonDenied = "RequestDenied"
+	CertificateRequestReasonDenied = "Denied"
 )
 
 // +genclient

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -202,11 +202,31 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should do nothing": {
+		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
+						gen.DefaultTestNamespace,
+						gen.CertificateRequestFrom(baseCRDenied,
+							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:               cmapi.CertificateRequestConditionReady,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "RequestDenied",
+								Message:            "The CertificateRequest was denied by an approval controller",
+								LastTransitionTime: &metaFixedClockStart,
+							}),
+							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
+						),
+					)),
+				},
 			},
 		},
 		"a badly formed CSR should report failure": {

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -202,14 +202,12 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
+		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -219,7 +217,7 @@ func TestSign(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &metaFixedClockStart,
 							}),

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -189,14 +189,12 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
+		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -206,7 +204,7 @@ func TestSign(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &metaFixedClockStart,
 							}),

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -189,11 +189,31 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should do nothing": {
+		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
+						gen.DefaultTestNamespace,
+						gen.CertificateRequestFrom(baseCRDenied,
+							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:               cmapi.CertificateRequestConditionReady,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "RequestDenied",
+								Message:            "The CertificateRequest was denied by an approval controller",
+								LastTransitionTime: &metaFixedClockStart,
+							}),
+							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
+						),
+					)),
+				},
 			},
 		},
 		"a missing CA key pair should set the condition to pending and wait for a re-sync": {

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
@@ -212,11 +212,31 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should do nothing": {
+		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
+						gen.DefaultTestNamespace,
+						gen.CertificateRequestFrom(baseCRDenied,
+							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:               cmapi.CertificateRequestConditionReady,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "RequestDenied",
+								Message:            "The CertificateRequest was denied by an approval controller",
+								LastTransitionTime: &metaFixedClockStart,
+							}),
+							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
+						),
+					)),
+				},
 			},
 		},
 		"a CertificateRequest with no cert-manager.io/selfsigned-private-key annotation should fail": {

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
@@ -212,14 +212,12 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
+		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -229,7 +227,7 @@ func TestSign(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &metaFixedClockStart,
 							}),

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -168,7 +168,7 @@ func TestSync(t *testing.T) {
 				ExpectedActions:    []testpkg.Action{},
 			},
 		},
-		"should update RequestDenied if certificate request is denied": {
+		"should update Ready condition with 'Denied' if certificate request is denied": {
 			certificateRequest: gen.CertificateRequestFrom(baseCRNotApproved,
 				gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 					Type:               cmapi.CertificateRequestConditionDenied,
@@ -180,9 +180,7 @@ func TestSync(t *testing.T) {
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer, baseCR},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -199,7 +197,7 @@ func TestSync(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &nowMetaTime,
 							}),
@@ -209,7 +207,7 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
-		"should update RequestDenied if certificate request is denied and also has Failed condition": {
+		"should overwrite Ready condition with Denied if certificate request is denied": {
 			certificateRequest: gen.CertificateRequestFrom(baseCRNotApproved,
 				gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 					Type:               cmapi.CertificateRequestConditionDenied,
@@ -229,9 +227,7 @@ func TestSync(t *testing.T) {
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer, baseCR},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -248,7 +244,7 @@ func TestSync(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &nowMetaTime,
 							}),
@@ -258,7 +254,7 @@ func TestSync(t *testing.T) {
 				},
 			},
 		},
-		"should do nothing if request has both Denied and Ready with reason RequestDenied conditions": {
+		"should do nothing if request has a Denied condition and already has a False Ready condition": {
 			certificateRequest: gen.CertificateRequestFrom(baseCRNotApproved,
 				gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 					Type:               cmapi.CertificateRequestConditionDenied,
@@ -270,7 +266,7 @@ func TestSync(t *testing.T) {
 				gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 					Type:               cmapi.CertificateRequestConditionReady,
 					Status:             cmmeta.ConditionFalse,
-					Reason:             "RequestDenied",
+					Reason:             "Denied",
 					Message:            "The CertificateRequest was denied by an approval controller",
 					LastTransitionTime: &nowMetaTime,
 				}),
@@ -289,7 +285,7 @@ func TestSync(t *testing.T) {
 						gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 							Type:               cmapi.CertificateRequestConditionReady,
 							Status:             cmmeta.ConditionFalse,
-							Reason:             "RequestDenied",
+							Reason:             "Denied",
 							Message:            "The CertificateRequest was denied by an approval controller",
 							LastTransitionTime: &nowMetaTime,
 						}),
@@ -300,7 +296,7 @@ func TestSync(t *testing.T) {
 				ExpectedActions: []testpkg.Action{},
 			},
 		},
-		"should update Failed if certificate request is denied and has Ready Pending condition": {
+		"should set Ready condition reason to Denied if certificate request is denied and has a Pending reason for the Ready condition": {
 			certificateRequest: gen.CertificateRequestFrom(baseCRNotApproved,
 				gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 					Type:               cmapi.CertificateRequestConditionDenied,
@@ -319,9 +315,7 @@ func TestSync(t *testing.T) {
 			),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer, baseCR},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -338,7 +332,7 @@ func TestSync(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &nowMetaTime,
 							}),

--- a/pkg/controller/certificaterequests/util/reporter.go
+++ b/pkg/controller/certificaterequests/util/reporter.go
@@ -59,6 +59,20 @@ func (r *Reporter) Failed(cr *cmapi.CertificateRequest, err error, reason, messa
 
 }
 
+func (r *Reporter) Denied(cr *cmapi.CertificateRequest) {
+	// Set the FailureTime to c.clock.Now(), only if it has not been already set.
+	if cr.Status.FailureTime == nil {
+		nowTime := metav1.NewTime(r.clock.Now())
+		cr.Status.FailureTime = &nowTime
+	}
+
+	message := "The CertificateRequest was denied by an approval controller"
+
+	r.recorder.Event(cr, corev1.EventTypeWarning, cmapi.CertificateRequestReasonDenied, message)
+	apiutil.SetCertificateRequestCondition(cr, cmapi.CertificateRequestConditionReady,
+		cmmeta.ConditionFalse, cmapi.CertificateRequestReasonDenied, message)
+}
+
 func (r *Reporter) InvalidRequest(cr *cmapi.CertificateRequest, reason, message string) {
 	apiutil.SetCertificateRequestCondition(cr, cmapi.CertificateRequestConditionInvalidRequest,
 		cmmeta.ConditionTrue, reason, message)

--- a/pkg/controller/certificaterequests/util/reporter.go
+++ b/pkg/controller/certificaterequests/util/reporter.go
@@ -68,7 +68,13 @@ func (r *Reporter) Denied(cr *cmapi.CertificateRequest) {
 
 	message := "The CertificateRequest was denied by an approval controller"
 
-	r.recorder.Event(cr, corev1.EventTypeWarning, cmapi.CertificateRequestReasonDenied, message)
+	// If RequestDenied condition not already set then fire a RequestDenied
+	// Event. This is to reduce strain on the API server and avoid rate limiting
+	// ourselves for Event creation.
+	if apiutil.CertificateRequestReadyReason(cr) != cmapi.CertificateRequestReasonDenied {
+		r.recorder.Event(cr, corev1.EventTypeWarning, cmapi.CertificateRequestReasonDenied, message)
+	}
+
 	apiutil.SetCertificateRequestCondition(cr, cmapi.CertificateRequestConditionReady,
 		cmmeta.ConditionFalse, cmapi.CertificateRequestReasonDenied, message)
 }

--- a/pkg/controller/certificaterequests/util/reporter.go
+++ b/pkg/controller/certificaterequests/util/reporter.go
@@ -67,14 +67,6 @@ func (r *Reporter) Denied(cr *cmapi.CertificateRequest) {
 	}
 
 	message := "The CertificateRequest was denied by an approval controller"
-
-	// If RequestDenied condition not already set then fire a RequestDenied
-	// Event. This is to reduce strain on the API server and avoid rate limiting
-	// ourselves for Event creation.
-	if apiutil.CertificateRequestReadyReason(cr) != cmapi.CertificateRequestReasonDenied {
-		r.recorder.Event(cr, corev1.EventTypeWarning, cmapi.CertificateRequestReasonDenied, message)
-	}
-
 	apiutil.SetCertificateRequestCondition(cr, cmapi.CertificateRequestConditionReady,
 		cmmeta.ConditionFalse, cmapi.CertificateRequestReasonDenied, message)
 }

--- a/pkg/controller/certificaterequests/util/reporter_test.go
+++ b/pkg/controller/certificaterequests/util/reporter_test.go
@@ -213,14 +213,23 @@ func TestReporter(t *testing.T) {
 			call: "ready",
 		},
 
-		"a denied report should update the conditions and send an event, but not update failure time if existing": {
+		"a denied report should update the conditions and send an event": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR),
+			expectedEvents: []string{
+				"Warning RequestDenied The CertificateRequest was denied by an approval controller",
+			},
+			expectedConditions:  []cmapi.CertificateRequestCondition{deniedReadyCondition},
+			expectedFailureTime: &nowMetaTime,
+
+			call: "denied",
+		},
+
+		"a denied report should update the conditions and send an event, but not update failure time or send event if existing": {
 			certificateRequest: gen.CertificateRequestFrom(baseCR,
 				gen.SetCertificateRequestStatusCondition(deniedReadyCondition),
 				gen.SetCertificateRequestFailureTime(oldMetaTime),
 			),
-			expectedEvents: []string{
-				"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-			},
+			expectedEvents:      []string{},
 			expectedConditions:  []cmapi.CertificateRequestCondition{deniedReadyCondition},
 			expectedFailureTime: &oldMetaTime,
 

--- a/pkg/controller/certificaterequests/util/reporter_test.go
+++ b/pkg/controller/certificaterequests/util/reporter_test.go
@@ -102,7 +102,7 @@ func TestReporter(t *testing.T) {
 
 	deniedReadyCondition := cmapi.CertificateRequestCondition{
 		Type:               cmapi.CertificateRequestConditionReady,
-		Reason:             "RequestDenied",
+		Reason:             "Denied",
 		Message:            "The CertificateRequest was denied by an approval controller",
 		Status:             "False",
 		LastTransitionTime: &nowMetaTime,
@@ -213,18 +213,16 @@ func TestReporter(t *testing.T) {
 			call: "ready",
 		},
 
-		"a denied report should update the conditions and send an event": {
-			certificateRequest: gen.CertificateRequestFrom(baseCR),
-			expectedEvents: []string{
-				"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-			},
+		"a denied report should update the Ready condition to 'Denied'": {
+			certificateRequest:  gen.CertificateRequestFrom(baseCR),
+			expectedEvents:      []string{},
 			expectedConditions:  []cmapi.CertificateRequestCondition{deniedReadyCondition},
 			expectedFailureTime: &nowMetaTime,
 
 			call: "denied",
 		},
 
-		"a denied report should update the conditions and send an event, but not update failure time or send event if existing": {
+		"a denied report should update the Ready condition to 'Denied', but not update failure time existing": {
 			certificateRequest: gen.CertificateRequestFrom(baseCR,
 				gen.SetCertificateRequestStatusCondition(deniedReadyCondition),
 				gen.SetCertificateRequestFailureTime(oldMetaTime),

--- a/pkg/controller/certificaterequests/util/reporter_test.go
+++ b/pkg/controller/certificaterequests/util/reporter_test.go
@@ -100,6 +100,14 @@ func TestReporter(t *testing.T) {
 		LastTransitionTime: &nowMetaTime,
 	}
 
+	deniedReadyCondition := cmapi.CertificateRequestCondition{
+		Type:               cmapi.CertificateRequestConditionReady,
+		Reason:             "RequestDenied",
+		Message:            "The CertificateRequest was denied by an approval controller",
+		Status:             "False",
+		LastTransitionTime: &nowMetaTime,
+	}
+
 	tests := map[string]reporterT{
 		"a failed report should update the conditions and set FailureTime as it is nil": {
 			certificateRequest: gen.CertificateRequestFrom(baseCR),
@@ -204,6 +212,20 @@ func TestReporter(t *testing.T) {
 
 			call: "ready",
 		},
+
+		"a denied report should update the conditions and send an event, but not update failure time if existing": {
+			certificateRequest: gen.CertificateRequestFrom(baseCR,
+				gen.SetCertificateRequestStatusCondition(deniedReadyCondition),
+				gen.SetCertificateRequestFailureTime(oldMetaTime),
+			),
+			expectedEvents: []string{
+				"Warning RequestDenied The CertificateRequest was denied by an approval controller",
+			},
+			expectedConditions:  []cmapi.CertificateRequestCondition{deniedReadyCondition},
+			expectedFailureTime: &oldMetaTime,
+
+			call: "denied",
+		},
 	}
 
 	for name, test := range tests {
@@ -228,6 +250,8 @@ func (tt *reporterT) runTest(t *testing.T) {
 	case "pending":
 		reporter.Pending(tt.certificateRequest, tt.err,
 			tt.reason, tt.message)
+	case "denied":
+		reporter.Denied(tt.certificateRequest)
 	default:
 		reporter.Ready(tt.certificateRequest)
 	}

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -176,14 +176,12 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
+		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -193,7 +191,7 @@ func TestSign(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &metaFixedClockStart,
 							}),

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -176,11 +176,31 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should do nothing": {
+		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
+				},
+				ExpectedActions: []testpkg.Action{
+					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
+						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
+						"status",
+						gen.DefaultTestNamespace,
+						gen.CertificateRequestFrom(baseCRDenied,
+							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
+								Type:               cmapi.CertificateRequestConditionReady,
+								Status:             cmmeta.ConditionFalse,
+								Reason:             "RequestDenied",
+								Message:            "The CertificateRequest was denied by an approval controller",
+								LastTransitionTime: &metaFixedClockStart,
+							}),
+							gen.SetCertificateRequestFailureTime(metaFixedClockStart),
+						),
+					)),
+				},
 			},
 		},
 		"no token, app role secret or kubernetes auth reference should report pending": {

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -253,14 +253,12 @@ func TestSign(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseCRNotApproved.DeepCopy(), baseIssuer.DeepCopy()},
 			},
 		},
-		"a CertificateRequest with a denied condition should update Ready condition with RequestDenied": {
+		"a CertificateRequest with a denied condition should update Ready condition with 'Denied'": {
 			certificateRequest: baseCRDenied.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCRDenied.DeepCopy(), baseIssuer.DeepCopy()},
-				ExpectedEvents: []string{
-					"Warning RequestDenied The CertificateRequest was denied by an approval controller",
-				},
+				ExpectedEvents:     []string{},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapi.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -270,7 +268,7 @@ func TestSign(t *testing.T) {
 							gen.SetCertificateRequestStatusCondition(cmapi.CertificateRequestCondition{
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
-								Reason:             "RequestDenied",
+								Reason:             "Denied",
 								Message:            "The CertificateRequest was denied by an approval controller",
 								LastTransitionTime: &metaFixedClockStart,
 							}),


### PR DESCRIPTION
This PR changes all internal signers so that they set the Ready condition to False with the Reason "RequestDenied" when a CertificateRequest is Denied. This is to keep the same behavior where a terminal state of a CertificateRequest should have a Ready condition.

This should be backported to `release-1.3` and released in `v1.3.1`.

/assign @munnerz 

```release-note
Set the Ready condition to False when a CertificateRequest has been denied for all CertificateRequests that reference a cert-manager.io signer
```
