### PR TITLE
adding flags for config in the acme issuer tests

### DIFF
--- a/test/e2e/framework/config/acme.go
+++ b/test/e2e/framework/config/acme.go
@@ -21,12 +21,9 @@ import (
 )
 
 type ACMEServer struct {
-	URL       string
-	DNSServer string
-	IngressIP string
-}
-
-type ACMEConfig struct {
+	URL                         string
+	DNSServer                   string
+	IngressIP                   string
 	InvalidACMEURL              string
 	TestingACMEEmail            string
 	TestingACMEEmailAlternative string
@@ -37,9 +34,6 @@ func (p *ACMEServer) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&p.URL, "acme-server-url", "https://pebble.pebble.svc.cluster.local/dir", "URL for the ACME server used during end-to-end tests")
 	fs.StringVar(&p.DNSServer, "acme-dns-server", "10.0.0.16", "DNS server for ACME DNS01 tests to run against using RFC2136")
 	fs.StringVar(&p.IngressIP, "acme-ingress-ip", "10.0.0.15", "IP of the ingress server that solves HTTP01 ACME challenges")
-}
-
-func (p *ACMEConfig) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&p.InvalidACMEURL, "invalid-acme-url", "http://not-a-real-acme-url.com", "An invalid URL to be used during end-to-end tests")
 	fs.StringVar(&p.TestingACMEEmail, "testing-acme-email", "test@example.com", "Email to be used for the tests")
 	fs.StringVar(&p.TestingACMEEmailAlternative, "testing-acme-email-alternative", "another-test@example.com", "Alternate email to be used for the tests")

--- a/test/e2e/framework/config/acme.go
+++ b/test/e2e/framework/config/acme.go
@@ -26,10 +26,24 @@ type ACMEServer struct {
 	IngressIP string
 }
 
