### PR TITLE
CA Basic Constraint checks in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ help:
 	# ctl                - build a binary of the cert-manager kubectl plugin
 	# images             - builds docker images for all of the components, saving them in your Docker daemon
 	# images_push        - pushes docker images to the target registry
+	# crds               - runs the update-crds script to ensure that generated CRDs are up to date
 	# cluster            - creates a Kubernetes cluster for testing in CI (KIND by default)
 	#
 	# Image targets can be run with optional args DOCKER_REGISTRY and APP_VERSION:
@@ -83,6 +84,10 @@ verify_chart:
 .PHONY: verify_upgrade
 verify_upgrade:
 	$(HACK_DIR)/verify-upgrade.sh
+
+.PHONY: crds
+crds:
+	bazel run //hack:update-crds
 
 .PHONY: cluster
 cluster:

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -280,7 +280,6 @@ ensure-in-gopath
 old=${GOCACHE:-}
 export GOCACHE=$(mktemp -d -t codegen.gocache.XXXX)
 export GO111MODULE=on
-export GOPROXY=https://proxy.golang.org
 export GOSUMDB=sum.golang.org
 "$go_sdk/bin/go" mod vendor
 export GO111MODULE=off

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -18,23 +18,16 @@ package helper
 
 import (
 	"context"
-	"crypto/ecdsa"
-	"crypto/ed25519"
-	"crypto/rsa"
 	"crypto/x509"
 	"fmt"
 	"sort"
 	"time"
-
-	corev1 "k8s.io/api/core/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	apiutil "github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-	"github.com/jetstack/cert-manager/pkg/util"
-	"github.com/jetstack/cert-manager/pkg/util/pki"
 	"github.com/jetstack/cert-manager/test/e2e/framework/log"
 	e2eutil "github.com/jetstack/cert-manager/test/e2e/util"
 )
@@ -80,175 +73,6 @@ func (h *Helper) WaitForCertificateNotReadyUpdate(cert *cmapi.Certificate, timeo
 		ObservedGeneration: cert.Generation,
 	}, timeout)
 	return h.handleResult(cert.Namespace, cert.Name, result, err)
