### PR TITLE
Add startup api check Job

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -29,6 +29,7 @@ container_bundle(
         "{STABLE_DOCKER_REGISTRY}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//build:acmesolver.image",
         "{STABLE_DOCKER_REGISTRY}/cert-manager-webhook:{STABLE_DOCKER_TAG}": "//build:webhook.image",
         "{STABLE_DOCKER_REGISTRY}/cert-manager-cainjector:{STABLE_DOCKER_TAG}": "//build:cainjector.image",
+        "{STABLE_DOCKER_REGISTRY}/cert-manager-ctl:{STABLE_DOCKER_TAG}": "//build:ctl.image",
     },
     tags = ["manual"],
 )

--- a/build/BUILD.bazel
+++ b/build/BUILD.bazel
@@ -18,6 +18,9 @@ DOCKERIZED_BINARIES = {
     "webhook": {
         "target": "//cmd/webhook:webhook",
     },
+    "ctl": {
+        "target": "//cmd/ctl:ctl",
+    },
 }
 
 # Allows passing --define image_type custom flag to Bazel command. Used to allow

--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -181,6 +181,25 @@ The following table lists the configurable parameters of the cert-manager chart 
 | `cainjector.image.pullPolicy` | cainjector image pull policy | `IfNotPresent` |
 | `cainjector.securityContext` | Security context for cainjector pod assignment | `{}` |
 | `cainjector.containerSecurityContext` | Security context to be set on cainjector component container | `{}` |
