### PR TITLE
Add ArtifcactHUB pre-release annotation to the Helm chart

### DIFF
--- a/build/helm.bzl
+++ b/build/helm.bzl
@@ -149,7 +149,8 @@ def helm_chart_yaml(
           }
           /{PRERELEASE}/{
             gsub(/{PRERELEASE}/, pr)
-          }1
+          }
+          { print }
         ' $(location %s) > $@
         """ % (version_file, chart_yaml_template),
         **kwargs,

--- a/build/helm.bzl
+++ b/build/helm.bzl
@@ -145,10 +145,10 @@ def helm_chart_yaml(
         awk '
           BEGIN{
             getline v < "$(location %s)"
-            pr = match(v, "^v[0-9]+.[0-9]+.[0-9]+$$") == 0 ? "true" : "false"
+            pr = match(v, /^v[0-9]+\.[0-9]+\.[0-9]+$$/) == 0 ? "true" : "false"
           }
           /{PRERELEASE}/{
-            gsub("{PRERELEASE}", pr)
+            gsub(/{PRERELEASE}/, pr)
           }1
         ' $(location %s) > $@
         """ % (version_file, chart_yaml_template),

--- a/build/helm.bzl
+++ b/build/helm.bzl
@@ -128,6 +128,14 @@ def helm_chart_yaml(
     version_file = "//:version",
     **kwargs,
 ):
+    """
+    We don't want alpha and beta releases to show on ArtifactHub as releases.
+    To prevent pre-releases from appearing, we use the ArtifactHub-specific
+    annotation:
+      artifacthub.io/prerelease: "true"
+
+    See https://artifacthub.io/docs/topics/annotations/helm/
+    """
     native.genrule(
         name = name,
         srcs = [version_file, chart_yaml_template],

--- a/deploy/charts/cert-manager/BUILD.bazel
+++ b/deploy/charts/cert-manager/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
-load("//build:helm.bzl", "helm_pkg")
+load("//build:helm.bzl", "helm_chart_yaml", "helm_pkg")
 
 pkg_tar(
     name = "release-tar",
@@ -18,7 +18,7 @@ helm_pkg(
     name = "cert-manager",
     srcs = ["//deploy/charts/cert-manager/templates:chart-srcs"],
     chart_name = "cert-manager",
-    chart_yaml = ":Chart.yaml",
+    chart_yaml = ":annotated_chart_yaml",
     readme_file = ":README.md",
     tpl_files = [
         "//deploy/charts/cert-manager/templates:_helpers.tpl",
@@ -35,6 +35,12 @@ genrule(
     outs = ["README.md"],
     cmd = "cat $(location README.template.md) | sed -e \"s:{{RELEASE_VERSION}}:$$(cat $(location //:version)):g\" > $@",
     stamp = 1,
+    visibility = ["//visibility:public"],
+)
+
+helm_chart_yaml(
+    name = "annotated_chart_yaml",
+    chart_yaml_template = ":Chart.template.yaml",
     visibility = ["//visibility:public"],
 )
 

--- a/deploy/charts/cert-manager/Chart.template.yaml
+++ b/deploy/charts/cert-manager/Chart.template.yaml
@@ -16,3 +16,5 @@ sources:
 maintainers:
   - name: cert-manager-maintainers
     email: cert-manager-maintainers@googlegroups.com
+annotations:
+  artifacthub.io/prerelease: "{PRERELEASE}"


### PR DESCRIPTION
In https://github.com/jetstack/jetstack-charts/pull/15#pullrequestreview-648213790 @wallrj wrote:
> think it'd be nice to instead use the Charts.yaml annotations artifacthub.io/prerelease , so that people get to see the alphas and betas on Artifcact Hub
> 
> https://artifacthub.io/docs/topics/annotations/helm/

I hacked away at Bazel + shell script to parse the `//:version` artifact for `\d.\d.\d` to see if it is a release or a prerelease and use that to fill in in the `artifacthub.io/prerelease` annotation.

There may be a cleaner way to do this.

We're aiming to make it so that the next alpha / beta release of cert-manager doesn't show up here:
 * https://artifacthub.io/packages/helm/cert-manager/cert-manager

And when 1.4.0 is finally released, that will show up.

**Release note**:
```release-note
NONE
```

/kind cleanup