### PR TITLE
Change default devel K8S_VERSION to 1.20

### DIFF
--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -24,8 +24,8 @@ export REPO_ROOT="$LIB_ROOT/../.."
 export SKIP_BUILD_ADDON_IMAGES="${SKIP_BUILD_ADDON_IMAGES:-}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 export KIND_IMAGE_REPO="kindest/node"
-# Default Kubernetes version to use to 1.17
-export K8S_VERSION=${K8S_VERSION:-1.17}
+# Default Kubernetes version to use to 1.20
+export K8S_VERSION=${K8S_VERSION:-1.20}
 # Default OpenShift version to use to 3.11
 export OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-"3.11"}
 export SERVICE_IP_PREFIX="${SERVICE_IP_PREFIX:-10.0.0}"


### PR DESCRIPTION
1.17 is no longer supported by upstream, and 1.21 didn't work with just
a trivial version change, suggesting more work may need to be done

Signed-off-by: Ashley Davis <ashley.davis@jetstack.io>

```release-note
Update default development version of Kubernetes in kind from 1.17 to 1.20
```
