### PR TITLE
Handle cert renewal correctly

### DIFF
--- a/pkg/controller/certificates/readiness/readiness_controller.go
+++ b/pkg/controller/certificates/readiness/readiness_controller.go
@@ -169,7 +169,8 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 
 		notBefore := metav1.NewTime(x509cert.NotBefore)
 		notAfter := metav1.NewTime(x509cert.NotAfter)
-		renewalTime := c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, crt)
+		renewBeforeHint := crt.Spec.RenewBefore
+		renewalTime := c.renewalTimeCalculator(x509cert.NotBefore, x509cert.NotAfter, renewBeforeHint)
 
 		//update Certificate's Status
 		crt.Status.NotBefore = &notBefore

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -45,7 +45,7 @@ func policyEvaluatorBuilder(c cmapi.CertificateCondition) policyEvaluatorFunc {
 
 // renewalTimeBuilder returns a fake renewalTimeFunc for ReadinessController.
 func renewalTimeBuilder(rt *metav1.Time) certificates.RenewalTimeFunc {
-	return func(notBefore, notAfter time.Time, cert *cmapi.Certificate) *metav1.Time {
+	return func(notBefore, notAfter time.Time, cert *metav1.Duration) *metav1.Time {
 		return rt
 	}
 }

--- a/pkg/controller/certificates/trigger/policies/policies.go
+++ b/pkg/controller/certificates/trigger/policies/policies.go
@@ -213,8 +213,8 @@ func CurrentCertificateNearingExpiry(c clock.Clock, defaultRenewBeforeExpiryDura
 		notBefore := metav1.NewTime(x509cert.NotBefore)
 		notAfter := metav1.NewTime(x509cert.NotAfter)
 		crt := input.Certificate
-		renewBefore := certificates.RenewBeforeExpiryDuration(notBefore.Time, notAfter.Time, crt.Spec.RenewBefore, defaultRenewBeforeExpiryDuration)
-		renewalTime := metav1.NewTime(notAfter.Add(-1 * renewBefore))
+		renewalTimeCalculator := certificates.RenewalTimeWrapper(defaultRenewBeforeExpiryDuration)
+		renewalTime := renewalTimeCalculator(notBefore.Time, notAfter.Time, crt.Spec.RenewBefore)
 
 		renewIn := renewalTime.Time.Sub(c.Now())
 		if renewIn > 0 {

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -265,30 +265,27 @@ func GenerateLocallySignedTemporaryCertificate(crt *cmapi.Certificate, pkData []
 	return b, nil
 }
 
-//RenewalTimeFunc is a custom function type for calculating renewal time of a certificate
-type RenewalTimeFunc func(time.Time, time.Time, *cmapi.Certificate) *metav1.Time
+//RenewalTimeFunc is a custom function type for calculating renewal time of a certificate.
+type RenewalTimeFunc func(time.Time, time.Time, *metav1.Duration) *metav1.Time
 
 // RenewalTimeWrapper returns RenewalTimeFunc implementation
-// TODO: potentially merge RenewBeforeExpiryDuration into this function and rewrite the tests accordingly
 func RenewalTimeWrapper(defaultRenewBeforeExpiryDuration time.Duration) RenewalTimeFunc {
-	return func(notBefore, notAfter time.Time, cert *cmapi.Certificate) *metav1.Time {
-		renewBefore := RenewBeforeExpiryDuration(notBefore, notAfter, cert.Spec.RenewBefore, defaultRenewBeforeExpiryDuration)
+	return func(notBefore, notAfter time.Time, renewBeforeHint *metav1.Duration) *metav1.Time {
+
+		// 1. Calculate how long before expiry a cert should be renewed
+		renewBefore := defaultRenewBeforeExpiryDuration
+		if renewBeforeHint != nil {
+			renewBefore = renewBeforeHint.Duration
+		}
+		actualDuration := notAfter.Sub(notBefore)
+		// renewBefore = min(renewBefore, actualDuration/3)
+		if renewBefore >= (actualDuration / 3) {
+			renewBefore = actualDuration / 3
+		}
+
+		// 2. Calculate when a cert should be renewed
 		rt := metav1.NewTime(notAfter.Add(-1 * renewBefore))
 		return &rt
 	}
 
-}
-
-// RenewBeforeExpiryDuration will return the amount of time before the given
-// NotAfter time that the certificate should be renewed.
-func RenewBeforeExpiryDuration(notBefore, notAfter time.Time, specRenewBefore *metav1.Duration, defaultRenewBeforeExpiryDuration time.Duration) time.Duration {
-	renewBefore := defaultRenewBeforeExpiryDuration
-	if specRenewBefore != nil {
-		renewBefore = specRenewBefore.Duration
-	}
-	actualDuration := notAfter.Sub(notBefore)
-	if renewBefore >= actualDuration {
-		renewBefore = actualDuration / 3
-	}
-	return renewBefore
 }

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -282,67 +282,82 @@ func selfSignCertificate(t *testing.T, spec cmapi.CertificateSpec) []byte {
 	return pemData
 }
 
-func TestRenewBeforeExpiryDuration(t *testing.T) {
-	type testCase struct {
-		notBefore                        time.Time
-		notAfter                         time.Time
-		specRenewBefore                  *metav1.Duration
-		defaultRenewBeforeExpiryDuration time.Duration
-		expected                         time.Duration
+func TestRenewalTimeWrapper(t *testing.T) {
+	type scenario struct {
+		notBefore           time.Time
+		notAfter            time.Time
+		renewBeforeHint     *metav1.Duration
+		defaultRenewBefore  time.Duration
+		expectedRenewalTime *metav1.Time
 	}
 	now := time.Now()
-	tests := map[string]testCase{
-		"use default": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  nil,
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour,
+	tests := map[string]scenario{
+		"no renewBeforeHint, defaultRenewBefore < (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 23)},
 		},
-		"spec overrides default": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  &metav1.Duration{Duration: time.Hour * 2},
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour * 2,
+		"renewBeforeHint < (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     &metav1.Duration{Duration: time.Hour * 2},
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 22)},
 		},
-		"default larger than actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  nil,
-			defaultRenewBeforeExpiryDuration: time.Hour * 24 * 7,
-			expected:                         time.Hour * 8,
+		"no renewBeforeHint, defaultRenewBefore > (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour * 24 * 7,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
-		"spec larger than actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  &metav1.Duration{Duration: time.Hour * 24 * 7},
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour * 8,
+		"renewBeforeHint > (cert duration / 3)": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     &metav1.Duration{Duration: time.Hour * 24 * 7},
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
-		"default equal to actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  nil,
-			defaultRenewBeforeExpiryDuration: time.Hour * 24,
-			expected:                         time.Hour * 8,
+		"no renewBeforeHint, defaultRenewBefore == cert duration": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour * 24,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
-		"spec equal to actual duration": {
-			notBefore:                        now,
-			notAfter:                         now.Add(time.Hour * 24),
-			specRenewBefore:                  &metav1.Duration{Duration: time.Hour * 24},
-			defaultRenewBeforeExpiryDuration: time.Hour,
-			expected:                         time.Hour * 8,
+		"renewBeforeHint == cert duration": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     &metav1.Duration{Duration: time.Hour * 24},
+			defaultRenewBefore:  time.Hour,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
+		},
+
+		// The following two test cases would catch the bug reported in
+		// https://github.com/jetstack/cert-manager/issues/3897
+		"cert duration very slightly less than defaultRenewBefore": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour*24 + time.Minute,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
+		},
+		"cert duration very slightly less than renewBeforeHint": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24),
+			renewBeforeHint:     nil,
+			defaultRenewBefore:  time.Hour*24 + time.Minute,
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16)},
 		},
 	}
