### PR TITLE
Use ConfigmapsLeases Multilock for controller's leader election

### DIFF
--- a/cmd/controller/app/BUILD.bazel
+++ b/cmd/controller/app/BUILD.bazel
@@ -34,7 +34,6 @@ go_library(
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
-        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_client_go//informers:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",


### PR DESCRIPTION
This is a follow-up work to #3926 where we changed how leader election is done for `cainjector` , see the comment [here](https://github.com/jetstack/cert-manager/pull/3926#issuecomment-842187486) and #4013 .

This PR changes the lock used for `controller`'s leader election from `ConfigMap`s to a  [ConfigMapsLeasesResourceLock](https://github.com/kubernetes/client-go/blob/master/tools/leaderelection/resourcelock/interface.go#L38) [Multilock](https://github.com/kubernetes/client-go/blob/master/tools/leaderelection/resourcelock/multilock.go#L32) so that leader election is done in the same way for both `controller` and `cainjector`.


From user's perspective, the difference will be the new `Lease`s object created in the leader election namespace. This is not a breaking change.

We already modified `controller`'s RBAC to allow it to access `Lease` objects in #3926 see [this commit](https://github.com/jetstack/cert-manager/pull/3926/commits/6eb8ca3d07766dbfcea71be284c7f3dc64d4edad).

I have manually tested this change with a `cert-manager` deployment with 3 controller instances. I tested upgrade from `v1.3.1` -> this version as well as upgrade from to this version followed by a downgrade, followed by an upgrade again and checked that the leader identities in the `ConfigMap` and `Lease` are as expected.
We don't test with multiple replicas in CI (I think).



 fixes #4013 

```release-note
cert-manager controller now uses ConfigMapsLeasesResourceLock for leader election.
```

Signed-off-by: irbekrm <irbekrm@gmail.com>

/kind cleanup