### PR TITLE
bug: Don't sort json patch operations

### DIFF
--- a/pkg/internal/api/mutation/registry.go
+++ b/pkg/internal/api/mutation/registry.go
@@ -29,7 +29,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"sort"
 
 	"gomodules.xyz/jsonpatch/v2"
 	admissionv1 "k8s.io/api/admission/v1"
@@ -212,20 +211,12 @@ func (r *Registry) createMutatePatch(req *admissionv1.AdmissionRequest, obj runt
 		return nil, fmt.Errorf("failed to set mutation patch: %s", err)
 	}
 
-	sortOps(ops)
-
 	patch, err := json.Marshal(ops)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate json patch: %s", err)
 	}
 
 	return patch, nil
-}
-
-func sortOps(ops []jsonpatch.JsonPatchOperation) {
-	sort.Slice(ops, func(i, j int) bool {
-		return ops[i].Path < ops[j].Path
-	})
 }
 
 func (r *Registry) appendMutate(gvk schema.GroupVersionKind, fn MutateFunc) {


### PR DESCRIPTION
Signed-off-by: Tamal Saha <tamal@appscode.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
json-patch operations are applied in sequence and hence should not be sorted as their meaning might change. ref: https://datatracker.ietf.org/doc/html/rfc6902#page-6

![rfc6902](https://user-images.githubusercontent.com/94814/118722897-92011080-b7e1-11eb-9b56-aa5e70626e42.png)


**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
I have not come across any specific error log but this seems logically incorrect.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
