### PR TITLE
Add ArtifactHUB pre-release annotations to the Helm chart

### DIFF
--- a/deploy/charts/cert-manager/BUILD.bazel
+++ b/deploy/charts/cert-manager/BUILD.bazel
@@ -38,6 +38,28 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+# We don't want alpha and beta releases to show on ArtifactHUB as releases.
+# To prevent pre-releases from appearing, we use the ArtifactHUB-specific:
+#
+#   annotation:
+#     artifacthub.io/prerelease: "true"
+#
+# See https://artifacthub.io/docs/topics/annotations/helm/
+genrule(
+    name = "chart-yaml",
+    srcs = [
+        "Chart.template.yaml",
+        "//:version",
+    ],
+    outs = ["Chart.yaml"],
+    cmd = """
+    IS_PRERELEASE=$$(grep -q '^v[0-9]\\+.[0-9]\\+.[0-9]\\+$$' $(location //:version) && echo "false" || echo "true")
+    sed -e "s:{{IS_PRERELEASE}}:$${IS_PRERELEASE}:g" < $(location Chart.template.yaml) > $@
+    """,
+    stamp = 1,
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "chart-srcs",
     srcs = ["//deploy/charts/cert-manager/templates:chart-srcs"] + glob(

--- a/deploy/charts/cert-manager/Chart.template.yaml
+++ b/deploy/charts/cert-manager/Chart.template.yaml
@@ -16,3 +16,5 @@ sources:
 maintainers:
   - name: cert-manager-maintainers
     email: cert-manager-maintainers@googlegroups.com
+annotations:
+  artifacthub.io/prerelease: "{{IS_PRERELEASE}}"


### PR DESCRIPTION
A simpler and hopefully more widely compatible version of https://github.com/jetstack/cert-manager/pull/4049 

This time I use grep and sed  with hopefully only regexp and command line options which are available on Debian / Fedora and MacOS, instead of awk, which turned out to be installed as mawk on Debian rather than gawk on Fedora.

Please test as follows:

## Without tag we expect prerelease: true

```sh
[richard@drax cert-manager]$ bazel build //deploy/charts/cert-manager:cert-manager 
INFO: Analyzed target //deploy/charts/cert-manager:cert-manager (1 packages loaded, 9 targets configured).
INFO: Found 1 target...
Target //deploy/charts/cert-manager:cert-manager up-to-date:
  bazel-bin/deploy/charts/cert-manager/cert-manager.tgz
INFO: Elapsed time: 1.170s, Critical Path: 0.68s
INFO: 7 processes: 1 internal, 6 linux-sandbox.
INFO: Build completed successfully, 7 total actions

[richard@drax cert-manager]$ helm show chart ./bazel-bin/deploy/charts/cert-manager/cert-manager.tgz 
annotations:
  artifacthub.io/prerelease: "true"
apiVersion: v1
appVersion: v1.4.0-alpha.1.112-b81dd92673148a

```

## With tag we expect prerelease: false

```sh
[richard@drax cert-manager]$ git tag v1.4.0

[richard@drax cert-manager]$ bazel build //deploy/charts/cert-manager:cert-manager 
INFO: Analyzed target //deploy/charts/cert-manager:cert-manager (1 packages loaded, 9 targets configured).
INFO: Found 1 target...
Target //deploy/charts/cert-manager:cert-manager up-to-date:
  bazel-bin/deploy/charts/cert-manager/cert-manager.tgz
INFO: Elapsed time: 1.165s, Critical Path: 0.63s
INFO: 7 processes: 1 internal, 6 linux-sandbox.
INFO: Build completed successfully, 7 total actions

[richard@drax cert-manager]$ helm show chart ./bazel-bin/deploy/charts/cert-manager/cert-manager.tgz 
annotations:
  artifacthub.io/prerelease: "false"
apiVersion: v1
appVersion: v1.4.0
...
```

## Cleanup

```sh
$ git tag v1.4.0 --delete
Deleted tag 'v1.4.0' (was b81dd9267)

```

```release-note
NONE
```
