### PR TITLE
Make controller's sync period configurable

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -245,6 +245,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		SchedulerOptions: controller.SchedulerOptions{
 			MaxConcurrentChallenges: opts.MaxConcurrentChallenges,
 		},
+		SyncPeriod: opts.SyncPeriod,
 	}, kubeCfg, nil
 }
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -97,6 +97,7 @@ type ControllerOptions struct {
 	EnablePprof bool
 
 	DNS01CheckRetryPeriod time.Duration
+	SyncPeriod            time.Duration
 }
 
 const (
@@ -129,6 +130,8 @@ const (
 	defaultPrometheusMetricsServerAddress = "0.0.0.0:9402"
 
 	defaultDNS01CheckRetryPeriod = 10 * time.Second
+
+	defaultSyncPeriod = time.Second
 )
 
 var (
@@ -190,6 +193,7 @@ func NewControllerOptions() *ControllerOptions {
 		MetricsListenAddress:              defaultPrometheusMetricsServerAddress,
 		DNS01CheckRetryPeriod:             defaultDNS01CheckRetryPeriod,
 		EnablePprof:                       false,
+		SyncPeriod:                        defaultSyncPeriod,
 	}
 }
 
@@ -295,6 +299,9 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The host and port that the metrics endpoint should listen on.")
 	fs.BoolVar(&s.EnablePprof, "enable-profiling", false, ""+
 		"Enable profiling for controller.")
+	fs.DurationVar(&s.SyncPeriod, "sync-period", defaultSyncPeriod, ""+
+		"The duration the controller should wait between pulling items from the workqueue for processing"+
+		"This should be a valid duration string, for example 180s or 1h")
 }
 
 func (o *ControllerOptions) Validate() error {

--- a/pkg/controller/builder.go
+++ b/pkg/controller/builder.go
@@ -51,7 +51,7 @@ type Builder struct {
 	runDurationFuncs []runDurationFunc
 }
 
-// New creates a basic Builder, setting the sync call to the one given
+// NewBuilder creates a basic Builder, setting the sync call to the one given
 func NewBuilder(controllerctx *Context, name string) *Builder {
 	ctx := logf.NewContext(controllerctx.RootContext, nil, name)
 	return &Builder{
@@ -97,5 +97,5 @@ func (b *Builder) Complete() (Interface, error) {
 		return nil, fmt.Errorf("error registering controller: %v", err)
 	}
 
-	return NewController(b.ctx, b.name, b.context.Metrics, b.impl.ProcessItem, mustSync, b.runDurationFuncs, queue), nil
+	return NewController(b.ctx, b.name, b.context.Metrics, b.impl.ProcessItem, mustSync, b.runDurationFuncs, queue, b.context.SyncPeriod), nil
 }

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -71,6 +71,10 @@ type Context struct {
 	// Metrics is used for exposing Prometheus metrics across the controllers
 	Metrics *metrics.Metrics
 
+	// SyncPeriod is used to configure the frequency at which the controller will
+	// pull items off the workqueue for processing.
+	SyncPeriod time.Duration
+
 	IssuerOptions
 	ACMEOptions
 	IngressShimOptions

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -115,6 +115,7 @@ func (b *Builder) Init() {
 	b.SharedInformerFactory = informers.NewSharedInformerFactory(b.CMClient, informerResyncPeriod)
 	b.stopCh = make(chan struct{})
 	b.Metrics = metrics.New(logs.Log)
+	b.SyncPeriod = time.Second
 
 	// set the Clock on the context
 	if b.Clock == nil {


### PR DESCRIPTION
Fixes #3915

Adds the `sync-period` flag (defaulted to 1s), that allows modification of the frequency at which the controller will
pull items off the workqueue for processing.

```release-note
Adds --sync-period flag to modify the period of time between items being pulled from the controller's workqueue.
```

Signed-off-by: David Bond <davidsbond93@gmail.com>