### PR TITLE
Cloudflare: refactor DNS01 challenge to use API for finding the nearest Zone

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -13588,6 +13588,36 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 
 ================================================================================
+= vendor/github.com/stretchr/objx licensed under: =
+
+The MIT License
+
+Copyright (c) 2014 Stretchr, Inc.
+Copyright (c) 2017-2018 objx contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+= vendor/github.com/stretchr/objx/LICENSE d023fd31d3ca39ec61eec65a91732735
+================================================================================
+
+
+================================================================================
 = vendor/github.com/stretchr/testify licensed under: =
 
 MIT License

--- a/pkg/issuer/acme/dns/cloudflare/BUILD.bazel
+++ b/pkg/issuer/acme/dns/cloudflare/BUILD.bazel
@@ -18,6 +18,7 @@ go_test(
     deps = [
         "//pkg/issuer/acme/dns/util:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@com_github_stretchr_testify//mock:go_default_library",
     ],
 )
 

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -9,12 +9,16 @@ this directory.
 package cloudflare
 
 import (
+	"encoding/json"
+	"io"
 	"os"
 	"testing"
 	"time"
 
-	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 var (
@@ -24,6 +28,16 @@ var (
 	cflareAPIToken string
 	cflareDomain   string
 )
+
+type DNSProviderMock struct {
+	mock.Mock
+}
+
+func (c *DNSProviderMock) makeRequest(method, uri string, body io.Reader) (json.RawMessage, error) {
+	//stub makeRequest
+	args := c.Called(method, uri, nil)
+	return args.Get(0).([]uint8), args.Error(1)
+}
 
 func init() {
 	cflareEmail = os.Getenv("CLOUDFLARE_EMAIL")
@@ -77,6 +91,24 @@ func TestNewDNSProviderMissingCredErr(t *testing.T) {
 	_, err := NewDNSProvider(util.RecursiveNameservers)
 	assert.EqualError(t, err, "CloudFlare credentials missing")
 	restoreCloudFlareEnv()
+}
+
+func TestFindNearestZoneForFQDN(t *testing.T) {
+	dnsProvider := new(DNSProviderMock)
+
+	noResult := []byte(`[]`)
+
+	dnsProvider.On("makeRequest", "GET", "/zones?name=_acme-challenge.test.sub.domain.com", mock.Anything).Maybe().Return(noResult, nil)
+	dnsProvider.On("makeRequest", "GET", "/zones?name=test.sub.domain.com", mock.Anything).Maybe().Return(noResult, nil)
+	dnsProvider.On("makeRequest", "GET", "/zones?name=sub.domain.com", mock.Anything).Return([]byte(`[
+		{"id":"1a23cc4567b8def91a01c23a456e78cd","name":"sub.domain.com"}
+	]`), nil)
+
+	zone, err := FindNearestZoneForFQDN(dnsProvider, "_acme-challenge.test.sub.domain.com.")
+
+	assert.NoError(t, err)
+	assert.Equal(t, zone, DNSZone{ID: "1a23cc4567b8def91a01c23a456e78cd", Name: "sub.domain.com"})
+
 }
 
 func TestCloudFlarePresent(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Bottomline the current implementation isn't using the official Cloudflare API for finding the nearest Zone-ID, instead it uses the generic utility method `/pkg/issuer/acme/dns/util/wait.go#FindZoneByFqdn` which tries to find the Zone by getting SOA records for the public domain. If there are any DNS-Issues (for example if your local DNS-Resolver e.g. is misconfigured or even more common - the Domain is simply incorrectly setup) and there are no SOA-Records returned then this method does not work at all. Or also common in relation with the DNS-Challenge if the Domain in question points to a LAN-Address if its just used for certification.

Furthermore FindZoneByFqdn also is bugged in that it returns the TLD as the default zone to try to access the Cloudflare API in case there are no SOA-Records found at all - e.g. Zone "com" - in general for cloudflare this should be the SLD in combination with the TLD as the default (and likely for others too). Since I do know to little about the specific bits of this generic utility code I didn't touch that part yet.

Instead what I did is refactor the code in the DNS-Issuer for Cloudflare to use the official API for querying the DNS-Tree in the same way, just trought the API (and also fixing that it won't traverse the TLD as a possible Zone-Entry-Name in that regard, like mentioned above).


I've added mocks and a basic unit-test that doesn't need e2e testing to validate the basic-functionality described in the comments.

This was also tested with my own domain in my local test-environment (setup via official means from /devel/README.md)

**Which issue this PR fixes**: 

fixes #4134

**Special notes for your reviewer**:

- See my comments in regard to solving the underlying issue and to get a better idea of the issue itself.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Cloudflare: Refactored DNS01 challenge to use API for finding the nearest Zone (fixing potential DNS-Issues)
```

