### PR TITLE
Fix how last published release version is calculated for upgrade tests

### DIFF
--- a/hack/verify-upgrade.sh
+++ b/hack/verify-upgrade.sh
@@ -23,13 +23,13 @@ export REPO_ROOT="${SCRIPT_ROOT}/.."
 source "${REPO_ROOT}/devel/lib/lib.sh"
 source "${REPO_ROOT}/hack/build/version.sh"
 
-kube::version::get_version_vars
+kube::version::last_published_release
 
 LATEST_RELEASE="${KUBE_LAST_RELEASE}"
 CURRENT_VERSION="${KUBE_GIT_VERSION}"
 
 # Ensure helm, kind, kubectl, ytt, jq are available
-bazel build //hack/bin:helm //hack/bin:kind //hack/bin:ytt //hack/bin:jq //hack/bin:kubectl
+bazel build //hack/bin:helm //hack/bin:kind //hack/bin:ytt //hack/bin:jq //hack/bin:kubectl //hack/bin:kubectl-cert_manager
 bindir="$(bazel info bazel-bin)"
 export PATH="${bindir}/hack/bin/:$PATH"
 


### PR DESCRIPTION
Upgrade tests should always upgrade from latest published non-alpha/beta release.



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR just fixes a bug where the calculation of release version in the upgrade test broke after `v1.5.0-alpha.0` was released, see https://github.com/jetstack/cert-manager/pull/4218#issuecomment-884089497



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
