### PR TITLE
Controller-gen can now update CRDs like before

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -30,14 +30,14 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        {{- if .Values.webhook.url.host }}
+        # {{- if .Values.webhook.url.host }}
         url: https://{{ .Values.webhook.url.host }}/convert
-        {{- else }}
+        # {{- else }}
         service:
-          name: {{ template "webhook.fullname" . }}
-          namespace: {{ .Release.Namespace | quote }}
+          name: '{{ template "webhook.fullname" . }}'
+          namespace: "{{ .Release.Namespace }}"
           path: /convert
-        {{- end }}
+          # {{- end }}
   versions:
     - name: v1alpha2
       subresources:

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -30,14 +30,14 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        {{- if .Values.webhook.url.host }}
+        # {{- if .Values.webhook.url.host }}
         url: https://{{ .Values.webhook.url.host }}/convert
-        {{- else }}
+        # {{- else }}
         service:
-          name: {{ template "webhook.fullname" . }}
-          namespace: {{ .Release.Namespace | quote }}
+          name: '{{ template "webhook.fullname" . }}'
+          namespace: "{{ .Release.Namespace }}"
           path: /convert
-        {{- end }}
+          # {{- end }}
   versions:
     - name: v1alpha2
       subresources:

--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -28,14 +28,14 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        {{- if .Values.webhook.url.host }}
+        # {{- if .Values.webhook.url.host }}
         url: https://{{ .Values.webhook.url.host }}/convert
-        {{- else }}
+        # {{- else }}
         service:
-          name: {{ template "webhook.fullname" . }}
-          namespace: {{ .Release.Namespace | quote }}
+          name: '{{ template "webhook.fullname" . }}'
+          namespace: "{{ .Release.Namespace }}"
           path: /convert
-        {{- end }}
+          # {{- end }}
   versions:
     - additionalPrinterColumns:
         - jsonPath: .status.state

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -27,14 +27,14 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        {{- if .Values.webhook.url.host }}
+        # {{- if .Values.webhook.url.host }}
         url: https://{{ .Values.webhook.url.host }}/convert
-        {{- else }}
+        # {{- else }}
         service:
-          name: {{ template "webhook.fullname" . }}
-          namespace: {{ .Release.Namespace | quote }}
+          name: '{{ template "webhook.fullname" . }}'
+          namespace: "{{ .Release.Namespace }}"
           path: /convert
-        {{- end }}
+          # {{- end }}
   versions:
     - name: v1alpha2
       subresources:

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -27,14 +27,14 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        {{- if .Values.webhook.url.host }}
+        # {{- if .Values.webhook.url.host }}
         url: https://{{ .Values.webhook.url.host }}/convert
-        {{- else }}
+        # {{- else }}
         service:
-          name: {{ template "webhook.fullname" . }}
-          namespace: {{ .Release.Namespace | quote }}
+          name: '{{ template "webhook.fullname" . }}'
+          namespace: "{{ .Release.Namespace }}"
           path: /convert
-        {{- end }}
+          # {{- end }}
   versions:
     - name: v1alpha2
       subresources:

--- a/deploy/crds/crd-orders.yaml
+++ b/deploy/crds/crd-orders.yaml
@@ -28,14 +28,14 @@ spec:
     webhook:
       conversionReviewVersions: ["v1", "v1beta1"]
       clientConfig:
-        {{- if .Values.webhook.url.host }}
+        # {{- if .Values.webhook.url.host }}
         url: https://{{ .Values.webhook.url.host }}/convert
-        {{- else }}
+        # {{- else }}
         service:
-          name: {{ template "webhook.fullname" . }}
-          namespace: {{ .Release.Namespace | quote }}
+          name: '{{ template "webhook.fullname" . }}'
+          namespace: "{{ .Release.Namespace }}"
           path: /convert
-        {{- end }}
+          # {{- end }}
   versions:
     - name: v1alpha2
       subresources:


### PR DESCRIPTION
Fixes https://github.com/jetstack/cert-manager/issues/3943. The controller-gen tool is quite rude and won't tell you when one of the CRD manifests cannot be parsed when the option schemapatch is used. As an example, the following:

```
  sed -i 's/RFC8555/RFC8556/g' pkg/apis/certmanager/v1/types_issuer.go
  controller-gen schemapatch:manifests=./deploy/crds output:dir=./deploy/crds paths=./pkg/apis/...
```

should trigger a change in the crd-clusterissuers.yaml:

```diff
--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -3184,7 +3184,7 @@ spec:
               type: object
               properties:
                 acme:
-                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  description: ACME configures this issuer to communicate with a RFC8556 (ACME) server to obtain signed x509 certificates.
                   type: object
--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -3184,7 +3184,7 @@ spec:
               type: object
               properties:
                 acme:
-                  description: ACME configures this issuer to communicate with a RFC8555 (ACME) server to obtain signed x509 certificates.
+                  description: ACME configures this issuer to communicate with a RFC8556 (ACME) server to obtain signed x509 certificates.
                   type: object
```

Unfortunately, controller-gen v0.2.9 ([645d44dc](https://github.com/kubernetes-sigs/controller-tools/commit/645d44dc)) silently skips faulty CRD manifests. In our case, the CRD had become a non-YAML file (we need to use some if statements):

```yaml
  {{- if .Values.webhook.url.host }}
  url: https://{{ .Values.webhook.url.host }}/convert
  {{- else }}
  service:
    name: {{ template "webhook.fullname" . }}
    namespace: {{ .Release.Namespace | quote }}
    path: /convert
  {{- end }}
```

Two issues can be found (we can use a YAML parser like yq for that):

1. The pipe "|" used in `.Release.Namespace | quote` makes it an invalid YAML file. We could rewrite that to
   ```yaml
     {{ quote .Release.Namespace }}
   ```

   but I decided to go with actual quotes like with the rest of the file:

   ```yaml
     "{{ .Release.Namespace }}"
   ```

2. The `{{ if }}`, `{{ else }}` and `{{ end }}` are also invalid YAML syntax, and one easy workaround is to comment them.

/kind cleanup
/milestone v1.4

```release-note
NONE
```