### PR TITLE
WIP: Omit null CertificateRequest.Spec.Request when serialized to JSON

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -83,7 +83,6 @@ spec:
               description: Desired state of the CertificateRequest resource.
               type: object
               required:
-                - csr
                 - issuerRef
               properties:
                 csr:
@@ -252,7 +251,6 @@ spec:
               description: Desired state of the CertificateRequest resource.
               type: object
               required:
-                - csr
                 - issuerRef
               properties:
                 csr:
@@ -424,7 +422,6 @@ spec:
               type: object
               required:
                 - issuerRef
-                - request
               properties:
                 duration:
                   description: The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.
@@ -595,7 +592,6 @@ spec:
               type: object
               required:
                 - issuerRef
-                - request
               properties:
                 duration:
                   description: The requested 'duration' (i.e. lifetime) of the Certificate. This option may be ignored/overridden by some issuer types.

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -94,7 +94,8 @@ type CertificateRequestSpec struct {
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
 	// CA for signing.
-	Request []byte `json:"request"`
+	// +kubebuilder:validation:Required
+	Request []byte `json:"request,omitempty"`
 
 	// IsCA will request to mark the certificate as valid for certificate signing
 	// when submitting to the issuer.

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -92,7 +92,8 @@ type CertificateRequestSpec struct {
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
 	// CA for signing.
-	CSRPEM []byte `json:"csr"`
+	// +kubebuilder:validation:Required
+	CSRPEM []byte `json:"csr,omitempty"`
 
 	// IsCA will request to mark the certificate as valid for certificate signing
 	// when submitting to the issuer.

--- a/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -92,7 +92,8 @@ type CertificateRequestSpec struct {
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
 	// CA for signing.
-	CSRPEM []byte `json:"csr"`
+	// +kubebuilder:validation:Required
+	CSRPEM []byte `json:"csr,omitempty"`
 
 	// IsCA will request to mark the certificate as valid for certificate signing
 	// when submitting to the issuer.

--- a/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
@@ -93,7 +93,8 @@ type CertificateRequestSpec struct {
 
 	// The PEM-encoded x509 certificate signing request to be submitted to the
 	// CA for signing.
-	Request []byte `json:"request"`
+	// +kubebuilder:validation:Required
+	Request []byte `json:"request,omitempty"`
 
 	// IsCA will request to mark the certificate as valid for certificate signing
 	// when submitting to the issuer.


### PR DESCRIPTION
I thought it should be possible for  `CR.Spec.Request` to be a required field, whilst also allowing it to be omitted during JSON serialization, if null.

But the [`// +kubebuilder:validation:Required` annotation](https://book.kubebuilder.io/reference/markers/crd-validation.html) seems to be ignored if the field is also marked `omitempty`, as reported in https://github.com/kubernetes-sigs/controller-tools/issues/479

And in [Optional vs. Required](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#optional-vs-required) says:
> Required fields have the opposite properties, namely:
> 
>     They do not have an +optional comment tag.
>     They do not have an omitempty struct tag.
>     They are not a pointer type in the Go definition (e.g. AnotherFlag SomeFlag).
>     The API server should not allow POSTing or PUTing a resource with this field unset.
> 

This arose while reviewing https://github.com/jetstack/cert-manager/pull/4018#pullrequestreview-662955398 where @tamalsaha


```release-note
NONE
```
