### PR TITLE
Parse certificate chain CA Issuer

### DIFF
--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -124,12 +124,11 @@ func TestSign(t *testing.T) {
 		Subject: pkix.Name{
 			CommonName: "root",
 		},
-		PublicKeyAlgorithm: x509.RSA,
-		NotBefore:          time.Now(),
-		NotAfter:           time.Now().Add(time.Minute),
-		KeyUsage:           x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		PublicKey:          rootPK.Public(),
-		IsCA:               true,
+		NotBefore: time.Now(),
+		NotAfter:  time.Now().Add(time.Minute),
+		KeyUsage:  x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		PublicKey: rootPK.Public(),
+		IsCA:      true,
 	}
 
 	_, rootCert, err := pki.SignCertificate(rootTmpl, rootTmpl, rootPK.Public(), rootPK)

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/x509/pkix"
 	"encoding/pem"
 	"errors"
+	"math/big"
 	"net"
 	"reflect"
 	"testing"
@@ -111,6 +112,31 @@ func TestSign(t *testing.T) {
 		}),
 	)
 
+	rootPK, err := pki.GenerateECPrivateKey(256)
+	if err != nil {
+		t.Fatal()
+	}
+
+	rootTmpl := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName: "root",
+		},
+		PublicKeyAlgorithm: x509.RSA,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Minute),
+		KeyUsage:           x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		PublicKey:          rootPK.Public(),
+		IsCA:               true,
+	}
+
+	_, rootCert, err := pki.SignCertificate(rootTmpl, rootTmpl, rootPK.Public(), rootPK)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	sk, err := pki.GenerateRSAPrivateKey(2048)
 	if err != nil {
 		t.Fatal(err)
@@ -158,7 +184,7 @@ func TestSign(t *testing.T) {
 		t.Errorf("error generating template: %v", err)
 	}
 
-	certPEM, _, err := pki.SignCSRTemplate([]*x509.Certificate{template}, sk, template)
+	certBundle, err := pki.SignCSRTemplate([]*x509.Certificate{rootCert}, rootPK, template)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -173,7 +199,7 @@ func TestSign(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	certPEM2, _, err := pki.SignCSRTemplate([]*x509.Certificate{template}, sk, template2)
+	cert2Bundle, err := pki.SignCSRTemplate([]*x509.Certificate{rootCert}, rootPK, template2)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -561,7 +587,7 @@ func TestSign(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{gen.OrderFrom(baseOrder,
 					gen.SetOrderState(cmacme.Valid),
-					gen.SetOrderCertificate(certPEM2),
+					gen.SetOrderCertificate(cert2Bundle.ChainPEM),
 				), baseCR.DeepCopy(), baseIssuer.DeepCopy()},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewDeleteAction(
@@ -581,7 +607,7 @@ func TestSign(t *testing.T) {
 				},
 				CertManagerObjects: []runtime.Object{gen.OrderFrom(baseOrder,
 					gen.SetOrderState(cmacme.Valid),
-					gen.SetOrderCertificate(certPEM),
+					gen.SetOrderCertificate(certBundle.ChainPEM),
 				), baseCR.DeepCopy(), baseIssuer.DeepCopy()},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -596,7 +622,7 @@ func TestSign(t *testing.T) {
 								Message:            "Certificate fetched from issuer successfully",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.SetCertificateRequestCertificate(certPEM),
+							gen.SetCertificateRequestCertificate(certBundle.ChainPEM),
 						),
 					)),
 				},

--- a/pkg/controller/certificaterequests/ca/ca.go
+++ b/pkg/controller/certificaterequests/ca/ca.go
@@ -80,7 +80,7 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 	resourceNamespace := c.issuerOptions.ResourceNamespace(issuerObj)
 
 	// get a copy of the CA certificate named on the Issuer
-	caCerts, caKey, err := kube.SecretTLSKeyPair(ctx, c.secretsLister, resourceNamespace, issuerObj.GetSpec().CA.SecretName)
+	caCerts, caKey, err := kube.SecretTLSKeyPairAndCA(ctx, c.secretsLister, resourceNamespace, issuerObj.GetSpec().CA.SecretName)
 	if k8sErrors.IsNotFound(err) {
 		message := fmt.Sprintf("Referenced secret %s/%s not found", resourceNamespace, secretName)
 
@@ -117,7 +117,7 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 	template.CRLDistributionPoints = issuerObj.GetSpec().CA.CRLDistributionPoints
 	template.OCSPServer = issuerObj.GetSpec().CA.OCSPServers
 
-	certPEM, caPEM, err := pki.SignCSRTemplate(caCerts, caKey, template)
+	bundle, err := pki.SignCSRTemplate(caCerts, caKey, template)
 	if err != nil {
 		message := "Error signing certificate"
 		c.reporter.Failed(cr, err, "SigningError", message)
@@ -128,7 +128,7 @@ func (c *CA) Sign(ctx context.Context, cr *cmapi.CertificateRequest, issuerObj c
 	log.V(logf.DebugLevel).Info("certificate issued")
 
 	return &issuerpkg.IssueResponse{
-		Certificate: certPEM,
-		CA:          caPEM,
+		Certificate: bundle.ChainPEM,
+		CA:          bundle.CAPEM,
 	}, nil
 }

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package ca
 
 import (
-	"bytes"
 	"context"
 	"crypto"
 	"crypto/rand"
@@ -48,6 +47,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/controller"
 	"github.com/jetstack/cert-manager/pkg/controller/certificaterequests"
 	"github.com/jetstack/cert-manager/pkg/controller/certificaterequests/util"
+	controllertest "github.com/jetstack/cert-manager/pkg/controller/test"
 	testpkg "github.com/jetstack/cert-manager/pkg/controller/test"
 	"github.com/jetstack/cert-manager/pkg/util/pki"
 	"github.com/jetstack/cert-manager/test/unit/gen"
@@ -70,8 +70,7 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 
 	csrBytes, err := x509.CreateCertificateRequest(rand.Reader, &template, secretKey)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	csr := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE REQUEST", Bytes: csrBytes})
@@ -79,27 +78,28 @@ func generateCSR(t *testing.T, secretKey crypto.Signer) []byte {
 	return csr
 }
 
-func generateSelfSignedCertFromCR(t *testing.T, cr *cmapi.CertificateRequest, key crypto.Signer,
-	duration time.Duration) (*x509.Certificate, []byte) {
-	template, err := pki.GenerateTemplateFromCertificateRequest(cr)
-	if err != nil {
-		t.Errorf("error generating template: %v", err)
+func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
+	tmpl := &x509.Certificate{
+		Version:               3,
+		BasicConstraintsValid: true,
+		SerialNumber:          big.NewInt(0),
+		Subject: pkix.Name{
+			CommonName: name,
+		},
+		PublicKeyAlgorithm: x509.RSA,
+		NotBefore:          time.Now(),
+		NotAfter:           time.Now().Add(time.Minute),
+		KeyUsage:           x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		PublicKey:          key.Public(),
+		IsCA:               true,
 	}
 
-	derBytes, err := x509.CreateCertificate(rand.Reader, template, template, key.Public(), key)
+	pem, cert, err := pki.SignCertificate(tmpl, tmpl, key.Public(), key)
 	if err != nil {
-		t.Errorf("error signing cert: %v", err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
-	pemByteBuffer := bytes.NewBuffer([]byte{})
-	err = pem.Encode(pemByteBuffer, &pem.Block{Type: "CERTIFICATE", Bytes: derBytes})
-	if err != nil {
-		t.Errorf("failed to encode cert: %v", err)
-		t.FailNow()
-	}
-
-	return template, pemByteBuffer.Bytes()
+	return cert, pem
 }
 
 func TestSign(t *testing.T) {
@@ -114,18 +114,21 @@ func TestSign(t *testing.T) {
 	)
 
 	// Build root RSA CA
-	skRSA, err := pki.GenerateRSAPrivateKey(2048)
+	rootPK, err := pki.GenerateRSAPrivateKey(2048)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal()
 	}
+	rootPKPEM := pki.EncodePKCS1PrivateKey(rootPK)
 
-	skRSAPEM := pki.EncodePKCS1PrivateKey(skRSA)
-	rsaCSR := generateCSR(t, skRSA)
+	testpk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal()
+	}
+	testCSR := generateCSR(t, testpk)
 
 	baseCRNotApproved := gen.CertificateRequest("test-cr",
 		gen.SetCertificateRequestIsCA(true),
-		gen.SetCertificateRequestCSR(rsaCSR),
+		gen.SetCertificateRequestCSR(testCSR),
 		gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
 			Name:  baseIssuer.DeepCopy().Name,
 			Group: certmanager.GroupName,
@@ -153,15 +156,15 @@ func TestSign(t *testing.T) {
 	)
 
 	// generate a self signed root ca valid for 60d
-	_, rsaPEMCert := generateSelfSignedCertFromCR(t, baseCR, skRSA, time.Hour*24*60)
+	rootCert, rootCertPEM := generateSelfSignedCACert(t, rootPK, "root")
 	rsaCASecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "root-ca-secret",
 			Namespace: gen.DefaultTestNamespace,
 		},
 		Data: map[string][]byte{
-			corev1.TLSPrivateKeyKey: skRSAPEM,
-			corev1.TLSCertKey:       rsaPEMCert,
+			corev1.TLSPrivateKeyKey: rootPKPEM,
+			corev1.TLSCertKey:       rootCertPEM,
 		},
 	}
 
@@ -170,13 +173,11 @@ func TestSign(t *testing.T) {
 
 	template, err := pki.GenerateTemplateFromCertificateRequest(baseCR)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
-	certPEM, _, err := pki.SignCSRTemplate([]*x509.Certificate{template}, skRSA, template)
+	certBundle, err := pki.SignCSRTemplate([]*x509.Certificate{rootCert}, rootPK, template)
 	if err != nil {
-		t.Error(err)
-		t.FailNow()
+		t.Fatal(err)
 	}
 
 	tests := map[string]testT{
@@ -392,8 +393,8 @@ func TestSign(t *testing.T) {
 								Message:            "Certificate fetched from issuer successfully",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
-							gen.SetCertificateRequestCA(rsaPEMCert),
-							gen.SetCertificateRequestCertificate(certPEM),
+							gen.SetCertificateRequestCertificate(certBundle.ChainPEM),
+							gen.SetCertificateRequestCA(rootCertPEM),
 						),
 					)),
 				},
@@ -436,13 +437,10 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	controller := certificaterequests.New(apiutil.IssuerCA, ca)
-	_, _, err := controller.Register(test.builder.Context)
-	if err != nil {
-		t.Errorf("controller.Register failed: %v", err)
-	}
+	controller.Register(test.builder.Context)
 	test.builder.Start()
 
-	err = controller.Sync(context.Background(), test.certificateRequest)
+	err := controller.Sync(context.Background(), test.certificateRequest)
 	if err != nil && !test.expectedErr {
 		t.Errorf("expected to not get an error, but got: %v", err)
 	}
@@ -454,9 +452,19 @@ func runTest(t *testing.T, test testT) {
 }
 
 func TestCA_Sign(t *testing.T) {
-	rsaPair, err := pki.GenerateRSAPrivateKey(2048)
-	require.NoError(t, err)
-	rsaCSR := generateCSR(t, rsaPair)
+	// Build root RSA CA
+	rootPK, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal()
+	}
+	rootCert, _ := generateSelfSignedCACert(t, rootPK, "root")
+
+	// Build test CSR
+	testpk, err := pki.GenerateRSAPrivateKey(2048)
+	if err != nil {
+		t.Fatal()
+	}
+	testCSR := generateCSR(t, testpk)
 
 	tests := map[string]struct {
 		givenCASecret    *corev1.Secret
@@ -466,11 +474,12 @@ func TestCA_Sign(t *testing.T) {
 		wantErr          string
 	}{
 		"when the CertificateRequest has the duration field set, it should appear as notAfter on the signed ca": {
+			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rootPK, rootCert))),
 			givenCAIssuer: gen.Issuer("issuer-1", gen.SetIssuerCA(cmapi.CAIssuer{
 				SecretName: "secret-1",
 			})),
 			givenCR: gen.CertificateRequest("cr-1",
-				gen.SetCertificateRequestCSR(rsaCSR),
+				gen.SetCertificateRequestCSR(testCSR),
 				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
 					Name:  "issuer-1",
 					Group: certmanager.GroupName,
@@ -480,12 +489,6 @@ func TestCA_Sign(t *testing.T) {
 					Duration: 30 * time.Minute,
 				}),
 			),
-			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rsaPair,
-				&x509.Certificate{
-					SerialNumber: big.NewInt(1234),
-					IsCA:         true,
-				},
-			))),
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
 				// Although there is less than 1µs between the time.Now
 				// call made by the certificate template func (in the "pki"
