### PR TITLE
Include HTTPS proxy variable in Helm values

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -170,7 +170,7 @@ prometheus:
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"
-# http_proxy: "http://proxy:8080"
+# https_proxy: "https://proxy:8080"
 # no_proxy: 127.0.0.1,localhost
 
 # expects input structure as per specification https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#affinity-v1-core


### PR DESCRIPTION
**What this PR does / why we need it**:
The `http_proxy` key was defined twice and is therefore replaced once with the `https_proxy` key.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
