### PR TITLE
Fire event when CertificateSigningRequest hasn't been Approved yet

### DIFF
--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -183,11 +183,14 @@ func TestSign(t *testing.T) {
 	}
 
 	tests := map[string]testT{
-		"a CertificateSigningRequest without an approved condition should do nothing": {
+		"a CertificateSigningRequest without an approved condition should fire event": {
 			csr: baseCSRNotApproved.DeepCopy(),
 			builder: &testpkg.Builder{
 				KubeObjects:        []runtime.Object{baseCSRNotApproved.DeepCopy()},
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingApproval Waiting for the Approved condition before issuing",
+				},
 			},
 		},
 		"a CertificateSigningRequest with a denied condition should do nothing": {

--- a/pkg/controller/certificatesigningrequests/controller_test.go
+++ b/pkg/controller/certificatesigningrequests/controller_test.go
@@ -161,13 +161,14 @@ func TestController(t *testing.T) {
 			signerImpl:  signerExpectNoCall,
 			sarReaction: sarReactionExpectNoCall,
 		},
-		"do nothing if CertificateSigningRequest is no yet approved": {
+		"fire event if CertificateSigningRequest is no yet approved": {
 			signerType: apiutil.IssuerCA,
 			existingCSR: gen.CertificateSigningRequest("csr-1",
 				gen.SetCertificateSigningRequestSignerName("issuers.cert-manager.io/hello.world"),
 			),
 			signerImpl:  signerExpectNoCall,
 			sarReaction: sarReactionExpectNoCall,
+			wantEvent:   "Normal WaitingApproval Waiting for the Approved condition before issuing",
 		},
 		"do nothing if CertificateSigningRequest already has a non empty Certificate present": {
 			signerType: apiutil.IssuerCA,

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
@@ -136,10 +136,13 @@ func TestProcessItem(t *testing.T) {
 		fakeLister  *testlisters.FakeSecretLister
 		expectedErr bool
 	}{
-		"a CertificateSigningRequest without an approved condition should do nothing": {
+		"a CertificateSigningRequest without an approved condition should fire an event": {
 			csr: gen.CertificateSigningRequestFrom(baseCSR),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingApproval Waiting for the Approved condition before issuing",
+				},
 			},
 		},
 		"a CertificateSigningRequest with a denied condition should do nothing": {

--- a/pkg/controller/certificatesigningrequests/sync.go
+++ b/pkg/controller/certificatesigningrequests/sync.go
@@ -58,7 +58,12 @@ func (c *Controller) Sync(ctx context.Context, csr *certificatesv1.CertificateSi
 		dbg.Info("certificate signing request has failed so skipping processing")
 		return nil
 	}
+	if util.CertificateSigningRequestIsDenied(csr) {
+		dbg.Info("certificate signing request has been denied so skipping processing")
+		return nil
+	}
 	if !util.CertificateSigningRequestIsApproved(csr) {
+		c.recorder.Event(csr, corev1.EventTypeNormal, "WaitingApproval", "Waiting for the Approved condition before issuing")
 		dbg.Info("certificate signing request is not approved so skipping processing")
 		return nil
 	}

--- a/pkg/controller/certificatesigningrequests/vault/vault_test.go
+++ b/pkg/controller/certificatesigningrequests/vault/vault_test.go
@@ -99,10 +99,13 @@ func TestProcessItem(t *testing.T) {
 		clientBuilder internalvault.ClientBuilder
 		expectedErr   bool
 	}{
-		"a CertificateSigningRequest without an approved condition should do nothing": {
+		"a CertificateSigningRequest without an approved condition should fire an event": {
 			csr: gen.CertificateSigningRequestFrom(baseCSR),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingApproval Waiting for the Approved condition before issuing",
+				},
 			},
 		},
 		"a CertificateSigningRequest with a denied condition should do nothing": {

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -122,10 +122,13 @@ func TestProcessItem(t *testing.T) {
 		clientBuilder venaficlient.VenafiClientBuilder
 		expectedErr   bool
 	}{
-		"a CertificateSigningRequest without an approved condition should do nothing": {
+		"a CertificateSigningRequest without an approved condition should fire an event": {
 			csr: gen.CertificateSigningRequestFrom(baseCSR),
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
+				ExpectedEvents: []string{
+					"Normal WaitingApproval Waiting for the Approved condition before issuing",
+				},
 			},
 		},
 		"a CertificateSigningRequest with a denied condition should do nothing": {


### PR DESCRIPTION
Signed-off-by: joshvanl <vleeuwenjoshua@gmail.com>


/assign @maelvls 
/milestone v1.5
/kind feature

```release-note
Fire event when a CertificateSigningRequest has not yet been approved, so will skip processing until it is.
```
