### PR TITLE
Fix sync issue for CD systems trying to sync ValidatingWebhookConfiguration

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -133,6 +133,7 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `webhook.deploymentAnnotations` | Annotations to add to the webhook deployment | `{}` |
 | `webhook.mutatingWebhookConfigurationAnnotations` | Annotations to add to the mutating webhook configuration | `{}` |
 | `webhook.validatingWebhookConfigurationAnnotations` | Annotations to add to the validating webhook configuration | `{}` |
+| `webhook.validatingWebhookConfigurationNamespaceSelectorMatchExpressions` | Additional matchExpressions for the namespaceSelector of the validating webhook configuration | `[]` |
 | `webhook.extraArgs` | Optional flags for cert-manager webhook component | `[]` |
 | `webhook.serviceAccount.create` | If `true`, create a new service account for the webhook component | `true` |
 | `webhook.serviceAccount.name` | Service account for the webhook component to be used. If not set and `webhook.serviceAccount.create` is `true`, a name is generated using the fullname template |  |

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -26,6 +26,8 @@ webhooks:
         operator: "NotIn"
         values:
         - {{ .Release.Namespace }}
+      - key: control-plane
+        operator: DoesNotExist
     rules:
       - apiGroups:
           - "cert-manager.io"

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -26,8 +26,9 @@ webhooks:
         operator: "NotIn"
         values:
         - {{ .Release.Namespace }}
-      - key: control-plane
-        operator: DoesNotExist
+      {{- if .Values.webhook.validatingWebhookConfigurationNamespaceSelectorMatchExpressions }}
+      {{- toYaml .Values.webhook.validatingWebhookConfigurationAnnotations | nindent 6 }}
+      {{- end }}
     rules:
       - apiGroups:
           - "cert-manager.io"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Azure Kubernetes Service force-injects an additional matchExpression on the namespaceSelector of this webhook... one that, if you don't template it out, causes continuous synchronization failures using most Continuous Delivery tools, namely ArgoCD in the parent issue.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4114 

**Special notes for your reviewer**: none needed really.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```Add namespaceSelector matchExpression for Azure Kubernetes Service for ValidatingWebhookConfiguration
```
