### PR TITLE
3879 test acme issuer setup

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -90,6 +90,7 @@ filegroup(
         "//test/acme/dns:all-srcs",
         "//test/e2e:all-srcs",
         "//test/integration:all-srcs",
+        "//test/unit/coreclients:all-srcs",
         "//test/unit/gen:all-srcs",
         "//test/unit/listers:all-srcs",
         "//tools/cobra:all-srcs",

--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -32,7 +32,12 @@ import (
 	"github.com/jetstack/cert-manager/pkg/util"
 )
 
-// NewClient will return a new ACME client.
+// NewClientFunc is a function type for building a new ACME client.
+type NewClientFunc func(*http.Client, cmacme.ACMEIssuer, *rsa.PrivateKey) acmecl.Interface
+
+var _ NewClientFunc = NewClient
+
+// NewClient is an implementation of NewClientFunc that returns a real ACME client.
 func NewClient(client *http.Client, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey) acmecl.Interface {
 	return &acmeapi.Client{
 		Key:          privateKey,

--- a/pkg/acme/accounts/test/BUILD.bazel
+++ b/pkg/acme/accounts/test/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/acme/accounts/test",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/acme/accounts:go_default_library",
         "//pkg/acme/client:go_default_library",
         "//pkg/apis/acme/v1:go_default_library",
     ],

--- a/pkg/acme/accounts/test/registry.go
+++ b/pkg/acme/accounts/test/registry.go
@@ -18,10 +18,15 @@ package test
 
 import (
 	"crypto/rsa"
+	"net/http"
 
 	acmecl "github.com/jetstack/cert-manager/pkg/acme/client"
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+
+	"github.com/jetstack/cert-manager/pkg/acme/accounts"
 )
+
+var _ accounts.Registry = &FakeRegistry{}
 
 // FakeRegistry implements the accounts.Registry interface using stub functions
 type FakeRegistry struct {
@@ -31,7 +36,7 @@ type FakeRegistry struct {
 	ListClientsFunc  func() map[string]acmecl.Interface
 }
 
-func (f *FakeRegistry) AddClient(uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey) {
+func (f *FakeRegistry) AddClient(client *http.Client, uid string, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey) {
 	f.AddClientFunc(uid, config, privateKey)
 }
 

--- a/pkg/acme/client/fake.go
+++ b/pkg/acme/client/fake.go
@@ -26,7 +26,7 @@ import (
 // TODO: expand this out one day to be backed by the pebble wfe package
 // this will allow us to simulate a 'real' acme server in lightweight tests
 
-// FakeACME is a convenience structure to create a stub ACME implementation
+// FakeACME implements Interface and can be used as a mock acme.Client in tests.
 type FakeACME struct {
 	FakeAuthorizeOrder          func(ctx context.Context, id []acme.AuthzID, opt ...acme.OrderOption) (*acme.Order, error)
 	FakeGetOrder                func(ctx context.Context, url string) (*acme.Order, error)

--- a/pkg/issuer/acme/BUILD.bazel
+++ b/pkg/issuer/acme/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -48,4 +48,30 @@ filegroup(
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["setup_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/acme/accounts:go_default_library",
+        "//pkg/acme/accounts/test:go_default_library",
+        "//pkg/acme/client:go_default_library",
+        "//pkg/api/util:go_default_library",
+        "//pkg/apis/acme/v1:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "//pkg/controller/test:go_default_library",
+        "//pkg/util:go_default_library",
+        "//pkg/util/errors:go_default_library",
+        "//pkg/util/pki:go_default_library",
+        "//test/unit/coreclients:go_default_library",
+        "//test/unit/gen:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
+        "@org_golang_x_crypto//acme:go_default_library",
+    ],
 )

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -1,0 +1,520 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package acme
+
+import (
+	"context"
+	"crypto"
+	"crypto/rsa"
+	"fmt"
+	"net/http"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+
+	acmeapi "golang.org/x/crypto/acme"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakeclock "k8s.io/utils/clock/testing"
+
+	"github.com/jetstack/cert-manager/pkg/acme/accounts"
+	fakeregistry "github.com/jetstack/cert-manager/pkg/acme/accounts/test"
+	acmecl "github.com/jetstack/cert-manager/pkg/acme/client"
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	controllertest "github.com/jetstack/cert-manager/pkg/controller/test"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/unit/coreclients"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+func TestAcme_Setup(t *testing.T) {
+	var (
+		fixedClockStart = time.Now()
+		fakeclock       = fakeclock.NewFakeClock(fixedClockStart)
+		nowMetaTime     = metav1.NewTime(fakeclock.Now())
+
+		baseIssuer = gen.Issuer("test-issuer",
+			gen.SetIssuerACMEURL(acmev2Prod))
+		// base issuer condition
+		baseCondition = gen.IssuerCondition(v1.IssuerConditionReady,
+			gen.SetIssuerConditionStatus(cmmeta.ConditionFalse),
+			gen.SetIssuerConditionLastTransitionTime(&nowMetaTime))
+		issuerSecretKeyName = "test"
+
+		ecdsaPrivKey = mustGenerateEDCSAKey(t)
+		rsaPrivKey   = mustGenerateRSAKey(t)
+
+		notFoundErr    = apierrors.NewNotFound(corev1.Resource("test"), "test")
+		invalidDataErr = errors.NewInvalidData("test")
+		someErr        = fmt.Errorf("test")
+		invalidURL     = "%"
+		acmeErr450     = &acmeapi.Error{StatusCode: 450}
+		acmeErr500     = &acmeapi.Error{StatusCode: 500}
+		//TODO: we should probably mock calls to net/url instead of doing this.
+		invalidURLErr = parseURLErr(invalidURL)
+
+		invalidURLMessage        = fmt.Sprintf(messageTemplateFailedToParseURL, invalidURL, invalidURLErr)
+		invalidAccountURLMessage = fmt.Sprintf(messageTemplateFailedToParseAccountURL, invalidURL, invalidURLErr)
+
+		someEmail    = "test@test.com"
+		someEmailURL = fmt.Sprintf("mailto:%s", someEmail)
+
+		// to be used where we don't care what value is passed
+		someString = "test"
+
+		// eabSecret is a mock value for secret with EAB key that user would have created.
+		// 'ZEdWemRBbz0K' is 'test' double base64-encoded.
+		// cert-manager only accepts double-encoded values, see https://github.com/jetstack/cert-manager/pull/3877#discussion_r610717791 .
+		eabSecret = gen.Secret(someString,
+			gen.SetSecretData(map[string][]byte{"key": []byte("ZEdWemRBbz0K")}))
+
+		// 'dGVzdAo=\n' is 'ZEdWemRBbz0K' decoded + a newline.
+		// This is the decoded EAB key that we send to the ACME server.
+		// TODO: could the newline cause any issues?
+		eabKey = "dGVzdAo=\n"
+	)
+
+	tests := map[string]struct {
+		issuer v1.GenericIssuer
+
+		// Private key returned by keyFromSecret stub.
+		kfsKey crypto.Signer
+		// Error returned by keyFromSecret stub.
+		kfsErr error
+		// Whether keyFromSecret should be called.
+		kfsShouldBeCalled bool
+
+		// Whether RemoveClient should be called.
+		removeClientShouldBeCalled bool
+
+		// Whether AddClient should be called.
+		addClientShouldBeCalled bool
+
+		// Error returned by cl.Register
+		registerErr error
+
+		// ACME account returned by cl.GetReg
+		getRegAcc *acmeapi.Account
+		// Error returned by cl.GetReg
+		getRegErr error
+
+		acmePrivKeySecretCreateErr error
+
+		eabSecret       *corev1.Secret
+		eabSecretGetErr error
+
+		// expected ACME account passed to cl.Register
+		expectedRegisteredAcc *acmeapi.Account
+		// expected issuer conditions after Setup has been called.
+		expectedConditions []cmapi.IssuerCondition
+		expectedEvents     []string
+		wantsErr           bool
+	}{
+		"LetsEncrypt ACME v1 prod URL specified, return early": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEURL(acmev1Prod)),
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorInvalidConfig),
+					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateUpdateToV2, acmev1Prod, acmev2Prod))),
+			},
+		},
+		"LetsEncrypt ACME v1 staging URL with trailing slash specified, return early": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEURL(fmt.Sprintf("%s/", acmev1Staging))),
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorInvalidConfig),
+					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateUpdateToV2, fmt.Sprintf("%s/", acmev1Staging), acmev2Staging))),
+			},
+		},
+		"ACME private key secret does not exist, account key generation not disabled, key secret creation fails": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEPrivKeyRef(issuerSecretKeyName)),
+			kfsShouldBeCalled:          true,
+			kfsErr:                     notFoundErr,
+			acmePrivKeySecretCreateErr: someErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+someErr.Error())),
+			},
+			wantsErr: true,
+		},
+		"ACME private key secret does not exist, account key generation is disabled": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEDisableAccountKeyGeneration(true),
+			),
+			kfsShouldBeCalled: true,
+			kfsErr:            notFoundErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
+					gen.SetIssuerConditionMessage(messageAccountVerificationFailed+messageNoSecretKeyGenerationDisabled+notFoundErr.Error())),
+			},
+			wantsErr: true,
+		},
+		"ACME private key secret exists, but contains invalid private key": {
+			issuer:            gen.IssuerFrom(baseIssuer),
+			kfsShouldBeCalled: true,
+			kfsErr:            invalidDataErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
+					gen.SetIssuerConditionMessage(fmt.Sprintf("%s%v", messageInvalidPrivateKey, invalidDataErr))),
+			},
+		},
+		"Checking ACME private key secret fails with an unknown error": {
+			issuer:            gen.IssuerFrom(baseIssuer),
+			kfsShouldBeCalled: true,
+			kfsErr:            someErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
+					gen.SetIssuerConditionMessage(messageAccountVerificationFailed+someErr.Error())),
+			},
+			wantsErr: true,
+		},
+		"ACME account's key is not an RSA key": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEPrivKeyRef(issuerSecretKeyName)),
+			kfsShouldBeCalled: true,
+			kfsKey:            ecdsaPrivKey,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountVerificationFailed),
+					gen.SetIssuerConditionMessage(fmt.Sprintf(messageTemplateNotRSA, issuerSecretKeyName))),
+			},
+		},
+		"ACME server URL is an invalid URL": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEURL(invalidURL)),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorInvalidURL),
+					gen.SetIssuerConditionMessage(invalidURLMessage)),
+			},
+			expectedEvents: []string{
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorInvalidURL, invalidURLMessage)},
+		},
+		"ACME account URL is an invalid URL": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEAccountURL(invalidURL)),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorInvalidURL),
+					gen.SetIssuerConditionMessage(invalidAccountURLMessage)),
+			},
+			expectedEvents: []string{
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorInvalidURL, invalidAccountURLMessage),
+			},
+		},
+		"ACME Issuer is ready, URL and email are matching": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEAccountURL(acmev2Prod),
+				gen.SetIssuerACMEEmail(someEmail),
+				gen.SetIssuerACMELastRegisteredEmail(someEmail),
+				gen.AddIssuerCondition(
+					*gen.IssuerConditionFrom(baseCondition,
+						gen.SetIssuerConditionStatus(cmmeta.ConditionTrue)))),
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionStatus(cmmeta.ConditionTrue),
+					gen.SetIssuerConditionMessage(messageAccountRegistered),
+					gen.SetIssuerConditionReason(successAccountRegistered)),
+			},
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			addClientShouldBeCalled:    true,
+		},
+		"Attempt to register ACME account returns unknown error": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			registerErr:                someErr,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+someErr.Error())),
+			},
+			wantsErr: true,
+		},
+		"Attempt to register ACME account returns an ACME error in range [400,500)": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			registerErr:                acmeErr450,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+acmeErr450.Error())),
+			},
+		},
+		"Attempt to register ACME account returns an ACME error outside of range [400,500)": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			registerErr:                acmeErr500,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+acmeErr500.Error())),
+			},
+			wantsErr: true,
+		},
+		"ACME account already exists, attempting to retrieve it fails with unknown error": {
+			issuer:                     gen.IssuerFrom(baseIssuer),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			expectedRegisteredAcc:      &acmeapi.Account{},
+			registerErr:                acmeapi.ErrAccountAlreadyExists,
+			getRegErr:                  someErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+someErr.Error())),
+			},
+			wantsErr: true,
+		},
+		"EAB for issuer specified, but the corresponding secret is not found": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEEAB(someString, someString)),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			eabSecretGetErr:            notFoundErr,
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionReason(errorAccountRegistrationFailed),
+					gen.SetIssuerConditionMessage(messageAccountRegistrationFailed+notFoundErr.Error())),
+			},
+			expectedEvents: []string{
+				fmt.Sprintf("%s %s %s", corev1.EventTypeWarning, errorAccountRegistrationFailed, messageAccountRegistrationFailed+notFoundErr.Error()),
+			},
+		},
+		"ACME account with EAB registered successfully": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEEAB(someString, someString)),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			addClientShouldBeCalled:    true,
+			eabSecret:                  eabSecret,
+			expectedRegisteredAcc: &acmeapi.Account{ExternalAccountBinding: &acmeapi.ExternalAccountBinding{
+				KID: someString,
+				Key: []byte(eabKey),
+			}},
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionStatus(cmmeta.ConditionTrue),
+					gen.SetIssuerConditionReason(successAccountRegistered),
+					gen.SetIssuerConditionMessage(messageAccountRegistered)),
+			},
+		},
+		"ACME account with legacy EAB key algorithm set and with an email is registered successfully": {
+			issuer: gen.IssuerFrom(baseIssuer,
+				gen.SetIssuerACMEEmail(someEmail),
+				gen.SetIssuerACMEEABWithKeyAlgorithm(someString, someString, cmacme.HS256)),
+			kfsShouldBeCalled:          true,
+			kfsKey:                     rsaPrivKey,
+			removeClientShouldBeCalled: true,
+			addClientShouldBeCalled:    true,
+			eabSecret:                  eabSecret,
+			expectedRegisteredAcc: &acmeapi.Account{ExternalAccountBinding: &acmeapi.ExternalAccountBinding{
+				KID: someString,
+				Key: []byte(eabKey),
+			},
+				Contact: []string{someEmailURL},
+			},
+			expectedConditions: []cmapi.IssuerCondition{
+				*gen.IssuerConditionFrom(baseCondition,
+					gen.SetIssuerConditionStatus(cmmeta.ConditionTrue),
+					gen.SetIssuerConditionReason(successAccountRegistered),
+					gen.SetIssuerConditionMessage(messageAccountRegistered)),
+			},
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			// Secrets client that will be called from the Setup function to
+			// create new secrets and get EAB secret.
+			// TODO: this secretsClient fake is really hacky. It relies on the
+			// fact that the Setup function currently only uses secretsClient to
+			// create account private key secret and to retrieve the EAB secret.
+			// We should refactor the Setup function and test this in a better way.
+			secretsClient := coreclients.NewFakeSecretsGetterFrom(
+				coreclients.NewFakeSecretsGetter(),
+				coreclients.SetFakeSecretsGetterCreate(nil,
+					test.acmePrivKeySecretCreateErr),
+				coreclients.SetFakeSecretsGetterGet(test.eabSecret,
+					test.eabSecretGetErr),
+			)
+
+			// Set up a mock keyFromSecret.
+			kfsWasCalled := false
+			kfs := keyFromSecretMockBuilder(&(kfsWasCalled), test.kfsKey, test.kfsErr)
+
+			// Mock ACME accounts registry.
+			removeClientWasCalled := false
+			addClientWasCalled := false
+			ar := &fakeregistry.FakeRegistry{
+				RemoveClientFunc: func(string) {
+					removeClientWasCalled = true
+				},
+				AddClientFunc: func(string, cmacme.ACMEIssuer, *rsa.PrivateKey) {
+					addClientWasCalled = true
+				},
+			}
+
+			// Mock ACME client.
+			var gotAcc *acmeapi.Account
+			cl := acmecl.FakeACME{
+				FakeRegister: func(_ context.Context, a *acmeapi.Account, _ func(string) bool) (*acmeapi.Account, error) {
+					gotAcc = a
+					return a, test.registerErr
+				},
+				FakeGetReg: func(context.Context, string) (*acmeapi.Account, error) {
+					return test.getRegAcc, test.getRegErr
+				},
+			}
+
+			// Mock events recorder.
+			recorder := new(controllertest.FakeRecorder)
+			a := Acme{
+				issuer:          test.issuer,
+				secretsClient:   secretsClient,
+				accountRegistry: ar,
+				keyFromSecret:   kfs,
+				clientBuilder:   clientBuilderMock(&cl),
+				recorder:        recorder,
+			}
+
+			// Stub the clock to get consistent last transition times on conditions.
+			fakeclock.SetTime(fixedClockStart)
+			apiutil.Clock = fakeclock
+
+			// Verify that an error is/is not returned as expected.
+			gotErr := a.Setup(context.Background())
+			if gotErr == nil && test.wantsErr {
+				t.Errorf("Expected error %v, got %v", test.wantsErr, gotErr)
+			}
+
+			if kfsWasCalled != test.kfsShouldBeCalled {
+				t.Errorf("Expected Acme.keyFromSecret to be called: %v, was called: %v",
+					test.kfsShouldBeCalled,
+					kfsWasCalled)
+			}
+
+			// Verify that a client was removed from cache if expected.
+			if removeClientWasCalled != test.removeClientShouldBeCalled {
+				t.Errorf("Expected Acme.accountsRegistry.RemoveClient to be called: %v, was called: %v",
+					test.removeClientShouldBeCalled,
+					removeClientWasCalled)
+			}
+
+			// Verify that a new client was added to cache if expected.
+			if addClientWasCalled != test.addClientShouldBeCalled {
+				t.Errorf("Expected Acme.accountsRegistry.AddClient to be called: %v, was called: %v",
+					test.addClientShouldBeCalled,
+					addClientWasCalled)
+			}
+
+			// Verify that the expected account value was passed when the
+			// account was registered.
+			if !reflect.DeepEqual(gotAcc, test.expectedRegisteredAcc) {
+				t.Errorf("Expected account value passed to register: %#+v\ngot: %+#v",
+					test.expectedRegisteredAcc, gotAcc)
+			}
+
+			// Verify issuer's state after Setup was called.
+			gotConditions := a.issuer.GetStatus().Conditions
+			// Issuer can only have a single condition, so no need to sort the
+			// conditions.
+			if !reflect.DeepEqual(gotConditions, test.expectedConditions) {
+				t.Errorf("Expected issuer's conditions: %#+v\ngot: %#+v",
+					test.expectedConditions, gotConditions)
+			}
+
+			// Verify that the expected events were recorded.
+			if !util.EqualSorted(test.expectedEvents, recorder.Events) {
+				t.Errorf("Expected events:\n%+#v\ngot:%+#v",
+					test.expectedEvents,
+					recorder.Events)
+			}
+		})
+	}
+}
+
+// keyFromSecretMockBuilder returns a mock implementation of keyFromSecretFunc.
+func keyFromSecretMockBuilder(wasCalled *bool, key crypto.Signer, err error) keyFromSecretFunc {
+	return func(context.Context, string, string, string) (crypto.Signer, error) {
+		*wasCalled = true
+		return key, err
+	}
+}
+
+func clientBuilderMock(cl acmecl.Interface) accounts.NewClientFunc {
+	return func(*http.Client, cmacme.ACMEIssuer, *rsa.PrivateKey) acmecl.Interface {
+		return cl
+	}
+}
+
+func parseURLErr(s string) error {
+	_, err := url.Parse(s)
+	return err
+}
+
+func mustGenerateEDCSAKey(t *testing.T) crypto.Signer {
+	t.Helper()
+	key, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}
+
+func mustGenerateRSAKey(t *testing.T) crypto.Signer {
+	t.Helper()
+	key, err := pki.GenerateRSAPrivateKey(pki.MinRSAKeySize)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return key
+}

