### PR TITLE
Add Houssem to security advisory readers list

### DIFF
--- a/SECURITY_CONTACTS.md
+++ b/SECURITY_CONTACTS.md
@@ -14,3 +14,4 @@ SECURITY.md and report your vulnerability via e-mail.
 - [maelvls](https://github.com/maelvls)
 - [wallrj](https://github.com/wallrj)
 - [munnerz](https://github.com/munnerz)
+- [SpectralHiss](https://github.com/SpectralHiss)


### PR DESCRIPTION
Hello,

What this PR does / why we need it:
This MR gives read access to me (Houssem El Fekih) for the security advisory list, this is to see what kind of data i can get from it, in the view of making a CVE aggregation utility on common projects clients would use.

I might later have to add a bot user email, would it be ok to do the same process for the functional user email in that case?
for now this will be enough to explore the data and develop a solution.

Thanks!