### PR TITLE
Static analysis tool party: fix my batch of linter warnings

### DIFF
--- a/pkg/controller/certificates/issuing/BUILD.bazel
+++ b/pkg/controller/certificates/issuing/BUILD.bazel
@@ -62,6 +62,7 @@ go_test(
         "//pkg/controller/certificates/internal/test:go_default_library",
         "//pkg/controller/test:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -999,12 +999,9 @@ func TestIssuingController(t *testing.T) {
 			test.builder.Init()
 			defer test.builder.Stop()
 
-			// Instantiate/setup the controller
 			w := controllerWrapper{}
-			w.Register(test.builder.Context)
+			_, _, _ = w.Register(test.builder.Context)
 			w.controller.localTemporarySigner = testLocalTemporarySignerFn(exampleBundle.LocalTemporaryCertificateBytes)
-
-			// Start the unit test builder
 			test.builder.Start()
 
 			key, err := cache.MetaNamespaceKeyFunc(test.certificate)

--- a/pkg/controller/certificates/issuing/issuing_controller_test.go
+++ b/pkg/controller/certificates/issuing/issuing_controller_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1000,7 +1001,8 @@ func TestIssuingController(t *testing.T) {
 			defer test.builder.Stop()
 
 			w := controllerWrapper{}
-			_, _, _ = w.Register(test.builder.Context)
+			_, _, err := w.Register(test.builder.Context)
+			require.NoError(t, err)
 			w.controller.localTemporarySigner = testLocalTemporarySignerFn(exampleBundle.LocalTemporaryCertificateBytes)
 			test.builder.Start()
 

--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -145,7 +145,7 @@ func ValidateCertificateRequestApprovalCondition(crConds []cmapi.CertificateRequ
 	} {
 		switch len(cond.conditions) {
 		case 0:
-			break
+			// Do nothing.
 		case 1:
 			if condition := cond.conditions[0]; condition.Status != cmmeta.ConditionTrue {
 				el = append(el, field.Invalid(fldPath.Child(string(condition.Type)), condition.Status,

--- a/pkg/internal/apis/certmanager/validation/certificaterequest.go
+++ b/pkg/internal/apis/certmanager/validation/certificaterequest.go
@@ -136,23 +136,27 @@ func ValidateCertificateRequestApprovalCondition(crConds []cmapi.CertificateRequ
 		}
 	}
 
-	for _, cond := range []struct {
-		condType   cmapi.CertificateRequestConditionType
-		conditions []cmapi.CertificateRequestCondition
+	for _, condType := range []struct {
+		condType cmapi.CertificateRequestConditionType
+		found    []cmapi.CertificateRequestCondition
 	}{
 		{cmapi.CertificateRequestConditionApproved, approvedConditions},
 		{cmapi.CertificateRequestConditionDenied, deniedConditions},
 	} {
-		switch len(cond.conditions) {
-		case 0:
-			// Do nothing.
-		case 1:
-			if condition := cond.conditions[0]; condition.Status != cmmeta.ConditionTrue {
-				el = append(el, field.Invalid(fldPath.Child(string(condition.Type)), condition.Status,
-					fmt.Sprintf("%q condition may only be set to True", cond.condType)))
-			}
-		default:
-			el = append(el, field.Forbidden(fldPath, fmt.Sprintf("multiple %q conditions present", cond.condType)))
+		if len(condType.found) == 0 {
+			continue
+		}
+
+		if len(condType.found) > 1 {
+			el = append(el, field.Forbidden(fldPath, fmt.Sprintf("multiple %q conditions present", condType.condType)))
+			continue
+		}
+
+		first := condType.found[0]
+		if first.Status != cmmeta.ConditionTrue {
+			el = append(el, field.Invalid(fldPath.Child(string(first.Type)), first.Status,
+				fmt.Sprintf("%q condition may only be set to True", condType.condType)))
+			continue
 		}
 	}
 

--- a/pkg/issuer/acme/dns/acmedns/acmedns_test.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns_test.go
@@ -27,21 +27,21 @@ import (
 var (
 	acmednsLiveTest    bool
 	acmednsHost        string
-	acmednsAccountJson []byte
+	acmednsAccountJSON []byte
 	acmednsDomain      string
 )
 
 func init() {
 	acmednsHost = os.Getenv("ACME_DNS_HOST")
-	acmednsAccountJson = []byte(os.Getenv("ACME_DNS_ACCOUNTS_JSON"))
+	acmednsAccountJSON = []byte(os.Getenv("ACME_DNS_ACCOUNTS_JSON"))
 	acmednsDomain = os.Getenv("ACME_DNS_DOMAIN")
-	if len(acmednsHost) > 0 && len(acmednsAccountJson) > 0 {
+	if len(acmednsHost) > 0 && len(acmednsAccountJSON) > 0 {
 		acmednsLiveTest = true
 	}
 }
 
 func TestValidJsonAccount(t *testing.T) {
-	accountJson := []byte(`{
+	accountJSON := []byte(`{
         "domain": {
             "fulldomain": "fooldom",
             "password": "secret",
@@ -49,7 +49,7 @@ func TestValidJsonAccount(t *testing.T) {
             "username": "usernom"
         }
     }`)
-	provider, err := NewDNSProviderHostBytes("http://localhost/", accountJson, util.RecursiveNameservers)
+	provider, err := NewDNSProviderHostBytes("http://localhost/", accountJSON, util.RecursiveNameservers)
 	assert.NoError(t, err, "Expected no error constructing DNSProvider")
 	assert.Equal(t, provider.accounts["domain"].FullDomain, "fooldom")
 }
@@ -70,7 +70,7 @@ func TestLiveAcmeDnsPresent(t *testing.T) {
 	if !acmednsLiveTest {
 		t.Skip("skipping live test")
 	}
-	provider, err := NewDNSProviderHostBytes(acmednsHost, acmednsAccountJson, util.RecursiveNameservers)
+	provider, err := NewDNSProviderHostBytes(acmednsHost, acmednsAccountJSON, util.RecursiveNameservers)
 	assert.NoError(t, err)
 
 	// ACME-DNS requires 43 character keys or it throws a bad TXT error

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -267,7 +267,7 @@ func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 	}
 	resp, err := client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("Error querying Cloudflare API for %s %q -> %v", method, uri, err)
+		return nil, fmt.Errorf("while querying the Cloudflare API for %s %q: %v", method, uri, err)
 	}
 
 	defer resp.Body.Close()
@@ -287,9 +287,9 @@ func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 					errStr += fmt.Sprintf("<- %d: %s", chainErr.Code, chainErr.Message)
 				}
 			}
-			return nil, fmt.Errorf("Cloudflare API Error for %s %q \n%s", method, uri, errStr)
+			return nil, fmt.Errorf("error from the Cloudflare API for %s %q \n%s", method, uri, errStr)
 		}
-		return nil, fmt.Errorf("Cloudflare API error for %s %q", method, uri)
+		return nil, fmt.Errorf("error from the Cloudflare API for %s %q", method, uri)
 	}
 
 	return r.Result, nil

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -62,10 +62,10 @@ func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
 // DNSProvider instance configured for cloudflare.
 func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []string) (*DNSProvider, error) {
 	if (email == "" && key != "") || (key == "" && token == "") {
-		return nil, fmt.Errorf("no cloudflare credential has been given (can be either an API key or an API token)")
+		return nil, fmt.Errorf("no Cloudflare credential has been given (can be either an API key or an API token)")
 	}
 	if key != "" && token != "" {
-		return nil, fmt.Errorf("the Cloudflare API key and API token cannot be both present simultanously")
+		return nil, fmt.Errorf("the Cloudflare API key and API token cannot be both present simultaneously")
 	}
 	// Cloudflare uses the X-Auth-Key header for its authentication.
 	// However, if the value of the X-Auth-Key header is invalid, the go
@@ -287,9 +287,9 @@ func (c *DNSProvider) makeRequest(method, uri string, body io.Reader) (json.RawM
 					errStr += fmt.Sprintf("<- %d: %s", chainErr.Code, chainErr.Message)
 				}
 			}
-			return nil, fmt.Errorf("error from the Cloudflare API for %s %q \n%s", method, uri, errStr)
+			return nil, fmt.Errorf("while querying the Cloudflare API for %s %q \n%s", method, uri, errStr)
 		}
-		return nil, fmt.Errorf("error from the Cloudflare API for %s %q", method, uri)
+		return nil, fmt.Errorf("while querying the Cloudflare API for %s %q", method, uri)
 	}
 
 	return r.Result, nil

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -62,23 +62,23 @@ func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
 // DNSProvider instance configured for cloudflare.
 func NewDNSProviderCredentials(email, key, token string, dns01Nameservers []string) (*DNSProvider, error) {
 	if (email == "" && key != "") || (key == "" && token == "") {
-		return nil, fmt.Errorf("CloudFlare credentials missing")
+		return nil, fmt.Errorf("no cloudflare credential has been given (can be either an API key or an API token)")
 	}
 	if key != "" && token != "" {
-		return nil, fmt.Errorf("CloudFlare key and token are both present")
+		return nil, fmt.Errorf("the Cloudflare API key and API token cannot be both present simultanously")
 	}
-	// cloudflare uses X-Auth-Key as a header for its
-	// authentication. However, if it's an invalid value, the go
+	// Cloudflare uses the X-Auth-Key header for its authentication.
+	// However, if the value of the X-Auth-Key header is invalid, the go
 	// http library will "helpfully" print out the value to help with
-	// debugging.
-	//
-	// Check that the auth key is a valid header value before we leak it to the logs
+	// debugging. To prevent leaking the X-Auth-Key value into the logs, we
+	// first check that the X-Auth-Key header contains a valid value to
+	// prevent the Go HTTP library from displaying it.
 	if !validHeaderFieldValue(key) {
-		return nil, fmt.Errorf("Cloudflare key invalid (does the key contain a newline?)")
+		return nil, fmt.Errorf("the Cloudflare API key is invalid (does the API key contain a newline?)")
 	}
 
 	if !validHeaderFieldValue(token) {
-		return nil, fmt.Errorf("Cloudflare token invalid (does the token contain a newline?)")
+		return nil, fmt.Errorf("the Cloudflare API token is invalid (does the API token contain a newline?)")
 	}
 
 	return &DNSProvider{

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -73,7 +73,7 @@ func TestNewDNSProviderKeyAndTokenProvided(t *testing.T) {
 	os.Setenv("CLOUDFLARE_EMAIL", "")
 	os.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProviderCredentials("123", "123", "123", util.RecursiveNameservers)
-	assert.EqualError(t, err, "CloudFlare key and token are both present")
+	assert.EqualError(t, err, "the Cloudflare API key and API token cannot be both present simultaneously")
 	restoreCloudFlareEnv()
 }
 
@@ -89,7 +89,7 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	os.Setenv("CLOUDFLARE_EMAIL", "")
 	os.Setenv("CLOUDFLARE_API_KEY", "")
 	_, err := NewDNSProvider(util.RecursiveNameservers)
-	assert.EqualError(t, err, "CloudFlare credentials missing")
+	assert.EqualError(t, err, "no Cloudflare credential has been given (can be either an API key or an API token)")
 	restoreCloudFlareEnv()
 }
 

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136.go
@@ -78,7 +78,7 @@ func NewDNSProviderCredentials(nameserver, tsigAlgorithm, tsigKeyName, tsigSecre
 		if value, ok := supportedAlgorithms[strings.ToUpper(tsigAlgorithm)]; ok {
 			tsigAlgorithm = value
 		} else {
-			return nil, fmt.Errorf("the algorithm '%v' is not supported", tsigAlgorithm)
+			return nil, fmt.Errorf("algorithm '%v' is not supported", tsigAlgorithm)
 
 		}
 	}

--- a/pkg/issuer/acme/dns/rfc2136/rfc2136.go
+++ b/pkg/issuer/acme/dns/rfc2136/rfc2136.go
@@ -78,7 +78,7 @@ func NewDNSProviderCredentials(nameserver, tsigAlgorithm, tsigKeyName, tsigSecre
 		if value, ok := supportedAlgorithms[strings.ToUpper(tsigAlgorithm)]; ok {
 			tsigAlgorithm = value
 		} else {
-			return nil, fmt.Errorf("The algorithm '%v' is not supported", tsigAlgorithm)
+			return nil, fmt.Errorf("the algorithm '%v' is not supported", tsigAlgorithm)
 
 		}
 	}
@@ -124,7 +124,7 @@ func (r *DNSProvider) changeRecord(action, fqdn, zone, value string, ttl int) er
 	case "REMOVE":
 		m.Remove(rrs)
 	default:
-		return fmt.Errorf("Unexpected action: %s", action)
+		return fmt.Errorf("unexpected action: %s", action)
 	}
 
 	// Setup client

--- a/pkg/issuer/ca/setup.go
+++ b/pkg/issuer/ca/setup.go
@@ -34,8 +34,7 @@ const (
 
 	successKeyPairVerified = "KeyPairVerified"
 
-	messageErrorGetKeyPair     = "Error getting keypair for CA issuer: "
-	messageErrorInvalidKeyPair = "Invalid signing key pair: "
+	messageErrorGetKeyPair = "Error getting keypair for CA issuer: "
 
 	messageKeyPairVerified = "Signing CA verified"
 )

--- a/pkg/logs/testing/log_testing.go
+++ b/pkg/logs/testing/log_testing.go
@@ -39,7 +39,7 @@ func (log TestLogger) Info(msg string, keysAndValues ...interface{}) {
 	log.T.Logf("%s: %v", msg, strings.Join(withValues, " "))
 }
 
-func (_ TestLogger) Enabled() bool {
+func (TestLogger) Enabled() bool {
 	return true
 }
 

--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -21,7 +21,6 @@ import (
 	"crypto"
 	"crypto/x509"
 
-	api "k8s.io/api/core/v1"
 	corev1 "k8s.io/api/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 
@@ -51,7 +50,7 @@ func SecretTLSKeyRef(ctx context.Context, secretLister corelisters.SecretLister,
 // secret with 'name' in 'namespace'. It will read the private key data from the secret
 // entry with name 'keyName'.
 func SecretTLSKey(ctx context.Context, secretLister corelisters.SecretLister, namespace, name string) (crypto.Signer, error) {
-	return SecretTLSKeyRef(ctx, secretLister, namespace, name, api.TLSPrivateKeyKey)
+	return SecretTLSKeyRef(ctx, secretLister, namespace, name, corev1.TLSPrivateKeyKey)
 }
 
 // ParseTLSKeyFromSecret will parse and decode a private key from the given
@@ -76,9 +75,9 @@ func SecretTLSCertChain(ctx context.Context, secretLister corelisters.SecretList
 		return nil, err
 	}
 
-	certBytes, ok := secret.Data[api.TLSCertKey]
+	certBytes, ok := secret.Data[corev1.TLSCertKey]
 	if !ok {
-		return nil, errors.NewInvalidData("no data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+		return nil, errors.NewInvalidData("no data for %q in secret '%s/%s'", corev1.TLSCertKey, namespace, name)
 	}
 
 	cert, err := pki.DecodeX509CertificateChainBytes(certBytes)
@@ -121,18 +120,18 @@ func SecretTLSKeyPair(ctx context.Context, secretLister corelisters.SecretLister
 		return nil, nil, err
 	}
 
-	keyBytes, ok := secret.Data[api.TLSPrivateKeyKey]
+	keyBytes, ok := secret.Data[corev1.TLSPrivateKeyKey]
 	if !ok {
-		return nil, nil, errors.NewInvalidData("no private key data for %q in secret '%s/%s'", api.TLSPrivateKeyKey, namespace, name)
+		return nil, nil, errors.NewInvalidData("no private key data for %q in secret '%s/%s'", corev1.TLSPrivateKeyKey, namespace, name)
 	}
 	key, err := pki.DecodePrivateKeyBytes(keyBytes)
 	if err != nil {
 		return nil, nil, errors.NewInvalidData(err.Error())
 	}
 
-	certBytes, ok := secret.Data[api.TLSCertKey]
+	certBytes, ok := secret.Data[corev1.TLSCertKey]
 	if !ok {
-		return nil, key, errors.NewInvalidData("no certificate data for %q in secret '%s/%s'", api.TLSCertKey, namespace, name)
+		return nil, key, errors.NewInvalidData("no certificate data for %q in secret '%s/%s'", corev1.TLSCertKey, namespace, name)
 	}
 	cert, err := pki.DecodeX509CertificateChainBytes(certBytes)
 	if err != nil {


### PR DESCRIPTION
From https://github.com/cert-manager/website/issues/538: here is the PR with my batch of linter fixes.

Suggestion: I propose to have a common `.golangci.yml` so that we all have the same linter configuration:
- `golangci-lint` would be the single binary to run,
- no need to install `staticcheck` or `golint`.

Suggestion 2: I propose to not enforce the "exported function should have a comment" as discussed [here](https://github.com/golangci/golangci-lint/issues/21).
