### PR TITLE
e2e Vault intermediate CA optionally configured with root

### DIFF
--- a/test/e2e/framework/addon/vault/setup.go
+++ b/test/e2e/framework/addon/vault/setup.go
@@ -301,6 +301,8 @@ func (v *VaultInitializer) generateRootCert() (string, error) {
 		"common_name":          "Root CA",
 		"ttl":                  "87600h",
 		"exclude_cn_from_sans": "true",
+		"key_type":             "ec",
+		"key_bits":             "256",
 	}
 	url := path.Join("/v1", v.RootMount, "root", "generate", "internal")
 
@@ -317,6 +319,8 @@ func (v *VaultInitializer) generateIntermediateSigningReq() (string, error) {
 		"common_name":          "Intermediate CA",
 		"ttl":                  "43800h",
 		"exclude_cn_from_sans": "true",
+		"key_type":             "ec",
+		"key_bits":             "256",
 	}
 	url := path.Join("/v1", v.IntermediateMount, "intermediate", "generate", "internal")
 


### PR DESCRIPTION
This PR modifies the setup of the Vault intermediate CA used in e2e tests so that it can be optionally configured with a root CA cert (not just the intermediate) and changes Vault issuer's e2e tests to run with both configurations (and verify that the `ca.crt` contains the root if that is expected).

Note: this is a very simple fix. I started refactoring the e2e tests so that it is easier to add new config options as well as the setup of the addons, but perhaps that could be done after the `v1.4` release.

Fixes #3894 
/kind cleanup