### PR TITLE
3969 parameterize and document image building

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ images_push:
 	bazel run \
 		--stamp \
 		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+		--@io_bazel_rules_go//go/config:pure \
 		//:images.push
 
 ctl:

--- a/Makefile
+++ b/Makefile
@@ -94,6 +94,7 @@ images:
 	bazel run \
 		--stamp \
 		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+		--@io_bazel_rules_go//go/config:pure \
 		//build:server-images
 
 images_push: 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -85,10 +85,6 @@ load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
 
 pip_deps()
 
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
-)
 load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -20,10 +20,12 @@ DOCKERIZED_BINARIES = {
     },
 }
 
-# Allows passing --define image_type=dynamic custom flag to Bazel command. Used
-# to allow optionally build with the dynamic base image. This would only be used
-# by alternative/experimental cert-manager builds that, for example, need to
-# create dynamically linked binaries due to linking to a C library.
+# Allows passing --define image_type custom flag to Bazel command. Used to allow
+# optionally build with the dynamic base image. This would only be used by
+# alternative/experimental cert-manager builds that, for example, need to create
+# dynamically linked binaries due to linking to a C library.
+# Example command to build server images with dynamic base:
+# bazel run --define image_type=dynamic --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //build:server-images.
 config_setting(
     name = "dynamic_image",
     values = {

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -20,12 +20,25 @@ DOCKERIZED_BINARIES = {
     },
 }
 
+# Allows passing --define image_type=dynamic custom flag to Bazel command.
+# Used to allow optionally build with the dynamic base image.
+config_setting(
+    name = "dynamic_image",
+    values = {
+        "define": "image_type=dynamic"
+    }
+)
+
 # When pushing to quay.io, we want to use an arch, since the archless name is now used for a
 # manifest list. Bazel doesn't support manifest lists (yet), so we can't do that either.
 [multi_arch_container(
     name = binary,
     architectures = SERVER_PLATFORMS["linux"],
-    base = "@static_base//image",
+    # Always use the static base unless dynamic explicitly requested.
+    base = select({
+        ":dynamic_image": "@dynamic_base//image",
+        "//conditions:default": "@static_base//image",
+    }),
     binary = select(for_platforms(
         for_server = meta["target"],
         only_os = "linux",

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -88,6 +88,10 @@ grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt \
     stamp = 1,
 )
 
+# Building this rule will result in invocation of multi_arch_container rule because
+# the srcs list contains Bazel labels that correspond to the output of the
+# native.genrule in multi_arch_container definiton.
+# This rule will produce tarballs and docker tags for all server images.
 release_filegroup(
     name = "server-artifacts",
     srcs = [":%s.tar" % binary for binary in DOCKERIZED_BINARIES.keys()] +

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -25,8 +25,8 @@ DOCKERIZED_BINARIES = {
 config_setting(
     name = "dynamic_image",
     values = {
-        "define": "image_type=dynamic"
-    }
+        "define": "image_type=dynamic",
+    },
 )
 
 # When pushing to quay.io, we want to use an arch, since the archless name is now used for a

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -20,8 +20,10 @@ DOCKERIZED_BINARIES = {
     },
 }
 
-# Allows passing --define image_type=dynamic custom flag to Bazel command.
-# Used to allow optionally build with the dynamic base image.
+# Allows passing --define image_type=dynamic custom flag to Bazel command. Used
+# to allow optionally build with the dynamic base image. This would only be used
+# by alternative/experimental cert-manager builds that, for example, need to
+# create dynamically linked binaries due to linking to a C library.
 config_setting(
     name = "dynamic_image",
     values = {
@@ -88,10 +90,10 @@ grep ^STABLE_BUILD_SCM_REVISION bazel-out/stable-status.txt \
     stamp = 1,
 )
 
-# Building this rule will result in invocation of multi_arch_container rule because
-# the srcs list contains Bazel labels that correspond to the output of the
-# native.genrule in multi_arch_container definiton.
 # This rule will produce tarballs and docker tags for all server images.
+# Building this rule will result in invocation of the multi_arch_container rule
+# because the srcs list contains Bazel labels that correspond to the output of
+# the native.genrule in multi_arch_container definiton.
 release_filegroup(
     name = "server-artifacts",
     srcs = [":%s.tar" % binary for binary in DOCKERIZED_BINARIES.keys()] +

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,13 @@
+## Images
+
+### Stamping
+
+Bazel has a concept of stamping which allows embedding additional information into binaries and ensuring that those binaries get rebuilt when the information changes. 
+The additional information has to come from Bazel's stable workspace variables, see https://docs.bazel.build/versions/master/user-manual.html#workspace_status.
+Stamping can be used with rules that have the `stamp` attribute such as `go_image`.
+To enable stamping on a particular rule and build, we set `stamp = True` on the rule and pass `--stamp` to the `bazel build` command.
+
+We use stamping to tag images with a name of a Docker registry and a version and ensure that if a different registry or version is specified, the image will be re-bundled.
+
+Stamping values come from `STABLE_DOCKER_REGISTRY`, `STABLE_DOCKER_TAG` stable workspace variables declared in ./hack/build/print-workspace-status.sh.
+This script will be run before every Bazel build as specified in our in .bazelrc file.

--- a/build/README.md
+++ b/build/README.md
@@ -3,10 +3,23 @@
 ### How the images are built
 
 `cert-manager` images in `quay.io` are multi-arch images for a number of `linux` architectures.
-The individual container bundles for each architecture are built using `Bazel` functionality in this repository.
-Docker [manifest list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list) is then created by [`cmrel`](https://github.com/cert-manager/release) and the arch-specific container bundles and the manifest list pushed to `quay.io`.
+The individual container bundles for each architecture are built using `Bazel` functionality in cert-manager repository.
+Docker [manifest list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list) is then created using [`cmrel`](https://github.com/cert-manager/release) and the arch-specific container bundles and the manifest list pushed to `quay.io`.
 Therefore the `multi_arch..`-named rules in this repository don't refer to 'multi-arch' in a sense of creating multi-arch images (i.e manifest lists) and the functionality related to pushing images is mostly unused.
+### Base image types
 
+By default, cert-manager binaries are built statically linked, with cgo disabled. Binaries are packaged in a [static distroless base image](https://github.com/GoogleContainerTools/distroless). Unless you're making changes to cert-manager itself, this default is probably exactly what you want.
+
+In some scenarios - such as if you need to link against a different TLS library - you might want to enable cgo and use a dynamic distroless base image.
+Example command to build cert-manager images for linux/amd64 with cgo enabled and dynamic linking:
+
+```bash
+bazel run \
+		--stamp \
+		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64_cgo \
+		--define image_type=dynamic \
+		//build:server-images
+```
 ### Stamping
 
 Bazel has a concept of stamping which allows embedding additional information into binaries and ensuring that those binaries get rebuilt when the information changes. 
@@ -14,7 +27,5 @@ The additional information has to come from Bazel's stable workspace variables, 
 Stamping can be used with rules that have the `stamp` attribute such as `go_image`.
 To enable stamping on a particular rule and build, we set `stamp = True` on the rule and pass `--stamp` to the `bazel build` command.
 
-We use stamping to tag images with a name of a Docker registry and a version and ensure that if a different registry or version is specified, the image will be re-bundled.
-
-Stamping values come from `STABLE_DOCKER_REGISTRY`, `STABLE_DOCKER_TAG` stable workspace variables declared in ./hack/build/print-workspace-status.sh.
+We use stamping to tag images with a name of a Docker registry and a version and ensure that if a different registry or version is specified, the image will be re-bundled.These image stamping values come from `STABLE_DOCKER_REGISTRY`, `STABLE_DOCKER_TAG` stable workspace variables declared in ./hack/build/print-workspace-status.sh.
 This script will be run before every Bazel build as specified in our in .bazelrc file.

--- a/build/README.md
+++ b/build/README.md
@@ -1,5 +1,12 @@
 ## Images
 
+### How the images are built
+
+`cert-manager` images in `quay.io` are multi-arch images for a number of `linux` architectures.
+The individual container bundles for each architecture are built using `Bazel` functionality in this repository.
+Docker [manifest list](https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list) is then created by [`cmrel`](https://github.com/cert-manager/release) and the arch-specific container bundles and the manifest list pushed to `quay.io`.
+Therefore the `multi_arch..`-named rules in this repository don't refer to 'multi-arch' in a sense of creating multi-arch images (i.e manifest lists) and the functionality related to pushing images is mostly unused.
+
 ### Stamping
 
 Bazel has a concept of stamping which allows embedding additional information into binaries and ensuring that those binaries get rebuilt when the information changes. 

--- a/build/container.bzl
+++ b/build/container.bzl
@@ -44,6 +44,8 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 #   visibility: will be applied only to the container_bundles; the internal
 #     container_image is private
 #   All other args will be applied to the internal container_image.
+# TODO: remove kwargs, instead pass all args explicitly. I think we don't need
+# dynamic params and defining them explicitly would make this more clear.
 def multi_arch_container(
         name,
         architectures,

--- a/build/container.bzl
+++ b/build/container.bzl
@@ -57,10 +57,7 @@ def multi_arch_container(
 
     go_image(
         name = "%s-internal-notimestamp" % name,
-        base = select({
-            go_platform_constraint(os = "linux", arch = arch): base.format(ARCH = arch)
-            for arch in architectures
-        }),
+        base = base,
         architecture = select({
             go_platform_constraint(os = "linux", arch = arch): arch
             for arch in architectures

--- a/build/container.bzl
+++ b/build/container.bzl
@@ -33,6 +33,7 @@ load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 #     configure
 #   base: base image to use for the containers. The format string {ARCH} will
 #     be replaced with the configured GOARCH.
+#   binary: the Bazel target name that builds the Go binary.
 #   docker_tags: list of docker tags to apply to the image. The format string
 #     {ARCH} will be replaced with the configured GOARCH; any stamping variables
 #     should be escaped, e.g. {{STABLE_MY_VAR}}.
@@ -47,6 +48,7 @@ def multi_arch_container(
         name,
         architectures,
         base,
+        binary,
         docker_tags,
         stamp = True,
         docker_push_tags = None,
@@ -64,9 +66,9 @@ def multi_arch_container(
         }),
         stamp = stamp,
         tags = tags,
-        user = user,
         visibility = ["//visibility:private"],
-        **kwargs
+        binary = binary,
+        **kwargs,
     )
 
     # Create a tar file containing the created license files

--- a/build/images.bzl
+++ b/build/images.bzl
@@ -25,6 +25,12 @@ def define_base_images():
         repository = "distroless/static",
         digest = "sha256:a7752b29b18bb106938caefd8dcce8a94199022cbd06ea42268b968f35e837a8",
     )
+    # Use 'dynamic' distroless image for modified cert-manager deployments that
+    # are dynamically linked. (This is not the default and you probably don't
+    # need this.)
+    # To get the latest-amd64 digest for gcr.io/distroless/base,
+    # assuming that $GOPATH/bin is in your $PATH, run:
+    # go get github.com/genuinetools/reg && reg digest gcr.io/distroless/base:latest-amd64
     container_pull(
         name = "dynamic_base",
         registry = "gcr.io",

--- a/build/images.bzl
+++ b/build/images.bzl
@@ -15,7 +15,7 @@
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 
 def define_base_images():
-    # Use 'static' distroless image for all builds
+    # Use 'static' distroless image for all builds by default.
     # To get the latest-amd64 digest for gcr.io/distroless/static, assuming
     # that $GOPATH/bin is in your $PATH, run:
     # go get github.com/genuinetools/reg && reg digest gcr.io/distroless/static:latest-amd64
@@ -25,4 +25,9 @@ def define_base_images():
         repository = "distroless/static",
         digest = "sha256:a7752b29b18bb106938caefd8dcce8a94199022cbd06ea42268b968f35e837a8",
     )
-
+    container_pull(
+        name = "dynamic_base",
+        registry = "gcr.io",
+        repository = "distroless/base",
+        digest = "sha256:75f63d4edd703030d4312dc7528a349ca34d48bec7bd754652b2d47e5a0b7873",
+    )

--- a/build/release-tars/BUILD.bazel
+++ b/build/release-tars/BUILD.bazel
@@ -11,13 +11,19 @@ load(
 load("@io_k8s_repo_infra//defs:build.bzl", "release_filegroup")
 load("@io_k8s_repo_infra//defs:pkg.bzl", "pkg_tar")
 
-# Bazel doesn't make the output filename
-# (such as kubernetes-server-{OS}-{ARCH}.tar.gz) configurable, so we instead
-# create rules for all platforms and tag them manual.
-# We then select the correct set of platform-specific tarballs in this filegroup
-# using a select() statement.
-# Thus the release-tars target always selects the correct set of tarballs
-# for the configured platform being built.
+# Bazel doesn't make the output filename (such as
+# kubernetes-server-{OS}-{ARCH}.tar.gz) configurable, so we instead create rules
+# for all platforms and tag them manual. We then select the correct set of
+# platform-specific tarballs in this filegroup using a select() statement. Thus
+# the release-tars target always selects the correct set of tarballs for the
+# configured platform being built.
+
+# This rule is called by 'cmrel stage' to create all release artifacts for a
+# particular os/arch combination. OS and ARCH args get substituted in one of the
+# functions that 'for_platforms' call. That way a Bazel target name gets built
+# that corresponds to the output of one of the rules below and thus invokes
+# rules below to generate the actual artifacts (server images, manifests,
+# kubectl plugin binaries).
 release_filegroup(
     name = "release-tars",
     conditioned_srcs = for_platforms(
@@ -62,6 +68,8 @@ filegroup(
     visibility = ["//visibility:private"],
 )
 
+# _server-images takes the files (image tars and docker tags) output by
+# //build:server-artifacts and tars them up
 pkg_tar(
     name = "_server-images",
     srcs = [
@@ -89,6 +97,14 @@ pkg_tar(
     visibility = ["//visibility:private"],
 )
 
+# This expands to a list of rules that each generate a tarball of server images
+# (controller, webhook etc) for an os/arch combination. A rule from this list is
+# invoked when 'release-tars' release filegroup (above) for the particular
+# os/arch is built. To follow where the images get built, look at the
+# '_server_images' pkg_tar above which gets invoked as a dependency of any rule
+# from this list. A rule from this list takes the .tar output from
+# '_server_images', extracts it and tars it together with licenses and a version
+# file into a .tar.gz archive.
 [[pkg_tar(
     name = "cert-manager-server-%s-%s" % (os, arch),
     srcs = [
@@ -102,6 +118,9 @@ pkg_tar(
         "manual",
         "no-cache",
     ],
+    # For a rule "cert-manager-server-linux-amd64" this will generate
+    # select({"@io_bazel_rules_go//go/platform:linux_amd64": [_server_images]})
+    # TODO: the select statement can probably be removed here.
     deps = select({
         go_platform_constraint(os, arch): [
             ":_server-images",
@@ -120,6 +139,9 @@ pkg_tar(
         "manual",
         "no-cache",
     ],
+    # For a rule "cert-manager-test-linux-amd64" this will generate
+    # select({"@io_bazel_rules_go//go/platform:linux_amd64": [_ctl]})
+    # TODO: the select statement can probably be removed here.
     deps = select({
         go_platform_constraint(os, arch): [
             ":_ctl",
@@ -165,6 +187,9 @@ pkg_tar(
         "manual",
         "no-cache",
     ],
+    # For a rule "cert-manager-test-linux-amd64" this will generate
+    # select({"@io_bazel_rules_go//go/platform:linux_amd64": [_test_bin]})
+    # TODO: the select statement can probably be removed here.
     deps = select({go_platform_constraint(os, arch): [":_test-bin"]}),
 ) for arch in archs] for os, archs in TEST_PLATFORMS.items()]
 

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//build:version.bzl", "version_x_defs")
 load("//build:go_binary.bzl", "go_binary")
 
 go_library(

--- a/cmd/acmesolver/BUILD.bazel
+++ b/cmd/acmesolver/BUILD.bazel
@@ -16,7 +16,6 @@ go_library(
 go_binary(
     name = "acmesolver",
     embed = [":go_default_library"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//build:version.bzl", "version_x_defs")
 load("//build:go_binary.bzl", "go_binary")
 
 go_library(

--- a/cmd/cainjector/BUILD.bazel
+++ b/cmd/cainjector/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
 go_binary(
     name = "cainjector",
     embed = [":go_default_library"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//build:version.bzl", "version_x_defs")
 load("//build:go_binary.bzl", "go_binary")
 
 go_library(

--- a/cmd/controller/BUILD.bazel
+++ b/cmd/controller/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
 go_binary(
     name = "controller",
     embed = [":go_default_library"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -1,5 +1,4 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
-load("//build:version.bzl", "version_x_defs")
 load("//build:go_binary.bzl", "go_binary")
 
 go_library(

--- a/cmd/webhook/BUILD.bazel
+++ b/cmd/webhook/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
 go_binary(
     name = "webhook",
     embed = [":go_default_library"],
-    pure = "on",
     visibility = ["//visibility:public"],
 )
 

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 def install():

--- a/hack/build/docker.bzl
+++ b/hack/build/docker.bzl
@@ -17,6 +17,9 @@ load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
+
+# TODO: It seems like this code is never used, see https://github.com/jetstack/cert-manager/issues/3072
+# It should be either removed or the work on it finished.
 def covered_image(name, component, **kwargs):
     native.genrule(
         name = "%s.covered-testfile" % name,


### PR DESCRIPTION
Adds a README and some comments to document how the component images are built with Bazel.

Allows to specify a different base image and whether cgo is enabled for a build.



```release-note
NONE
```
fixes #3969 