--- a/test/unit/coreclients/BUILD.bazel
+++ b/test/unit/coreclients/BUILD.bazel
@@ -1,0 +1,29 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["secrets.go"],
+    importpath = "github.com/jetstack/cert-manager/test/unit/coreclients",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/types:go_default_library",
+        "@io_k8s_apimachinery//pkg/watch:go_default_library",
+        "@io_k8s_client_go//kubernetes/typed/core/v1:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/test/unit/coreclients/secrets.go
+++ b/test/unit/coreclients/secrets.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// coreclients contains fakes for some of the types from
+// k8s.io/client-go/kubernetes/typed/core/v1
+package coreclients
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	typedcorev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+)
+
+var _ typedcorev1.SecretsGetter = &FakeSecretsGetter{}
+
+// FakeSecretsGetter can be used to mock typedcorev1.SecretsGetter in tests.
+type FakeSecretsGetter struct {
+	c *fakeSecretClient
+}
+
+type FakeSecretsGetterModifier func(*FakeSecretsGetter)
+
+// NewFakeSecretsGetterFrom can be used to create a mock typedcorev1.SecretsGetter for tests.
+// Example: NewFakeSecretsGetterFrom(NewFakeSecretsGetter(), SetFakeSecretsGetterCreate(<secret>, <error>)).
+func NewFakeSecretsGetterFrom(f *FakeSecretsGetter, mods ...FakeSecretsGetterModifier) *FakeSecretsGetter {
+	for _, mod := range mods {
+		mod(f)
+	}
+	return f
+}
+
+func NewFakeSecretsGetter() *FakeSecretsGetter {
+	return &FakeSecretsGetter{
+		c: &fakeSecretClient{},
+	}
+}
+
+// SetFakeSecretsGetterCreate is a modifier that can be used to set secret and
+// error that will be returned when
+// FakeSecretsGetter(<namespace>).Create(<secret>, <opts>) is called.
+func SetFakeSecretsGetterCreate(s *corev1.Secret, err error) FakeSecretsGetterModifier {
+	return func(f *FakeSecretsGetter) {
+		f.c.CreateFn = func() (*corev1.Secret, error) {
+			return s, err
+		}
+	}
+}
+
+// SetFakeSecretsGetterGet is a modifier that can be used to set secret and
+// error that will be returned when
+// FakeSecretsGetter(<namespace>).Get(<context>,<uid>,<opts>) is called.
+func SetFakeSecretsGetterGet(s *corev1.Secret, err error) FakeSecretsGetterModifier {
+	return func(f *FakeSecretsGetter) {
+		f.c.GetFn = func() (*corev1.Secret, error) {
+			return s, err
+		}
+	}
+}
+
+func (f *FakeSecretsGetter) Secrets(string) typedcorev1.SecretInterface {
+	return f.c
+}
+
+type fakeSecretClient struct {
+	CreateFn           func() (*corev1.Secret, error)
+	UpdateFn           func() (*corev1.Secret, error)
+	DeleteFn           func() error
+	DeleteCollectionFn func() error
+	GetFn              func() (*corev1.Secret, error)
+	ListFn             func() (*corev1.SecretList, error)
+	WatchFn            func() (watch.Interface, error)
+	PatchFn            func() (*corev1.Secret, error)
+	// Currently there is no need to mock this interface
+	typedcorev1.SecretExpansion
+}
+
+func (f *fakeSecretClient) Create(context.Context, *corev1.Secret, metav1.CreateOptions) (*corev1.Secret, error) {
+	return f.CreateFn()
+}
+
+func (f *fakeSecretClient) Update(context.Context, *corev1.Secret, metav1.UpdateOptions) (*corev1.Secret, error) {
+	return f.UpdateFn()
+}
+
+func (f *fakeSecretClient) Delete(context.Context, string, metav1.DeleteOptions) error {
+	return f.DeleteFn()
+}
+
+func (f *fakeSecretClient) DeleteCollection(context.Context, metav1.DeleteOptions, metav1.ListOptions) error {
+	return f.DeleteCollectionFn()
+}
+
+func (f *fakeSecretClient) Get(context.Context, string, metav1.GetOptions) (*corev1.Secret, error) {
+	return f.GetFn()
+}
+
+func (f *fakeSecretClient) List(context.Context, metav1.ListOptions) (*corev1.SecretList, error) {
+	return f.ListFn()
+}
+
+func (f *fakeSecretClient) Watch(context.Context, metav1.ListOptions) (watch.Interface, error) {
+	return f.WatchFn()
+}
+
+func (f *fakeSecretClient) Patch(context.Context, string, types.PatchType, []byte, metav1.PatchOptions, ...string) (*corev1.Secret, error) {
+	return f.PatchFn()
+}

