### PR TITLE
add "components" Helm value

### DIFF
--- a/deploy/charts/cert-manager/templates/BUILD.bazel
+++ b/deploy/charts/cert-manager/templates/BUILD.bazel
@@ -6,7 +6,7 @@ modify_file(
     name = "crds",
     src = "//deploy/crds:templates",
     out = "crds.yaml",
-    prefix = """{{- if .Values.installCRDs }}""",
+    prefix = """{{- if or (has "crd" .Values.components) .Values.installCRDs }}""",
     suffix = """{{- end }}""",
     visibility = ["//visibility:private"],
 )

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -1,4 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
+{{- if has "cainjector" .Values.components }}
+{{- if .Values.cainjector.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -98,3 +99,4 @@ spec:
 {{ toYaml . | indent 8 }}
     {{- end }}
 {{- end -}}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if has "cainjector" .Values.components }}
+{{- if and .Values.cainjector.enabled .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if has "cainjector" .Values.components }}
+{{- if and .Values.cainjector.enabled .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/deploy/charts/cert-manager/templates/cainjector-psp.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.global.podSecurityPolicy.enabled }}
+{{- if has "cainjector" .Values.components }}
+{{- if and .Values.cainjector.enabled .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
 metadata:

--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.global.rbac.create -}}
+{{- if has "cainjector" .Values.components }}
+{{- if and .Values.cainjector.enabled .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.cainjector.serviceAccount.create -}}
+{{- if has "cainjector" .Values.components }}
+{{- if and .Values.cainjector.enabled .Values.cainjector.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.cainjector.serviceAccount.automountServiceAccountToken }}

--- a/deploy/charts/cert-manager/templates/certmanager-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -164,4 +165,5 @@ spec:
 {{- if .Values.podDnsConfig }}
       dnsConfig:
 {{ toYaml .Values.podDnsConfig | indent 8 }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-prometheus-service.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-prometheus-service.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 {{- if .Values.prometheus.enabled }}
 apiVersion: v1
 kind: Service
@@ -24,4 +25,5 @@ spec:
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-prometheus-servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-prometheus-servicemonitor.yaml
@@ -1,4 +1,5 @@
-{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+{{- if has "certmanager" .Values.components }}
+{{- if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled -}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -33,4 +34,5 @@ spec:
     path: {{ .Values.prometheus.servicemonitor.path }}
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -15,4 +16,5 @@ rules:
   verbs:     ['use']
   resourceNames:
   - {{ template "cert-manager.fullname" . }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-psp.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-psp.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -46,4 +47,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 {{- if .Values.global.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -544,4 +545,5 @@ subjects:
   - name: {{ template "cert-manager.serviceAccountName" . }}
     namespace: {{ .Release.Namespace | quote }}
     kind: ServiceAccount
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/certmanager-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/certmanager-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if has "certmanager" .Values.components }}
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -18,4 +19,5 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if and (has "webhook" .Values.components) .Values.startupapicheck.enabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if and (has "webhook" .Values.components) .Values.startupapicheck.enabled -}}
 {{- if .Values.global.rbac.create -}}
 # create certificate role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if and (has "webhook" .Values.components) .Values.startupapicheck.enabled -}}
 {{- if .Values.startupapicheck.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -115,3 +116,4 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -52,3 +53,4 @@ webhooks:
         namespace: {{ .Release.Namespace | quote }}
         path: /mutate
       {{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-psp-clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -16,3 +17,4 @@ rules:
   resourceNames:
   - {{ template "webhook.fullname" . }}
 {{- end }} 
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-psp-clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -17,4 +18,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "webhook.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-psp.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-psp.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -51,4 +52,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 {{- if .Values.global.rbac.create -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -81,3 +82,4 @@ subjects:
   name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -26,3 +27,4 @@ spec:
     app.kubernetes.io/name: {{ include "webhook.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "webhook"
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 {{- if .Values.webhook.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
@@ -19,3 +20,4 @@ metadata:
 imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -1,3 +1,4 @@
+{{- if has "webhook" .Values.components }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -61,3 +62,4 @@ webhooks:
         namespace: {{ .Release.Namespace | quote }}
         path: /validate
       {{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -39,6 +39,23 @@ global:
     # renewal of a leadership.
     # retryPeriod: 15s
 
+# Each resource is part of one of these 4 components: "crd", "certmanager",
+# "webhook" and "cainjector". Each template filenames is prefixed with the name
+# of the component. This option can be used to only include a subset of the
+# components. This makes it possible to only install the crds and install the other
+# components using another chart deployment. Note that combined, all components
+# have to be selected. This option should ONLY be used to not render a subset
+# of components, NOT to disable a component (that should be done using the relevant
+# "enabled" Helm values).
+components:
+- certmanager
+- webhook
+- cainjector
+# - crd
+
+# DEPRECATED: use components instead!
+# Setting this value to true is the same as adding "crd" to the components list.
+# CRDs will be rendered if "crd" is added to components OR installCRDs is set to true.
 installCRDs: false
 
 replicaCount: 1


### PR DESCRIPTION
**What this PR does / why we need it**:
The helm value `components` is added, this value selects what resources should be included in the rendered helm chart.
Now, we can render the CRDs with Helm too, this allows to install cert-manager in a custom namespace or use a custom release name. (Using the static CRDs as described here: https://cert-manager.io/docs/installation/helm/ will result in a failed install in both of those cases.)
```bash
$ helm template \
  cert-manager jetstack/cert-manager \
  --set components={crd} \
  --version v1.4.0 | kubectl apply -f -

$ helm install \
  cert-manager jetstack/cert-manager \
  --namespace cert-manager \
  --create-namespace \
  --version v1.4.0
```

The `installCRDs` helm value can be replaced by `components`. I added a deprecation warning notifying the chart user that this option might get removed in later releases.

+ this can be used when generating static yaml manifests (bazel)
+ this can be used for automated testing (test for different install scenarios)

**Which issue this PR fixes**

Allows for installing cert-manager in namespace that differs from cert-manager, by creating 2 Helm deployments: https://github.com/jetstack/cert-manager/issues/2752#issuecomment-605883456

Should bring us closer to supporting a multi-controller scenario: https://github.com/jetstack/cert-manager/issues/2525#issuecomment-618982292

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
add components selector in Helm values
```
