### PR TITLE
Bump the version of Go SDK being downloaded

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,7 +31,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//hack/build:nogo_vet",
-    version = "1.16.5",
+    version = "1.16.6",
 )
 
 ## Load gazelle and dependencies


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Bump the version of Go SDK that Bazel downloads v1.16.5 -> v1.16.6.
I was looking at bumping Bazel Go rules at the same time, but looks like the latest release only supports Bazel v4.0.0 which we cannot use, because Bazel base images used for GCB release builds don't have a v4.0.0 version.

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
Signed-off-by: irbekrm <irbekrm@gmail.com>
/kind cleanup