-}
-
-// ValidateIssuedCertificate will ensure that the given Certificate has a
-// certificate issued for it, and that the details on the x509 certificate are
-// correct as defined by the Certificate's spec.
-func (h *Helper) ValidateIssuedCertificate(certificate *cmapi.Certificate, rootCAPEM []byte) (*x509.Certificate, error) {
-	log.Logf("Getting the TLS certificate Secret resource")
-	secret, err := h.KubeClient.CoreV1().Secrets(certificate.Namespace).Get(context.TODO(), certificate.Spec.SecretName, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	if !(len(secret.Data) == 2 || len(secret.Data) == 3) {
-		return nil, fmt.Errorf("Expected 2 keys in certificate secret, but there was %d", len(secret.Data))
-	}
-
-	keyBytes, ok := secret.Data[corev1.TLSPrivateKeyKey]
-	if !ok {
-		return nil, fmt.Errorf("No private key data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
-	}
-	key, err := pki.DecodePrivateKeyBytes(keyBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	// validate private key is of the correct type (rsa, ed25519 or ecdsa)
-	privateKey := certificate.Spec.PrivateKey
-	if privateKey == nil {
-		privateKey = &cmapi.CertificatePrivateKey{}
-	}
-	switch privateKey.Algorithm {
-	case cmapi.PrivateKeyAlgorithm(""),
-		cmapi.RSAKeyAlgorithm:
-		_, ok := key.(*rsa.PrivateKey)
-		if !ok {
-			return nil, fmt.Errorf("Expected private key of type RSA, but it was: %T", key)
-		}
-	case cmapi.ECDSAKeyAlgorithm:
-		_, ok := key.(*ecdsa.PrivateKey)
-		if !ok {
-			return nil, fmt.Errorf("Expected private key of type ECDSA, but it was: %T", key)
-		}
-	case cmapi.Ed25519KeyAlgorithm:
-		_, ok := key.(ed25519.PrivateKey)
-		if !ok {
-			return nil, fmt.Errorf("Expected private key of type Ed25519, but it was: %T", key)
-		}
-	default:
-		return nil, fmt.Errorf("unrecognised requested private key algorithm %q", certificate.Spec.PrivateKey.Algorithm)
-	}
-
-	// TODO: validate private key KeySize
-
-	// check the provided certificate is valid
-	expectedOrganization := pki.OrganizationForCertificate(certificate)
-	expectedDNSNames := certificate.Spec.DNSNames
-	expectedIPAddresses := certificate.Spec.IPAddresses
-	uris, err := pki.URIsForCertificate(certificate)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse URIs: %s", err)
-	}
-
-	expectedURIs := pki.URLsToString(uris)
-
-	certBytes, ok := secret.Data[corev1.TLSCertKey]
-	if !ok {
-		return nil, fmt.Errorf("No certificate data found for Certificate %q (secret %q)", certificate.Name, certificate.Spec.SecretName)
-	}
-
-	cert, err := pki.DecodeX509CertificateBytes(certBytes)
-	if err != nil {
-		return nil, err
-	}
-
-	commonNameCorrect := true
-	expectedCN := certificate.Spec.CommonName
-	if len(expectedCN) == 0 && len(cert.Subject.CommonName) > 0 {
-		// issuers might set an IP or DNSName as CN
-		if !util.Contains(cert.DNSNames, cert.Subject.CommonName) && !util.Contains(pki.IPAddressesToString(cert.IPAddresses), cert.Subject.CommonName) {
-			commonNameCorrect = false
-		}
-	} else if expectedCN != cert.Subject.CommonName {
-		commonNameCorrect = false
-	}
-
-	if !commonNameCorrect || !util.Subset(cert.DNSNames, expectedDNSNames) || !util.EqualUnsorted(pki.URLsToString(cert.URIs), expectedURIs) ||
-		!util.Subset(pki.IPAddressesToString(cert.IPAddresses), expectedIPAddresses) ||
-		!(len(cert.Subject.Organization) == 0 || util.EqualUnsorted(cert.Subject.Organization, expectedOrganization)) {
-		return nil, fmt.Errorf("Expected certificate valid for CN %q, O %v, dnsNames %v, uriSANs %v,but got a certificate valid for CN %q, O %v, dnsNames %v, uriSANs %v, ipAddresses %v",
-			expectedCN, expectedOrganization, expectedDNSNames, expectedURIs, cert.Subject.CommonName, cert.Subject.Organization, cert.DNSNames, cert.URIs, cert.IPAddresses)
-	}
-
-	if certificate.Status.NotAfter == nil {
-		return nil, fmt.Errorf("No certificate expiration found for Certificate %q", certificate.Name)
-	}
-	if !cert.NotAfter.Equal(certificate.Status.NotAfter.Time) {
-		return nil, fmt.Errorf("Expected certificate expiry date to be %v, but got %v", certificate.Status.NotAfter, cert.NotAfter)
-	}
-
-	label, ok := secret.Annotations[cmapi.CertificateNameKey]
-	if !ok {
-		return nil, fmt.Errorf("Expected secret to have certificate-name label, but had none")
-	}
-
-	if label != certificate.Name {
-		return nil, fmt.Errorf("Expected secret to have certificate-name label with a value of %q, but got %q", certificate.Name, label)
-	}
-
-	certificateKeyUsages, certificateExtKeyUsages, err := pki.BuildKeyUsages(certificate.Spec.Usages, certificate.Spec.IsCA)
-	if err != nil {
-		return nil, fmt.Errorf("failed to build key usages from certificate: %s", err)
-	}
-
-	defaultCertKeyUsages, defaultCertExtKeyUsages, err := h.defaultKeyUsagesToAdd(certificate.Namespace, &certificate.Spec.IssuerRef)
-	if err != nil {
-		return nil, err
-	}
-
-	certificateKeyUsages |= defaultCertKeyUsages
-	certificateExtKeyUsages = append(certificateExtKeyUsages, defaultCertExtKeyUsages...)
-
-	// If using ECDSA then ignore key encipherment
-	if certificate.Spec.PrivateKey != nil && certificate.Spec.PrivateKey.Algorithm == cmapi.ECDSAKeyAlgorithm {
-		certificateKeyUsages &^= x509.KeyUsageKeyEncipherment
-		cert.KeyUsage &^= x509.KeyUsageKeyEncipherment
-	}
-
-	certificateExtKeyUsages = h.deduplicateExtKeyUsages(certificateExtKeyUsages)
-
-	if !h.keyUsagesMatch(cert.KeyUsage, cert.ExtKeyUsage,
-		certificateKeyUsages, certificateExtKeyUsages) {
-		return nil, fmt.Errorf("key usages and extended key usages do not match: exp=%s got=%s exp=%s got=%s",
-			apiutil.KeyUsageStrings(certificateKeyUsages), apiutil.KeyUsageStrings(cert.KeyUsage),
-			apiutil.ExtKeyUsageStrings(certificateExtKeyUsages), apiutil.ExtKeyUsageStrings(cert.ExtKeyUsage))
-	}
-
-	if !util.EqualUnsorted(cert.EmailAddresses, certificate.Spec.EmailAddresses) {
-		return nil, fmt.Errorf("certificate doesn't contain Email SANs: exp=%v got=%v", certificate.Spec.EmailAddresses, cert.EmailAddresses)
-	}
-
-	var dnsName string
-	if len(expectedDNSNames) > 0 {
-		dnsName = expectedDNSNames[0]
-	}
-
-	// TODO: move this verification step out of this function
-	if rootCAPEM != nil {
-		rootCertPool := x509.NewCertPool()
-		rootCertPool.AppendCertsFromPEM(rootCAPEM)
-		intermediateCertPool := x509.NewCertPool()
-		intermediateCertPool.AppendCertsFromPEM(certBytes)
-		opts := x509.VerifyOptions{
-			DNSName:       dnsName,
-			Intermediates: intermediateCertPool,
-			Roots:         rootCertPool,
-		}
-
-		if _, err := cert.Verify(opts); err != nil {
-			return nil, err
-		}
-	}
-
-	readyCond := apiutil.GetCertificateCondition(certificate, cmapi.CertificateConditionReady)
-	if readyCond.Status != cmmeta.ConditionTrue || readyCond.ObservedGeneration != certificate.Generation {
-		return nil, fmt.Errorf(
-			"expected Certificate to have ready condition true, with an observedGeneration matching the Certificate generation, got=%+v",
-			readyCond)
-	}
-
-	return cert, nil
 }
 
 func (h *Helper) deduplicateExtKeyUsages(us []x509.ExtKeyUsage) []x509.ExtKeyUsage {

--- a/test/e2e/framework/helper/featureset/featureset.go
+++ b/test/e2e/framework/helper/featureset/featureset.go
@@ -87,13 +87,11 @@ const (
 	WildcardsFeature Feature = "Wildcards"
 
 	// ECDSAFeature denotes whether the target issuer is able to sign
-	// certificates with an elliptic curve private key. This is useful for some
-	// issuers that have trouble being configured to support this feature.
+	// certificates with an elliptic curve private key.
 	ECDSAFeature Feature = "ECDSA"
 
 	// ReusePrivateKey denotes whether the target issuer is able to sign multiple
-	// certificates for the same private key. This is useful for some issuers
-	// that have trouble being configured to support this feature.
+	// certificates for the same private key.
 	ReusePrivateKeyFeature Feature = "ReusePrivateKey"
 
 	// URISANs denotes whether to the target issuer is able to sign a certificate
@@ -126,8 +124,7 @@ const (
 	// represent a root CA (sub-feature of SaveCAToSecret)
 	SaveRootCAToSecret = "SaveRootCAToSecret"
 
-	// Ed25519 denotes whether the target issuer is able to sign
-	// certificates with an Ed25519 private key. This is useful for some
-	// issuers that have may not support this feature.
+	// Ed25519FeatureSet denotes whether the target issuer is able to sign
+	// certificates with an Ed25519 private key.
 	Ed25519FeatureSet Feature = "Ed25519"
 )

--- a/test/e2e/framework/helper/featureset/featureset.go
+++ b/test/e2e/framework/helper/featureset/featureset.go
@@ -127,4 +127,8 @@ const (
 	// Ed25519FeatureSet denotes whether the target issuer is able to sign
 	// certificates with an Ed25519 private key.
 	Ed25519FeatureSet Feature = "Ed25519"
+
+	// IssueCAFeature denotes whether the target issuer is able to issue CA
+	// certificates (i.e., certificates for which the CA basicConstraint is true)
+	IssueCAFeature Feature = "IssueCA"
 )

--- a/test/e2e/framework/helper/validation/certificates/certificates.go
+++ b/test/e2e/framework/helper/validation/certificates/certificates.go
@@ -348,3 +348,19 @@ func ExpectConditionReadyObservedGeneration(certificate *cmapi.Certificate, secr
 
 	return nil
 }
+
+// ExpectValidBasicConstraints asserts that basicConstraints are set correctly on issued certificates
+func ExpectValidBasicConstraints(certificate *cmapi.Certificate, secret *corev1.Secret) error {
+	cert, err := pki.DecodeX509CertificateBytes(secret.Data[corev1.TLSCertKey])
+	if err != nil {
+		return err
+	}
+
+	if certificate.Spec.IsCA != cert.IsCA {
+		return fmt.Errorf("Expected CA basicConstraint to be %v, but got %v", certificate.Spec.IsCA, cert.IsCA)
+	}
+
+	// TODO: also validate pathLen
+
+	return nil
+}

--- a/test/e2e/framework/helper/validation/validation.go
+++ b/test/e2e/framework/helper/validation/validation.go
@@ -37,6 +37,7 @@ func DefaultCertificateSet() []certificates.ValidationFunc {
 		certificates.ExpectValidNotAfterDate,
 		certificates.ExpectValidPrivateKeyData,
 		certificates.ExpectConditionReadyObservedGeneration,
+		certificates.ExpectValidBasicConstraints,
 	}
 }
 
@@ -71,6 +72,7 @@ func CertificateSetForUnsupportedFeatureSet(fs featureset.FeatureSet) []certific
 		certificates.ExpectValidNotAfterDate,
 		certificates.ExpectValidPrivateKeyData,
 		certificates.ExpectConditionReadyObservedGeneration,
+		certificates.ExpectValidBasicConstraints,
 	}
 
 	if !fs.Contains(featureset.URISANsFeature) {
@@ -83,6 +85,7 @@ func CertificateSetForUnsupportedFeatureSet(fs featureset.FeatureSet) []certific
 
 	if !fs.Contains(featureset.SaveCAToSecret) {
 		out = append(out, certificates.ExpectCorrectTrustChain)
+
 		if !fs.Contains(featureset.SaveRootCAToSecret) {
 			out = append(out, certificates.ExpectCARootCertificate)
 		}

--- a/test/e2e/suite/conformance/certificates/acme/acme.go
+++ b/test/e2e/suite/conformance/certificates/acme/acme.go
@@ -54,6 +54,7 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.KeyUsagesFeature,
 		featureset.EmailSANsFeature,
 		featureset.SaveCAToSecret,
+		featureset.IssueCAFeature,
 	)
 
 	// unsupportedDNS01Features is a list of features that are not supported by the ACME
@@ -66,6 +67,7 @@ func runACMEIssuerTests(eab *cmacme.ACMEExternalAccountBinding) {
 		featureset.KeyUsagesFeature,
 		featureset.EmailSANsFeature,
 		featureset.SaveCAToSecret,
+		featureset.IssueCAFeature,
 	)
 
 	provisionerHTTP01 := &acmeIssuerProvisioner{

--- a/test/e2e/suite/conformance/certificates/external/external.go
+++ b/test/e2e/suite/conformance/certificates/external/external.go
@@ -43,6 +43,8 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		featureset.DurationFeature,
 		featureset.KeyUsagesFeature,
 		featureset.SaveCAToSecret,
+		featureset.Ed25519FeatureSet,
+		featureset.IssueCAFeature,
 	)
 
 	issuerBuilder := newIssuerBuilder("Issuer")

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -27,6 +27,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/pkg/util"

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -44,8 +44,9 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 	var unsupportedFeatures = featureset.NewFeatureSet(
 		featureset.KeyUsagesFeature,
 		featureset.SaveRootCAToSecret,
-		//Vault does not support signing using Ed25519
+		// Vault does not support signing using Ed25519
 		featureset.Ed25519FeatureSet,
+		featureset.IssueCAFeature,
 	)
 
 	provisioner := new(vaultAppRoleProvisioner)

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -49,8 +49,9 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		featureset.IPAddressFeature,
 		// Venafi doesn't allow certs with empty CN & DN
 		featureset.OnlySAN,
-		//Venafi Cloud seems to only support for SSH Ed25519
+		// Venafi seems to only support SSH Ed25519 keys
 		featureset.Ed25519FeatureSet,
+		featureset.IssueCAFeature,
 	)
 
 	provisioner := new(venafiProvisioner)

--- a/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
+++ b/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
@@ -46,8 +46,9 @@ var _ = framework.ConformanceDescribe("[Feature:Issuers:Venafi:Cloud] Certificat
 		featureset.URISANsFeature,
 		// Venafi doesn't allow certs with empty CN & DN
 		featureset.OnlySAN,
-		//Venafi Cloud seems to only support for SSH Ed25519
+		// Venafi seems to only support SSH Ed25519 keys
 		featureset.Ed25519FeatureSet,
+		featureset.IssueCAFeature,
 	)
 
 	provisioner := new(venafiProvisioner)


### PR DESCRIPTION
Adds support for checking the CA basic constraint in e2e tests, and a conformance suite test for the same.

Currently enabled only for CA and SelfSigned issuers.

There are also other minor changes to the Makefile and hack/update-codegen.sh. These changes are explained in commit messages. `ValidateIssuedCertificate` is also removed since it doesn't appear to be used anywhere; again, this is explained by the commit message.

This is the first part of implementing #2820 

```release-note
Add e2e test checks for the CA basic constraint, enabled on CA and SelfSigned issuers
```
