### PR TITLE
Add kubectl 'cert-manager check api' command

### DIFF
--- a/cmd/ctl/BUILD.bazel
+++ b/cmd/ctl/BUILD.bazel
@@ -34,6 +34,7 @@ filegroup(
         ":package-srcs",
         "//cmd/ctl/cmd:all-srcs",
         "//cmd/ctl/pkg/approve:all-srcs",
+        "//cmd/ctl/pkg/check:all-srcs",
         "//cmd/ctl/pkg/convert:all-srcs",
         "//cmd/ctl/pkg/create:all-srcs",
         "//cmd/ctl/pkg/deny:all-srcs",

--- a/cmd/ctl/cmd/BUILD.bazel
+++ b/cmd/ctl/cmd/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//cmd/ctl/pkg/approve:go_default_library",
+        "//cmd/ctl/pkg/check:go_default_library",
         "//cmd/ctl/pkg/convert:go_default_library",
         "//cmd/ctl/pkg/create:go_default_library",
         "//cmd/ctl/pkg/deny:go_default_library",

--- a/cmd/ctl/cmd/cmd.go
+++ b/cmd/ctl/cmd/cmd.go
@@ -31,6 +31,7 @@ import (
 	cmdutil "k8s.io/kubectl/pkg/cmd/util"
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/approve"
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/check"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/convert"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/create"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/deny"
@@ -74,6 +75,7 @@ kubectl cert-manager is a CLI tool manage and configure cert-manager resources f
 	cmds.AddCommand(inspect.NewCmdInspect(ctx, ioStreams, factory))
 	cmds.AddCommand(approve.NewCmdApprove(ctx, ioStreams, factory))
 	cmds.AddCommand(deny.NewCmdDeny(ctx, ioStreams, factory))
+	cmds.AddCommand(check.NewCmdCheck(ctx, ioStreams, factory))
 
 	// Experimental features
 	cmds.AddCommand(experimental.NewCmdExperimental(ctx, ioStreams, factory))

--- a/cmd/ctl/main.go
+++ b/cmd/ctl/main.go
@@ -33,5 +33,6 @@ func main() {
 
 	if err := cmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
 	}
 }

--- a/cmd/ctl/pkg/check/BUILD.bazel
+++ b/cmd/ctl/pkg/check/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["check.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/check",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/ctl/pkg/check/api:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//cmd/ctl/pkg/check/api:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ctl/pkg/check/api/BUILD.bazel
+++ b/cmd/ctl/pkg/check/api/BUILD.bazel
@@ -1,0 +1,30 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["api.go"],
+    importpath = "github.com/jetstack/cert-manager/cmd/ctl/pkg/check/api",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/cmapichecker:go_default_library",
+        "@com_github_spf13_cobra//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
+        "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/ctl/pkg/check/api/BUILD.bazel
+++ b/cmd/ctl/pkg/check/api/BUILD.bazel
@@ -10,8 +10,10 @@ go_library(
         "@com_github_spf13_cobra//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
         "@io_k8s_cli_runtime//pkg/genericclioptions:go_default_library",
-        "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_kubectl//pkg/cmd/util:go_default_library",
+        "@io_k8s_kubectl//pkg/scheme:go_default_library",
+        "@io_k8s_kubectl//pkg/util/i18n:go_default_library",
+        "@io_k8s_kubectl//pkg/util/templates:go_default_library",
     ],
 )
 

--- a/cmd/ctl/pkg/check/api/api.go
+++ b/cmd/ctl/pkg/check/api/api.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/jetstack/cert-manager/pkg/util/cmapichecker"
+	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	restclient "k8s.io/client-go/rest"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+)
+
+// Options is a struct to support check api command
+type Options struct {
+	RESTConfig *restclient.Config
+
+	// APIChecker is used to check that the cert-manager CRDs have been installed on the K8S
+	// API server and that the cert-manager webhooks are all working
+	APIChecker cmapichecker.Interface
+
+	// If set to true, command will wait until creating resources against the api is possible
+	Wait bool
+
+	// Time before timeout when waiting
+	Timeout time.Duration
+
+	// Time between checks when waiting
+	Interval time.Duration
+
+	// Namespace that is used to dry-run create the certificate resource in
+	Namespace string
+
+	genericclioptions.IOStreams
+}
+
+// NewOptions returns initialized Options
+func NewOptions(ioStreams genericclioptions.IOStreams) *Options {
+	return &Options{
+		IOStreams: ioStreams,
+	}
+}
+
+// Complete takes the command arguments and factory and infers any remaining options.
+func (o *Options) Complete(factory cmdutil.Factory) error {
+	var err error
+
+	o.Namespace, _, err = factory.ToRawKubeConfigLoader().Namespace()
+	if err != nil {
+		return err
+	}
+
+	o.RESTConfig, err = factory.ToRESTConfig()
+	if err != nil {
+		return err
+	}
+
+	o.APIChecker, err = cmapichecker.New(o.RESTConfig, o.Namespace)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// NewCmdCheckApi returns a cobra command for checking creating cert-manager resources against the K8S API server
+func NewCmdCheckApi(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+	o := NewOptions(ioStreams)
+
+	cmd := &cobra.Command{
+		Use: "api",
+		Short: `
+			This check attempts to perform a dry-run create of a cert-manager *v1alpha2*
+			Certificate resource in order to verify that CRDs are installed and all the
+			required webhooks are reachable by the K8S API server.
+			We use v1alpha2 API to ensure that the API server has also connected to the
+			cert-manager conversion webhook.
+		`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := o.Complete(factory); err != nil {
+				return err
+			}
+			return o.Run(ctx)
+		},
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+	cmd.Flags().BoolVar(&o.Wait, "wait", true, "If set to true, command will wait until creating resources against the api is possible")
+	cmd.Flags().DurationVar(&o.Timeout, "timeout", 30*time.Second, "Time before timeout when waiting, must include unit, e.g. 5s or 10m")
+	cmd.Flags().DurationVar(&o.Interval, "interval", 5*time.Second, "Time between checks when waiting, must include unit, e.g. 5s or 10m")
+
+	return cmd
+}
+
+// Run executes check api command
+func (o *Options) Run(ctx context.Context) error {
+	log.SetFlags(0) // Disable prefixing logs with timestamps.
+
+	if !o.Wait {
+		if err := o.APIChecker.Check(ctx); err != nil {
+			return err
+		}
+
+		log.Print("The Kubernetes Api is ready to created cert-manager resources against")
+
+		return nil
+	}
+
+	return wait.PollImmediate(o.Interval, o.Timeout, func() (done bool, err error) {
+		if err := o.APIChecker.Check(ctx); err != nil {
+			log.Printf("%v", err)
+			return false, nil
+		}
+
+		log.Print("The Kubernetes Api is ready to created cert-manager resources against")
+
+		return true, nil
+	})
+}

--- a/cmd/ctl/pkg/check/check.go
+++ b/cmd/ctl/pkg/check/check.go
@@ -1,0 +1,43 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package check
+
+import (
+	"context"
+
+	"github.com/spf13/cobra"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	cmdutil "k8s.io/kubectl/pkg/cmd/util"
+
+	"github.com/jetstack/cert-manager/cmd/ctl/pkg/check/api"
+)
+
+func NewCmdCheck(ctx context.Context, ioStreams genericclioptions.IOStreams, factory cmdutil.Factory) *cobra.Command {
+	cmds := NewCmdCreateBare()
+	cmds.AddCommand(api.NewCmdCheckApi(ctx, ioStreams, factory))
+
+	return cmds
+}
+
+// Create a bare Create Command, without any subcommands
+func NewCmdCreateBare() *cobra.Command {
+	return &cobra.Command{
+		Use:   "check",
+		Short: "Check cert-manager components",
+		Long:  `Check cert-manager components`,
+	}
+}

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -31,6 +31,7 @@ SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 
 # Require kubectl & helm available on PATH
 check_tool kubectl
+check_tool kubectl-cert_manager
 check_tool helm
 
 # Use the current timestamp as the APP_VERSION so a rolling update will be
@@ -65,3 +66,5 @@ helm upgrade \
     --set "extraArgs={--dns01-recursive-nameservers=${SERVICE_IP_PREFIX}.16:53,--dns01-recursive-nameservers-only=true}" \
     "$RELEASE_NAME" \
     "$REPO_ROOT/bazel-bin/deploy/charts/cert-manager/cert-manager.tgz"
+
+kubectl cert-manager check api

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -53,6 +53,9 @@ kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 # Build the Helm chart package .tgz
 bazel build //deploy/charts/cert-manager
 
+# Pre-compile the kubectl plugin, so it can quickly check the api status
+bazel build //hack/bin:kubectl-cert_manager
+
 # Upgrade or install cert-manager
 helm upgrade \
     --install \
@@ -67,4 +70,4 @@ helm upgrade \
     "$RELEASE_NAME" \
     "$REPO_ROOT/bazel-bin/deploy/charts/cert-manager/cert-manager.tgz"
 
-kubectl cert-manager check api
+kubectl cert-manager check api --wait=1m -v

--- a/pkg/util/BUILD.bazel
+++ b/pkg/util/BUILD.bazel
@@ -33,6 +33,7 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
+        "//pkg/util/cmapichecker:all-srcs",
         "//pkg/util/cmd:all-srcs",
         "//pkg/util/coverage:all-srcs",
         "//pkg/util/errors:all-srcs",

--- a/pkg/util/cmapichecker/BUILD.bazel
+++ b/pkg/util/cmapichecker/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["cmapichecker.go"],
+    importpath = "github.com/jetstack/cert-manager/pkg/util/cmapichecker",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "//pkg/apis/meta/v1:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/pkg/util/cmapichecker/BUILD.bazel
+++ b/pkg/util/cmapichecker/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -28,4 +28,16 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["cmapichecker_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/apis/certmanager/v1alpha2:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client/fake:go_default_library",
+    ],
 )

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmapichecker
+
+import (
+	"context"
+
+	errors "github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	// Use v1alpha2 API to ensure that the API server has also connected to the
+	// cert-manager conversion webhook.
+	// TODO(wallrj): Only change this when the old deprecated APIs are removed,
+	// at which point the conversion webhook may be removed anyway.
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
+)
+
+// Interface is used to check that the cert-manager CRDs have been installed and are usable.
+type Interface interface {
+	Check(context.Context) error
+}
+
+type cmapiChecker struct {
+	// The client controller-runtime client.New function fails if can't reach
+	// the API server, so we load it lazily, to avoid breaking integration tests
+	// which rely on being able to start the webhook server before the API
+	// server.
+	clientBuilder func() (client.Client, error)
+
+	client client.Client
+}
+
+// New returns a cert-manager API checker
+func New(restcfg *rest.Config, namespace string) (Interface, error) {
+	scheme := runtime.NewScheme()
+	if err := cmapi.AddToScheme(scheme); err != nil {
+		return nil, errors.Wrap(err, "while configuring scheme")
+	}
+	return &cmapiChecker{
+		clientBuilder: func() (client.Client, error) {
+			cl, err := client.New(restcfg, client.Options{
+				Scheme: scheme,
+			})
+			if err != nil {
+				return nil, errors.Wrap(err, "while creating client")
+			}
+			return client.NewNamespacedClient(client.NewDryRunClient(cl), namespace), nil
+		},
+	}, nil
+}
+
+func (o *cmapiChecker) Client() (client.Client, error) {
+	if o.client != nil {
+		return o.client, nil
+	}
+
+	cl, err := o.clientBuilder()
+	if err != nil {
+		return nil, err
+	}
+	o.client = cl
+
+	return o.client, nil
+}
+
+// Check attempts to perform a dry-run create of a cert-manager *v1alpha2*
+// Certificate resource in order to verify that CRDs are installed and all the
+// required webhooks are reachable by the K8S API server.
+// We use v1alpha2 API to ensure that the API server has also connected to the
+// cert-manager conversion webhook.
+func (o *cmapiChecker) Check(ctx context.Context) error {
+	cert := &cmapi.Certificate{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Certificate",
+			APIVersion: "cert-manager.io/v1alpha2",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "cmapichecker-",
+		},
+		Spec: cmapi.CertificateSpec{
+			DNSNames:   []string{"cmapichecker.example"},
+			SecretName: "cmapichecker",
+			IssuerRef: cmmeta.ObjectReference{
+				Name: "cmapichecker",
+			},
+		},
+	}
+	cl, err := o.Client()
+	if err != nil {
+		return err
+	}
+
+	if err := cl.Create(ctx, cert); err != nil {
+		return errors.Wrap(err, "while attempting dry-run creation of Certificate")
+	}
+	return nil
+}

