### PR TITLE
Fix incorrect comparison function for public keys

### DIFF
--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -454,3 +454,109 @@ O7WnDn8nuLFdW+NzzbIrTw==
 		t.Run(test.name, testFn(test))
 	}
 }
+
+func TestPublicKeysEqualECDSA(t *testing.T) {
+	key1, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("couldn't generate P256 key: %v", err)
+	}
+
+	// note the different curve type
+	key2, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		t.Fatalf("couldn't generate P521 key: %v", err)
+	}
+
+	pub1 := key1.Public().(*ecdsa.PublicKey)
+
+	// (pub1.X, pub1.Y) isn't likely to be on the curve for key2, so pub2 will be
+	// invalid after changing its X and Y below; still, pub2 is useful for
+	// the test
+
+	// this is not dissimilar to the standard library's test:
+	// https://github.com/golang/go/blob/14a18b7d2538232c6cd6937297c421d5f6b7d92f/src/crypto/ecdsa/equal_test.go#L55-L64
+	pub2 := key2.Public().(*ecdsa.PublicKey)
+	pub2.X = pub1.X
+	pub2.Y = pub1.Y
+
+	if pub1.Equal(pub2) {
+		t.Fatalf("invalid test: got a match from curves which should differ:\npub1: %#v\npub2: %#v\n", pub1, pub2)
+	}
+
+	match, err := PublicKeysEqual(pub1, pub2)
+	if err != nil {
+		t.Fatalf("unexpected error from PublicKeysEqual: %v", err)
+	}
+
+	if match {
+		t.Errorf("got an incorrect match from different curves:\npub1 type: %#v\npub2 type: %#v\n", pub1.Params().Name, pub2.Params().Name)
+	}
+}
+
+const hardcodedTestKey = `-----BEGIN RSA PRIVATE KEY-----
+MIIEpQIBAAKCAQEAtaX7TB+WQ4yhTRLw6G0V8oLRaRzjJ1UiAh1Uw+K8SpgMehfm
+WS6//y0iBwCfQWTC4Fw1sU99XA8yOIN+fMMdNcmPxvP7JKlUQRrM3RpXXD5eo+MZ
+fJmc344Pn5f/aMoFvDq745YLTP3C5PJj1qcljch00FPORCCCFtdFkynzKoclZruW
+cJpbFgt9mE/Qk2Xed8FZ+AESZmxAYVEhCv3JETpQfO3cW15+Hxug4eMQ6daAyYjT
++52QbENIXliKYCS+LrguQJsMNMveajoWcGMHbQBs+I2umlh0UDYRAZ3PbgO9GDfZ
+tUoasBDM0SDjvtpiL+8UnbDlrwfZYgwGo/YixQIDAQABAoIBAQCIc0yYXEn2KBeq
+3AWXswn/iAFiok6IZ00KpZndI98pcZo9xOJGL/YN64taEz+OUfCJtPqoXPvgQZIK
+HczQT4kLtIOKghAv8/rUhRtLI9Rn+HoDRj8I+CN9UyutSPKVdtxkDwLA7R9EEINs
+lCAnSJvPK7uEGtAhIQJXwhIDgEmnsWSKq3OTNRbKe4kF7bOAVsEj9KZjmHcWuhDV
+LJ0x1+uWo18UFztHmQL/Vp0VJKYBo2tAql3LjHtGFI+uZ38X2HsAgIQSjVvXZyR1
+FvZx0XymoF8zYJzV2yfzgF9Toot4SWlKsUuX3w2FYj8hnQbn02x0m7sZmhNY25Fd
+ljZCWOFpAoGBAOloRL0kKAA71lR6zwV7M+Xxozzk3u2x+GdTRCeBtnzjMQGtLs5/
+KsOROPNj2/wv+rH8FhAFiFKcwr4RrouVWxqCd6YwtAiRe92NfkuXPIDTq2G6K9ge
+i5Z5yMImjeG1P4GvaQg9f1YF8oNO/EEtWihyN+VcLQHJFy714cMhurZDAoGBAMc7
+JjRmjtybZj3VzPTp0c2emce1fGHMtcmFX+dauLmGNDXCo/cJs4XYKlp6vhuBY4PR
+IcbqVFBshk2cCC6IRTsAIcPLi4rwqe8uRhtHbyXN1lmcNqJq/l9Q8xoQf7l/ik4r
+ttrSb7/I2hyEm2xJFTTXqbpx3AQqQQbPwl3sFuZXAoGBAKpv6UH0VQFWsHuf8ewe
+uxb+DCU7O0521t0cgHgY0BkCDZcbz0Iaui90rBGOqeTNZFLzsWihoZoxvkLsxnhG
+5+/DtXs1tUFMexada8vm89deuZbzS3DVXTjUVTTw0kou/+DDJf9OaN14Gk6oLqup
+YlyGiyqA1JypKrSv99t1ldHhAoGAQBFKWOF+IX0rpMjjLwMd/8R36Vv4Uq706ogk
+bg6jhq2cjok4FxIck/cOr6f3CHtUWChhd0kVsgMkMULy8pvJv45sTT1gc16vFwZH
+bzBKktqdipWMkDBd+qLaelBB8pIMFNVD6Rxw6Tiawz71iB38XtDXeOhyezhnTtxy
+wadROeMCgYEAlsfw3Gk5zftMFsPsfvFREvq3em+UC0jP5FLcz+LzTk1mEn+1SXtB
+lFP7bcMXkRBh4tlk0gDLHvnwIomA+/dRnEIGBPl5nvZNF1HybUWxXTa3dW9Jw9V/
+3J9xMYH/v9uMSt0j5xhPcTrI6HYtrT5lZMZNOI5vbVo3D6KYLWtfgWA=
+-----END RSA PRIVATE KEY-----
+`
+
+func TestPublicKeysEqualRSA(t *testing.T) {
+	// parse a hardcoded key rather than generating since generating RSA keys
+	// is absurdly slow:
+	// BenchmarkGen-8                12         101415795 ns/op
+	// BenchmarkParse-8           48930             24361 ns/op
+	rawKey, err := DecodePrivateKeyBytes([]byte(hardcodedTestKey))
+	if err != nil {
+		t.Fatalf("couldn't parse RSA test key: %v", err)
+	}
+
+	key1 := rawKey.(*rsa.PrivateKey)
+
+	pub1 := key1.Public().(*rsa.PublicKey)
+
+	// changing E like this might mean the public key is invalid, but
+	// it should still be fine for testing our comparison function
+	pub2 := &rsa.PublicKey{}
+	*pub2 = *pub1
+
+	// 3 is valid because the exponent in hardcodedTestKey is 65535
+	// if the test key changes, this could have to change.
+	// note that there are relatively few exponents actually used in the real world
+	// and as such this shouldn't just be a random value
+	pub2.E = 3
+
+	if pub1.Equal(pub2) {
+		t.Fatalf("invalid test: got a match from keys which should differ:\npub1: %#v\npub2: %#v\n", pub1, pub2)
+	}
+
+	match, err := PublicKeysEqual(pub1, pub2)
+	if err != nil {
+		t.Fatalf("unexpected error from PublicKeysEqual: %v", err)
+	}
+
+	if match {
+		t.Errorf("got an incorrect match from different RSA keys:\npub1: %#v\npub2: %#v\n", pub1, pub2)
+	}
+}