+| `startupapicheck.enabled` | Toggles whether the startupapicheck Job should be installed | `true` |
+| `startupapicheck.securityContext` | Pod Security Context to be set on the startupapicheck component Pod | `{}` |
+| `startupapicheck.timeout` | Timeout for 'kubectl check api' command | `1m` |
+| `startupapicheck.backoffLimit` | Job backoffLimit | `4` |
+| `startupapicheck.jobAnnotations` | Optional additional annotations to add to the startupapicheck Job | `{}` |
+| `startupapicheck.podAnnotations` | Optional additional annotations to add to the startupapicheck Pods | `{}` |
+| `startupapicheck.extraArgs` | Optional additional arguments for startupapicheck | `[]` |
+| `startupapicheck.resources` | CPU/memory resource requests/limits for the startupapicheck pod | `{}` |
+| `startupapicheck.nodeSelector` | Node labels for startupapicheck pod assignment | `{}` |
+| `startupapicheck.affinity` | Node affinity for startupapicheck pod assignment | `{}` |
+| `startupapicheck.tolerations` | Node tolerations for startupapicheck pod assignment | `[]` |
+| `startupapicheck.podLabels` | Optional additional labels to add to the startupapicheck Pods | `{}` |
+| `startupapicheck.image.repository` | startupapicheck image repository | `quay.io/jetstack/cert-manager-ctl` |
+| `startupapicheck.image.tag` | startupapicheck image tag | `{{RELEASE_VERSION}}` |
+| `startupapicheck.image.pullPolicy` | startupapicheck image pull policy | `IfNotPresent` |
+| `startupapicheck.serviceAccount.create` | If `true`, create a new service account for the startupapicheck component | `true` |
+| `startupapicheck.serviceAccount.name` | Service account for the startupapicheck component to be used. If not set and `startupapicheck.serviceAccount.create` is `true`, a name is generated using the fullname template |  |
+| `startupapicheck.serviceAccount.annotations` | Annotations to add to the service account for the startupapicheck component |  |
+| `startupapicheck.serviceAccount.automountServiceAccountToken` | Automount API credentials for the startupapicheck Service Account | `true` |
 
 Specify each parameter using the `--set key=value[,key=value]` argument to `helm install`.
 

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -107,6 +107,40 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+startupapicheck templates
+*/}}
+
+{{/*
+Expand the name of the chart.
+Manually fix the 'app' and 'name' labels to 'startupapicheck' to maintain
+compatibility with the v0.9 deployment selector.
+*/}}
+{{- define "startupapicheck.name" -}}
+{{- printf "startupapicheck" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "startupapicheck.fullname" -}}
+{{- $trimmedName := printf "%s" (include "cert-manager.fullname" .) | trunc 52 | trimSuffix "-" -}}
+{{- printf "%s-startupapicheck" $trimmedName | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "startupapicheck.serviceAccountName" -}}
+{{- if .Values.startupapicheck.serviceAccount.create -}}
+    {{ default (include "startupapicheck.fullname" .) .Values.startupapicheck.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.startupapicheck.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "chartName" -}}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -1,0 +1,75 @@
+{{- if .Values.startupapicheck.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "startupapicheck.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.jobAnnotations }}
+  annotations:
+{{ toYaml .Values.startupapicheck.jobAnnotations | indent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "startupapicheck.name" . }}
+        app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/component: "startupapicheck"
+        {{- include "labels" . | nindent 8 }}
+{{- if .Values.startupapicheck.podLabels }}
+{{ toYaml .Values.startupapicheck.podLabels | indent 8 }}
+{{- end }}
+      {{- if .Values.startupapicheck.podAnnotations }}
+      annotations:
+{{ toYaml .Values.startupapicheck.podAnnotations | indent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ template "startupapicheck.serviceAccountName" . }}
+      {{- if .Values.global.priorityClassName }}
+      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- end }}
+      {{- if .Values.startupapicheck.securityContext}}
+      securityContext:
+{{ toYaml .Values.startupapicheck.securityContext | indent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.startupapicheck.image }}
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          {{- end }}
+          imagePullPolicy: {{ .Values.startupapicheck.image.pullPolicy }}
+          args:
+          - check
+          - api
+          - --wait={{ .Values.startupapicheck.timeout }}
+          {{- if .Values.startupapicheck.extraArgs }}
+{{ toYaml .Values.startupapicheck.extraArgs | indent 10 }}
+          {{- end }}
+          {{- if .Values.startupapicheck.containerSecurityContext }}
+          securityContext:
+            {{- toYaml .Values.startupapicheck.containerSecurityContext | nindent 12 }}
+          {{- end }}
+          resources:
+{{ toYaml .Values.startupapicheck.resources | indent 12 }}
+    {{- with .Values.startupapicheck.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.startupapicheck.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.startupapicheck.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
@@ -12,6 +12,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+{{ toYaml .Values.startupapicheck.rbac.annotations | indent 4 }}
+  {{- end }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
@@ -29,6 +33,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+{{ toYaml .Values.startupapicheck.rbac.annotations | indent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.rbac.create -}}
+# create certificate role
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}:create-cert
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates"]
+    verbs: ["create"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "startupapicheck.fullname" . }}:create-cert
+  namespace: {{ .Release.Namespace | quote }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ template "startupapicheck.fullname" . }}:create-cert
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "startupapicheck.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.startupapicheck.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.startupapicheck.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ template "startupapicheck.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- if .Values.startupapicheck.serviceAccount.annotations }}
+  annotations:
+{{ toYaml .Values.startupapicheck.serviceAccount.annotations | indent 4 }}
+  {{- end }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+{{- if .Values.global.imagePullSecrets }}
+imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- end }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -396,3 +396,66 @@ cainjector:
     # annotations: {}
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true
+
+startupapicheck:
+  enabled: true
+
+  # Pod Security Context to be set on the cainjector component Pod
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+  securityContext:
+    runAsNonRoot: true
+
+  # Timeout for 'kubectl check api' command
+  timeout: 1m
+
+  # Job backoffLimit
+  backoffLimit: 4
+
+  # Optional additional annotations to add to the cainjector Job
+  # jobAnnotations: {}
+
+  # Optional additional annotations to add to the cainjector Pods
+  # podAnnotations: {}
+
+  # Optional additional arguments for cainjector
+  extraArgs: []
+
+  resources: {}
+    # requests:
+    #   cpu: 10m
+    #   memory: 32Mi
+
+  nodeSelector: {}
+
+  affinity: {}
+
+  tolerations: []
+
+  # Optional additional labels to add to the CA Injector Pods
+  podLabels: {}
+
+  image:
+    repository: quay.io/jetstack/cert-manager-ctl
+    # You can manage a registry with
+    # registry: quay.io
+    # repository: jetstack/cert-manager-ctl
+
+    # Override the image tag to deploy by setting this variable.
+    # If no value is set, the chart's appVersion will be used.
+    # tag: canary
+
+    # Setting a digest will override any tag
+    # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+
+    pullPolicy: IfNotPresent
+
+  serviceAccount:
+    # Specifies whether a service account should be created
+    create: true
+    # The name of the service account to use.
+    # If not set and create is true, a name is generated using the fullname template
+    # name: ""
+    # Optional additional annotations to add to the controller's ServiceAccount
+    # annotations: {}
+    # Automount API credentials for a Service Account.
+    automountServiceAccountToken: true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -416,7 +416,8 @@ startupapicheck:
   # Optional additional annotations to add to the startupapicheck Job
   jobAnnotations:
     helm.sh/hook: post-install
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+    helm.sh/hook-weight: "1"
+    helm.sh/hook-delete-policy: hook-succeeded
 
   # Optional additional annotations to add to the startupapicheck Pods
   # podAnnotations: {}
