### PR TITLE
A webhook startup probe to check that the cert-manager API is usable

### DIFF
--- a/cmd/webhook/app/BUILD.bazel
+++ b/cmd/webhook/app/BUILD.bazel
@@ -7,9 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/webhook/app/options:go_default_library",
-        "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/cmapichecker:go_default_library",
         "//pkg/webhook:go_default_library",
         "//pkg/webhook/authority:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
@@ -17,10 +17,8 @@ go_library(
         "//pkg/webhook/server/tls:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
-        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )
 

--- a/cmd/webhook/app/BUILD.bazel
+++ b/cmd/webhook/app/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/webhook/app/options:go_default_library",
+        "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/webhook:go_default_library",
@@ -16,8 +17,10 @@ go_library(
         "//pkg/webhook/server/tls:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
     ],
 )
 

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -93,6 +93,17 @@ spec:
             timeoutSeconds: {{ .Values.webhook.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.webhook.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.webhook.readinessProbe.failureThreshold }}
+          startupProbe:
+            httpGet:
+              path: /startupz
+              port: 6080
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.webhook.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.webhook.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.webhook.startupProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.webhook.startupProbe.successThreshold }}
+            failureThreshold: {{ .Values.webhook.startupProbe.failureThreshold }}
+
           {{- if .Values.webhook.containerSecurityContext }}
           securityContext:
             {{- toYaml .Values.webhook.containerSecurityContext | nindent 12 }}

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -22,6 +22,12 @@ rules:
 - apiGroups: [""]
   resources: ["secrets"]
   verbs: ["create"]
+# Allows the webhook server to perform a health check on the cert-manager CRDs.
+# It will perform a *dry-run* create Certificate operation only,
+# in the namespace where the webhook is running.
+- apiGroups: ["cert-manager.io"]
+  resources: ["certificates"]
+  verbs: ["create"]
 ---
 
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -11,6 +11,11 @@ metadata:
     app.kubernetes.io/component: "webhook"
     helm.sh/chart: {{ include "webhook.chart" . }}
 spec:
+  # Allow the K8S API server to reach the webhook server even before its
+  # readiness probes are passing.
+  # This allows the /startupz code in the webhook server to verify that the K8S
+  # API server can connect to it, by performing a dry-run create Certificate.
+  publishNotReadyAddresses: true
   type: {{ .Values.webhook.serviceType }}
   {{- if .Values.webhook.loadBalancerIP }}
   loadBalancerIP: {{ .Values.webhook.loadBalancerIP }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -342,7 +342,7 @@ webhook:
 
 cainjector:
   enabled: true
-  replicaCount: 0
+  replicaCount: 1
 
   strategy: {}
     # type: RollingUpdate

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -254,7 +254,13 @@ webhook:
     timeoutSeconds: 1
   readinessProbe:
     failureThreshold: 3
-    initialDelaySeconds: 5
+    initialDelaySeconds: 0
+    periodSeconds: 5
+    successThreshold: 1
+    timeoutSeconds: 1
+  startupProbe:
+    failureThreshold: 12
+    initialDelaySeconds: 20
     periodSeconds: 5
     successThreshold: 1
     timeoutSeconds: 1

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -243,8 +243,19 @@ webhook:
     #   cpu: 10m
     #   memory: 32Mi
 
-  ## Liveness and readiness probe values
+  ## Liveness, Readiness and Startup probe values
   ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
+  ##
+  ## The Startup probe verifies that the cert-manager API is usable by
+  ## attempting to connect to the K8S API and create a cert-manager Certificate,
+  ## which will only succeed when the K8S API server has a TLS client
+  ## certificate to authenticate with the webhook server, and a CA certificate
+  ## to verify the webhook TLS serving certificate.
+  ## On first startup this will be delayed by the time taken to generate a new
+  ## webhook key pair and the time taken to pull the cainjector image and for
+  ## cainjector to inject the webhook CA certifcate in to the various webhook
+  ## and CRD resources.
+  ## See https://cert-manager.io/docs/concepts/webhook/#diagnosing-other-webhook-problems
   ##
   livenessProbe:
     failureThreshold: 3
@@ -260,7 +271,7 @@ webhook:
     timeoutSeconds: 1
   startupProbe:
     failureThreshold: 12
-    initialDelaySeconds: 20
+    initialDelaySeconds: 0
     periodSeconds: 5
     successThreshold: 1
     timeoutSeconds: 1

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -331,7 +331,7 @@ webhook:
 
 cainjector:
   enabled: true
-  replicaCount: 1
+  replicaCount: 0
 
   strategy: {}
     # type: RollingUpdate

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "context.go",
+        "get_incluster_namespace.go",
         "useragent.go",
         "util.go",
         "version.go",
@@ -33,6 +34,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/util/cmapichecker:all-srcs",
         "//pkg/util/cmd:all-srcs",
         "//pkg/util/coverage:all-srcs",
         "//pkg/util/errors:all-srcs",

--- a/pkg/util/cmapichecker/BUILD.bazel
+++ b/pkg/util/cmapichecker/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",

--- a/pkg/util/cmapichecker/BUILD.bazel
+++ b/pkg/util/cmapichecker/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cmapichecker.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/util/cmapichecker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/cmapichecker/BUILD.bazel
+++ b/pkg/util/cmapichecker/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/util/cmapichecker",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package cmapichecker
 
 import (

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -1,0 +1,65 @@
+package cmapichecker
+
+import (
+	"context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+// Interface is used to check that the cert-manager CRDs have been installed and are usable.
+type Interface interface {
+	Check(context.Context) error
+}
+
+type cmapiChecker struct {
+	dryRunClient client.Client
+	namespace    string
+}
+
+// New returns a cert-manager API checker
+func New(restcfg *rest.Config, namespace string) (Interface, error) {
+	scheme := runtime.NewScheme()
+	if err := cmapi.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	cl, err := client.New(restcfg, client.Options{
+		Scheme: scheme,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &cmapiChecker{
+		dryRunClient: client.NewDryRunClient(cl),
+		namespace:    namespace,
+	}, nil
+}
+
+// Check attempts to perform a dry-run create of a cert-manager Certificate
+// resource in order to verify that CRDs are installed and all the required
+// webhooks are reachable by the K8S API server.
+func (o *cmapiChecker) Check(ctx context.Context) error {
+	cert := &cmapi.Certificate{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "cmapichecker-",
+			Namespace:    o.namespace,
+		},
+		Spec: cmapi.CertificateSpec{
+			DNSNames:   []string{"cmapichecker.example"},
+			SecretName: "cmapichecker",
+			IssuerRef: cmmeta.ObjectReference{
+				Name: "cmapichecker",
+			},
+		},
+	}
+	if err := o.dryRunClient.Create(ctx, cert); err != nil {
+		return fmt.Errorf("error creating Certificate: %v", err)
+	}
+	return nil
+}

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -25,7 +25,11 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	// Use v1alpha2 API to ensure that the API server has also connected to the
+	// cert-manager conversion webhook.
+	// TODO(wallrj): Only change this when the old deprecated APIs are removed,
+	// at which point the conversion webhook may be removed anyway.
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 )
 
@@ -61,9 +65,11 @@ func New(restcfg *rest.Config, namespace string) (Interface, error) {
 	}, nil
 }
 
-// Check attempts to perform a dry-run create of a cert-manager Certificate
-// resource in order to verify that CRDs are installed and all the required
-// webhooks are reachable by the K8S API server.
+// Check attempts to perform a dry-run create of a cert-manager *v1alpha2*
+// Certificate resource in order to verify that CRDs are installed and all the
+// required webhooks are reachable by the K8S API server.
+// We use v1alpha2 API to ensure that the API server has also connected to the
+// cert-manager conversion webhook.
 func (o *cmapiChecker) Check(ctx context.Context) error {
 	cert := &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/util/get_incluster_namespace.go
+++ b/pkg/util/get_incluster_namespace.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 import (

--- a/pkg/util/get_incluster_namespace.go
+++ b/pkg/util/get_incluster_namespace.go
@@ -1,0 +1,36 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+const inClusterNamespacePath = "/var/run/secrets/kubernetes.io/serviceaccount/namespace"
+
+var ErrNotInCluster = errors.New("not running in a cluster")
+
+// GetInClusterNamespace returns the Kubernetes namespace of the Pod in which
+// this process is running in a Kubernetes cluster.
+// It checks for a well known namespace file path which is mounted into all
+// Kubernetes Pods.
+// Copied from controller-runtime
+// https://github.com/kubernetes-sigs/controller-runtime/blob/1e4d87c9f9e15e4a58bb81909dd787f30ede7693/pkg/leaderelection/leader_election.go#L104-L119
+func GetInClusterNamespace() (string, error) {
+	// Check whether the namespace file exists.
+	// If not, we are not running in cluster so can't guess the namespace.
+	_, err := os.Stat(inClusterNamespacePath)
+	if os.IsNotExist(err) {
+		return "", fmt.Errorf("%w: %v", ErrNotInCluster, err)
+	} else if err != nil {
+		return "", fmt.Errorf("error checking namespace file: %v", err)
+	}
+
+	// Load the namespace file and return its content
+	namespace, err := ioutil.ReadFile(inClusterNamespacePath)
+	if err != nil {
+		return "", fmt.Errorf("error reading namespace file: %v", err)
+	}
+	return string(namespace), nil
+}

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util/profiling:go_default_library",
         "//pkg/webhook/handlers:go_default_library",

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/webhook/server",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util/profiling:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
@@ -23,6 +24,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/serializer/json:go_default_library",
         "@io_k8s_apimachinery//pkg/util/runtime:go_default_library",
         "@io_k8s_component_base//cli/flag:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
     ],
 )

--- a/pkg/webhook/server/BUILD.bazel
+++ b/pkg/webhook/server/BUILD.bazel
@@ -6,9 +6,8 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/pkg/webhook/server",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/apis/certmanager/v1:go_default_library",
-        "//pkg/apis/meta/v1:go_default_library",
         "//pkg/logs:go_default_library",
+        "//pkg/util/cmapichecker:go_default_library",
         "//pkg/util/profiling:go_default_library",
         "//pkg/webhook/handlers:go_default_library",
         "//pkg/webhook/server/tls:go_default_library",
@@ -25,7 +24,6 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime/serializer/json:go_default_library",
         "@io_k8s_apimachinery//pkg/util/runtime:go_default_library",
         "@io_k8s_component_base//cli/flag:go_default_library",
-        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
     ],
 )