+	for n, s := range tests {
+		t.Run(n, func(t *testing.T) {
+			f := RenewalTimeWrapper(s.defaultRenewBefore)
+			renewalTime := f(s.notBefore, s.notAfter, s.renewBeforeHint)
+			assert.Equal(t, s.expectedRenewalTime, renewalTime)
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
-			assert.Equal(
-				t,
-				tc.expected,
-				RenewBeforeExpiryDuration(tc.notBefore, tc.notAfter, tc.specRenewBefore, tc.defaultRenewBeforeExpiryDuration),
-			)
 		})
 	}
 }


### PR DESCRIPTION
See #3897 for context.

This PR changes cert's renewBefore period to be calculated as `min(renewBefore, cert duration / 3)` where `renewBefore` is either `cert.spec.renewBefore` or 30d.

It fixes a bug, where when cert's duration is very slightly longer than the `renewBefore` period, we enter a renewal loop.
This has so far hit a number of Vault issuer's users.

**The bug:**

See the below section of cert status:

```
nextPrivateKeySecretName: example-com-l2g4c
  notAfter: "2021-06-06T09:06:50Z"
  notBefore: "2021-05-07T09:06:20Z"
  renewalTime: "2021-05-07T09:06:50Z"
  revision: 185
```

See [these functions](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/util.go#L273-L294) where we calculate renewal time.

This cert has `defaultRenewBefore`=30d, `actualDuration`=30d30s, which means that we return `30d` as the `renewBefore` time [here](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/util.go#L293).
We then calculate renewal time [here](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/util.go#L276). 
In this case the renewal time it will be `cert.spec.NotAfter - 30d` resulting in renewal time `30s` from now and we start renewing every `30s` (when I tested this, every cert issued by Vault had the duration with the extra `30s`).

This particular case would have also been solved by rounding up the cert duration, but it still seems like `min(renewBefore, cert duration / 3)` is a more sane formula.



```release-note
Fixes cert renewal bug for Vault certificates with duration close to renewBefore period. Thanks to @andreas-p for raising the issue.
```

This PR is based on #4031 , but also refactors the renewal functionality so that these kind of bugs can be more easily spotted in future. I have added two test cases for these error cases and tested with an actual Vault instance.
Fixes #3897
Signed-off-by: irbekrm <irbekrm@gmail.com>