@@ -456,7 +457,8 @@ startupapicheck:
   rbac:
     annotations:
       helm.sh/hook: post-install
-      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: hook-succeeded
 
   serviceAccount:
     # Specifies whether a service account should be created
@@ -469,7 +471,8 @@ startupapicheck:
     # Optional additional annotations to add to the Job's ServiceAccount
     annotations:
       helm.sh/hook: post-install
-      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+      helm.sh/hook-weight: "-5"
+      helm.sh/hook-delete-policy: hook-succeeded
 
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -397,6 +397,8 @@ cainjector:
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true
 
+# This startupapicheck is a Helm post-install hook that waits for the webhook
+# endpoints to become available.
 startupapicheck:
   enabled: true
 
@@ -412,7 +414,9 @@ startupapicheck:
   backoffLimit: 4
 
   # Optional additional annotations to add to the startupapicheck Job
-  # jobAnnotations: {}
+  jobAnnotations:
+    helm.sh/hook: post-install
+    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
 
   # Optional additional annotations to add to the startupapicheck Pods
   # podAnnotations: {}
@@ -449,13 +453,23 @@ startupapicheck:
 
     pullPolicy: IfNotPresent
 
+  rbac:
+    annotations:
+      helm.sh/hook: post-install
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
   serviceAccount:
     # Specifies whether a service account should be created
     create: true
+
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     # name: ""
+
     # Optional additional annotations to add to the Job's ServiceAccount
-    # annotations: {}
+    annotations:
+      helm.sh/hook: post-install
+      helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
+
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -400,7 +400,7 @@ cainjector:
 startupapicheck:
   enabled: true
 
-  # Pod Security Context to be set on the cainjector component Pod
+  # Pod Security Context to be set on the startupapicheck component Pod
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
   securityContext:
     runAsNonRoot: true
@@ -411,13 +411,13 @@ startupapicheck:
   # Job backoffLimit
   backoffLimit: 4
 
-  # Optional additional annotations to add to the cainjector Job
+  # Optional additional annotations to add to the startupapicheck Job
   # jobAnnotations: {}
 
-  # Optional additional annotations to add to the cainjector Pods
+  # Optional additional annotations to add to the startupapicheck Pods
   # podAnnotations: {}
 
-  # Optional additional arguments for cainjector
+  # Optional additional arguments for startupapicheck
   extraArgs: []
 
   resources: {}
@@ -431,7 +431,7 @@ startupapicheck:
 
   tolerations: []
 
-  # Optional additional labels to add to the CA Injector Pods
+  # Optional additional labels to add to the startupapicheck Pods
   podLabels: {}
 
   image:
@@ -455,7 +455,7 @@ startupapicheck:
     # The name of the service account to use.
     # If not set and create is true, a name is generated using the fullname template
     # name: ""
-    # Optional additional annotations to add to the controller's ServiceAccount
+    # Optional additional annotations to add to the Job's ServiceAccount
     # annotations: {}
     # Automount API credentials for a Service Account.
     automountServiceAccountToken: true

--- a/deploy/crds/BUILD.bazel
+++ b/deploy/crds/BUILD.bazel
@@ -50,6 +50,7 @@ helm_tmpl(
         # Set creator to "static", so the Helm chart does
         # not add Helm-specific labels to the resources.
         "creator": "static",
+        "startupapicheck.enabled": "false",
     },
     visibility = ["//visibility:public"],
 )