### PR DESCRIPTION
Also adds/improves doc comments on related functions, and adds tests of
comparisons RSA keys and ECDSA keys. these tests failed as expected
before the function was changed, e.g.:

```text
Executing tests from //pkg/util/pki:go_default_test
---------------------------------------------------
--- FAIL: TestPublicKeysEqualECDSA (0.00s)
  generate_test.go:492: got an incorrect match from different curves:
    pub1 type: "P-256"
    pub2 type: "P-521"
--- FAIL: TestPublicKeysEqualRSA (0.00s)
  generate_test.go:560: got an incorrect match from different RSA keys:
    pub1: &rsa.PublicKey{N:2293...<snip>...8869, E:65537}
    pub2: &rsa.PublicKey{N:2293...<snip>...8869, E:3}
```

**Note for reviewer**: This also changes `PublicKeyMatchesCertificate`, which previously re-implemented the public key matching logic. It now just calls `PublicKeysEqual`

**Notes on backporting**: This PR was discussed in the cert-manager standup on 2021-04-22; despite this issue being in crypto-related code, we decided not to backport this since the comparison function is currently used as a sanity check and not in any security-related way. Even if this were to be used in a security-critical context, exploiting it seems immensely difficult.



```release-note
- Fix incorrect `PublicKeysEqual` comparison function for public keys and improve doc comments on related functions
```
