### PR TITLE
Static Analysis Fixes from Static Analysis Party

### DIFF
--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -18,9 +18,7 @@ package acmeorders
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"hash/fnv"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -79,21 +77,6 @@ func buildChallenge(ctx context.Context, cl acmecl.Interface, issuer cmapi.Gener
 		},
 		Spec: *chSpec,
 	}, nil
-}
-
-func hashChallenge(spec cmacme.ChallengeSpec) (uint32, error) {
-	specBytes, err := json.Marshal(spec)
-	if err != nil {
-		return 0, err
-	}
-
-	hashF := fnv.New32()
-	_, err = hashF.Write(specBytes)
-	if err != nil {
-		return 0, err
-	}
-
-	return hashF.Sum32(), nil
 }
 
 func challengeSpecForAuthorization(ctx context.Context, cl acmecl.Interface, issuer cmapi.GenericIssuer, o *cmacme.Order, authz cmacme.ACMEAuthorization) (*cmacme.ChallengeSpec, error) {

--- a/pkg/controller/certificaterequests/approver/approver.go
+++ b/pkg/controller/certificaterequests/approver/approver.go
@@ -69,7 +69,7 @@ func (c *Controller) Register(ctx *controllerpkg.Context) (workqueue.RateLimitin
 	c.queue = workqueue.NewNamedRateLimitingQueue(controllerpkg.DefaultItemBasedRateLimiter(), ControllerName)
 
 	certificateRequestInformer := ctx.SharedInformerFactory.Certmanager().V1().CertificateRequests()
-	mustSync := append([]cache.InformerSynced{certificateRequestInformer.Informer().HasSynced})
+	mustSync := []cache.InformerSynced{certificateRequestInformer.Informer().HasSynced}
 	certificateRequestInformer.Informer().AddEventHandler(&controllerpkg.QueuingEventHandler{Queue: c.queue})
 
 	c.certificateRequestLister = certificateRequestInformer.Lister()

--- a/pkg/controller/certificaterequests/vault/vault_test.go
+++ b/pkg/controller/certificaterequests/vault/vault_test.go
@@ -532,7 +532,10 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	controller := certificaterequests.New(apiutil.IssuerVault, vault)
-	controller.Register(test.builder.Context)
+	if _, _, err := controller.Register(test.builder.Context); err != nil {
+		t.Errorf("failed to register context with controller: %v", err)
+	}
+
 	test.builder.Start()
 
 	err := controller.Sync(context.Background(), test.certificateRequest)

--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -169,7 +169,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 		notBefore := metav1.NewTime(x509cert.NotBefore)
 		notAfter := metav1.NewTime(x509cert.NotAfter)
-		renewalTime := c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, crt)
+		renewBeforeHint := crt.Spec.RenewBefore
+		renewalTime := c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, renewBeforeHint)
 
 		//update Certificate's Status
 		crt.Status.NotBefore = &notBefore

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -45,7 +45,7 @@ func policyEvaluatorBuilder(c cmapi.CertificateCondition) policyEvaluatorFunc {
 
 // renewalTimeBuilder returns a fake renewalTimeFunc for ReadinessController.
 func renewalTimeBuilder(rt *metav1.Time) certificates.RenewalTimeFunc {
-	return func(notBefore, notAfter time.Time, cert *cmapi.Certificate) *metav1.Time {
+	return func(notBefore, notAfter time.Time, cert *metav1.Duration) *metav1.Time {
 		return rt
 	}
 }

--- a/pkg/controller/certificates/trigger/policies/policies.go
+++ b/pkg/controller/certificates/trigger/policies/policies.go
@@ -118,7 +118,7 @@ func SecretPublicKeysDiffer(input Input) (string, string, bool) {
 
 func SecretPrivateKeyMatchesSpec(input Input) (string, string, bool) {
 	if input.Secret.Data == nil || len(input.Secret.Data[corev1.TLSPrivateKeyKey]) == 0 {
-		return SecretMismatch, fmt.Sprintf("Existing issued Secret does not contain private key data"), true
+		return SecretMismatch, "Existing issued Secret does not contain private key data", true
 	}
 
 	pkBytes := input.Secret.Data[corev1.TLSPrivateKeyKey]

--- a/pkg/controller/certificates/trigger/policies/policies.go
+++ b/pkg/controller/certificates/trigger/policies/policies.go
@@ -213,8 +213,8 @@ func CurrentCertificateNearingExpiry(c clock.Clock, defaultRenewBeforeExpiryDura
 		notBefore := metav1.NewTime(x509cert.NotBefore)
 		notAfter := metav1.NewTime(x509cert.NotAfter)
 		crt := input.Certificate
-		renewBefore := certificates.RenewBeforeExpiryDuration(notBefore.Time, notAfter.Time, crt.Spec.RenewBefore, defaultRenewBeforeExpiryDuration)
-		renewalTime := metav1.NewTime(notAfter.Add(-1 * renewBefore))
+		renewalTimeCalculator := certificates.RenewalTimeWrapper(defaultRenewBeforeExpiryDuration)
+		renewalTime := renewalTimeCalculator(notBefore.Time, notAfter.Time, crt.Spec.RenewBefore)
 
 		renewIn := renewalTime.Time.Sub(c.Now())
 		if renewIn > 0 {

--- a/pkg/controller/certificates/trigger/policies/policies.go
+++ b/pkg/controller/certificates/trigger/policies/policies.go
@@ -54,7 +54,7 @@ type Input struct {
 // in the 'reason' and 'message' return parameters if so.
 type Func func(Input) (reason, message string, reissue bool)
 
-// A chain of PolicyFuncs to be evaluated in order.
+// A Chain of PolicyFuncs to be evaluated in order.
 type Chain []Func
 
 // Evaluate will evaluate the entire policy chain using the provided input.

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -265,30 +265,27 @@ func GenerateLocallySignedTemporaryCertificate(crt *cmapi.Certificate, pkData []
 	return b, nil
 }
 
-//RenewalTimeFunc is a custom function type for calculating renewal time of a certificate
-type RenewalTimeFunc func(time.Time, time.Time, *cmapi.Certificate) *metav1.Time
+//RenewalTimeFunc is a custom function type for calculating renewal time of a certificate.
+type RenewalTimeFunc func(time.Time, time.Time, *metav1.Duration) *metav1.Time
 
 // RenewalTimeWrapper returns RenewalTimeFunc implementation
-// TODO: potentially merge RenewBeforeExpiryDuration into this function and rewrite the tests accordingly
 func RenewalTimeWrapper(defaultRenewBeforeExpiryDuration time.Duration) RenewalTimeFunc {
-	return func(notBefore, notAfter time.Time, cert *cmapi.Certificate) *metav1.Time {
-		renewBefore := RenewBeforeExpiryDuration(notBefore, notAfter, cert.Spec.RenewBefore, defaultRenewBeforeExpiryDuration)
+	return func(notBefore, notAfter time.Time, renewBeforeHint *metav1.Duration) *metav1.Time {
+
+		// 1. Calculate how long before expiry a cert should be renewed
+		renewBefore := defaultRenewBeforeExpiryDuration
+		if renewBeforeHint != nil {
+			renewBefore = renewBeforeHint.Duration
+		}
+		actualDuration := notAfter.Sub(notBefore)
+		// renewBefore = min(renewBefore, actualDuration/3)
+		if renewBefore >= (actualDuration / 3) {
+			renewBefore = actualDuration / 3
+		}
+
+		// 2. Calculate when a cert should be renewed
 		rt := metav1.NewTime(notAfter.Add(-1 * renewBefore))
 		return &rt
 	}
 
-}
-
-// RenewBeforeExpiryDuration will return the amount of time before the given
-// NotAfter time that the certificate should be renewed.
-func RenewBeforeExpiryDuration(notBefore, notAfter time.Time, specRenewBefore *metav1.Duration, defaultRenewBeforeExpiryDuration time.Duration) time.Duration {
-	renewBefore := defaultRenewBeforeExpiryDuration
-	if specRenewBefore != nil {
-		renewBefore = specRenewBefore.Duration
-	}
-	actualDuration := notAfter.Sub(notBefore)
-	if renewBefore >= actualDuration {
-		renewBefore = actualDuration / 3
-	}
-	return renewBefore
 }

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -282,67 +282,82 @@ func selfSignCertificate(t *testing.T, spec cmapi.CertificateSpec) []byte {
 	return pemData
 }
 
-func TestRenewBeforeExpiryDuration(t *testing.T) {
-	type testCase struct {
-		notBefore                        time.Time
-		notAfter                         time.Time
-		specRenewBefore                  *metav1.Duration
-		defaultRenewBeforeExpiryDuration time.Duration
-		expected                         time.Duration
+func TestRenewalTimeWrapper(t *testing.T) {
+	type scenario struct {
+		notBefore           time.Time
+		notAfter            time.Time
+		renewBeforeHint     *metav1.Duration
+		defaultRenewBefore  time.Duration
+		expectedRenewalTime *metav1.Time
 	}
 	now := time.Now()
-	tests := map[string]testCase{
-		"use default": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  nil,
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour,
+	tests := map[string]scenario{
+		"no renewBeforeHint, defaultRenewBefore < (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 23)},
 		},
-		"spec overrides default": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  &metav1.Duration{Duration: time.Hour * 2},
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour * 2,
+		"renewBeforeHint < (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     &metav1.Duration{Duration: time.Hour * 2},
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 22)},
 		},
-		"default larger than actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  nil,
-			defaultRenewBeforeExpiryDuration: time.Hour * 24 * 7,
-			expected:                         time.Hour * 8,
+		"no renewBeforeHint, defaultRenewBefore > (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour * 24 * 7,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
-		"spec larger than actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  &metav1.Duration{Duration: time.Hour * 24 * 7},
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour * 8,
+		"renewBeforeHint > (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     &metav1.Duration{Duration: time.Hour * 24 * 7},
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
-		"default equal to actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  nil,
-			defaultRenewBeforeExpiryDuration: time.Hour * 24,
-			expected:                         time.Hour * 8,
+		"no renewBeforeHint, defaultRenewBefore == cert duration": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour * 24,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
-		"spec equal to actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  &metav1.Duration{Duration: time.Hour * 24},
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour * 8,
+		"renewBeforeHint == cert duration": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     &metav1.Duration{Duration: time.Hour * 24},
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
+		},
+
+		// The following two test cases would catch the bug reported in
+		// https://github.com/jetstack/cert-manager/issues/3897
+		"cert duration very slightly less than defaultRenewBefore": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour*24 + time.Minute,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
+		},
+		"cert duration very slightly less than renewBeforeHint": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour*24 + time.Minute,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
 	}
+	for n, s := range tests {
+		t.Run(n, func(t *testing.T) {
+			f := RenewalTimeWrapper(s.defaultRenewBefore)
+			renewalTime := f(s.notBefore, s.notAfter, s.renewBeforeHint)
+			assert.Equal(t, s.expectedRenewalTime, renewalTime)
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(
-				t,
-				tc.expected,
-				RenewBeforeExpiryDuration(tc.notBefore, tc.notAfter, tc.specRenewBefore, tc.defaultRenewBeforeExpiryDuration),
-			)
 		})
 	}
 }

--- a/pkg/controller/clusterissuers/sync_test.go
+++ b/pkg/controller/clusterissuers/sync_test.go
@@ -52,7 +52,10 @@ func TestUpdateIssuerStatus(t *testing.T) {
 	defer b.Stop()
 
 	c := &controller{}
-	c.Register(b.Context)
+	if _, _, err := c.Register(b.Context); err != nil {
+		t.Errorf("failed to register context against controller: %v", err)
+		return
+	}
 	b.Start()
 
 	fakeClient := b.FakeCMClient()

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -298,7 +298,7 @@ func setIssuerSpecificConfig(crt *cmapi.Certificate, ing *networkingv1beta1.Ingr
 	}
 
 	// for ACME issuers
-	editInPlaceVal, _ := ingAnnotations[cmacme.IngressEditInPlaceAnnotationKey]
+	editInPlaceVal := ingAnnotations[cmacme.IngressEditInPlaceAnnotationKey]
 	editInPlace := editInPlaceVal == "true"
 	if editInPlace {
 		if crt.Annotations == nil {

--- a/pkg/controller/ingress-shim/sync.go
+++ b/pkg/controller/ingress-shim/sync.go
@@ -33,7 +33,6 @@ import (
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"github.com/jetstack/cert-manager/pkg/logs"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 )
@@ -143,7 +142,7 @@ func validateIngressTLSBlock(tlsBlock networkingv1beta1.IngressTLS) []error {
 
 func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1beta1.Ingress,
 	issuerName, issuerKind, issuerGroup string) (new, update []*cmapi.Certificate, _ error) {
-	log := logs.FromContext(ctx)
+	log := logf.FromContext(ctx)
 
 	var newCrts []*cmapi.Certificate
 	var updateCrts []*cmapi.Certificate
@@ -187,7 +186,7 @@ func (c *controller) buildCertificates(ctx context.Context, ing *networkingv1bet
 		// check if a Certificate for this TLS entry already exists, and if it
 		// does then skip this entry
 		if existingCrt != nil {
-			log := logs.WithRelatedResource(log, existingCrt)
+			log := logf.WithRelatedResource(log, existingCrt)
 			log.V(logf.DebugLevel).Info("certificate already exists for ingress resource, ensuring it is up to date")
 
 			if metav1.GetControllerOf(existingCrt) == nil {

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -45,8 +45,8 @@ import (
 
 func init() {
 	logs.InitLogs(nil)
-	flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
-	flag.Lookup("v").Value.Set("4")
+	_ = flag.Set("alsologtostderr", fmt.Sprintf("%t", true))
+	_ = flag.Lookup("v").Value.Set("4")
 }
 
 // Builder is a structure used to construct new Contexts for use during tests.

--- a/pkg/ctl/scheme.go
+++ b/pkg/ctl/scheme.go
@@ -58,13 +58,13 @@ func init() {
 	utilruntime.Must(metainternalversion.AddToScheme(Scheme))
 
 	// Adds the conversion between internalmeta.List and corev1.List
-	Scheme.AddConversionFunc((*corev1.List)(nil), (*metainternalversion.List)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	_ = Scheme.AddConversionFunc((*corev1.List)(nil), (*metainternalversion.List)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		metaList := &metav1.List{}
 		metaList.Items = a.(*corev1.List).Items
 		return metainternalversion.Convert_v1_List_To_internalversion_List(metaList, b.(*metainternalversion.List), scope)
 	})
 
-	Scheme.AddConversionFunc((*metainternalversion.List)(nil), (*corev1.List)(nil), func(a, b interface{}, scope conversion.Scope) error {
+	_ = Scheme.AddConversionFunc((*metainternalversion.List)(nil), (*corev1.List)(nil), func(a, b interface{}, scope conversion.Scope) error {
 		metaList := &metav1.List{}
 		err := metainternalversion.Convert_internalversion_List_To_v1_List(a.(*metainternalversion.List), metaList, scope)
 		if err != nil {

--- a/pkg/ctl/scheme.go
+++ b/pkg/ctl/scheme.go
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// This package was created to have a scheme that has the internal cert-manager types,
+// Package ctl was created to have a scheme that has the internal cert-manager types,
 // and their conversion functions as well as the List object type registered, which is needed for ctl command like
 // `convert` or `create certificaterequest`.
+
 package ctl
 
 import (

--- a/pkg/internal/apis/certmanager/validation/certificate_for_issuer_test.go
+++ b/pkg/internal/apis/certmanager/validation/certificate_for_issuer_test.go
@@ -31,7 +31,6 @@ import (
 
 const (
 	defaultTestIssuerName = "test-issuer"
-	defaultTestCrtName    = "test-crt"
 	defaultTestNamespace  = gen.DefaultTestNamespace
 )
 

--- a/pkg/issuer/acme/dns/acmedns/acmedns.go
+++ b/pkg/issuer/acme/dns/acmedns/acmedns.go
@@ -40,19 +40,19 @@ type DNSProvider struct {
 // Credentials and acme-dns server host are given in environment variables
 func NewDNSProvider(dns01Nameservers []string) (*DNSProvider, error) {
 	host := os.Getenv("ACME_DNS_HOST")
-	accountJson := os.Getenv("ACME_DNS_ACCOUNT_JSON")
-	return NewDNSProviderHostBytes(host, []byte(accountJson), dns01Nameservers)
+	accountJSON := os.Getenv("ACME_DNS_ACCOUNT_JSON")
+	return NewDNSProviderHostBytes(host, []byte(accountJSON), dns01Nameservers)
 }
 
 // NewDNSProviderHostBytes returns a DNSProvider instance configured for ACME DNS
 // acme-dns server host is given in a string
 // credentials are stored in json in the given string
-func NewDNSProviderHostBytes(host string, accountJson []byte, dns01Nameservers []string) (*DNSProvider, error) {
+func NewDNSProviderHostBytes(host string, accountJSON []byte, dns01Nameservers []string) (*DNSProvider, error) {
 	client := goacmedns.NewClient(host)
 
 	var accounts map[string]goacmedns.Account
-	if err := json.Unmarshal(accountJson, &accounts); err != nil {
-		return nil, fmt.Errorf("Error unmarshalling accountJson: %s", err)
+	if err := json.Unmarshal(accountJSON, &accounts); err != nil {
+		return nil, fmt.Errorf("Error unmarshalling accountJSON: %s", err)
 	}
 
 	return &DNSProvider{

--- a/pkg/issuer/acme/dns/rfc2136/provider_test.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider_test.go
@@ -39,7 +39,11 @@ func TestRunSuiteWithTSIG(t *testing.T) {
 	if err := server.Run(ctx); err != nil {
 		t.Fatalf("failed to start test server: %v", err)
 	}
-	defer server.Shutdown()
+	defer func() {
+		if err := server.Shutdown(); err != nil {
+			t.Errorf("failed to gracefully shut down test server: %v", err)
+		}
+	}()
 
 	var validConfig = cmacme.ACMEIssuerDNS01ProviderRFC2136{
 		Nameserver: server.ListenAddr(),
@@ -74,7 +78,11 @@ func TestRunSuiteNoTSIG(t *testing.T) {
 	if err := server.Run(ctx); err != nil {
 		t.Fatalf("failed to start test server: %v", err)
 	}
-	defer server.Shutdown()
+	defer func() {
+		if err := server.Shutdown(); err != nil {
+			t.Errorf("failed to gracefully shut down test server: %v", err)
+		}
+	}()
 
 	var validConfig = cmacme.ACMEIssuerDNS01ProviderRFC2136{
 		Nameserver: server.ListenAddr(),

--- a/pkg/issuer/vault/setup.go
+++ b/pkg/issuer/vault/setup.go
@@ -34,7 +34,6 @@ const (
 	errorVault = "VaultError"
 
 	messageVaultClientInitFailed         = "Failed to initialize Vault client: "
-	messageVaultHealthCheckFailed        = "Failed to call Vault health check: "
 	messageVaultStatusVerificationFailed = "Vault is not initialized or is sealed"
 	messageVaultConfigRequired           = "Vault config cannot be empty"
 	messageServerAndPathRequired         = "Vault server and path are required fields"

--- a/pkg/issuer/venafi/client/request.go
+++ b/pkg/issuer/venafi/client/request.go
@@ -140,7 +140,6 @@ func convertCustomFieldsToVcert(customFields []api.CustomField) ([]certificate.C
 			switch field.Type {
 			case api.CustomFieldTypePlain, "":
 				fieldType = certificate.CustomFieldPlain
-				break
 			default:
 				return nil, ErrCustomFieldsType{Type: field.Type}
 			}

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -65,7 +65,7 @@ func InitLogs(fs *flag.FlagSet) {
 		fs = flag.CommandLine
 	}
 	klog.InitFlags(fs)
-	fs.Set("logtostderr", "true")
+	_ = fs.Set("logtostderr", "true")
 
 	log.SetOutput(GlogWriter{})
 	log.SetFlags(0)

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime/serializer/json:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/runtime:go_default_library",
         "@io_k8s_component_base//cli/flag:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
     ],


### PR DESCRIPTION
**What this PR does / why we need it**: Fixes arising from https://github.com/cert-manager/website/issues/538 - mostly low-hanging-fruit changes and not relating to doc comments.

/kind cleanup

```release-note
Panic when failing to register schemes during initialization for pkg/webhook/server
Various static analysis fixes across many files including removing unused or redundant code
```
