### PR TITLE
HTTP01 ACME solver pod: add imagePullSecret

### DIFF
--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -246,7 +246,7 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
 	// Only the 'priorityClassName', 'nodeSelector', 'affinity',
-	// 'serviceAccountName' and 'tolerations' fields are supported currently.
+	// 'serviceAccountName', 'tolerations' and 'imagePullSecret' fields are supported currently.
 	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec `json:"spec"`
@@ -284,6 +284,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's service account
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// If specified, the imagePullSecret
+	// +optional
+	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -222,7 +222,7 @@ type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
 
 	// PodSpec defines overrides for the HTTP01 challenge solver pod.
 	// Only the 'priorityClassName', 'nodeSelector', 'affinity',
-	// 'serviceAccountName' and 'tolerations' fields are supported currently.
+	// 'serviceAccountName', 'tolerations' and 'imagePullSecret' fields are supported currently.
 	// All other fields will be ignored.
 	// +optional
 	Spec ACMEChallengeSolverHTTP01IngressPodSpec
@@ -254,6 +254,10 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	// If specified, the pod's service account
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+
+	// If specified, the imagePullSecret
+	// +optional
+	ImagePullSecret string `json:"imagePullSecret,omitempty"`
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/pkg/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/acme/v1/zz_generated.conversion.go
@@ -590,6 +590,7 @@ func autoConvert_acme_ACMEChallengeSolverHTTP01IngressPodSpec_To_v1_ACMEChalleng
 	out.Tolerations = *(*[]corev1.Toleration)(unsafe.Pointer(&in.Tolerations))
 	out.PriorityClassName = in.PriorityClassName
 	out.ServiceAccountName = in.ServiceAccountName
+	out.ImagePullSecret = in.ImagePullSecret
 	return nil
 }
 


### PR DESCRIPTION
cert-manager create the HTTP01 ACME solver pod, when can specify:

The image: --acme-http01-solver-image
The serviceAccount (##3817): --acme-http01-solver-service-account
The resources
But we can't specify the imagePullSecret to use.

This is an issue for:

Air gapped environments with private registries
Docker Hub rate limits for anonymous pulls
It is currently possible to use the serviceAccount with an attached
imagePullSecret, but it is not always convenient because it requires to
update the serviceAccount of every namespace in the cluster to link the
imagePullsecret.

Signed-off-by: primael <primael.bruant@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
