### PR TITLE
Update distroless/static base images to latest version

### DIFF
--- a/build/images.bzl
+++ b/build/images.bzl
@@ -15,11 +15,14 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 def define_base_images():
-    ## Use 'static' distroless image for all builds
+    # Use 'static' distroless image for all builds
+    # To get the latest-amd64 digest for gcr.io/distroless/static, assuming
+    # that $GOPATH/bin is in your $PATH, run:
+    # go get github.com/genuinetools/reg && reg digest gcr.io/distroless/static:latest-amd64
     container_pull(
         name = "static_base",
         registry = "gcr.io",
         repository = "distroless/static",
-        digest = "sha256:359e0c5c9a1364d82f567db01e1419dead4dfc04d33271248f9c713007d0c22e",
+        digest = "sha256:a7752b29b18bb106938caefd8dcce8a94199022cbd06ea42268b968f35e837a8",
     )
 


### PR DESCRIPTION
**What this PR does / why we need it**: Updates distroless/static base images used to build cert-manager containers to the latest version. Also adds a comment explaining how to retrieve the latest version, to make this easier in the future and potentially for when we automate this in the future.

Sort-of arises from #4033 

This could also arguably be backported into new releases of v1.2 and v1.3 as our current supported versions, but I don't think that's required.

```release-note
Updates distroless/static base image to latest version as of 2021-05-20
```
