### PR TITLE
vault: Fix when certificate chain does not have a root ca 

### DIFF
--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -254,6 +254,9 @@ func (c *chainNode) toBundleAndCA() (PEMBundle, error) {
 		// If the issuer is nil, we have hit the root of the chain. Assign the CA
 		// to this certificate and stop traversing.
 		if c.issuer == nil {
+			if !isSelfSignedCertificate(c.cert) {
+				certs = append(certs, c.cert)
+			}
 			ca = c.cert
 			break
 		}
@@ -335,4 +338,8 @@ func (c *chainNode) root() *chainNode {
 	}
 
 	return c
+}
+
+func isSelfSignedCertificate(cert *x509.Certificate) bool {
+	return cert.Issuer.CommonName == cert.Subject.CommonName
 }

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -252,7 +252,10 @@ func (c *chainNode) toBundleAndCA() (PEMBundle, error) {
 
 	for {
 		// If the issuer is nil, we have hit the root of the chain. Assign the CA
-		// to this certificate and stop traversing.
+		// to this certificate and stop traversing. If the root certificate is not
+		// a self-signed certificate, i.e. is not a root CA, append the certificate
+		// to the certificate chain.
+
 		if c.issuer == nil {
 			if !isSelfSignedCertificate(c.cert) {
 				certs = append(certs, c.cert)
@@ -340,6 +343,8 @@ func (c *chainNode) root() *chainNode {
 	return c
 }
 
+// isSelfSignedCertificate returns true if the given X.509 certificate has been
+// signed by itself (self-signed).
 func isSelfSignedCertificate(cert *x509.Certificate) bool {
-	return cert.Issuer.CommonName == cert.Subject.CommonName
+	return cert.CheckSignatureFrom(cert) == nil
 }

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -316,6 +316,11 @@ func TestParseSingleCertificateChain(t *testing.T) {
 			expPEMBundle: PEMBundle{},
 			expErr:       true,
 		},
+		"if certificate chain does not have a root ca, should append all intermediates to chain pem": {
+			inputBundle:  joinPEM(intA1.pem, intA2.pem, leaf.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem, intA2.pem, intA1.pem), CAPEM: intA1.pem},
+			expErr:       false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
We were trying to use vault issuer to sign a certificate using an intermediate certificate, but the secret generated have this format: 

 

ca.crt -> intermediate CA 

tls.crt -> leaf certificate 

 

The browser do not know the full certificate chain: leaf->intermediate->root, we had inspected the output of vault: 

 
```json
{ 
  "data": { 
    "ca_chain": [ 
      " intermediate CA" 
    ], 
    "certificate": "leaf-ca", 
    "issuing_ca": " intermediate CA " 
  } 
} 
```
 
we thought: "the output of vault is missing the root ca", but we found a closed issue about this: https://github.com/hashicorp/vault/issues/8407 that informs that behavior is expected in vault. 

 
We solved this problem by identifying when we need to bundle ca in a certificate. 

Thanks @nettoclaudio and @fbomlisboa to help us to figure out the solution 

