### PR TITLE
Check certificate chain for Vault Issuer in E2E

### DIFF
--- a/test/e2e/suite/issuers/vault/certificate/approle.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle.go
@@ -37,7 +37,7 @@ import (
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
 	runVaultAppRoleTests(cmapi.IssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole, CA with root)", func() {
@@ -46,7 +46,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole, CA wit
 })
 
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
 	runVaultAppRoleTests(cmapi.ClusterIssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole, CA with root)", func() {

--- a/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
+++ b/test/e2e/suite/issuers/vault/certificate/approle_custom_mount.go
@@ -36,7 +36,7 @@ import (
 )
 
 var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole with a custom mount path, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
 	runVaultCustomAppRoleTests(cmapi.IssuerKind, false, fs)
 })
 
@@ -45,7 +45,7 @@ var _ = framework.CertManagerDescribe("Vault Issuer Certificate (AppRole with a 
 	runVaultCustomAppRoleTests(cmapi.IssuerKind, true, fs)
 })
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole with a custom mount path, CA without root)", func() {
-	fs := featureset.NewFeatureSet(featureset.SaveCAToSecret)
+	fs := featureset.NewFeatureSet(featureset.SaveRootCAToSecret)
 	runVaultCustomAppRoleTests(cmapi.ClusterIssuerKind, false, fs)
 })
 var _ = framework.CertManagerDescribe("Vault ClusterIssuer Certificate (AppRole with a custom mount path, CA with root)", func() {


### PR DESCRIPTION
With the changes made in https://github.com/jetstack/cert-manager/pull/3982 we should check the certificate chain for the Vault Issuer in E2E tests.


```release-note
NONE
```