--- a/test/unit/gen/BUILD.bazel
+++ b/test/unit/gen/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "certificate.go",
         "certificaterequest.go",
         "challenge.go",
+        "conditions.go",
         "csr.go",
         "doc.go",
         "issuer.go",

--- a/test/unit/gen/conditions.go
+++ b/test/unit/gen/conditions.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gen
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+type IssuerConditionModifier func(*v1.IssuerCondition)
+
+func IssuerCondition(t v1.IssuerConditionType, mods ...IssuerConditionModifier) *v1.IssuerCondition {
+	c := &v1.IssuerCondition{
+		Type: t,
+	}
+	for _, m := range mods {
+		m(c)
+	}
+	return c
+}
+
+func IssuerConditionFrom(c *v1.IssuerCondition, mods ...IssuerConditionModifier) *v1.IssuerCondition {
+	c = c.DeepCopy()
+	for _, m := range mods {
+		m(c)
+	}
+	return c
+}
+
+func SetIssuerConditionStatus(s cmmeta.ConditionStatus) IssuerConditionModifier {
+	return func(c *v1.IssuerCondition) {
+		c.Status = s
+	}
+}
+
+func SetIssuerConditionLastTransitionTime(t *metav1.Time) IssuerConditionModifier {
+	return func(c *v1.IssuerCondition) {
+		c.LastTransitionTime = t
+	}
+}
+
+func SetIssuerConditionReason(s string) IssuerConditionModifier {
+	return func(c *v1.IssuerCondition) {
+		c.Reason = s
+	}
+}
+
+func SetIssuerConditionMessage(s string) IssuerConditionModifier {
+	return func(c *v1.IssuerCondition) {
+		c.Message = s
+	}
+}

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -157,6 +157,16 @@ func SetIssuerACMESkipTLSVerify(shouldSkip bool) IssuerModifier {
 	}
 }
 
