### PR TITLE
Update old references to replaced/obsolete email addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -34,7 +34,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at hello@jetstack.io or james@jetstack.io. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at cert-manager-maintainers@googlegroups.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -14,5 +14,5 @@ keywords:
 sources:
   - https://github.com/jetstack/cert-manager
 maintainers:
-  - name: munnerz
-    email: james@jetstack.io
+  - name: cert-manager-maintainers
+    email: cert-manager-maintainers@googlegroups.com


### PR DESCRIPTION
**What this PR does / why we need it**: This changes old email addresses to use a new, non-Jetstack, `cert-manager-maintainers@googlegroups.com` point of contact. See #4025 

/release-note-none
/kind cleanup
/priority important-soon
/milestone v1.4