--- a/pkg/util/cmapichecker/cmapichecker.go
+++ b/pkg/util/cmapichecker/cmapichecker.go
@@ -18,6 +18,7 @@ package cmapichecker
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 
 	errors "github.com/pkg/errors"
@@ -35,43 +36,30 @@ import (
 )
 
 var (
-	ErrAPIServerUnreachable                  = errors.New("unable to connect to the Kubernetes API server")
-	ErrCertManagerCRDsNotFound               = errors.New("the cert-manager CRDs are not yet installed on the Kubernetes API server")
-	ErrCertManagerAPIEndpointsNotEstablished = errors.New("the cert-manager API endpoints have not yet been published by the Kubernetes API server")
-	ErrWebhookConnectionFailure              = errors.New("the cert-manager webhook server can't be reached yet")
-	ErrWebhookCertificateFailure             = errors.New("the client CA bundle is not yet updated to the certificate of the cert-manager webhook")
-
-	regexErrCertManagerCRDsNotFound               = regexp.MustCompile(`^error finding the scope of the object: failed to get restmapping: no matches for kind "Certificate" in group "cert-manager.io"$`)
-	regexErrCertManagerAPIEndpointsNotEstablished = regexp.MustCompile(`failed calling webhook "(.*)\.cert-manager\.io": Post "(.*)\/mutate(.*)": service "(.*)-webhook" not found$`)
-	regexErrWebhookConnectionFailure              = regexp.MustCompile(`failed calling webhook "(.*)\.cert-manager\.io": Post "(.*)\/mutate(.*)": (.*): connect: connection refused$`)
-	regexErrWebhookCertificateFailure             = regexp.MustCompile(`Post "(.*)": x509: certificate signed by unknown authority`)
+	ErrCertManagerCRDsNotFound   = errors.New("the cert-manager CRDs are not yet installed on the Kubernetes API server")
+	ErrWebhookServiceFailure     = errors.New("the cert-manager webhook service is not created yet")
+	ErrWebhookDeploymentFailure  = errors.New("the cert-manager webhook deployment is not ready yet")
+	ErrWebhookCertificateFailure = errors.New("the cert-manager webhook CA bundle is not injected yet")
 )
 
