### PR TITLE
test/integration/acme: fix dropped error

### DIFF
--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -202,6 +202,9 @@ func TestAcmeOrdersController(t *testing.T) {
 	var chal *cmacme.Challenge
 	err = wait.Poll(time.Millisecond*100, time.Minute, func() (done bool, err error) {
 		chals, err := cmCl.AcmeV1().Challenges(testName).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false, err
+		}
 		l := len(chals.Items)
 		// Challenge has not been created yet
 		if l == 0 {


### PR DESCRIPTION
This fixes a dropped error in `test/integration/acme`.

```release-note
NONE
```