@@ -512,11 +515,12 @@ func TestCA_Sign(t *testing.T) {
 			},
 		},
 		"when the CertificateRequest has the isCA field set, it should appear on the signed ca": {
+			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rootPK, rootCert))),
 			givenCAIssuer: gen.Issuer("issuer-1", gen.SetIssuerCA(cmapi.CAIssuer{
 				SecretName: "secret-1",
 			})),
 			givenCR: gen.CertificateRequest("cr-1",
-				gen.SetCertificateRequestCSR(rsaCSR),
+				gen.SetCertificateRequestCSR(testCSR),
 				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
 					Name:  "issuer-1",
 					Group: certmanager.GroupName,
@@ -524,59 +528,43 @@ func TestCA_Sign(t *testing.T) {
 				}),
 				gen.SetCertificateRequestIsCA(true),
 			),
-			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rsaPair,
-				&x509.Certificate{
-					SerialNumber: big.NewInt(1234),
-					IsCA:         true,
-				},
-			))),
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
 				assert.Equal(t, true, got.IsCA)
 			},
 		},
 		"when the Issuer has ocspServers set, it should appear on the signed ca": {
+			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rootPK, rootCert))),
 			givenCAIssuer: gen.Issuer("issuer-1", gen.SetIssuerCA(cmapi.CAIssuer{
 				SecretName:  "secret-1",
 				OCSPServers: []string{"http://ocsp-v3.example.org"},
 			})),
 			givenCR: gen.CertificateRequest("cr-1",
-				gen.SetCertificateRequestCSR(rsaCSR),
+				gen.SetCertificateRequestCSR(testCSR),
 				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
 					Name:  "issuer-1",
 					Group: certmanager.GroupName,
 					Kind:  "Issuer",
 				}),
 			),
