### PR TITLE
Fix check for self-signed certs in EncodeX509Chain

### DIFF
--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -219,7 +219,7 @@ func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle
 	)
 
 	if issuer == nil {
-		// Selfsigned (no issuer)
+		// No issuer implies the cert should be self signed
 		issuerKey = pk
 		issuerCert = template
 	} else {
@@ -235,6 +235,14 @@ func mustCreateBundle(t *testing.T, issuer *testBundle, name string) *testBundle
 	return &testBundle{pem: certPEM, cert: cert, pk: pk}
 }
 
+func joinPEM(first []byte, rest ...[]byte) []byte {
+	for _, b := range rest {
+		first = append(first, b...)
+	}
+
+	return first
+}
+
 func TestParseSingleCertificateChain(t *testing.T) {
 	root := mustCreateBundle(t, nil, "root")
 	intA1 := mustCreateBundle(t, root, "intA-1")
@@ -242,14 +250,8 @@ func TestParseSingleCertificateChain(t *testing.T) {
 	intB1 := mustCreateBundle(t, root, "intB-1")
 	intB2 := mustCreateBundle(t, intB1, "intB-2")
 	leaf := mustCreateBundle(t, intA2, "leaf")
+	leafInterCN := mustCreateBundle(t, intA2, intA2.cert.Subject.CommonName)
 	random := mustCreateBundle(t, nil, "random")
-
-	joinPEM := func(first []byte, rest ...[]byte) []byte {
-		for _, b := range rest {
-			first = append(first, b...)
-		}
-		return first
-	}
 
 	tests := map[string]struct {
 		inputBundle  []byte
@@ -284,6 +286,12 @@ func TestParseSingleCertificateChain(t *testing.T) {
 		"if 4 certificate chain passed in order, should return single ca and chain in order": {
 			inputBundle:  joinPEM(leaf.pem, intA1.pem, intA2.pem, root.pem),
 			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem, intA2.pem, intA1.pem), CAPEM: root.pem},
+			expErr:       false,
+		},
+		"if certificate chain has two certs with the same CN, shouldn't affect output": {
+			// see https://github.com/jetstack/cert-manager/issues/4142
+			inputBundle:  joinPEM(leafInterCN.pem, intA1.pem, intA2.pem, root.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leafInterCN.pem, intA2.pem, intA1.pem), CAPEM: root.pem},
 			expErr:       false,
 		},
 		"if 4 certificate chain passed out of order, should return single ca and chain in order": {


### PR DESCRIPTION
See also https://github.com/jetstack/cert-manager/issues/4142

EncodeX509Chain checked for self-signed certs by comparing the subject
and issuer of the cert in question, which is invalid since it's
perfectly fine for those to match.

the correct behavior is to use cert.CheckSignatureFrom(cert). this bug
was exposed in 1.4 when ParseSingleCertificateChain started using
EncodeX509Chain in the critical path of several issuers; when end-users
had leaf certificates with subjects matching their issuer's subject, the
bug was triggered.

includes tests for EncodeX509Chain, a test for
ParseSingleCertificateChain, and some defence-in-depth measures

```release-note
Fix check for self-signed certificates in EncodeX509Chain which broke certs whose subject DN matched their issuer's subject DN
```

fixes #4142 