### PR TITLE
Set linkopts "-w" instead of "-w -s" when building go binaries

### DIFF
--- a/build/go_binary.bzl
+++ b/build/go_binary.bzl
@@ -23,6 +23,6 @@ def go_binary(name, **kwargs):
         # (https://blog.filippo.io/shrink-your-go-binaries-with-this-one-weird-trick/)
         # it strips the DWARF tables needed for debuggers, not the annotations
         # needed for stack traces, so our panics are still readable!
-        gc_linkopts = ["-s", "-w"],
+        gc_linkopts = ["-w"],
         **kwargs,
     )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
In https://github.com/jetstack/cert-manager/pull/4169, the "-w" and "-s" flags were introduced when building go binaries.
These options remove both the DWARF tables and the symbol tables from the binary. However, removing the symbols table from the binaries causes some issues https://github.com/jetstack/cert-manager/pull/4169#issuecomment-873947733.
@SgtCoDFish noticed that the binary size reduction is mostly thanks to removing the DWARF tables.
Results for the kubectl plugin:
- no flags: 74M
- "-w": 62M
- "-w", "-s": 49M

This PR removes the "-s" flag and only keeps the "-w" flag for building go binaries.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
reduce binary sizes by adding "-w" as ldflag
```
\kind feature