-type ApiCheckError struct {
-	SimpleError     error
-	UnderlyingError error
-}
+const (
+	crdsMappingError  = `error finding the scope of the object: failed to get restmapping: no matches for kind "Certificate" in group "cert-manager.io"`
+	crdsNotFoundError = `the server could not find the requested resource (post certificates.cert-manager.io)`
+)
 
-func (e *ApiCheckError) Error() string {
-	return e.SimpleError.Error()
-}
-
-func (e *ApiCheckError) Cause() error {
-	return e.UnderlyingError
-}
+var (
+	regexErrCertManagerCRDsNotFound   = regexp.MustCompile(`^(` + regexp.QuoteMeta(crdsMappingError) + `|` + regexp.QuoteMeta(crdsNotFoundError) + `)$`)
+	regexErrWebhookServiceFailure     = regexp.MustCompile(`Post "(.*)": service "(.*)-webhook" not found`)
+	regexErrWebhookDeploymentFailure  = regexp.MustCompile(`Post "(.*)": (.*): connect: connection refused`)
+	regexErrWebhookCertificateFailure = regexp.MustCompile(`Post "(.*)": x509: certificate signed by unknown authority`)
+)
 
 // Interface is used to check that the cert-manager CRDs have been installed and are usable.
 type Interface interface {
-	Check(context.Context) *ApiCheckError
+	Check(context.Context) error
 }
 
 type cmapiChecker struct {
-	// The client controller-runtime client.New function fails if can't reach
-	// the API server, so we load it lazily, to avoid breaking integration tests
-	// which rely on being able to start the webhook server before the API
-	// server.
-	clientBuilder func() (client.Client, error)
-
 	client client.Client
 }
 