+type ACMEConfig struct {
+	InvalidACMEURL              string
+	TestingACMEEmail            string
+	TestingACMEEmailAlternative string
+	TestingACMEPrivateKey       string
+}
+
 func (p *ACMEServer) AddFlags(fs *flag.FlagSet) {
 	fs.StringVar(&p.URL, "acme-server-url", "https://pebble.pebble.svc.cluster.local/dir", "URL for the ACME server used during end-to-end tests")
 	fs.StringVar(&p.DNSServer, "acme-dns-server", "10.0.0.16", "DNS server for ACME DNS01 tests to run against using RFC2136")
 	fs.StringVar(&p.IngressIP, "acme-ingress-ip", "10.0.0.15", "IP of the ingress server that solves HTTP01 ACME challenges")
+}
+
+func (p *ACMEConfig) AddFlags(fs *flag.FlagSet) {
+	fs.StringVar(&p.InvalidACMEURL, "invalid-acme-url", "http://not-a-real-acme-url.com", "An invalid URL to be used during end-to-end tests")
+	fs.StringVar(&p.TestingACMEEmail, "testing-acme-email", "test@example.com", "Email to be used for the tests")
+	fs.StringVar(&p.TestingACMEEmailAlternative, "testing-acme-email-alternative", "another-test@example.com", "Alternate email to be used for the tests")
+	fs.StringVar(&p.TestingACMEPrivateKey, "testing-acme-private-key", "test-acme-private-key", "Private key for the ACME tests")
 }
 
 func (p *ACMEServer) Validate() []error {

--- a/test/e2e/framework/config/addons.go
+++ b/test/e2e/framework/config/addons.go
@@ -32,9 +32,6 @@ type Addons struct {
 	// tests.
 	ACMEServer ACMEServer
 
-	// Config details to be used during the ACME end-to-end tests
-	ACMEConfig ACMEConfig
-
 	// IngressController contains configuration for the ingress controller
 	// being used during ACME HTTP01 tests.
 	IngressController IngressController
@@ -54,7 +51,6 @@ func (a *Addons) AddFlags(fs *flag.FlagSet) {
 	a.Tiller.AddFlags(fs)
 	a.Helm.AddFlags(fs)
 	a.ACMEServer.AddFlags(fs)
-	a.ACMEConfig.AddFlags(fs)
 	a.IngressController.AddFlags(fs)
 	a.Venafi.AddFlags(fs)
 	a.CertManager.AddFlags(fs)

--- a/test/e2e/framework/config/addons.go
+++ b/test/e2e/framework/config/addons.go
@@ -32,6 +32,9 @@ type Addons struct {
 	// tests.
 	ACMEServer ACMEServer
 
+	// Config details to be used during the ACME end-to-end tests
+	ACMEConfig ACMEConfig
+
 	// IngressController contains configuration for the ingress controller
 	// being used during ACME HTTP01 tests.
 	IngressController IngressController
@@ -51,6 +54,7 @@ func (a *Addons) AddFlags(fs *flag.FlagSet) {
 	a.Tiller.AddFlags(fs)
 	a.Helm.AddFlags(fs)
 	a.ACMEServer.AddFlags(fs)
+	a.ACMEConfig.AddFlags(fs)
 	a.IngressController.AddFlags(fs)
 	a.Venafi.AddFlags(fs)
 	a.CertManager.AddFlags(fs)

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -45,16 +45,16 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	AfterEach(func() {
 		By("Cleaning up")
 		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.DeleteOptions{})
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.DeleteOptions{})
 	})
 
 	It("should register ACME account", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -80,7 +80,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying ACME account private key exists")
-		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.GetOptions{})
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if len(secret.Data) != 1 {
 			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
@@ -90,10 +90,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	It("should recover a lost ACME account URI", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -121,7 +121,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying ACME account private key exists")
-		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.GetOptions{})
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		if len(secret.Data) != 1 {
@@ -135,10 +135,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		By("Recreating the Issuer")
 		acmeIssuer = gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey))
 		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -170,10 +170,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	It("should fail to register an ACME account", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
-			gen.SetIssuerACMEURL(f.Config.Addons.ACMEConfig.InvalidACMEURL),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.InvalidACMEURL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey))
 
 		By("Creating an Issuer with an invalid server")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
@@ -192,10 +192,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	It("should handle updates to the email field", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey))
 
 		By("Creating an Issuer")
 		acmeIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
@@ -222,7 +222,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying ACME account private key exists")
-		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.GetOptions{})
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEServer.TestingACMEPrivateKey, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if len(secret.Data) != 1 {
 			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
@@ -233,7 +233,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			acmeIssuer.Name,
 			func(i *v1.Issuer) (bool, error) {
 				registeredEmail := i.GetStatus().ACMEStatus().LastRegisteredEmail
-				if registeredEmail == f.Config.Addons.ACMEConfig.TestingACMEEmail {
+				if registeredEmail == f.Config.Addons.ACMEServer.TestingACMEEmail {
 					return true, nil
 				}
 				return false, nil
@@ -243,7 +243,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		By("Changing the email field")
 		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Get(context.TODO(), acmeIssuer.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		acmeIssuer.Spec.ACME.Email = f.Config.Addons.ACMEConfig.TestingACMEEmailAlternative
+		acmeIssuer.Spec.ACME.Email = f.Config.Addons.ACMEServer.TestingACMEEmailAlternative
 		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Update(context.TODO(), acmeIssuer, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -261,7 +261,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			acmeIssuer.Name,
 			func(i *v1.Issuer) (bool, error) {
 				registeredEmail := i.GetStatus().ACMEStatus().LastRegisteredEmail
-				if registeredEmail == f.Config.Addons.ACMEConfig.TestingACMEEmailAlternative {
+				if registeredEmail == f.Config.Addons.ACMEServer.TestingACMEEmailAlternative {
 					return true, nil
 				}
 				return false, nil
@@ -289,10 +289,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEServer.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey),
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEServer.TestingACMEPrivateKey),
 			gen.SetIssuerACMEEABWithKeyAlgorithm(keyID, secretName, cmacme.HS256))
 
 		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(

--- a/test/e2e/suite/issuers/acme/issuer.go
+++ b/test/e2e/suite/issuers/acme/issuer.go
@@ -37,11 +37,6 @@ import (
 	"github.com/jetstack/cert-manager/test/unit/gen"
 )
 
-const invalidACMEURL = "http://not-a-real-acme-url.com"
-const testingACMEEmail = "test@example.com"
-const testingACMEEmailAlternative = "another-test@example.com"
-const testingACMEPrivateKey = "test-acme-private-key"
-
 var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	f := framework.NewDefaultFramework("create-acme-issuer")
 
@@ -50,16 +45,16 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	AfterEach(func() {
 		By("Cleaning up")
 		f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Delete(context.TODO(), issuerName, metav1.DeleteOptions{})
-		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), testingACMEPrivateKey, metav1.DeleteOptions{})
+		f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Delete(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.DeleteOptions{})
 	})
 
 	It("should register ACME account", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -85,7 +80,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying ACME account private key exists")
-		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), testingACMEPrivateKey, metav1.GetOptions{})
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if len(secret.Data) != 1 {
 			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
@@ -95,10 +90,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	It("should recover a lost ACME account URI", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
 		By("Creating an Issuer")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
@@ -126,7 +121,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying ACME account private key exists")
-		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), testingACMEPrivateKey, metav1.GetOptions{})
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		if len(secret.Data) != 1 {
@@ -140,10 +135,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		By("Recreating the Issuer")
 		acmeIssuer = gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
 		_, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -175,10 +170,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	It("should fail to register an ACME account", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(testingACMEEmail),
-			gen.SetIssuerACMEURL(invalidACMEURL),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
+			gen.SetIssuerACMEURL(f.Config.Addons.ACMEConfig.InvalidACMEURL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
 
 		By("Creating an Issuer with an invalid server")
 		_, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
@@ -197,10 +192,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 	It("should handle updates to the email field", func() {
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey))
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey))
 
 		By("Creating an Issuer")
 		acmeIssuer, err := f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(context.TODO(), acmeIssuer, metav1.CreateOptions{})
@@ -227,7 +222,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Verifying ACME account private key exists")
-		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), testingACMEPrivateKey, metav1.GetOptions{})
+		secret, err := f.KubeClientSet.CoreV1().Secrets(f.Namespace.Name).Get(context.TODO(), f.Config.Addons.ACMEConfig.TestingACMEPrivateKey, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 		if len(secret.Data) != 1 {
 			Fail("Expected 1 key in ACME account private key secret, but there was %d", len(secret.Data))
@@ -238,7 +233,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			acmeIssuer.Name,
 			func(i *v1.Issuer) (bool, error) {
 				registeredEmail := i.GetStatus().ACMEStatus().LastRegisteredEmail
-				if registeredEmail == testingACMEEmail {
+				if registeredEmail == f.Config.Addons.ACMEConfig.TestingACMEEmail {
 					return true, nil
 				}
 				return false, nil
@@ -248,7 +243,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 		By("Changing the email field")
 		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Get(context.TODO(), acmeIssuer.Name, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-		acmeIssuer.Spec.ACME.Email = testingACMEEmailAlternative
+		acmeIssuer.Spec.ACME.Email = f.Config.Addons.ACMEConfig.TestingACMEEmailAlternative
 		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Update(context.TODO(), acmeIssuer, metav1.UpdateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -266,7 +261,7 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 			acmeIssuer.Name,
 			func(i *v1.Issuer) (bool, error) {
 				registeredEmail := i.GetStatus().ACMEStatus().LastRegisteredEmail
-				if registeredEmail == testingACMEEmailAlternative {
+				if registeredEmail == f.Config.Addons.ACMEConfig.TestingACMEEmailAlternative {
 					return true, nil
 				}
 				return false, nil
@@ -294,10 +289,10 @@ var _ = framework.CertManagerDescribe("ACME Issuer", func() {
 
 		acmeIssuer := gen.Issuer(issuerName,
 			gen.SetIssuerNamespace(f.Namespace.Name),
-			gen.SetIssuerACMEEmail(testingACMEEmail),
+			gen.SetIssuerACMEEmail(f.Config.Addons.ACMEConfig.TestingACMEEmail),
 			gen.SetIssuerACMEURL(f.Config.Addons.ACMEServer.URL),
 			gen.SetIssuerACMESkipTLSVerify(true),
-			gen.SetIssuerACMEPrivKeyRef(testingACMEPrivateKey),
+			gen.SetIssuerACMEPrivKeyRef(f.Config.Addons.ACMEConfig.TestingACMEPrivateKey),
 			gen.SetIssuerACMEEABWithKeyAlgorithm(keyID, secretName, cmacme.HS256))
 
 		acmeIssuer, err = f.CertManagerClientSet.CertmanagerV1().Issuers(f.Namespace.Name).Create(


### PR DESCRIPTION
Signed-off-by: RinkiyaKeDad <arshsharma461@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Allowing passing config for the acme tests using flags so that we can use them with the EKS cluster for testing.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/assign @jakexks 