@@ -76,6 +77,7 @@ helm_tmpl(
         # Set creator to "static", so the Helm chart does
         # not add Helm-specific labels to the resources.
         "creator": "static",
+        "startupapicheck.enabled": "false",
     },
     visibility = ["//visibility:public"],
 ) for crd in crds]

--- a/deploy/manifests/BUILD.bazel
+++ b/deploy/manifests/BUILD.bazel
@@ -19,6 +19,7 @@ helm_tmpl(
         # Set creator to "static", so the Helm chart does
         # not add Helm-specific labels to the resources.
         "creator": "static",
+        "startupapicheck.enabled": "false",
     },
 )
 

--- a/devel/addon/certmanager/BUILD.bazel
+++ b/devel/addon/certmanager/BUILD.bazel
@@ -7,6 +7,7 @@ container_bundle(
         "{STABLE_DOCKER_REGISTRY}/cert-manager-acmesolver:{STABLE_DOCKER_TAG}": "//build:acmesolver.image",
         "{STABLE_DOCKER_REGISTRY}/cert-manager-webhook:{STABLE_DOCKER_TAG}": "//build:webhook.image",
         "{STABLE_DOCKER_REGISTRY}/cert-manager-cainjector:{STABLE_DOCKER_TAG}": "//build:cainjector.image",
+        "{STABLE_DOCKER_REGISTRY}/cert-manager-ctl:{STABLE_DOCKER_TAG}": "//build:ctl.image",
     },
     tags = ["manual"],
 )

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -59,7 +59,6 @@ bazel build //deploy/charts/cert-manager
 helm upgrade \
     --install \
     --wait \
-    --wait-for-jobs \
     --namespace "${NAMESPACE}" \
     --set image.tag="${APP_VERSION}" \
     --set cainjector.image.tag="${APP_VERSION}" \

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -55,10 +55,11 @@ kubectl get namespace "${NAMESPACE}" || kubectl create namespace "${NAMESPACE}"
 bazel build //deploy/charts/cert-manager
 
 # Upgrade or install cert-manager
-# --wait flag should wait for Job to complete
+# --wait & --wait-for-jobs flags should wait for resources and Jobs to complete
 helm upgrade \
     --install \
     --wait \
+    --wait-for-jobs \
     --namespace "${NAMESPACE}" \
     --set image.tag="${APP_VERSION}" \
     --set cainjector.image.tag="${APP_VERSION}" \

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -64,6 +64,7 @@ helm upgrade \
     --set image.tag="${APP_VERSION}" \
     --set cainjector.image.tag="${APP_VERSION}" \
     --set webhook.image.tag="${APP_VERSION}" \
+    --set startupapicheck.image.tag="${APP_VERSION}" \
     --set installCRDs=true \
     --set featureGates="${FEATURE_GATES:-}" \
     --set "extraArgs={--dns01-recursive-nameservers=${SERVICE_IP_PREFIX}.16:53,--dns01-recursive-nameservers-only=true,--controllers=*\,gateway-shim}" \

--- a/hack/verify-upgrade.sh
+++ b/hack/verify-upgrade.sh
@@ -156,6 +156,7 @@ load_image "quay.io/jetstack/cert-manager-controller:${APP_VERSION}" &
 load_image "quay.io/jetstack/cert-manager-acmesolver:${APP_VERSION}" &
 load_image "quay.io/jetstack/cert-manager-cainjector:${APP_VERSION}" &
 load_image "quay.io/jetstack/cert-manager-webhook:${APP_VERSION}" &
+load_image "quay.io/jetstack/cert-manager-ctl:${APP_VERSION}" &
 wait
 
 # Overwrite image tags in the static manifests and deploy.


### PR DESCRIPTION
**What this PR does / why we need it**:
Add `startupapicheck` Job that waits for the cert-manager api to become ready.
This Job can be awaited for by adding the `--wait` flag to the `helm install` command.

Alternatively, the following kubectl command can be used to wait for the cert-manager api to be ready:
```bash
kubectl wait -n cert-manager --for=condition=complete job/cert-manager-startupapicheck
```

**Which issue this PR fixes**
fixes #4155

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added a startup api check Job that waits for the cert-manager api to become ready
```
/kind feature