+func SetIssuerACMEDisableAccountKeyGeneration(disabled bool) IssuerModifier {
+	return func(iss v1.GenericIssuer) {
+		spec := iss.GetSpec()
+		if spec.ACME == nil {
+			spec.ACME = &cmacme.ACMEIssuer{}
+		}
+		spec.ACME.DisableAccountKeyGeneration = disabled
+	}
+}
+
 func SetIssuerACMEEAB(keyID, secretName string) IssuerModifier {
 	return func(iss v1.GenericIssuer) {
 		spec := iss.GetSpec()
@@ -193,6 +203,26 @@ func SetIssuerACMEEABWithKeyAlgorithm(keyID, secretName string, keyAlgorithm cma
 				},
 			},
 		}
+	}
+}
+
+func SetIssuerACMEAccountURL(url string) IssuerModifier {
+	return func(iss v1.GenericIssuer) {
+		status := iss.GetStatus()
+		if status.ACME == nil {
+			status.ACME = &cmacme.ACMEIssuerStatus{}
+		}
+		status.ACME.URI = url
+	}
+}
+
+func SetIssuerACMELastRegisteredEmail(email string) IssuerModifier {
+	return func(iss v1.GenericIssuer) {
+		status := iss.GetStatus()
+		if status.ACME == nil {
+			status.ACME = &cmacme.ACMEIssuerStatus{}
+		}
+		status.ACME.LastRegisteredEmail = email
 	}
 }
 