### PR DESCRIPTION
In collaboration with @inteon  this is an attempt to add a startup probe to the webhook deployment which attempts to submit a cert-manager Certificate to the API server.


This is an end-to-end check which verifies that the K8S API server has the cert-manager CRDs installed and also that the K8S API server has established a TLS connection back to the cert-manager webhook.

Only when the webhooks connections are established can the cert-manager API be considered ready.

This should obviates the need for the "Create the test resources" verification step described in https://cert-manager.io/docs/installation/kubernetes/#verifying-the-installation 

And it should simplify the installation of cert-manager in CI where administrators often want to install Issuers and Certificates immediately after installing cert-manager.

For example:
 * https://github.com/jetstack/cert-manager/issues/4155 
 * https://github.com/jetstack/cert-manager/issues/4107
 * https://github.com/knative/serving/blob/main/DEVELOPMENT.md#deploy-cert-manager

We also considered a startup probe in cainjector: https://github.com/jetstack/cert-manager/pull/4133
But `cainjector` is not used in OpenShift which has it's own webhook CA injection system.

We considered adding --wait to the `kubectl cert-manager install` command, but this approach has the advantage that it benefits all existing Helm users.

```release-note
helm install jetstack/cert-manager --wait now waits until the cert-manager API is usable
```

/kind feature