### PR TITLE
Add startup probe to cainjector deployment

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -181,6 +181,11 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | `{}` |
 | `cainjector.containerSecurityContext` | Security context to be set on cainjector component container | `{}` |
+| `cainjector.startupProbe.failureThreshold` | The startup probe failure threshold | `12` |
+| `cainjector.startupProbe.initialDelaySeconds` | The startup probe initial delay (in seconds) | `20` |
+| `cainjector.startupProbe.periodSeconds` | The startup probe period (in seconds) | `5` |
+| `cainjector.startupProbe.successThreshold` | The startup probe success threshold | `1` |
+| `cainjector.startupProbe.timeoutSeconds` | The startup probe timeout (in seconds) | `1` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -76,6 +76,16 @@ spec:
           {{- if .Values.cainjector.extraArgs }}
 {{ toYaml .Values.cainjector.extraArgs | indent 10 }}
           {{- end }}
+          startupProbe:
+            httpGet:
+              path: /healthz
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.cainjector.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.cainjector.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.cainjector.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.cainjector.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.cainjector.startupProbe.failureThreshold }}
           env:
           - name: POD_NAMESPACE
             valueFrom:

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -347,6 +347,15 @@ cainjector:
     # readOnlyRootFilesystem: true
     # runAsNonRoot: true
 
+  ## Startup probe values
+  ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  startupProbe:
+    failureThreshold: 12
+    initialDelaySeconds: 20
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 1
 
   # Optional additional annotations to add to the cainjector Deployment
   # deploymentAnnotations: {}

--- a/pkg/controller/cainjector/BUILD.bazel
+++ b/pkg/controller/cainjector/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "injectors.go",
         "setup.go",
         "sources.go",
+        "state.go",
     ],
     importpath = "github.com/jetstack/cert-manager/pkg/controller/cainjector",
     visibility = ["//visibility:public"],

--- a/pkg/controller/cainjector/controller.go
+++ b/pkg/controller/cainjector/controller.go
@@ -103,6 +103,8 @@ type genericInjectReconciler struct {
 	// the conversion webhook not being available.
 	sources []caDataSource
 
+	stateHandle *InjectorStateHandle
+
 	log logr.Logger
 	client.Client
 
@@ -122,6 +124,8 @@ func splitNamespacedName(nameStr string) types.NamespacedName {
 // Reconcile attempts to ensure that a particular object has all the CAs injected that
 // it has requested.
 func (r *genericInjectReconciler) Reconcile(_ context.Context, req ctrl.Request) (ctrl.Result, error) {
+	defer r.stateHandle.DoneRound()
+
 	ctx := context.Background()
 	log := r.log.WithValues(r.resourceName, req.NamespacedName)
 

--- a/pkg/controller/cainjector/state.go
+++ b/pkg/controller/cainjector/state.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cainjector
+
+import (
+	"fmt"
+	"sync"
+)
+
+// The CA injector can be in one of the 3 states described
+// below. The "Setup" stage is the starting stage and is
+// maintained until the DoneSetup() function is called.
+// The "FirstReconciliation" starts after the DoneSetup()
+// function is called, and indicates that the injector is
+// reconciling all objects for the first time. Once each
+// created InjectorStateHandle has called DoneRound(), the
+// stable "Reconciling" stage is started. During this last
+// stage the startup probe should succeed.
+type Stage int
+
+const (
+	Setup Stage = iota
+	FirstReconciliation
+	Reconciling
+)
+
+// InjectorState describes the state of the injector controller
+type InjectorState struct {
+	sync.Mutex
+	stage Stage
+
+	count int
+}
+
+// A InjectorStateHandle is a handle that is created when
+// calling Fork() on a InjectorState object. This handle is
+// only used to update the InjectorState once (the first time
+// DoneRound() is called).
+type InjectorStateHandle struct {
+	injectorState      *InjectorState
+	finishedFirstRound bool
+}
+
+func NewInjectorState() *InjectorState {
+	return &InjectorState{
+		stage: Setup,
+		count: 0,
+	}
+}
+
+// This function updates the InjectorState the first time it
+// called. After that first call, all subsequent calls to
+// DoneRound() will short circuit and directly return.
+func (h *InjectorStateHandle) DoneRound() {
+	if h.finishedFirstRound {
+		return
+	}
+
+	h.finishedFirstRound = true
+
+	h.injectorState.Lock()
+	defer h.injectorState.Unlock()
+
+	h.injectorState.count -= 1
+}
+
+// This function is called after all InjectorStateHandle objects
+// are created.
+func (s *InjectorState) DoneSetup() error {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.stage != Setup {
+		return fmt.Errorf("Cannot be called when not in Setup stage.")
+	}
+
+	s.stage = FirstReconciliation
+
+	return nil
+}
+
+// Create a new handle and update InjectorState, so it will wait
+// for DoneRound() to be called on the InjectorStateHandle object.
+func (s *InjectorState) Fork() (*InjectorStateHandle, error) {
+	s.Lock()
+	defer s.Unlock()
+
+	if s.stage != Setup {
+		return nil, fmt.Errorf("Cannot be called when not in Setup stage.")
+	}
+
+	s.count += 1
+
+	return &InjectorStateHandle{
+		injectorState:      s,
+		finishedFirstRound: false,
+	}, nil
+}
+
+// Return the current state of the injector. This function is used
+// by the startup probe.
+func (s *InjectorState) GetState() Stage {
+	s.Lock()
+	defer s.Unlock()
+
+	if (s.stage == FirstReconciliation) && (s.count == 0) {
+		s.stage = Reconciling
+	}
+
+	return s.stage
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, directly after deploying cert-manager, certificates cannot be created yet.
Instead when trying to create such resources, "x509: certificate signed by unknown authority" will be returned as an error.
This PR makes sure that the cainjector does not switch to the ready state before certificates can be created.

This approach works with a static manifest deployment, helm deployment, ... . These tools can wait for the deployments to go to a ready state. Once all deployments (also cainjector) are in a Ready state, we can be sure that new resources can be created without receiving a "x509: certificate signed by unknown authority" error.

fixes: #4155

The PR waits for the first reconciliation loop of the cainjector to complete before setting its state to `Ready`.
This means that each element in the `[]injectorSetup{MutatingWebhookSetup, ValidatingWebhookSetup, APIServiceSetup, CRDSetup}` array, has to be reconciled before the startup probe returns OK.

**Note to the reviewer:**

https://github.com/jetstack/cert-manager/pull/4171 is an alternative to this PR, please also check that approach. In that approach @wallrj tries to solve the problem ("x509: certificate signed by unknown authority" error) even if there is no cainjector installed. This approach however introduces some extra challenges: https://github.com/jetstack/cert-manager/pull/4171#pullrequestreview-697991775.

It is hard to find consensus on an ideal solution to this problem. In my opinion, this PR currently is the best way to fix the problem for as many use cases as possible.

**Also, note that in case a better solution were to get invented, that covers all use cases covered by this approach, we can easily remove this solution and switch to the other solution. This approach aims to be forward compatible, the only added requirement is that a replacement solution at least fix the problem in case an cainjector is installed.**

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
cainjector's deployment state now better reflects how ready cert-manager is after doing a new install
```
