### PR TITLE
Simplify the installation of sample-external-issuer

### DIFF
--- a/devel/addon/sample-external-issuer/BUILD.bazel
+++ b/devel/addon/sample-external-issuer/BUILD.bazel
@@ -1,15 +1,5 @@
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 
-container_bundle(
-    name = "bundle",
-    images = {
-        # TODO: Move this image to quay.io
-        # https://github.com/jetstack/cert-manager/issues/3531
-        "ghcr.io/wallrj/sample-external-issuer/controller:v0.0.0-30-gf333b9e": "@io_ghcr_wallrj_sample-external-issuer_controller//image",
-    },
-    tags = ["manual"],
-)
-
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),

--- a/devel/addon/sample-external-issuer/install.sh
+++ b/devel/addon/sample-external-issuer/install.sh
@@ -21,26 +21,11 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+SEI_VERSION="v0.1.0"
+
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_ROOT}/../../lib/lib.sh"
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
-setup_tools
+check_tool kubectl
 
-repo_dir="$(mktemp -d)"
-
-function cleanup {
-    rm -rf "${repo_dir}"
-}
-
-trap cleanup EXIT
-
-git clone https://github.com/cert-manager/sample-external-issuer "${repo_dir}"
-
-# TODO: Move this image to quay.io
-# https://github.com/jetstack/cert-manager/issues/3531
-img="ghcr.io/wallrj/sample-external-issuer/controller:v0.0.0-30-gf333b9e"
-
-require_image "${img}" "//devel/addon/sample-external-issuer:bundle"
-
-make -C "${repo_dir}" "IMG=${img}" deploy
+kubectl apply -f "https://github.com/cert-manager/sample-external-issuer/releases/download/${SEI_VERSION}/install.yaml"


### PR DESCRIPTION
When  https://github.com/cert-manager/sample-external-issuer/pull/15 merges, there will be a Docker image and an `install.yaml` file for the sample-external-issuer, allowing us to simplify the installation in cert-manager E2E tests.
No longer any need to `git clone` the repo.

Fixes: #3531


```release-note
NONE
```