-			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rsaPair,
-				&x509.Certificate{
-					SerialNumber: big.NewInt(1234),
-					IsCA:         true,
-				},
-			))),
 			assertSignedCert: func(t *testing.T, got *x509.Certificate) {
 				assert.Equal(t, []string{"http://ocsp-v3.example.org"}, got.OCSPServer)
 			},
 		},
 		"when the Issuer has crlDistributionPoints set, it should appear on the signed ca ": {
+			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rootPK, rootCert))),
 			givenCAIssuer: gen.Issuer("issuer-1", gen.SetIssuerCA(cmapi.CAIssuer{
 				SecretName:            "secret-1",
 				CRLDistributionPoints: []string{"http://www.example.com/crl/test.crl"},
 			})),
 			givenCR: gen.CertificateRequest("cr-1",
 				gen.SetCertificateRequestIsCA(true),
-				gen.SetCertificateRequestCSR(rsaCSR),
+				gen.SetCertificateRequestCSR(testCSR),
 				gen.SetCertificateRequestIssuer(cmmeta.ObjectReference{
 					Name:  "issuer-1",
 					Group: certmanager.GroupName,
 					Kind:  "Issuer",
 				}),
 			),
-			givenCASecret: gen.SecretFrom(gen.Secret("secret-1"), gen.SetSecretNamespace("default"), gen.SetSecretData(secretDataFor(t, rsaPair,
-				&x509.Certificate{
-					SerialNumber: big.NewInt(1234),
-					IsCA:         true,
-				},
-			))),
 			assertSignedCert: func(t *testing.T, gotCA *x509.Certificate) {
 				assert.Equal(t, []string{"http://www.example.com/crl/test.crl"}, gotCA.CRLDistributionPoints)
 			},
