### PR TITLE
Data race: fix concurrent read and write of secret annotations and certificaterequests

### DIFF
--- a/pkg/controller/certificaterequests/approver/sync.go
+++ b/pkg/controller/certificaterequests/approver/sync.go
@@ -53,6 +53,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	}
 
 	// Update the CertificateRequest approved condition to true.
+	cr = cr.DeepCopy()
 	apiutil.SetCertificateRequestCondition(cr,
 		cmapi.CertificateRequestConditionApproved,
 		cmmeta.ConditionTrue,

--- a/pkg/controller/certificates/internal/secretsmanager/secret.go
+++ b/pkg/controller/certificates/internal/secretsmanager/secret.go
@@ -102,6 +102,7 @@ func (s *SecretsManager) UpdateData(ctx context.Context, crt *cmapi.Certificate,
 		secret.OwnerReferences = []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)}
 	}
 
+	secret = secret.DeepCopy()
 	err = s.setValues(crt, secret, data)
 	if err != nil {
 		return err


### PR DESCRIPTION
cert-manager keeps crashing every now and then on clusters with more than 1000 certificates due to a bug of concurrent read and write of Secret annotations as detailed in https://github.com/jetstack/cert-manager/issues/3664. This bug was introduced in v0.15.0 (https://github.com/jetstack/cert-manager/commit/ffb5201d95b25861168df8dec26138878e5bcad0) and affect all cert-manager versions since then.

The panic can be reproduced by creating and constantly renewing 5000 certificates:

<details>
<summary>🎩 Steps to reproduce the panic (takes about 1 minute to see a panic)</summary>

```sh
#! /bin/bash
#
# A Certificate bomb to reproduce memory leaks and concurrent read and write
# issues in cert-manager.

set -e

k3d cluster create bomb
helm upgrade --install cert-manager jetstack/cert-manager --version 1.4.0 --namespace cert-manager --set installCRDs=true --create-namespace --wait
kubectl wait --for=condition=available deploy/cert-manager-webhook -n cert-manager --timeout=5m

kubectl apply -f- <<EOF
apiVersion: v1
kind: Namespace
metadata:
  name: bomb
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: example-selfsigned-issuer
  namespace: bomb
spec:
  selfSigned: {}
EOF

kubectl apply -f <(
    for i in {1..5000}; do
        cat <<EOF
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: bomb-${i}
  namespace: bomb
spec:
  secretName: example-cert-tls
  commonName: example-cert
  isCA: false
  duration: 1h
  renewBefore: 5m
  dnsNames:
  - example.com
  issuerRef:
    name: example-selfsigned-issuer
    kind: Issuer
---
EOF
    done
)

while true; do for i in {1..5000}; do
    kubectl cert-manager renew -n bomb "bomb-${i}"
done; done
```

</details>

Instead of waiting for minutes for the panic to appear, we can instead use Go's data race detector to exhibit the issue. First, run cert-manager out-of-cluster and with the race detector:

```sh
k3d cluster create foo
helm upgrade --install cert-manager jetstack/cert-manager --version 1.4.0 --namespace cert-manager --set installCRDs=true --create-namespace --wait
kubectl wait --for=condition=available -n cert-manager deploy/cert-manager-webhook --timeout=5m
kubectl -n cert-manager scale deployment --replicas=0 cert-manager
go install github.com/maelvls/kubectl-incluster@latest
go run -race ./cmd/controller/ --leader-elect=false --kubeconfig=<(kubectl incluster) 2>&1 | tee /dev/stderr | grep -qi "data race"
```

Then, create one Certificate:

```sh
kubectl apply -f- <<EOF
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: example-selfsigned-issuer
spec:
  selfSigned: {}
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: example
spec:
  secretName: example-cert-tls
  commonName: example-cert
  isCA: false
  duration: 1h
  renewBefore: 5m
  dnsNames:
  - example.com
  issuerRef:
    name: example-selfsigned-issuer
    kind: Issuer
EOF
```

This uncovered two bugs:


- [`secretsmanager/secret.go`](https://github.com/jetstack/cert-manager/blob/88e85d07/pkg/controller/certificates/internal/secretsmanager/secret.go#L218-L223) mutates Secrets without deep copying:

  ```
  WARNING: DATA RACE
  Write at 0x00c00420f3e0 by goroutine 431:
    github.com/jetstack/cert-manager/pkg/controller/certificates/internal/secretsmanager.(*SecretsManager).setValues()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/internal/secretsmanager/secret.go:208 +0x206
    github.com/jetstack/cert-manager/pkg/controller/certificates/internal/secretsmanager.(*SecretsManager).UpdateData()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/internal/secretsmanager/secret.go:105 +0x2a4
    github.com/jetstack/cert-manager/pkg/controller/certificates/issuing.(*controller).issueCertificate()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/issuing/issuing_controller.go:343 +0x334
    github.com/jetstack/cert-manager/pkg/controller/certificates/issuing.(*controller).ProcessItem()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/issuing/issuing_controller.go:282 +0x1376

  Previous read at 0x00c00420f3e0 by goroutine 309:
    github.com/jetstack/cert-manager/pkg/controller/certificates/trigger/policies.SecretIsMissingData()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/trigger/policies/policies.go:97 +0x11c
    github.com/jetstack/cert-manager/pkg/controller/certificates/trigger/policies.Chain.Evaluate()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/trigger/policies/policies.go:65 +0xb2
    github.com/jetstack/cert-manager/pkg/controller/certificates/trigger/policies.Chain.Evaluate-fm()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/trigger/policies/policies.go:63 +0xaf
    github.com/jetstack/cert-manager/pkg/controller/certificates/trigger.(*controller).ProcessItem()
        /home/mvalais/code/cert-manager/pkg/controller/certificates/trigger/trigger_controller.go:173 +0x7b3
  ```

- [`approver/sync.go`](https://github.com/jetstack/cert-manager/blob/88e85d07/pkg/controller/certificaterequests/approver/sync.go#L64) mutates CertificateRequests without deep copying first (introduced in 1.3, https://github.com/jetstack/cert-manager/commit/2db7582586f7eba2e5cf391c13268c896a2162ff):
  ```
  WARNING: DATA RACE
  Write at 0x00c0008d6240 by goroutine 86:
    github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1.(*certificateRequests).UpdateStatus()
        /home/mvalais/code/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1/certificaterequest.go:149 +0x38b
    github.com/jetstack/cert-manager/pkg/controller/certificaterequests/approver.(*Controller).Sync()
        /home/mvalais/code/cert-manager/pkg/controller/certificaterequests/approver/sync.go:64 +0x321
  +0x405
  
  Previous read at 0x00c00014a888 by goroutine 140:
    github.com/jetstack/cert-manager/pkg/apis/certmanager/v1.(*CertificateRequest).DeepCopy()
        /home/mvalais/code/cert-manager/pkg/apis/certmanager/v1/zz_generated.deepcopy.go:195 +0x134
    github.com/jetstack/cert-manager/pkg/controller/certificaterequests.(*Controller).Sync()
        /home/mvalais/code/cert-manager/pkg/controller/certificaterequests/sync.go:51 +0x106
  ```

## How do we avoid future data races?

- **Idea 1:** run all our e2e test suite with `go run -race` instead of the binary itself. The performance penalty would be insignificant, but that means having an ad-hoc Dockerfile just for this. From the Go documentation about the [runtime overhead](https://golang.org/doc/articles/race_detector#Runtime_Overheads) of the race detector:
  > The cost of race detection varies by program, but for a typical program, memory usage may increase by 5-10x and execution time by 2-20x.

  We will do that in https://github.com/jetstack/cert-manager/issues/4248 after merging this PR.

Fixes #3664

```release-note
Fixed a race condition introduced in v0.15.0 that would crash cert-manager for clusters
with a large number of certificates.
```