### PR TITLE
Change Vault Issuer to construct the certificate chain to populate the CertificateRequest CA with the root most cert.

### DIFF
--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -353,7 +353,7 @@ func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]b
 		return nil, nil, fmt.Errorf("unable to convert certificate bundle to PEM bundle: %s", err.Error())
 	}
 
-	bundle, err := pki.ParseCertificateChainPEM([]byte(
+	bundle, err := pki.ParseSingleCertificateChainPEM([]byte(
 		strings.Join(append(
 			vbundle.CAChain,
 			vbundle.IssuingCA,

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -76,7 +76,8 @@ A5oRrSHcd8Hd8/lk0Y9BpFTnZEg7RLhFhh9nazVp1/pjwaGx449uHIGEoxREQoPq
 bfHWnmdelE0WP7h7B0PSA0EXn0pdg2VQIQsknV6y3MCzFQCCSAog/OSguokXG1PG
 l6fctDJ3+AF07EjtgArOBkUn7Nt3/CgMN8I1rnBZ1Vmd8yrHEP0E3yRXBL7cDj5j
 Fqmd89NQLlGs
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+`
 
 	testIntermediateCa = `-----BEGIN CERTIFICATE-----
 MIIFaTCCA1GgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwQTEPMA0GA1UEAwwGYmFy
@@ -108,7 +109,8 @@ rFQvv3jOPJ99IUpYpJydpv0Rfds3zMy2FJ6uex8gmlF7+XDZUSLQLuuFcjyHybfB
 zwZlUQ6EVmjOWLDdAmpeIAIkNEiogPuSz9E7xKdU+5bFYSgm6uxe8tFZSge2VEMC
 vPY2RcZ6uPZwpItqPmna8beydzlYohPcNcs4eK3hblLLacBV6eltP+q4/td+y87N
 yNCb90/k5dhi3YML4qoFeZjYfbY65RKHTztv5iqHH36dIZos0LucuphEWlKK
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+`
 	testRootCa = `-----BEGIN CERTIFICATE-----
 MIIFczCCA1ugAwIBAgIUcq3TKhc/RJfQOLCF2UQ805R+lkIwDQYJKoZIhvcNAQEL
 BQAwQTEPMA0GA1UEAwwGYmFyLmNhMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0Ex
@@ -140,7 +142,8 @@ O4MslwSiWvenq5apF9PzvwDndFIfSKzIE6A7/gyKKKuMYz87FTiHipsA/GAOjNUO
 Pc7TUJiY8gW9SWhPVUPaMkTIBgfN11c6BzLlhzN2r1zaZyghXr8QmcG4kWywkX7k
 oXeN5eS8iO5fx0EOvIcYQ4yRZLGafZxsLHlsZmt32N/ZZtcl4KDP5LRE7iZEOaE/
 UXY5wAUH2A==
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+`
 )
 
 func generateRSAPrivateKey(t *testing.T) *rsa.PrivateKey {
@@ -310,7 +313,7 @@ func TestSign(t *testing.T) {
 
 type testExtractCertificatesFromVaultCertT struct {
 	secret       *certutil.Secret
-	expectedCert []string
+	expectedCert string
 	expectedCA   string
 }
 
@@ -318,17 +321,17 @@ func TestExtractCertificatesFromVaultCertificateSecret(t *testing.T) {
 	tests := map[string]testExtractCertificatesFromVaultCertT{
 		"when a Vault engine is a root CA": {
 			secret:       signedCertificateSecret(testIntermediateCa),
-			expectedCert: []string{testLeafCertificate},
+			expectedCert: testLeafCertificate,
 			expectedCA:   testIntermediateCa,
 		},
 		"when a Vault engine is an intermediate CA, and its parent is a root CA": {
 			secret:       signedCertificateSecret(testIntermediateCa, testRootCa),
-			expectedCert: []string{testLeafCertificate, testIntermediateCa},
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testRootCa,
 		},
 		"when a Vault engine is an intermediate CA, and its parent is a intermediate CA": {
 			secret:       signedCertificateSecret(testIntermediateCa, testIntermediateCa, testRootCa),
-			expectedCert: []string{testLeafCertificate, testIntermediateCa, testIntermediateCa},
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testRootCa,
 		},
 	}
@@ -339,12 +342,11 @@ func TestExtractCertificatesFromVaultCertificateSecret(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: failed to extract certificate: %s", name, err)
 		}
-		expectedCert := strings.Join(test.expectedCert, "\n")
-		if expectedCert != string(cert) {
-			t.Errorf("%s: unexpected leaf certificate, exp=%s, got=%s", name, expectedCert, cert)
+		if test.expectedCert != string(cert) {
+			t.Errorf("%s: unexpected leaf certificate, exp=%q, got=%q", name, test.expectedCert, cert)
 		}
 		if test.expectedCA != string(ca) {
-			t.Errorf("%s: unexpected root certificate, exp=%s, got=%s", name, test.expectedCA, cert)
+			t.Errorf("%s: unexpected root certificate, exp=%q, got=%q", name, test.expectedCA, cert)
 		}
 	}
 }

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -154,18 +154,18 @@ type chainNode struct {
 	issuer *chainNode
 }
 
-// ParseCertificateChainPEM decodes a PEM encoded certificate chain before
-// calling ParseCertificateChain
-func ParseCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
+// ParseSingleCertificateChainPEM decodes a PEM encoded certificate chain before
+// calling ParseSingleCertificateChainPEM
+func ParseSingleCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
 	certs, err := DecodeX509CertificateChainBytes(pembundle)
 	if err != nil {
 		return PEMBundle{}, err
 	}
-	return ParseCertificateChain(certs)
+	return ParseSingleCertificateChain(certs)
 }
 
-// ParseCertificateChain returns the PEM-encoded chain of certificates as well
-// as the PEM-encoded CA certificate. The certificate chain contains the
+// ParseSingleCertificateChain returns the PEM-encoded chain of certificates as
+// well as the PEM-encoded CA certificate. The certificate chain contains the
 // leaf certificate first.
 //
 // The CA may not be a true root, but the highest intermediate certificate.
@@ -176,7 +176,7 @@ func ParseCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
 //
 // An error is returned if the passed bundle is not a valid flat tree chain,
 // the bundle is malformed, or the chain is broken.
-func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
+func ParseSingleCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
 	// De-duplicate certificates. This moves "complicated" logic away from
 	// consumers and into a shared function, who would otherwise have to do this
 	// anyway.
@@ -186,7 +186,7 @@ func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
 				continue
 			}
 			if certs[i].Equal(certs[j]) {
-				certs = append(certs[:i], certs[i+1:]...)
+				certs = append(certs[:j], certs[j+1:]...)
 			}
 		}
 	}
@@ -220,7 +220,7 @@ func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
 					continue
 				}
 
-				// attempt to add both chain together
+				// attempt to add both chains together
 				chain, ok := chains[i].tryMergeChain(chains[j])
 				if ok {
 					// If adding the chains together was successful, remove inner chain from

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -140,3 +140,199 @@ func DecodeX509CertificateRequestBytes(csrBytes []byte) (*x509.CertificateReques
 
 	return csr, nil
 }
+
+// PEMBundle includes the PEM encoded X.509 certificate chain and CA. CAPEM
+// contains either 1 CA certificate, or is empty if only a single certificate
+// exists in the chain.
+type PEMBundle struct {
+	CAPEM    []byte
+	ChainPEM []byte
+}
+
+type chainNode struct {
+	cert   *x509.Certificate
+	issuer *chainNode
+}
+
+// ParseCertificateChainPEM decodes a PEM encoded certificate chain before
+// calling ParseCertificateChain
+func ParseCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
+	certs, err := DecodeX509CertificateChainBytes(pembundle)
+	if err != nil {
+		return PEMBundle{}, err
+	}
+	return ParseCertificateChain(certs)
+}
+
+// ParseCertificateChain returns the PEM-encoded chain of certificates as well
+// as the PEM-encoded CA certificate. The certificate chain contains the
+// leaf certificate first.
+//
+// The CA may not be a true root, but the highest intermediate certificate.
+// The returned CA may be empty if a single certificate was passed.
+//
+// This function removes duplicate certificate entries as well as comments and
+// unnecessary white space.
+//
+// An error is returned if the passed bundle is not a valid flat tree chain,
+// the bundle is malformed, or the chain is broken.
+func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
+	// De-duplicate certificates. This moves "complicated" logic away from
+	// consumers and into a shared function, who would otherwise have to do this
+	// anyway.
+	for i := 0; i < len(certs)-1; i++ {
+		for j := 1; j < len(certs); j++ {
+			if i == j {
+				continue
+			}
+			if certs[i].Equal(certs[j]) {
+				certs = append(certs[:i], certs[i+1:]...)
+			}
+		}
+	}
+
+	// A certificate chain can be well described as a linked list. Here we build
+	// multiple lists that contain a single node, each being a single certificate
+	// that was passed.
+	var chains []*chainNode
+	for i := range certs {
+		chains = append(chains, &chainNode{cert: certs[i]})
+	}
+
+	// The task is to build a single list which represents a single certificate
+	// chain. The strategy is to iteratively attempt to join items in the list to
+	// build this single chain. Once we have a single list, we have built the
+	// chain. If the number of lists do not decrease after a pass, then the list
+	// can never be reduced to a single chain and we error.
+	for {
+		// If a single list is left, then we have built the entire chain. Stop
+		// iterating.
+		if len(chains) == 1 {
+			break
+		}
+
+		// lastChainsLength is used to ensure that at every pass, the number of
+		// tested chains gets smaller.
+		lastChainsLength := len(chains)
+		for i := 0; i < len(chains)-1; i++ {
+			for j := 1; j < len(chains); j++ {
+				if i == j {
+					continue
+				}
+
+				// attempt to add both chain together
+				chain, ok := chains[i].tryMergeChain(chains[j])
+				if ok {
+					// If adding the chains together was successful, remove inner chain from
+					// list
+					chains = append(chains[:j], chains[j+1:]...)
+				}
+
+				chains[i] = chain
+			}
+		}
+
+		// If no chains were merged in this pass, the chain can never be built as a
+		// single list. Error.
+		if lastChainsLength == len(chains) {
+			return PEMBundle{}, errors.NewInvalidData("certificate chain is malformed or broken")
+		}
+	}
+
+	// There is only a single chain left at index 0. Return chain as PEM.
+	return chains[0].toBundleAndCA()
+}
+
+// toBundleAndCA will return the PEM bundle of this chain.
+func (c *chainNode) toBundleAndCA() (PEMBundle, error) {
+	var (
+		certs []*x509.Certificate
+		ca    *x509.Certificate
+	)
+
+	for {
+		// If the issuer is nil, we have hit the root of the chain. Assign the CA
+		// to this certificate and stop traversing.
+		if c.issuer == nil {
+			ca = c.cert
+			break
+		}
+
+		// Add this node's certificate to the list at the end. Ready to check
+		// next node up.
+		certs = append(certs, c.cert)
+		c = c.issuer
+	}
+
+	caPEM, err := EncodeX509(ca)
+	if err != nil {
+		return PEMBundle{}, err
+	}
+
+	// If no certificates parsed, then CA is the only certificate and should be
+	// the chain
+	if len(certs) == 0 {
+		return PEMBundle{ChainPEM: caPEM}, nil
+	}
+
+	// Encode full certificate chain
+	chainPEM, err := EncodeX509Chain(certs)
+	if err != nil {
+		return PEMBundle{}, err
+	}
+
+	// Return chain and ca
+	return PEMBundle{CAPEM: caPEM, ChainPEM: chainPEM}, nil
+}
+
+// tryMergeChain glues two chains A and B together by adding one on top of
+// the other. The function tries both gluing A on top of B and B on top of
+// A, which is why the argument order for the two input chains does not
+// matter.
+//
+// Gluability: We say that the chains A and B are glueable when either the
+// leaf certificate of A can be verified using the root certificate of B,
+// or that the leaf certificate of B can be verified using the root certificate
+// of A.
+//
+// A leaf certificate C (as in "child") is verified by a certificate P
+// (as in "parent"), when they satisfy C.CheckSignatureFrom(P). In the
+// following diagram, C.CheckSignatureFrom(P) is satisfied, i.e., the
+// signature ("sig") on the certificate C can be verified using the parent P:
+//
+//       head                                         tail
+//  +------+-------+      +------+-------+      +------+-------+
+//  |      |       |      |      |       |      |      |       |
+//  |      |  sig ------->|  C   |  sig ------->|  P   |       |
+//  |      |       |      |      |       |      |      |       |
+//  +------+-------+      +------+-------+      +------+-------+
+//  leaf certificate                            root certificate
+//
+// The function returns false if the chains A and B are not gluable.
+func (c *chainNode) tryMergeChain(chain *chainNode) (*chainNode, bool) {
+	// The given chain's root has been signed by this node. Add this node on top
+	// of the given chain.
+	if chain.root().cert.CheckSignatureFrom(c.cert) == nil {
+		chain.root().issuer = c
+		return chain, true
+	}
+
+	// The given chain is the issuer of the root of this node. Add the given
+	// chain on top of the root of this node.
+	if c.root().cert.CheckSignatureFrom(chain.cert) == nil {
+		c.root().issuer = chain
+		return c, true
+	}
+
+	// Chains cannot be added together.
+	return c, false
+}
+
+// Return the root most node of this chain.
+func (c *chainNode) root() *chainNode {
+	for c.issuer != nil {
+		c = c.issuer
+	}
+
+	return c
+}

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -188,7 +188,7 @@ type testBundle struct {
 }
 
 func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle {
-	pk, err := GenerateRSAPrivateKey(2048)
+	pk, err := GenerateECPrivateKey(256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle
 		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
-		PublicKeyAlgorithm:    x509.RSA,
+		PublicKeyAlgorithm:    x509.ECDSA,
 		PublicKey:             pk.Public(),
 		IsCA:                  true,
 		Subject: pkix.Name{


### PR DESCRIPTION
```release-note
The Vault issuer now constructs a certificate chain after signing, and populates the CertificateRequest.Status.CA with the root most certificate if available.
```

This PR is to separate the work from https://github.com/jetstack/cert-manager/pull/3978 into separate PRs. This PR includes only the `ParseCertificateChain` function, as well as the change to the vault issuer to make use of this new func.

/assign @maelvls @munnerz @SgtCoDFish @jakexks 