### PR TITLE
Certificate Signing Request CA e2e

### DIFF
--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -22,6 +22,8 @@ set -o pipefail
 NAMESPACE="${NAMESPACE:-cert-manager}"
 # Release name to use with Helm
 RELEASE_NAME="${RELEASE_NAME:-cert-manager}"
+# Default feature gates to enable
+FEATURE_GATES="${FEATURE_GATES:-ExperimentalCertificateSigningRequestControllers=true}"
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_ROOT}/../../lib/lib.sh"

--- a/pkg/controller/certificatesigningrequests/ca/ca.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca.go
@@ -123,7 +123,7 @@ func (c *CA) Sign(ctx context.Context, csr *certificatesv1.CertificateSigningReq
 		c.recorder.Event(csr, corev1.EventTypeWarning, "SigningError", message)
 		util.CertificateSigningRequestSetFailed(csr, "SigningError", message)
 		_, err = c.certClient.UpdateStatus(ctx, csr, metav1.UpdateOptions{})
-		return nil
+		return err
 	}
 
 	template.CRLDistributionPoints = issuerObj.GetSpec().CA.CRLDistributionPoints
@@ -134,8 +134,8 @@ func (c *CA) Sign(ctx context.Context, csr *certificatesv1.CertificateSigningReq
 		message := fmt.Sprintf("Error signing certificate: %s", err)
 		c.recorder.Event(csr, corev1.EventTypeWarning, "SigningError", message)
 		util.CertificateSigningRequestSetFailed(csr, "SigningError", message)
-		_, err = c.certClient.UpdateStatus(ctx, csr, metav1.UpdateOptions{})
-		return nil
+		_, err := c.certClient.UpdateStatus(ctx, csr, metav1.UpdateOptions{})
+		return err
 	}
 
 	csr.Status.Certificate = bundle.ChainPEM

--- a/pkg/controller/certificatesigningrequests/sync.go
+++ b/pkg/controller/certificatesigningrequests/sync.go
@@ -63,15 +63,8 @@ func (c *Controller) Sync(ctx context.Context, csr *certificatesv1.CertificateSi
 		return nil
 	}
 
