### PR TITLE
4082 Fix retrying of failed CertificateRequests

### DIFF
--- a/pkg/controller/certificates/requestmanager/BUILD.bazel
+++ b/pkg/controller/certificates/requestmanager/BUILD.bazel
@@ -66,5 +66,6 @@ go_test(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
+        "@io_k8s_utils//clock/testing:go_default_library",
     ],
 )

--- a/pkg/controller/certificates/requestmanager/BUILD.bazel
+++ b/pkg/controller/certificates/requestmanager/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "@io_k8s_client_go//tools/cache:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",
         "@io_k8s_client_go//util/workqueue:go_default_library",
+        "@io_k8s_utils//clock:go_default_library",
     ],
 )
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
@@ -66,6 +67,7 @@ type controller struct {
 	secretLister             corelisters.SecretLister
 	client                   cmclient.Interface
 	recorder                 record.EventRecorder
+	clock                    clock.Clock
 }
 
 func NewController(
@@ -74,6 +76,7 @@ func NewController(
 	factory informers.SharedInformerFactory,
 	cmFactory cminformers.SharedInformerFactory,
 	recorder record.EventRecorder,
+	clock clock.Clock,
 ) (*controller, workqueue.RateLimitingInterface, []cache.InformerSynced) {
 	// create a queue used to queue up items to be processed
 	queue := workqueue.NewNamedRateLimitingQueue(workqueue.NewItemExponentialFailureRateLimiter(time.Second*1, time.Second*30), ControllerName)
@@ -111,6 +114,7 @@ func NewController(
 		secretLister:             secretsInformer.Lister(),
 		client:                   client,
 		recorder:                 recorder,
+		clock:                    clock,
 	}, queue, mustSync
 }
 
@@ -378,6 +382,7 @@ func (c *controllerWrapper) Register(ctx *controllerpkg.Context) (workqueue.Rate
 		ctx.KubeSharedInformerFactory,
 		ctx.SharedInformerFactory,
 		ctx.Recorder,
+		ctx.Clock,
 	)
 	c.controller = ctrl
 

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -46,15 +46,7 @@ import (
 	"github.com/jetstack/cert-manager/pkg/util/predicate"
 )
 
-const (
-	ControllerName = "certificates-trigger"
-
-	// the amount of time after the LastFailureTime of a Certificate
-	// before the request should be retried.
-	// In future this should be replaced with a more dynamic exponential
-	// back-off algorithm.
-	retryAfterLastFailure = time.Hour
-)
+const ControllerName = "certificates-trigger"
 
 // This controller observes the state of the certificate's currently
 // issued `spec.secretName` and the rest of the `certificate.spec` fields to
@@ -237,11 +229,11 @@ func shouldBackoffReissuingOnFailure(log logr.Logger, c clock.Clock, crt *cmapi.
 
 	now := c.Now()
 	durationSinceFailure := now.Sub(crt.Status.LastFailureTime.Time)
-	if durationSinceFailure >= retryAfterLastFailure {
+	if durationSinceFailure >= certificates.RetryAfterLastFailure {
 		log.V(logf.ExtendedInfoLevel).WithValues("since_failure", durationSinceFailure).Info("Certificate has been in failure state long enough, no need to back off")
 		return false, 0
 	}
-	return true, retryAfterLastFailure - durationSinceFailure
+	return true, certificates.RetryAfterLastFailure - durationSinceFailure
 }
 
 // scheduleRecheckOfCertificateIfRequired will schedule the resource with the

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -34,6 +34,12 @@ import (
 	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
+// The amount of time after the LastFailureTime of a Certificate
+// before the request should be retried.
+// In future this should be replaced with a more dynamic exponential
+// back-off algorithm.
+const RetryAfterLastFailure = time.Hour
+
 // PrivateKeyMatchesSpec returns an error if the private key bit size
 // doesn't match the provided spec. RSA, Ed25519 and ECDSA are supported.
 // If any error is returned, a list of violations will also be returned.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR fixes a bug where failed certificate issuance is not retried by deleting the failed `CertificateRequest` in the next issuance cycle, so that a new one gets created for the same revision.
This will then work in the same way as retrying of failed issuances when private key rotation policy is 'Always' or when it is the fist `CertificateRequest` where the failed requests _are_ deleted in the next issuance cycle [here](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/requestmanager/requestmanager_controller.go#L286).
The downside is that once we implement exponential back off for failed `Certificate`s, we will no longer be able to use the static 1 hour period. But I think even then it will still make sense to manage the `CertificateRequest`s from the request manager controller.


**Which issue this PR fixes**:

fixes #4082 

**Special notes for your reviewer**:

Alternative approches:
- Change the revision mechanism so that the revision of a `Certificate` is bumped after an issuance has failed similarly to how it's done now after an issuance has succeeded.  Then the failed `CertificateRequest` would not be deleted, but a new one would be created. This would affect other parts of code (especially the back off functionality). It would also change the behaviour/meaning of revision from a user's perspective.
- Delete the failed `CertificateRequest` at [the point where we exit the back off period](https://github.com/jetstack/cert-manager/blob/67c817680198a990b6f4a17387a257062840f483/pkg/controller/certificates/trigger/trigger_controller.go#L241). This would make it easier to delete these `CertificateRequest`s once we have exponential back off, but makes the trigger controller less DRY.

I have tested the fix manually- see https://github.com/jetstack/cert-manager/issues/4082#issuecomment-865292890 for how to reproduce the bug.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix a bug where failed Certificate Requests were not retried
```

/kind bug