@@ -584,7 +572,7 @@ func TestCA_Sign(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			rec := &testpkg.FakeRecorder{}
+			rec := &controllertest.FakeRecorder{}
 
 			c := &CA{
 				issuerOptions: controller.IssuerOptions{

--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -353,7 +353,7 @@ func extractCertificatesFromVaultCertificateSecret(secret *certutil.Secret) ([]b
 		return nil, nil, fmt.Errorf("unable to convert certificate bundle to PEM bundle: %s", err.Error())
 	}
 
-	bundle, err := pki.ParseCertificateChainPEM([]byte(
+	bundle, err := pki.ParseSingleCertificateChainPEM([]byte(
 		strings.Join(append(
 			vbundle.CAChain,
 			vbundle.IssuingCA,

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -76,7 +76,8 @@ A5oRrSHcd8Hd8/lk0Y9BpFTnZEg7RLhFhh9nazVp1/pjwaGx449uHIGEoxREQoPq
 bfHWnmdelE0WP7h7B0PSA0EXn0pdg2VQIQsknV6y3MCzFQCCSAog/OSguokXG1PG
 l6fctDJ3+AF07EjtgArOBkUn7Nt3/CgMN8I1rnBZ1Vmd8yrHEP0E3yRXBL7cDj5j
 Fqmd89NQLlGs
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+`
 
 	testIntermediateCa = `-----BEGIN CERTIFICATE-----
 MIIFaTCCA1GgAwIBAgICEAAwDQYJKoZIhvcNAQELBQAwQTEPMA0GA1UEAwwGYmFy
@@ -108,7 +109,8 @@ rFQvv3jOPJ99IUpYpJydpv0Rfds3zMy2FJ6uex8gmlF7+XDZUSLQLuuFcjyHybfB
 zwZlUQ6EVmjOWLDdAmpeIAIkNEiogPuSz9E7xKdU+5bFYSgm6uxe8tFZSge2VEMC
 vPY2RcZ6uPZwpItqPmna8beydzlYohPcNcs4eK3hblLLacBV6eltP+q4/td+y87N
 yNCb90/k5dhi3YML4qoFeZjYfbY65RKHTztv5iqHH36dIZos0LucuphEWlKK
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+`
 	testRootCa = `-----BEGIN CERTIFICATE-----
 MIIFczCCA1ugAwIBAgIUcq3TKhc/RJfQOLCF2UQ805R+lkIwDQYJKoZIhvcNAQEL
 BQAwQTEPMA0GA1UEAwwGYmFyLmNhMQswCQYDVQQGEwJVUzELMAkGA1UECAwCQ0Ex
@@ -140,7 +142,8 @@ O4MslwSiWvenq5apF9PzvwDndFIfSKzIE6A7/gyKKKuMYz87FTiHipsA/GAOjNUO
 Pc7TUJiY8gW9SWhPVUPaMkTIBgfN11c6BzLlhzN2r1zaZyghXr8QmcG4kWywkX7k
 oXeN5eS8iO5fx0EOvIcYQ4yRZLGafZxsLHlsZmt32N/ZZtcl4KDP5LRE7iZEOaE/
 UXY5wAUH2A==
------END CERTIFICATE-----`
+-----END CERTIFICATE-----
+`
 )
 
 func generateRSAPrivateKey(t *testing.T) *rsa.PrivateKey {
@@ -310,7 +313,7 @@ func TestSign(t *testing.T) {
 
 type testExtractCertificatesFromVaultCertT struct {
 	secret       *certutil.Secret
-	expectedCert []string
+	expectedCert string
 	expectedCA   string
 }
 
@@ -318,17 +321,17 @@ func TestExtractCertificatesFromVaultCertificateSecret(t *testing.T) {
 	tests := map[string]testExtractCertificatesFromVaultCertT{
 		"when a Vault engine is a root CA": {
 			secret:       signedCertificateSecret(testIntermediateCa),
-			expectedCert: []string{testLeafCertificate},
+			expectedCert: testLeafCertificate,
 			expectedCA:   testIntermediateCa,
 		},
 		"when a Vault engine is an intermediate CA, and its parent is a root CA": {
 			secret:       signedCertificateSecret(testIntermediateCa, testRootCa),
-			expectedCert: []string{testLeafCertificate, testIntermediateCa},
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testRootCa,
 		},
 		"when a Vault engine is an intermediate CA, and its parent is a intermediate CA": {
 			secret:       signedCertificateSecret(testIntermediateCa, testIntermediateCa, testRootCa),
-			expectedCert: []string{testLeafCertificate, testIntermediateCa, testIntermediateCa},
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testRootCa,
 		},
 	}
@@ -339,12 +342,11 @@ func TestExtractCertificatesFromVaultCertificateSecret(t *testing.T) {
 		if err != nil {
 			t.Errorf("%s: failed to extract certificate: %s", name, err)
 		}
-		expectedCert := strings.Join(test.expectedCert, "\n")
-		if expectedCert != string(cert) {
-			t.Errorf("%s: unexpected leaf certificate, exp=%s, got=%s", name, expectedCert, cert)
+		if test.expectedCert != string(cert) {
+			t.Errorf("%s: unexpected leaf certificate, exp=%q, got=%q", name, test.expectedCert, cert)
 		}
 		if test.expectedCA != string(ca) {
-			t.Errorf("%s: unexpected root certificate, exp=%s, got=%s", name, test.expectedCA, cert)
+			t.Errorf("%s: unexpected root certificate, exp=%q, got=%q", name, test.expectedCA, cert)
 		}
 	}
 }

--- a/pkg/util/kube/BUILD.bazel
+++ b/pkg/util/kube/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/util/kube",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util/errors:go_default_library",
         "//pkg/util/pki:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -431,7 +431,7 @@ func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template 
 		return PEMBundle{}, err
 	}
 
-	bundle, err := ParseCertificateChain(append(caCerts, cert))
+	bundle, err := ParseSingleCertificateChain(append(caCerts, cert))
 	if err != nil {
 		return PEMBundle{}, err
 	}

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -154,18 +154,18 @@ type chainNode struct {
 	issuer *chainNode
 }
 
-// ParseCertificateChainPEM decodes a PEM encoded certificate chain before
-// calling ParseCertificateChain
-func ParseCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
+// ParseSingleCertificateChainPEM decodes a PEM encoded certificate chain before
+// calling ParseSingleCertificateChainPEM
+func ParseSingleCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
 	certs, err := DecodeX509CertificateChainBytes(pembundle)
 	if err != nil {
 		return PEMBundle{}, err
 	}
-	return ParseCertificateChain(certs)
+	return ParseSingleCertificateChain(certs)
 }
 
-// ParseCertificateChain returns the PEM-encoded chain of certificates as well
-// as the PEM-encoded CA certificate. The certificate chain contains the
+// ParseSingleCertificateChain returns the PEM-encoded chain of certificates as
+// well as the PEM-encoded CA certificate. The certificate chain contains the
 // leaf certificate first.
 //
 // The CA may not be a true root, but the highest intermediate certificate.
@@ -176,7 +176,7 @@ func ParseCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
 //
 // An error is returned if the passed bundle is not a valid flat tree chain,
 // the bundle is malformed, or the chain is broken.
-func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
+func ParseSingleCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
 	// De-duplicate certificates. This moves "complicated" logic away from
 	// consumers and into a shared function, who would otherwise have to do this
 	// anyway.
@@ -186,7 +186,7 @@ func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
 				continue
 			}
 			if certs[i].Equal(certs[j]) {
-				certs = append(certs[:i], certs[i+1:]...)
+				certs = append(certs[:j], certs[j+1:]...)
 			}
 		}
 	}
@@ -220,7 +220,7 @@ func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
 					continue
 				}
 
-				// attempt to add both chain together
+				// attempt to add both chains together
 				chain, ok := chains[i].tryMergeChain(chains[j])
 				if ok {
 					// If adding the chains together was successful, remove inner chain from

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -140,3 +140,199 @@ func DecodeX509CertificateRequestBytes(csrBytes []byte) (*x509.CertificateReques
 
 	return csr, nil
 }
+
+// PEMBundle includes the PEM encoded X.509 certificate chain and CA. CAPEM
+// contains either 1 CA certificate, or is empty if only a single certificate
+// exists in the chain.
+type PEMBundle struct {
+	CAPEM    []byte
+	ChainPEM []byte
+}
+
+type chainNode struct {
+	cert   *x509.Certificate
+	issuer *chainNode
+}
+
+// ParseCertificateChainPEM decodes a PEM encoded certificate chain before
+// calling ParseCertificateChain
+func ParseCertificateChainPEM(pembundle []byte) (PEMBundle, error) {
+	certs, err := DecodeX509CertificateChainBytes(pembundle)
+	if err != nil {
+		return PEMBundle{}, err
+	}
+	return ParseCertificateChain(certs)
+}
+
+// ParseCertificateChain returns the PEM-encoded chain of certificates as well
+// as the PEM-encoded CA certificate. The certificate chain contains the
+// leaf certificate first.
+//
+// The CA may not be a true root, but the highest intermediate certificate.
+// The returned CA may be empty if a single certificate was passed.
+//
+// This function removes duplicate certificate entries as well as comments and
+// unnecessary white space.
+//
+// An error is returned if the passed bundle is not a valid flat tree chain,
+// the bundle is malformed, or the chain is broken.
+func ParseCertificateChain(certs []*x509.Certificate) (PEMBundle, error) {
+	// De-duplicate certificates. This moves "complicated" logic away from
+	// consumers and into a shared function, who would otherwise have to do this
+	// anyway.
+	for i := 0; i < len(certs)-1; i++ {
+		for j := 1; j < len(certs); j++ {
+			if i == j {
+				continue
+			}
+			if certs[i].Equal(certs[j]) {
+				certs = append(certs[:i], certs[i+1:]...)
+			}
+		}
+	}
+
+	// A certificate chain can be well described as a linked list. Here we build
+	// multiple lists that contain a single node, each being a single certificate
+	// that was passed.
+	var chains []*chainNode
+	for i := range certs {
+		chains = append(chains, &chainNode{cert: certs[i]})
+	}
+
+	// The task is to build a single list which represents a single certificate
+	// chain. The strategy is to iteratively attempt to join items in the list to
+	// build this single chain. Once we have a single list, we have built the
+	// chain. If the number of lists do not decrease after a pass, then the list
+	// can never be reduced to a single chain and we error.
+	for {
+		// If a single list is left, then we have built the entire chain. Stop
+		// iterating.
+		if len(chains) == 1 {
+			break
+		}
+
+		// lastChainsLength is used to ensure that at every pass, the number of
+		// tested chains gets smaller.
+		lastChainsLength := len(chains)
+		for i := 0; i < len(chains)-1; i++ {
+			for j := 1; j < len(chains); j++ {
+				if i == j {
+					continue
+				}
+
+				// attempt to add both chain together
+				chain, ok := chains[i].tryMergeChain(chains[j])
+				if ok {
+					// If adding the chains together was successful, remove inner chain from
+					// list
+					chains = append(chains[:j], chains[j+1:]...)
+				}
+
+				chains[i] = chain
+			}
+		}
+
+		// If no chains were merged in this pass, the chain can never be built as a
+		// single list. Error.
+		if lastChainsLength == len(chains) {
+			return PEMBundle{}, errors.NewInvalidData("certificate chain is malformed or broken")
+		}
+	}
+
+	// There is only a single chain left at index 0. Return chain as PEM.
+	return chains[0].toBundleAndCA()
+}
+
+// toBundleAndCA will return the PEM bundle of this chain.
+func (c *chainNode) toBundleAndCA() (PEMBundle, error) {
+	var (
+		certs []*x509.Certificate
+		ca    *x509.Certificate
+	)
+
+	for {
+		// If the issuer is nil, we have hit the root of the chain. Assign the CA
+		// to this certificate and stop traversing.
+		if c.issuer == nil {
+			ca = c.cert
+			break
+		}
+
+		// Add this node's certificate to the list at the end. Ready to check
+		// next node up.
+		certs = append(certs, c.cert)
+		c = c.issuer
+	}
+
+	caPEM, err := EncodeX509(ca)
+	if err != nil {
+		return PEMBundle{}, err
+	}
+
+	// If no certificates parsed, then CA is the only certificate and should be
+	// the chain
+	if len(certs) == 0 {
+		return PEMBundle{ChainPEM: caPEM}, nil
+	}
+
+	// Encode full certificate chain
+	chainPEM, err := EncodeX509Chain(certs)
+	if err != nil {
+		return PEMBundle{}, err
+	}
+
+	// Return chain and ca
+	return PEMBundle{CAPEM: caPEM, ChainPEM: chainPEM}, nil
+}
+
+// tryMergeChain glues two chains A and B together by adding one on top of
+// the other. The function tries both gluing A on top of B and B on top of
+// A, which is why the argument order for the two input chains does not
+// matter.
+//
+// Gluability: We say that the chains A and B are glueable when either the
+// leaf certificate of A can be verified using the root certificate of B,
+// or that the leaf certificate of B can be verified using the root certificate
+// of A.
+//
+// A leaf certificate C (as in "child") is verified by a certificate P
+// (as in "parent"), when they satisfy C.CheckSignatureFrom(P). In the
+// following diagram, C.CheckSignatureFrom(P) is satisfied, i.e., the
+// signature ("sig") on the certificate C can be verified using the parent P:
+//
+//       head                                         tail
+//  +------+-------+      +------+-------+      +------+-------+
+//  |      |       |      |      |       |      |      |       |
+//  |      |  sig ------->|  C   |  sig ------->|  P   |       |
+//  |      |       |      |      |       |      |      |       |
+//  +------+-------+      +------+-------+      +------+-------+
+//  leaf certificate                            root certificate
+//
+// The function returns false if the chains A and B are not gluable.
+func (c *chainNode) tryMergeChain(chain *chainNode) (*chainNode, bool) {
+	// The given chain's root has been signed by this node. Add this node on top
+	// of the given chain.
+	if chain.root().cert.CheckSignatureFrom(c.cert) == nil {
+		chain.root().issuer = c
+		return chain, true
+	}
+
+	// The given chain is the issuer of the root of this node. Add the given
+	// chain on top of the root of this node.
+	if c.root().cert.CheckSignatureFrom(chain.cert) == nil {
+		c.root().issuer = chain
+		return c, true
+	}
+
+	// Chains cannot be added together.
+	return c, false
+}
+
+// Return the root most node of this chain.
+func (c *chainNode) root() *chainNode {
+	for c.issuer != nil {
+		c = c.issuer
+	}
+
+	return c
+}

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -188,7 +188,7 @@ type testBundle struct {
 }
 
 func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle {
-	pk, err := GenerateRSAPrivateKey(2048)
+	pk, err := GenerateECPrivateKey(256)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +202,7 @@ func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle
 		Version:               3,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
-		PublicKeyAlgorithm:    x509.RSA,
+		PublicKeyAlgorithm:    x509.ECDSA,
 		PublicKey:             pk.Public(),
 		IsCA:                  true,
 		Subject: pkix.Name{


### PR DESCRIPTION
```release-note
The CA issuer now constructs a certificate chain after signing, and populates the CertificateRequest.Status.CA with the root most certificate if available. Correctly passes down CA certificate when chaining CA Issuers together.
```

This PR is branched from https://github.com/jetstack/cert-manager/pull/3982 and should be merged first. EDIT: This should say "and that PR should be merged first" instead of "and should be merged first"

Updates `SignCSRTemplate` to use new `ParseCertificateChain` func, and passes through CA certificate when chaining CA Issuers together.

/assign @maelvls @munnerz @SgtCoDFish @jakexks 