### PR TITLE
renewBefore = min(renewBefore, actualDuration/3)

### DIFF
--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -287,7 +287,7 @@ func RenewBeforeExpiryDuration(notBefore, notAfter time.Time, specRenewBefore *m
 		renewBefore = specRenewBefore.Duration
 	}
 	actualDuration := notAfter.Sub(notBefore)
-	if renewBefore >= actualDuration {
+	if renewBefore >= actualDuration / 3 {
 		renewBefore = actualDuration / 3
 	}
 	return renewBefore


### PR DESCRIPTION
This addresses issue #3897 

renewBefore is calculated as min(TTL/3, 30d).

The former code would use the fixed renewBefore of 30d even if TTL is much less than 90d (would have renewed daily for TTL=31d), and create a loop when TTL == 30d.