### PR TITLE
Revert "Add ArtifcactHUB pre-release annotation to the Helm chart"

### DIFF
--- a/build/helm.bzl
+++ b/build/helm.bzl
@@ -121,37 +121,3 @@ def helm_tmpl(
         tools = [helm_cmd],
         **kwargs,
     )
-
-def helm_chart_yaml(
-    name,
-    chart_yaml_template,
-    version_file = "//:version",
-    **kwargs,
-):
-    """
-    We don't want alpha and beta releases to show on ArtifactHub as releases.
-    To prevent pre-releases from appearing, we use the ArtifactHub-specific
-    annotation:
-      artifacthub.io/prerelease: "true"
-
-    See https://artifacthub.io/docs/topics/annotations/helm/
-    """
-    native.genrule(
-        name = name,
-        srcs = [version_file, chart_yaml_template],
-        stamp = 1,
-        outs = ["Chart.yaml"],
-        cmd = """
-        awk '
-          BEGIN{
-            getline v < "$(location %s)"
-            pr = match(v, /^v[0-9]+\.[0-9]+\.[0-9]+$$/) == 0 ? "true" : "false"
-          }
-          /{PRERELEASE}/{
-            gsub(/{PRERELEASE}/, pr)
-          }
-          { print }
-        ' $(location %s) > $@
-        """ % (version_file, chart_yaml_template),
-        **kwargs,
-    )

--- a/deploy/charts/cert-manager/BUILD.bazel
+++ b/deploy/charts/cert-manager/BUILD.bazel
@@ -1,7 +1,7 @@
 package(default_visibility = ["//visibility:public"])
 
 load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
-load("//build:helm.bzl", "helm_chart_yaml", "helm_pkg")
+load("//build:helm.bzl", "helm_pkg")
 
 pkg_tar(
     name = "release-tar",
@@ -18,7 +18,7 @@ helm_pkg(
     name = "cert-manager",
     srcs = ["//deploy/charts/cert-manager/templates:chart-srcs"],
     chart_name = "cert-manager",
-    chart_yaml = ":annotated_chart_yaml",
+    chart_yaml = ":Chart.yaml",
     readme_file = ":README.md",
     tpl_files = [
         "//deploy/charts/cert-manager/templates:_helpers.tpl",
@@ -35,12 +35,6 @@ genrule(
     outs = ["README.md"],
     cmd = "cat $(location README.template.md) | sed -e \"s:{{RELEASE_VERSION}}:$$(cat $(location //:version)):g\" > $@",
     stamp = 1,
-    visibility = ["//visibility:public"],
-)
-
-helm_chart_yaml(
-    name = "annotated_chart_yaml",
-    chart_yaml_template = ":Chart.template.yaml",
     visibility = ["//visibility:public"],
 )
 

--- a/deploy/charts/cert-manager/Chart.yaml
+++ b/deploy/charts/cert-manager/Chart.yaml
@@ -16,5 +16,3 @@ sources:
 maintainers:
   - name: cert-manager-maintainers
     email: cert-manager-maintainers@googlegroups.com
-annotations:
-  artifacthub.io/prerelease: "{PRERELEASE}"


### PR DESCRIPTION
Reverts jetstack/cert-manager#4049

Because the Awk script fails in some environments:


```
ERROR: /home/josh/go/src/github.com/jetstack/cert-manager/build/helm.bzl:148:37: invalid escape sequence: \.. You can enable unknown escape sequences by passing the flag --incompatible_restrict_string_escapes=false
ERROR: /home/josh/go/src/github.com/jetstack/cert-manager/build/helm.bzl:148:45: invalid escape sequence: \.. You can enable unknown escape sequences by passing the flag --incompatible_restrict_string_escapes=false

```

```release-note
NONE
```

/kind bug