### PR TITLE
Add a name to Prometheus scraping service port for Istio compatibillity

### DIFF
--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -19,6 +19,7 @@ spec:
   ports:
     - protocol: TCP
       port: 9402
+      name: tcp-prometheus-servicemonitor
       targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
   selector:
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}


### PR DESCRIPTION
Signed-off-by: Fran Sanjuán <francesc.sanjuan@marfeel.com>

**What this PR does / why we need it**:

If applied, this PR will add a name to service port used for Prometheus scraping.
This will make the service follow Istio's requirements about port naming for explicit protocol selection.
https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection

```release-note
Add a name to Prometheus scraping service port
```