### PR TITLE
Update to kind 0.11.0/K8s 1.21

### DIFF
--- a/devel/cluster/config/v1beta2.yaml
+++ b/devel/cluster/config/v1beta2.yaml
@@ -3,7 +3,7 @@
 # we do this because we need a fixed/predictable clusterIP of 10.0.0.15 for the
 # nginx-ingress service, in order to perform HTTP01 validations during tests.
 
-apiVersion: kind.sigs.k8s.io/v1alpha3
+apiVersion: kind.x-k8s.io/v1alpha4
 kind: Cluster
 kubeadmConfigPatches:
   - |

--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -45,6 +45,8 @@ elif [[ "$K8S_VERSION" =~ 1\.19 ]] ; then
   KIND_IMAGE_SHA="sha256:6a6e4d588db3c2873652f382465eeadc2644562a64659a1da4db73d3beaa8848"
 elif [[ "$K8S_VERSION" =~ 1\.20 ]] ; then
   KIND_IMAGE_SHA="sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040"
+elif [[ "$K8S_VERSION" =~ 1\.21 ]] ; then
+  KIND_IMAGE_SHA="sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad"
 else
   echo "Unrecognised Kubernetes version '${K8S_VERSION}'! Aborting..."
   exit 1

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -24,8 +24,8 @@ export REPO_ROOT="$LIB_ROOT/../.."
 export SKIP_BUILD_ADDON_IMAGES="${SKIP_BUILD_ADDON_IMAGES:-}"
 export KIND_CLUSTER_NAME="${KIND_CLUSTER_NAME:-kind}"
 export KIND_IMAGE_REPO="kindest/node"
-# Default Kubernetes version to use to 1.20
-export K8S_VERSION=${K8S_VERSION:-1.20}
+# Default Kubernetes version to use to 1.21
+export K8S_VERSION=${K8S_VERSION:-1.21}
 # Default OpenShift version to use to 3.11
 export OPENSHIFT_VERSION=${OPENSHIFT_VERSION:-"3.11"}
 export SERVICE_IP_PREFIX="${SERVICE_IP_PREFIX:-10.0.0}"

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -256,14 +256,14 @@ def install_kind():
     http_file(
         name = "kind_darwin",
         executable = 1,
-        sha256 = "cdd8dfe7dff764429badcd636179b0e3eb937640cfe56749dd9b8f9c048cb7db",
-        urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-darwin-amd64"],
+        sha256 = "930bd1d7c7e6ec9e0130f58930b9265c41e362073b7f8746c518c346cdbdac2e",
+        urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.11.0/kind-darwin-amd64"],
     )
 
     http_file(
         name = "kind_linux",
         executable = 1,
-        sha256 = "781c3db479b805d161b7c2c7a31896d1a504b583ebfcce8fcd49538c684d96bc",
-        urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.8.1/kind-linux-amd64"],
+        sha256 = "e778b00f75c2c902c41ea5dceb23bbb9a5ad7274cfc1b3f7e0e2da881f4f7fd6",
+        urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.11.0/kind-linux-amd64"],
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This enables e2e tests to be run on k8s 1.21

**Release note**:
```release-note
NONE
```