-	var kind string
-	switch ref.Type {
-	case "issuers":
-		kind = cmapi.IssuerKind
-
-	case "clusterissuers":
-		kind = cmapi.ClusterIssuerKind
-
-	default:
+	kind, ok := util.IssuerKindFromType(ref.Type)
+	if !ok {
 		dbg.Info("certificate signing request signerName type does not match 'issuers' or 'clusterissuers' so skipping processing")
 		return nil
 	}

--- a/pkg/controller/certificatesigningrequests/util/BUILD.bazel
+++ b/pkg/controller/certificatesigningrequests/util/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/controller/certificatesigningrequests/util",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/logs:go_default_library",
         "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",

--- a/pkg/controller/certificatesigningrequests/util/conditions.go
+++ b/pkg/controller/certificatesigningrequests/util/conditions.go
@@ -37,6 +37,15 @@ func CertificateSigningRequestIsApproved(csr *certificatesv1.CertificateSigningR
 	return false
 }
 
+func CertificateSigningRequestIsDenied(csr *certificatesv1.CertificateSigningRequest) bool {
+	for _, cond := range csr.Status.Conditions {
+		if cond.Type == certificatesv1.CertificateDenied {
+			return true
+		}
+	}
+	return false
+}
+
 func CertificateSigningRequestIsFailed(csr *certificatesv1.CertificateSigningRequest) bool {
 	for _, cond := range csr.Status.Conditions {
 		if cond.Type == certificatesv1.CertificateFailed {

--- a/pkg/controller/certificatesigningrequests/util/signername.go
+++ b/pkg/controller/certificatesigningrequests/util/signername.go
@@ -18,6 +18,8 @@ package util
 
 import (
 	"strings"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 )
 
 type SignerIssuerRef struct {
@@ -26,7 +28,7 @@ type SignerIssuerRef struct {
 }
 
 // SignerIssuerRefFromSignerName will return a SignerIssuerRef from a
-// CertificateSigningRequests.SignerName
+// CertificateSigningRequests.Spec.SignerName
 func SignerIssuerRefFromSignerName(name string) (SignerIssuerRef, bool) {
 	split := strings.Split(name, "/")
 	if len(split) != 2 {
@@ -66,4 +68,19 @@ func SignerIssuerRefFromSignerName(name string) (SignerIssuerRef, bool) {
 		Type:      signerTypeSplit[0],
 		Group:     signerTypeSplit[1],
 	}, true
+}
+
+// IssuerKindFromType will return the cert-manager.io Issuer Kind from a
+// resource type name.
+func IssuerKindFromType(issuerType string) (string, bool) {
+	switch issuerType {
+	case "issuers":
+		return cmapi.IssuerKind, true
+
+	case "clusterissuers":
+		return cmapi.ClusterIssuerKind, true
+
+	default:
+		return "", false
+	}
 }

--- a/test/e2e/framework/helper/BUILD.bazel
+++ b/test/e2e/framework/helper/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "certificaterequests.go",
         "certificates.go",
+        "certificatesigningrequests.go",
         "helper.go",
         "kubectl.go",
         "pod_start.go",
@@ -17,8 +18,10 @@ go_library(
     deps = [
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/experimental/v1alpha1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
+        "//pkg/controller/certificatesigningrequests/util:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/e2e/framework/config:go_default_library",
@@ -26,6 +29,7 @@ go_library(
         "//test/e2e/framework/helper/validations:go_default_library",
         "//test/e2e/framework/log:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
+        "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",

--- a/test/e2e/framework/helper/certificatesigningrequests.go
+++ b/test/e2e/framework/helper/certificatesigningrequests.go
@@ -1,0 +1,250 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helper
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	certificatesv1 "k8s.io/api/certificates/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	experimentalapi "github.com/jetstack/cert-manager/pkg/apis/experimental/v1alpha1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	ctrlutil "github.com/jetstack/cert-manager/pkg/controller/certificatesigningrequests/util"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/test/e2e/framework/log"
+)
+
+// WaitForCertificateSigningRequestSigned waits for the
+// CertificateSigningRequest resource to be signed.
+func (h *Helper) WaitForCertificateSigningRequestSigned(ns, name string, timeout time.Duration) (*certificatesv1.CertificateSigningRequest, error) {
+	var csr *certificatesv1.CertificateSigningRequest
+	err := wait.PollImmediate(time.Second, timeout,
+		func() (bool, error) {
+			var err error
+			log.Logf("Waiting for CertificateSigningRequest %s to be ready", name)
+			csr, err = h.KubeClient.CertificatesV1().CertificateSigningRequests().Get(context.TODO(), name, metav1.GetOptions{})
+			if err != nil {
+				return false, fmt.Errorf("error getting CertificateSigningRequest %s: %v", name, err)
+			}
+			if len(csr.Status.Certificate) == 0 {
+				log.Logf("Expected CertificateSigningRequest to be signed")
+				return false, nil
+			}
+			return true, nil
+		},
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return csr, nil
+}
+
+// ValidateIssuedCertificateSigningRequest will ensure that the given
+// CertificateSigningRequest has a certificate issued for it, and that the
+// details on the x509 certificate are correct as defined by the
+// CertificateSigningRequest's spec.
+func (h *Helper) ValidateIssuedCertificateSigningRequest(kubeCSR *certificatesv1.CertificateSigningRequest, key crypto.Signer, rootCAPEM []byte) (*x509.Certificate, error) {
+	csr, err := pki.DecodeX509CertificateRequestBytes(kubeCSR.Spec.Request)
+	if err != nil {
+		return nil, err
+	}
+
+	// validate private key is of the correct type (rsa or ecdsa)
+	switch csr.PublicKeyAlgorithm {
+	case x509.RSA:
+		_, ok := key.(*rsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("Expected private key of type RSA, but it was: %T", key)
+		}
+	case x509.ECDSA:
+		_, ok := key.(*ecdsa.PrivateKey)
+		if !ok {
+			return nil, fmt.Errorf("Expected private key of type ECDSA, but it was: %T", key)
+		}
+	default:
+		return nil, fmt.Errorf("unrecognised requested private key algorithm %q", csr.PublicKeyAlgorithm)
+	}
+
+	// check the provided certificate is valid
+	expectedOrganization := csr.Subject.Organization
+	expectedDNSNames := csr.DNSNames
+	expectedIPAddresses := csr.IPAddresses
+	expectedURIs := csr.URIs
+
+	cert, err := pki.DecodeX509CertificateBytes(kubeCSR.Status.Certificate)
+	if err != nil {
+		return nil, err
+	}
+
+	commonNameCorrect := true
+	expectedCN := csr.Subject.CommonName
+	if len(expectedCN) == 0 && len(cert.Subject.CommonName) > 0 {
+		if !util.Contains(cert.DNSNames, cert.Subject.CommonName) {
+			commonNameCorrect = false
+		}
+	} else if expectedCN != cert.Subject.CommonName {
+		commonNameCorrect = false
+	}
+
+	if !commonNameCorrect ||
+		!util.EqualUnsorted(cert.DNSNames, expectedDNSNames) ||
+		!util.EqualUnsorted(cert.Subject.Organization, expectedOrganization) ||
+		!util.EqualIPsUnsorted(cert.IPAddresses, expectedIPAddresses) ||
+		!util.EqualURLsUnsorted(cert.URIs, expectedURIs) {
+		return nil, fmt.Errorf("Expected certificate valid for CN %q, O %v, dnsNames %v, IPs %v, URIs %v but got a certificate valid for CN %q, O %v, dnsNames %v, IPs %v URIs %v",
+			expectedCN, expectedOrganization, expectedDNSNames, expectedIPAddresses, expectedURIs,
+			cert.Subject.CommonName, cert.Subject.Organization, cert.DNSNames, cert.IPAddresses, cert.URIs)
+	}
+
+	var expectedDNSName string
+	if len(expectedDNSNames) > 0 {
+		expectedDNSName = expectedDNSNames[0]
+	}
+
+	certificateKeyUsages, certificateExtKeyUsages, err := pki.BuildKeyUsagesKube(kubeCSR.Spec.Usages)
+	if err != nil {
+		return nil, err
+	}
+
+	var keyAlg cmapi.PrivateKeyAlgorithm
+	switch csr.PublicKeyAlgorithm {
+	case x509.RSA:
+		keyAlg = cmapi.RSAKeyAlgorithm
+	case x509.ECDSA:
+		keyAlg = cmapi.ECDSAKeyAlgorithm
+	default:
+		return nil, fmt.Errorf("unsupported key algorithm type: %s", csr.PublicKeyAlgorithm)
+	}
+
+	signerRef, ok := ctrlutil.SignerIssuerRefFromSignerName(kubeCSR.Spec.SignerName)
+	if !ok {
+		return nil, fmt.Errorf("failed to build issuer ref from signer name %q", kubeCSR.Spec.SignerName)
+	}
+
+	issuerKind, ok := ctrlutil.IssuerKindFromType(signerRef.Type)
+	if !ok {
+		return nil, fmt.Errorf("issuer type is not recognised %q", signerRef.Type)
+	}
+
+	defaultCertKeyUsages, defaultCertExtKeyUsages, err := h.defaultKeyUsagesToAdd(signerRef.Namespace, &cmmeta.ObjectReference{
+		Name:  signerRef.Name,
+		Kind:  issuerKind,
+		Group: signerRef.Group,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	certificateKeyUsages |= defaultCertKeyUsages
+	certificateExtKeyUsages = append(certificateExtKeyUsages, defaultCertExtKeyUsages...)
+
+	certificateExtKeyUsages = h.deduplicateExtKeyUsages(certificateExtKeyUsages)
+
+	// If using ECDSA then ignore key encipherment
+	if keyAlg == cmapi.ECDSAKeyAlgorithm {
+		certificateKeyUsages &^= x509.KeyUsageKeyEncipherment
+		cert.KeyUsage &^= x509.KeyUsageKeyEncipherment
+	}
+
+	if !h.keyUsagesMatch(cert.KeyUsage, cert.ExtKeyUsage,
+		certificateKeyUsages, certificateExtKeyUsages) {
+		return nil, fmt.Errorf("key usages and extended key usages do not match: exp=%s got=%s exp=%s got=%s",
+			apiutil.KeyUsageStrings(certificateKeyUsages), apiutil.KeyUsageStrings(cert.KeyUsage),
+			apiutil.ExtKeyUsageStrings(certificateExtKeyUsages), apiutil.ExtKeyUsageStrings(cert.ExtKeyUsage))
+	}
+
+	kubeCSRCAPEM, err := base64.StdEncoding.DecodeString(kubeCSR.Annotations[experimentalapi.CertificateSigningRequestCAAnnotationKey])
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO: move this verification step out of this function
+	if rootCAPEM != nil {
+		rootCertPool := x509.NewCertPool()
+		rootCertPool.AppendCertsFromPEM(rootCAPEM)
+		intermediateCertPool := x509.NewCertPool()
+		intermediateCertPool.AppendCertsFromPEM(kubeCSRCAPEM)
+		opts := x509.VerifyOptions{
+			DNSName:       expectedDNSName,
+			Intermediates: intermediateCertPool,
+			Roots:         rootCertPool,
+		}
+
+		if _, err := cert.Verify(opts); err != nil {
+			return nil, err
+		}
+	}
+
+	if !ctrlutil.CertificateSigningRequestIsApproved(kubeCSR) {
+		return nil, fmt.Errorf("CertificateSigningRequest does not have an Approved condition: %+v", kubeCSR.Status.Conditions)
+	}
+	if ctrlutil.CertificateSigningRequestIsDenied(kubeCSR) {
+		return nil, fmt.Errorf("CertificateSigningRequest has a Denied conditon: %+v", kubeCSR.Status.Conditions)
+	}
+
+	return cert, nil
+}
+
+func (h *Helper) WaitCertificateSigningRequestIssuedValidTLS(ns, name string, timeout time.Duration, key crypto.Signer, rootCAPEM []byte) error {
+	csr, err := h.WaitForCertificateSigningRequestSigned(ns, name, timeout)
+	if err != nil {
+		log.Logf("Error waiting for CertificateSigningRequest to become Ready: %v", err)
+		h.Kubectl("").DescribeResource("certificatesigningrequest", name)
+		return err
+	}
+
+	_, err = h.ValidateIssuedCertificateSigningRequest(csr, key, rootCAPEM)
+	if err != nil {
+		log.Logf("Error validating issued certificate: %v", err)
+		h.Kubectl("").DescribeResource("certificatesigningrequest", name)
+		return err
+	}
+
+	return nil
+}
+
+func (h *Helper) CertificateSigningRequestDurationValid(csr *certificatesv1.CertificateSigningRequest, duration, fuzz time.Duration) error {
+	if len(csr.Status.Certificate) == 0 {
+		return fmt.Errorf("No certificate data found for CertificateSigningRequest %s", csr.Name)
+	}
+
+	cert, err := pki.DecodeX509CertificateBytes(csr.Status.Certificate)
+	if err != nil {
+		return err
+	}
+	certDuration := cert.NotAfter.Sub(cert.NotBefore)
+	if certDuration > (duration+fuzz) || certDuration < duration {
+		return fmt.Errorf("Expected duration of %s, got %s (fuzz: %s) [NotBefore: %s, NotAfter: %s]", duration, certDuration,
+			fuzz, cert.NotBefore.Format(time.RFC3339), cert.NotAfter.Format(time.RFC3339))
+	}
+
+	return nil
+}

--- a/test/e2e/suite/issuers/ca/BUILD.bazel
+++ b/test/e2e/suite/issuers/ca/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
-        "//pkg/apis/experimental/v1alpha1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",
         "//test/e2e/framework:go_default_library",

--- a/test/e2e/suite/issuers/ca/BUILD.bazel
+++ b/test/e2e/suite/issuers/ca/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "certificate.go",
         "certificaterequest.go",
+        "certificatesigningrequest.go",
         "clusterissuer.go",
         "fixtures.go",
         "issuer.go",
@@ -14,6 +15,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/experimental/v1alpha1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",
         "//test/e2e/framework:go_default_library",
@@ -21,6 +23,7 @@ go_library(
         "//test/unit/gen:go_default_library",
         "@com_github_onsi_ginkgo//:go_default_library",
         "@com_github_onsi_gomega//:go_default_library",
+        "@io_k8s_api//certificates/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
     ],

--- a/test/e2e/suite/issuers/ca/certificatesigningrequest.go
+++ b/test/e2e/suite/issuers/ca/certificatesigningrequest.go
@@ -35,6 +35,10 @@ import (
 	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
+// The tests in this file require that the CertificateSigningRequest
+// controllers are active
+// (--feature-gates=ExperimentalCertificateSigningRequestControllers=true). If
+// they are not active, these tests will fail.
 var _ = framework.CertManagerDescribe("CA CertificateSigningRequest", func() {
 	f := framework.NewDefaultFramework("create-ca-certificate-kube-csr")
 	h := f.Helper()

--- a/test/e2e/suite/issuers/ca/certificatesigningrequest.go
+++ b/test/e2e/suite/issuers/ca/certificatesigningrequest.go
@@ -1,0 +1,238 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ca
+
+import (
+	"context"
+	"crypto/x509"
+	"net"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	certificatesv1 "k8s.io/api/certificates/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	experimentalapi "github.com/jetstack/cert-manager/pkg/apis/experimental/v1alpha1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/util"
+	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+var _ = framework.CertManagerDescribe("CA CertificateSigningRequest", func() {
+	f := framework.NewDefaultFramework("create-ca-certificate-kube-csr")
+	h := f.Helper()
+
+	var (
+		issuerName       = "test-ca-issuer"
+		issuerSecretName = "ca-issuer-signing-keypair"
+
+		exampleDNSNames    = []string{"dnsName1.co", "dnsName2.ninja"}
+		exampleIPAddresses = []net.IP{
+			[]byte{8, 8, 8, 8},
+			[]byte{1, 1, 1, 1},
+		}
+
+		kubeCSRName string
+	)
+
+	JustBeforeEach(func() {
+		By("Creating an Issuer")
+		issuer := gen.Issuer(issuerName,
+			gen.SetIssuerNamespace(f.Namespace.Name),
+			gen.SetIssuerCASecretName(issuerSecretName))
+		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), issuer, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		By("Waiting for Issuer to become Ready")
+		err = util.WaitForIssuerCondition(f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name),
+			issuerName,
+			cmapi.IssuerCondition{
+				Type:   cmapi.IssuerConditionReady,
+				Status: cmmeta.ConditionTrue,
+			})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		By("Cleaning up")
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), issuerSecretName, metav1.DeleteOptions{})
+		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
+		if len(kubeCSRName) > 0 {
+			f.KubeClientSet.CertificatesV1().CertificateSigningRequests().Delete(context.TODO(), kubeCSRName, metav1.DeleteOptions{})
+			kubeCSRName = ""
+		}
+	})
+
+	Context("when the CA is the root", func() {
+		BeforeEach(func() {
+			By("Creating a signing keypair fixture")
+			_, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Create(context.TODO(), newSigningKeypairSecret(issuerSecretName), metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should generate a valid certificate from CertificateSigningRequest", func() {
+			csrClient := f.KubeClientSet.CertificatesV1().CertificateSigningRequests()
+
+			By("Creating a CertificateSigningRequest")
+			csr, pk, err := gen.CSR(x509.RSA,
+				gen.SetCSRDNSNames(exampleDNSNames...),
+				gen.SetCSRIPAddresses(exampleIPAddresses...),
+				gen.SetCSRURIs(exampleURLs()...),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			kubeCSR := gen.CertificateSigningRequest("",
+				gen.SetCertificateSigningRequestDuration("2160h"),
+				gen.SetCertificateSigningRequestSignerName("issuers.cert-manager.io/"+f.Namespace.Name+"."+issuerName),
+				gen.SetCertificateSigningRequestRequest(csr),
+				gen.SetCertificateSigningRequestUsages([]certificatesv1.KeyUsage{
+					certificatesv1.UsageKeyEncipherment,
+					certificatesv1.UsageDigitalSignature,
+				}),
+			)
+			kubeCSR.GenerateName = "test-ca-certificatesigningrequest-"
+			kubeCSR, err = csrClient.Create(context.TODO(), kubeCSR, metav1.CreateOptions{})
+			kubeCSRName = kubeCSR.Name
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Approving CertificateSigningRequest")
+			kubeCSR.Status.Conditions = append(kubeCSR.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+				Type:    certificatesv1.CertificateApproved,
+				Status:  corev1.ConditionTrue,
+				Reason:  "e2e.cert-manager.io",
+				Message: "Approved for e2e testing",
+			})
+			_, err = csrClient.UpdateApproval(context.TODO(), kubeCSR.Name, kubeCSR, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the certificate is valid")
+			err = h.WaitCertificateSigningRequestIssuedValidTLS(f.Namespace.Name, kubeCSR.Name, time.Second*30, pk, []byte(rootCert))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should be able to obtain an ECDSA key from a RSA backed issuer", func() {
+			csrClient := f.KubeClientSet.CertificatesV1().CertificateSigningRequests()
+
+			By("Creating a CertificateSigningRequest")
+			csr, pk, err := gen.CSR(x509.ECDSA,
+				gen.SetCSRDNSNames(exampleDNSNames...),
+				gen.SetCSRIPAddresses(exampleIPAddresses...),
+				gen.SetCSRURIs(exampleURLs()...),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			kubeCSR := gen.CertificateSigningRequest("",
+				gen.SetCertificateSigningRequestDuration("2160h"),
+				gen.SetCertificateSigningRequestSignerName("issuers.cert-manager.io/"+f.Namespace.Name+"."+issuerName),
+				gen.SetCertificateSigningRequestRequest(csr),
+				gen.SetCertificateSigningRequestUsages([]certificatesv1.KeyUsage{
+					certificatesv1.UsageKeyEncipherment,
+					certificatesv1.UsageDigitalSignature,
+				}),
+			)
+			kubeCSR.GenerateName = "test-ca-certificatesigningrequest-"
+			kubeCSR, err = csrClient.Create(context.TODO(), kubeCSR, metav1.CreateOptions{})
+			kubeCSRName = kubeCSR.Name
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Approving CertificateSigningRequest")
+			kubeCSR.Status.Conditions = append(kubeCSR.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+				Type:    certificatesv1.CertificateApproved,
+				Status:  corev1.ConditionTrue,
+				Reason:  "e2e.cert-manager.io",
+				Message: "Approved for e2e testing",
+			})
+			_, err = csrClient.UpdateApproval(context.TODO(), kubeCSR.Name, kubeCSR, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the certificate is valid")
+			err = h.WaitCertificateSigningRequestIssuedValidTLS(f.Namespace.Name, kubeCSR.Name, time.Second*30, pk, []byte(rootCert))
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		cases := []struct {
+			inputDuration    string
+			expectedDuration time.Duration
+			label            string
+		}{
+			{
+				inputDuration:    "840h",
+				expectedDuration: time.Hour * 24 * 35,
+				label:            "35 days",
+			},
+			{
+				inputDuration:    "",
+				expectedDuration: time.Hour * 24 * 90,
+				label:            "the default duration (90 days)",
+			},
+		}
+		for _, v := range cases {
+			v := v
+			It("should generate a signed certificate valid for "+v.label, func() {
+				csrClient := f.KubeClientSet.CertificatesV1().CertificateSigningRequests()
+
+				By("Creating a CertificateSigningRequest")
+				csr, pk, err := gen.CSR(x509.RSA,
+					gen.SetCSRDNSNames(exampleDNSNames...),
+					gen.SetCSRIPAddresses(exampleIPAddresses...),
+					gen.SetCSRURIs(exampleURLs()...),
+				)
+				Expect(err).NotTo(HaveOccurred())
+
+				kubeCSR := gen.CertificateSigningRequest("",
+					gen.SetCertificateSigningRequestSignerName("issuers.cert-manager.io/"+f.Namespace.Name+"."+issuerName),
+					gen.SetCertificateSigningRequestRequest(csr),
+					gen.SetCertificateSigningRequestUsages([]certificatesv1.KeyUsage{
+						certificatesv1.UsageKeyEncipherment,
+						certificatesv1.UsageDigitalSignature,
+					}),
+				)
+
+				if len(v.inputDuration) > 0 {
+					kubeCSR.Annotations[experimentalapi.CertificateSigningRequestDurationAnnotationKey] = v.inputDuration
+				}
+
+				kubeCSR.GenerateName = "test-ca-certificatesigningrequest-"
+				kubeCSR, err = csrClient.Create(context.TODO(), kubeCSR, metav1.CreateOptions{})
+				kubeCSRName = kubeCSR.Name
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Approving CertificateSigningRequest")
+				kubeCSR.Status.Conditions = append(kubeCSR.Status.Conditions, certificatesv1.CertificateSigningRequestCondition{
+					Type:    certificatesv1.CertificateApproved,
+					Status:  corev1.ConditionTrue,
+					Reason:  "e2e.cert-manager.io",
+					Message: "Approved for e2e testing",
+				})
+				_, err = csrClient.UpdateApproval(context.TODO(), kubeCSR.Name, kubeCSR, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("Verifying the certificate is valid")
+				err = h.WaitCertificateSigningRequestIssuedValidTLS(f.Namespace.Name, kubeCSR.Name, time.Second*30, pk, []byte(rootCert))
+				Expect(err).NotTo(HaveOccurred())
+
+				kubeCSR, err = csrClient.Get(context.TODO(), kubeCSR.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				err = f.Helper().CertificateSigningRequestDurationValid(kubeCSR, v.expectedDuration, 0)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		}
+	})
+})


### PR DESCRIPTION
This PR adds e2e tests for the Kubernetes CertificateSigningRequest CA Issuer. 

This also adds the field `featureGates="ExperimentalCertificateSigningRequestControllers=true"` to the `/devel/addons/cert-manager/install.sh` script for the cert-manager deployment. This enables the Kube CSR controllers for testing.

```release-note
testing: Adds Kubernetes CertificateSigningRequest CA Issuer E2E tests.
```