### PR TITLE
Add clock_time_seconds metric

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -215,7 +215,7 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		SharedInformerFactory:     sharedInformerFactory,
 		Namespace:                 opts.Namespace,
 		Clock:                     clock.RealClock{},
-		Metrics:                   metrics.New(log),
+		Metrics:                   metrics.New(log, clock.RealClock{}),
 		ACMEOptions: controller.ACMEOptions{
 			HTTP01SolverImage:                 opts.ACMEHTTP01SolverImage,
 			HTTP01SolverResourceRequestCPU:    HTTP01SolverResourceRequestCPU,

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -114,7 +114,7 @@ func (b *Builder) Init() {
 	b.KubeSharedInformerFactory = kubeinformers.NewSharedInformerFactory(b.Client, informerResyncPeriod)
 	b.SharedInformerFactory = informers.NewSharedInformerFactory(b.CMClient, informerResyncPeriod)
 	b.stopCh = make(chan struct{})
-	b.Metrics = metrics.New(logs.Log)
+	b.Metrics = metrics.New(logs.Log, clock.RealClock{})
 
 	// set the Clock on the context
 	if b.Clock == nil {

--- a/pkg/metrics/BUILD.bazel
+++ b/pkg/metrics/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/promhttp:go_default_library",
         "@io_k8s_client_go//tools/cache:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
     ],
 )
 
@@ -37,7 +38,10 @@ filegroup(
 
 go_test(
     name = "go_default_test",
-    srcs = ["certificates_test.go"],
+    srcs = [
+        "certificates_test.go",
+        "metrics_test.go",
+    ],
     embed = [":go_default_library"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
@@ -46,5 +50,7 @@ go_test(
         "//test/unit/gen:go_default_library",
         "@com_github_prometheus_client_golang//prometheus/testutil:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/clock"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -125,7 +126,7 @@ func TestCertificateMetrics(t *testing.T) {
 	}
 	for n, test := range tests {
 		t.Run(n, func(t *testing.T) {
-			m := New(logtesting.TestLogger{T: t})
+			m := New(logtesting.TestLogger{T: t}, clock.RealClock{})
 			m.UpdateCertificate(context.TODO(), test.crt)
 
 			if err := testutil.CollectAndCompare(m.certificateExpiryTimeSeconds,
@@ -146,7 +147,7 @@ func TestCertificateMetrics(t *testing.T) {
 }
 
 func TestCertificateCache(t *testing.T) {
-	m := New(logtesting.TestLogger{T: t})
+	m := New(logtesting.TestLogger{T: t}, clock.RealClock{})
 
 	crt1 := gen.Certificate("crt1",
 		gen.SetCertificateUID("uid-1"),

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -30,6 +30,7 @@ import (
 	"time"
 
 	logf "github.com/jetstack/cert-manager/pkg/logs"
+	"k8s.io/utils/clock"
 
 	"github.com/go-logr/logr"
 
@@ -65,7 +66,7 @@ type Metrics struct {
 
 var readyConditionStatuses = [...]cmmeta.ConditionStatus{cmmeta.ConditionTrue, cmmeta.ConditionFalse, cmmeta.ConditionUnknown}
 
-func New(log logr.Logger) *Metrics {
+func New(log logr.Logger, c clock.Clock) *Metrics {
 	var (
 		clockTimeSeconds = prometheus.NewCounterFunc(
 			prometheus.CounterOpts{
@@ -74,7 +75,7 @@ func New(log logr.Logger) *Metrics {
 				Help:      "The clock time given in seconds (from 1970/01/01 UTC).",
 			},
 			func() float64 {
-				return float64(time.Now().Unix())
+				return float64(c.Now().Unix())
 			},
 		)
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -55,6 +55,7 @@ type Metrics struct {
 	log      logr.Logger
 	registry *prometheus.Registry
 
+	clockTimeSeconds                 prometheus.CounterFunc
 	certificateExpiryTimeSeconds     *prometheus.GaugeVec
 	certificateReadyStatus           *prometheus.GaugeVec
 	acmeClientRequestDurationSeconds *prometheus.SummaryVec
@@ -66,6 +67,17 @@ var readyConditionStatuses = [...]cmmeta.ConditionStatus{cmmeta.ConditionTrue, c
 
 func New(log logr.Logger) *Metrics {
 	var (
+		clockTimeSeconds = prometheus.NewCounterFunc(
+			prometheus.CounterOpts{
+				Namespace: namespace,
+				Name:      "clock_time_seconds",
+				Help:      "The clock time given in seconds (from 1970/01/01 UTC).",
+			},
+			func() float64 {
+				return float64(time.Now().Unix())
+			},
+		)
+
 		certificateExpiryTimeSeconds = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
@@ -124,6 +136,7 @@ func New(log logr.Logger) *Metrics {
 		log:      log.WithName("metrics"),
 		registry: prometheus.NewRegistry(),
 
+		clockTimeSeconds:                 clockTimeSeconds,
 		certificateExpiryTimeSeconds:     certificateExpiryTimeSeconds,
 		certificateReadyStatus:           certificateReadyStatus,
 		acmeClientRequestCount:           acmeClientRequestCount,
@@ -136,6 +149,7 @@ func New(log logr.Logger) *Metrics {
 
 // Start will register the Prometheus metrics, and start the Prometheus server
 func (m *Metrics) Start(listenAddress string, enablePprof bool) (*http.Server, error) {
+	m.registry.MustRegister(m.clockTimeSeconds)
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)
 	m.registry.MustRegister(m.acmeClientRequestDurationSeconds)

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2020 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+
+	logtesting "github.com/jetstack/cert-manager/pkg/logs/testing"
+)
+
+func TestClockMetrics(t *testing.T) {
+	type testT struct {
+		expectedFmt string
+	}
+	tests := map[string]testT{
+		"clock time seconds as expected": {
+			expectedFmt: `
+  # HELP certmanager_clock_time_seconds The clock time given in seconds (from 1970/01/01 UTC).
+  # TYPE certmanager_clock_time_seconds counter
+	certmanager_clock_time_seconds %f
+	`,
+		},
+	}
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			m := New(logtesting.TestLogger{T: t})
+
+			if err := testutil.CollectAndCompare(m.clockTimeSeconds,
+				strings.NewReader(fmt.Sprintf(test.expectedFmt, float64(time.Now().Unix()))),
+				"certmanager_clock_time_seconds",
+			); err != nil {
+				t.Errorf("unexpected collecting result:\n%s", err)
+			}
+		})
+	}
+}

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -130,7 +130,7 @@ func TestAcmeOrdersController(t *testing.T) {
 	c := controllerpkg.NewController(
 		context.Background(),
 		"orders_test",
-		metrics.New(logf.Log),
+		metrics.New(logf.Log, clock.RealClock{}),
 		ctrl.ProcessItem,
 		mustSync,
 		nil,

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -60,7 +60,7 @@ func TestIssuingController(t *testing.T) {
 	c := controllerpkg.NewController(
 		context.Background(),
 		"issuing_test",
-		metrics.New(logf.Log),
+		metrics.New(logf.Log, clock.RealClock{}),
 		ctrl.ProcessItem,
 		mustSync,
 		nil,
@@ -264,7 +264,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 	c := controllerpkg.NewController(
 		context.Background(),
 		"issuing_test",
-		metrics.New(logf.Log),
+		metrics.New(logf.Log, clock.RealClock{}),
 		ctrl.ProcessItem,
 		mustSync,
 		nil,

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -26,10 +26,10 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/utils/clock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	fakeclock "k8s.io/utils/clock/testing"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -39,6 +39,13 @@ import (
 	"github.com/jetstack/cert-manager/pkg/metrics"
 	"github.com/jetstack/cert-manager/test/integration/framework"
 	"github.com/jetstack/cert-manager/test/unit/gen"
+)
+
+var (
+	fixedClock  = fakeclock.NewFakeClock(time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC))
+	clockMetric = fmt.Sprintf(`# HELP certmanager_clock_time_seconds The clock time given in seconds (from 1970/01/01 UTC).
+# TYPE certmanager_clock_time_seconds counter
+certmanager_clock_time_seconds %.9e`, float64(fixedClock.Now().Unix()))
 )
 
 // TestMetricscontoller performs a basic test to ensure that Certificates
@@ -51,7 +58,7 @@ func TestMetricsController(t *testing.T) {
 	// Build, instantiate and run the issuing controller.
 	kubernetesCl, factory, cmClient, cmFactory := framework.NewClients(t, config)
 
-	metricsHandler := metrics.New(logf.Log, clock.RealClock{})
+	metricsHandler := metrics.New(logf.Log, fixedClock)
 	server, err := metricsHandler.Start("127.0.0.1:0", false)
 	if err != nil {
 		t.Fatal(err)
@@ -122,8 +129,8 @@ func TestMetricsController(t *testing.T) {
 		}
 	}
 
-	// Should expose no metrics
-	waitForMetrics("")
+	// Should expose no additional metrics
+	waitForMetrics(clockMetric)
 
 	// Create Certificate
 	crt := gen.Certificate(crtName,
@@ -148,6 +155,7 @@ certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="t
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 1
+` + clockMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
 certmanager_controller_sync_call_count{controller="metrics_test"} 1
@@ -177,6 +185,7 @@ certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="t
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 1
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 0
+` + clockMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
 certmanager_controller_sync_call_count{controller="metrics_test"} 2
@@ -188,7 +197,8 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 2
 	}
 
 	// Should expose no Certificates and only metrics sync count increase
-	waitForMetrics(`# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
+	waitForMetrics(clockMetric + `
+# HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
 certmanager_controller_sync_call_count{controller="metrics_test"} 3
 `)

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -50,7 +51,7 @@ func TestMetricsController(t *testing.T) {
 	// Build, instantiate and run the issuing controller.
 	kubernetesCl, factory, cmClient, cmFactory := framework.NewClients(t, config)
 
-	metricsHandler := metrics.New(logf.Log)
+	metricsHandler := metrics.New(logf.Log, clock.RealClock{})
 	server, err := metricsHandler.Start("127.0.0.1:0", false)
 	if err != nil {
 		t.Fatal(err)

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -26,6 +26,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -54,7 +55,7 @@ func TestRevisionManagerController(t *testing.T) {
 	c := controllerpkg.NewController(
 		context.Background(),
 		"revisionmanager_controller_test",
-		metrics.New(logf.Log),
+		metrics.New(logf.Log, clock.RealClock{}),
 		ctrl.ProcessItem,
 		mustSync,
 		nil,

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -25,6 +25,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/utils/clock"
 	fakeclock "k8s.io/utils/clock/testing"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
@@ -69,7 +70,7 @@ func TestTriggerController(t *testing.T) {
 	c := controllerpkg.NewController(
 		context.Background(),
 		"trigger_test",
-		metrics.New(logf.Log),
+		metrics.New(logf.Log, clock.RealClock{}),
 		ctrl.ProcessItem,
 		mustSync,
 		nil,
@@ -181,7 +182,7 @@ func TestTriggerController_RenewNearExpiry(t *testing.T) {
 	c := controllerpkg.NewController(
 		logf.NewContext(context.Background(), logf.Log, "trigger_controller_RenewNearExpiry"),
 		"trigger_test",
-		metrics.New(logf.Log),
+		metrics.New(logf.Log, clock.RealClock{}),
 		ctrl.ProcessItem,
 		mustSync,
 		nil,


### PR DESCRIPTION
This PR adds a `clock_time_seconds` metric as suggested in https://github.com/jetstack/cert-manager/pull/3746

This metric allows for monitoring systems that do not have a built in time function (e.g. DataDog) to calculate the number of seconds until a certificate expires by subtracting this metric from the existing certificate_expiration_timestamp metrics.

fixes https://github.com/jetstack/cert-manager/issues/3730

Signed-off-by: kit837 <66801824+kit837@users.noreply.github.com>

```release-note
Adds clock_time_seconds metric for calculating expiration time in monitoring systems without a built in function.
```

/assign @jakexks @JoshVanL
/kind feature