### PR TITLE
Certificate's revision history limit validated by webhook

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -201,7 +201,6 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
-                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -500,7 +499,6 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
-                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -806,7 +804,6 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
-                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string
@@ -1112,7 +1109,6 @@ spec:
                   description: revisionHistoryLimit is the maximum number of CertificateRequest revisions that are maintained in the Certificate's history. Each revision represents a single `CertificateRequest` created by this Certificate, either when it was created, renewed, or Spec was changed. Revisions will be removed by oldest first if the number of revisions exceeds this number. If set, revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`), revisions will not be garbage collected. Default value is `nil`.
                   type: integer
                   format: int32
-                  minimum: 1
                 secretName:
                   description: SecretName is the name of the secret resource that will be automatically created and managed by this Certificate resource. It will be populated with a private key and certificate, signed by the denoted issuer.
                   type: string

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -175,10 +175,9 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
-	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"` // Validated by the validating webhook.
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -197,10 +197,9 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
-	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"` // Validated by the validating webhook.
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -195,10 +195,9 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
-	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"` // Validated by the validating webhook.
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -172,10 +172,9 @@ type CertificateSpec struct {
 	// oldest first if the number of revisions exceeds this number. If set,
 	// revisionHistoryLimit must be a value of `1` or greater. If unset (`nil`),
 	// revisions will not be garbage collected. Default value is `nil`.
-	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:ExclusiveMaximum=false
 	// +optional
-	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"`
+	RevisionHistoryLimit *int32 `json:"revisionHistoryLimit,omitempty"` // Validated by the validating webhook.
 }
 
 // CertificatePrivateKey contains configuration options for private keys

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -79,6 +79,9 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	if len(crt.Usages) > 0 {
 		el = append(el, validateUsages(crt, fldPath)...)
 	}
+	if crt.RevisionHistoryLimit != nil && *crt.RevisionHistoryLimit < 1 {
+		el = append(el, field.Invalid(fldPath.Child("revisionHistoryLimit"), *crt.RevisionHistoryLimit, "must not be less than 1"))
+	}
 
 	return el
 }

--- a/pkg/internal/apis/certmanager/validation/certificate_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_test.go
@@ -488,6 +488,29 @@ func TestValidateCertificate(t *testing.T) {
 				field.Invalid(fldPath.Child("emailAddresses").Index(0), "mailto:alice@example.com", "invalid email address: mail: expected comma"),
 			},
 		},
+		"valid certificate with revision history limit == 1": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName:           "abc",
+					SecretName:           "abc",
+					IssuerRef:            validIssuerRef,
+					RevisionHistoryLimit: int32Ptr(1),
+				},
+			},
+		},
+		"invalid certificate with revision history limit < 1": {
+			cfg: &internalcmapi.Certificate{
+				Spec: internalcmapi.CertificateSpec{
+					CommonName:           "abc",
+					SecretName:           "abc",
+					IssuerRef:            validIssuerRef,
+					RevisionHistoryLimit: int32Ptr(0),
+				},
+			},
+			errs: []*field.Error{
+				field.Invalid(fldPath.Child("revisionHistoryLimit"), int32(0), "must not be less than 1"),
+			},
+		},
 	}
 	for n, s := range scenarios {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
This PR tries to fix an issue were `helm upgrade` command seems to not be able to convert the `minimum` value of our new `certificate.spec.revisionHistoryLimit` field, see #3880 

I have removed the `minimum` field and instead moved the validation to of the `revisionHistoryLimit` to the validating webhook, similarly to how we did it in #3647 

In [the related helm discussion](https://github.com/helm/helm/issues/5806#issuecomment-788116838) I see that this issue should have been fixed in Kubernetes `v1.20` and this _does_ seem to be the case. But I guess since we still support Kubernetes from `v1.16` onwards, we will need to fix it somehow. 
Perhaps we could try to backport a fix [in Helm](https://github.com/helm/helm/issues/5806#issuecomment-788146025) as an alternative to moving the validation to the webhook?

To verify this fix:

1. create kind cluster 
```
./devel/cluster/create.sh
```

2. install cert-manager  `v1.2.0` 
```
helm install   cert-manager jetstack/cert-manager   --namespace cert-manager --create-namespace --version v1.2.0 --set installCRDs=true
```

3. (optional): verify that upgrading to `v1.3.0` fails:
 ```
helm upgrade --install cert-manager jetstack/cert-manager   --namespace cert-manager  --version v1.3.0 --set installCRDs=true
```
4. verify the fix (this install script [runs helm upgrade command](https://github.com/jetstack/cert-manager/blob/master/devel/addon/certmanager/install.sh#L54))
```
./devel/addon/cert-manager/install.sh 
``` 


Error from webhook if attempting to create a `Certificate` with  revison history limit set to 0:

![Screenshot from 2021-04-11 20-16-36](https://user-images.githubusercontent.com/24879183/114318023-e63e1400-9b02-11eb-8cd2-99d49e570ec2.png)






```release-note
Fixes Helm upgrade issue
```

Fixes #3880 

/kind bug