@@ -80,31 +68,17 @@ func New(restcfg *rest.Config, scheme *runtime.Scheme, namespace string) (Interf
 	if err := cmapi.AddToScheme(scheme); err != nil {
 		return nil, errors.Wrap(err, "while configuring scheme")
 	}
-	return &cmapiChecker{
-		clientBuilder: func() (client.Client, error) {
-			cl, err := client.New(restcfg, client.Options{
-				Scheme: scheme,
-			})
-			if err != nil {
-				return nil, errors.Wrap(err, "while creating client")
-			}
-			return client.NewNamespacedClient(client.NewDryRunClient(cl), namespace), nil
-		},
-	}, nil
-}
 
-func (o *cmapiChecker) Client() (client.Client, error) {
-	if o.client != nil {
-		return o.client, nil
-	}
-
-	cl, err := o.clientBuilder()
+	cl, err := client.New(restcfg, client.Options{
+		Scheme: scheme,
+	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "while creating client")
 	}
-	o.client = cl
 
-	return o.client, nil
+	return &cmapiChecker{
+		client: client.NewNamespacedClient(client.NewDryRunClient(cl), namespace),
+	}, nil
 }
 
 // Check attempts to perform a dry-run create of a cert-manager *v1alpha2*
@@ -112,7 +86,7 @@ func (o *cmapiChecker) Client() (client.Client, error) {
 // required webhooks are reachable by the K8S API server.
 // We use v1alpha2 API to ensure that the API server has also connected to the
 // cert-manager conversion webhook.
-func (o *cmapiChecker) Check(ctx context.Context) *ApiCheckError {
+func (o *cmapiChecker) Check(ctx context.Context) error {
 	cert := &cmapi.Certificate{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: "cmapichecker-",
@@ -126,21 +100,7 @@ func (o *cmapiChecker) Check(ctx context.Context) *ApiCheckError {
 		},
 	}
 
-	// while creating client: Get "http://localhost:8080/api?timeout=32s": dial tcp 127.0.0.1:8080: connect: connection refused
-	cl, err := o.Client()
-	if err != nil {
-		return &ApiCheckError{
-			SimpleError:     ErrAPIServerUnreachable,
-			UnderlyingError: err,
-		}
-	}
-
-	// error finding the scope of the object: failed to get restmapping: no matches for kind "Certificate" in group "cert-manager.io"
-	// Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": service "cert-manager-webhook" not found
-	// Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.38.90:443: connect: connection refused
-	// Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "cert-manager-webhook-ca")
-	// conversion webhook for cert-manager.io/v1alpha2, Kind=Certificate failed: Post "https://cert-manager-webhook.cert-manager.svc:443/convert?timeout=30s": x509: certificate signed by unknown authority
-	if err := cl.Create(ctx, cert); err != nil {
+	if err := o.client.Create(ctx, cert); err != nil {
 		return &ApiCheckError{
 			SimpleError:     translateToSimpleError(err),
 			UnderlyingError: err,
@@ -149,18 +109,51 @@ func (o *cmapiChecker) Check(ctx context.Context) *ApiCheckError {
 	return nil
 }
 
+type ApiCheckError struct {
+	SimpleError     error
+	UnderlyingError error
+}
+
+func (e *ApiCheckError) Error() string {
+	// If no simple error exists, print underlying error
+	if e.SimpleError == nil {
+		return e.UnderlyingError.Error()
+	}
+	return fmt.Sprintf("%v (%v)", e.SimpleError.Error(), e.UnderlyingError.Error())
+}
+
+// If no simple error exists, this function will return nil
+// which indicates that the error is not unwrappable
+func (e *ApiCheckError) Unwrap() error {
+	return e.SimpleError
+}
+
+// This translateToSimpleError function detects errors based on the error message.
+// It tries to map these error messages to a better understandable error message that
+// explains what is wrong. If it cannot create a simple error, it will return nil.
+// ErrCertManagerCRDsNotFound:
+// - error finding the scope of the object: failed to get restmapping: no matches for kind "Certificate" in group "cert-manager.io"
+// ErrWebhookServiceFailure:
+// - Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": service "cert-manager-webhook" not found
+// - conversion webhook for cert-manager.io/v1alpha2, Kind=Certificate failed: Post "https://cert-manager-webhook.cert-manager.svc:443/convert?timeout=30s": service "cert-manager-webhook" not found
+// ErrWebhookDeploymentFailure:
+// - Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": dial tcp 10.96.38.90:443: connect: connection refused
+// - conversion webhook for cert-manager.io/v1alpha2, Kind=Certificate failed: Post "https://cert-manager-webhook.cert-manager.svc:443/convert?timeout=30s": dial tcp 10.96.38.90:443: connect: connection refused
+// ErrWebhookCertificateFailure:
+// - Internal error occurred: failed calling webhook "webhook.cert-manager.io": Post "https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s": x509: certificate signed by unknown authority (possibly because of "x509: ECDSA verification failure" while trying to verify candidate authority certificate "cert-manager-webhook-ca")
+// - conversion webhook for cert-manager.io/v1alpha2, Kind=Certificate failed: Post "https://cert-manager-webhook.cert-manager.svc:443/convert?timeout=30s": x509: certificate signed by unknown authority
 func translateToSimpleError(err error) error {
 	s := err.Error()
 
 	if regexErrCertManagerCRDsNotFound.MatchString(s) {
 		return ErrCertManagerCRDsNotFound
-	} else if regexErrCertManagerAPIEndpointsNotEstablished.MatchString(s) {
-		return ErrCertManagerAPIEndpointsNotEstablished
-	} else if regexErrWebhookConnectionFailure.MatchString(s) {
-		return ErrWebhookConnectionFailure
+	} else if regexErrWebhookServiceFailure.MatchString(s) {
+		return ErrWebhookServiceFailure
+	} else if regexErrWebhookDeploymentFailure.MatchString(s) {
+		return ErrWebhookDeploymentFailure
 	} else if regexErrWebhookCertificateFailure.MatchString(s) {
 		return ErrWebhookCertificateFailure
 	}
 
-	return err
+	return nil
 }

--- a/pkg/util/cmapichecker/cmapichecker_test.go
+++ b/pkg/util/cmapichecker/cmapichecker_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmapichecker
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha2"
+)
+
+type fakeErrorClient struct {
+	client.Client
+
+	newError    error
+	createError error
+}
+
+func (cl *fakeErrorClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if cl.createError != nil {
+		return cl.createError
+	}
+
+	return cl.Client.Create(ctx, obj, opts...)
+}
+
+func newFakeCmapiChecker() (*fakeErrorClient, Interface, error) {
+	scheme := runtime.NewScheme()
+	if err := cmapi.AddToScheme(scheme); err != nil {
+		return nil, nil, err
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	errorClient := &fakeErrorClient{
+		Client:      cl,
+		newError:    nil,
+		createError: nil,
+	}
+
+	return errorClient, &cmapiChecker{
+		clientBuilder: func() (client.Client, error) {
+			if errorClient.newError != nil {
+				return nil, errorClient.newError
+			}
+			return errorClient, nil
+		},
+	}, nil
+}
+
+func TestCmapiChecker(t *testing.T) {
+	tests := map[string]testT{
+		"check API without errors": {
+			newError:    nil,
+			createError: nil,
+
+			expectedError: "",
+		},
+		"check API server unreachable": {
+			newError:    errors.New("while creating client: Get \"http://localhost:8080/api?timeout=32s\": dial tcp 127.0.0.1:8080: connect: connection refused"),
+			createError: nil,
+
+			expectedError: ErrAPIServerUnreachable.Error(),
+		},
+		"check API without CRDs installed": {
+			newError:    nil,
+			createError: errors.New("error finding the scope of the object: failed to get restmapping: no matches for kind \"Certificate\" in group \"cert-manager.io\""),
+
+			expectedError: ErrCertManagerCRDsNotFound.Error(),
+		},
+		"check API with webhook service not ready": {
+			newError:    nil,
+			createError: errors.New("Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": Post \"https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s\": service \"cert-manager-webhook\" not found"),
+
+			expectedError: ErrCertManagerAPIEndpointsNotEstablished.Error(),
+		},
+		"check API with webhook pod not accepting connections": {
+			newError:    nil,
+			createError: errors.New("Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": Post \"https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s\": dial tcp 10.96.38.90:443: connect: connection refused"),
+
+			expectedError: ErrWebhookConnectionFailure.Error(),
+		},
+		"check API with webhook certificate not updated in mutation webhook resource definitions": {
+			newError:    nil,
+			createError: errors.New("Internal error occurred: failed calling webhook \"webhook.cert-manager.io\": Post \"https://cert-manager-webhook.cert-manager.svc:443/mutate?timeout=10s\": x509: certificate signed by unknown authority (possibly because of \"x509: ECDSA verification failure\" while trying to verify candidate authority certificate \"cert-manager-webhook-ca\""),
+
+			expectedError: ErrWebhookCertificateFailure.Error(),
+		},
+		"check API with webhook certificate not updated in conversion webhook resource definitions": {
+			newError:    nil,
+			createError: errors.New("conversion webhook for cert-manager.io/v1alpha2, Kind=Certificate failed: Post \"https://cert-manager-webhook.cert-manager.svc:443/convert?timeout=30s\": x509: certificate signed by unknown authority"),
+
+			expectedError: ErrWebhookCertificateFailure.Error(),
+		},
+	}
+
+	for n, test := range tests {
+		t.Run(n, func(t *testing.T) {
+			runTest(t, test)
+		})
+	}
+}
+
+type testT struct {
+	newError    error
+	createError error
+
+	expectedError string
+}
+
+func runTest(t *testing.T, test testT) {
+	errorClient, checker, _ := newFakeCmapiChecker()
+
+	errorClient.newError = test.newError
+	errorClient.createError = test.createError
+
+	err := checker.Check(context.TODO())
+	if err != nil {
+		if err.Error() != test.expectedError {
+			t.Errorf("error differs from expected error:\n%s\n vs \n%s", err.Error(), test.expectedError)
+		}
+	} else {
+		if test.expectedError != "" {
+			t.Errorf("expected error did not occure:\n%s", test.expectedError)
+		}
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the kubectl 'cert-manager check api' command.
This check attempts to perform a dry-run create of a cert-manager *v1alpha2*
Certificate resource in order to verify that CRDs are installed and all the
required webhooks are reachable by the K8S API server.
We use v1alpha2 API to ensure that the API server has also connected to the
cert-manager conversion webhook.

**Release note**:
```release-note
Added the kubectl 'cert-manager check api' command
```
/kind feature