### PR TITLE
add -s and -w flags to the go_binary linkopts

### DIFF
--- a/build/go_binary.bzl
+++ b/build/go_binary.bzl
@@ -19,6 +19,10 @@ def go_binary(name, **kwargs):
     real_go_binary(
         name = name,
         x_defs = version_x_defs(),
+        # reduce the go binary size with this simple trick
+        # (https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/)
+        # it strips the DWARF tables needed for debuggers, not the annotations
+        # needed for stack traces, so our panics are still readable!
         gc_linkopts = ["-s", "-w"],
         **kwargs,
     )

--- a/build/go_binary.bzl
+++ b/build/go_binary.bzl
@@ -19,5 +19,6 @@ def go_binary(name, **kwargs):
     real_go_binary(
         name = name,
         x_defs = version_x_defs(),
+        gc_linkopts = ["-s", "-w"],
         **kwargs,
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Based on https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/, adding -s and -w flags as go_binary linkops arguments reduces the binary size.

From the article:

> Interestingly, what gets stripped is only the DWARF tables needed for debuggers, not the annotations needed for stack traces, so our panics are still readable!

The cert-manager kubectl plugin's size shrinks from 68M to 43M.

Kubernetes also applies these flags when compiling their binaries; https://github.com/kubernetes/kubernetes/blob/1861e4756df1818a2d4ca60c869780bf742fff6b/hack/lib/golang.sh#L798-L804.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
reduce binary sizes by adding "-s -w" as ldflags
```
/kind feature