### PR DESCRIPTION
This PR adds unit tests for ACME issuer's `Setup` function.

This follows #3877 , see the comment about testing [here](https://github.com/jetstack/cert-manager/pull/3877#discussion_r610749443) .

Some notes:

- This test is not a particularly good unit test- all the methods of `Acme` struct should be refactored to make them more testable. However, maybe it would be better if we merged (if we are going to at all) #3695 first. Also maybe already having _some_ unit test in place would make refactoring easier.

- We usually unit test using [test builder](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/test/context_builder.go#L60), which helps with mocking requests to kubernetes API server. It did not seem to make sense to use the test builder here because `Setup` does not have access to controller's context etc. This made it difficult to, for example, properly mock requests to create/list secrets. Again, refactoring `Setup` could help with this.

This PR slightly refactors the `Setup` function:
- pulls out some calls to external dependencies, so they can be mocked in tests
- turns a bunch of string literals into constants:
- moves the updating of issuer's Ready condition to a deferred function [here](https://github.com/irbekrm/cert-manager/blob/3879_test_acme_issuer_setup/pkg/issuer/acme/setup.go#L76). As a side-effect of this change issuer's observed generation is updated every time the issuer gets synced- at the moment it ends up in incorrect state when the `Setup` function is called due to issuer's spec having changed and we hit [this](https://github.com/jetstack/cert-manager/blob/master/pkg/issuer/acme/setup.go#L166) code path. (I have seen this when modifying `issuer.spec.acme.externalAccountBinding` for an already valid issuer). Perhaps this should have been a separate PR?

I think that the easiest way to code-review this PR might be to read through the test cases top to bottom and look at the `Setup` function's flow in parallel as the test cases are mostly ordered to follow the function's flow (/cc @wallrj ). The test does not cover all the code paths- I think that perhaps more thorough testing could be done after merging this PR when we are in a better position to refactor this function?





/kind cleanup