### PR TITLE
Resolve test flakes "the object has been modified"

### DIFF
--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -51,7 +51,7 @@ func (h *Helper) waitForCertificateNotIssuing(ns, name string, timeout time.Dura
 	return h.handleResult(ns, name, result, "Not Issuing", err)
 }
 
-// WaitForCertificateReady waits for the certificate resource to enter a Ready state.
+// WaitForCertificateReady waits for the certificate resource to enter a Ready state and to leave the Issuing state.
 func (h *Helper) WaitForCertificateReady(ns, name string, timeout time.Duration) (*cmapi.Certificate, error) {
 	result, err := e2eutil.WaitForCertificateCondition(h.CMClient.CertmanagerV1().Certificates(ns), name, cmapi.CertificateCondition{
 		Type:   cmapi.CertificateConditionReady,
@@ -60,12 +60,14 @@ func (h *Helper) WaitForCertificateReady(ns, name string, timeout time.Duration)
 	if err != nil {
 		return h.handleResult(ns, name, result, "Ready", err)
 	}
+	// Making sure that the Certificate is stable (see #4239) by also waiting for the Issuing state to disappear.
+	// A certificate that has state Ready=True and Issuing not set, is stable and will not change without outside changes.
 	return h.waitForCertificateNotIssuing(ns, name, timeout)
 }
 
 // WaitForCertificateReadyUpdate waits for the certificate resource to enter a
-// Ready state. If the provided cert was in a Ready state already, the function
-// waits for a state transition to have happened.
+// Ready state and to leave the Issuing state. If the provided cert was in a
+// Ready state already, the function waits for a state transition to have happened.
 func (h *Helper) WaitForCertificateReadyUpdate(cert *cmapi.Certificate, timeout time.Duration) (*cmapi.Certificate, error) {
 	result, err := e2eutil.WaitForCertificateConditionWithObservedGeneration(h.CMClient.CertmanagerV1().Certificates(cert.Namespace), cert.Name, cmapi.CertificateCondition{
 		Type:               cmapi.CertificateConditionReady,
@@ -75,12 +77,14 @@ func (h *Helper) WaitForCertificateReadyUpdate(cert *cmapi.Certificate, timeout 
 	if err != nil {
 		return h.handleResult(cert.Namespace, cert.Name, result, "Ready", err)
 	}
+	// Making sure that the Certificate is stable (see #4239) by also waiting for the Issuing state to disappear.
+	// A certificate that has state Ready=True and Issuing not set, is stable and will not change without outside changes.
 	return h.waitForCertificateNotIssuing(cert.Namespace, cert.Name, timeout)
 }
 
 // WaitForCertificateReadyUpdate waits for the certificate resource to enter a
-// Ready=False state. If the provided cert was in a Ready=False state already,
-// the function waits for a state transition to have happened.
+// Ready=False state and to leave the Issuing state. If the provided cert was
+// in a Ready=False state already, the function waits for a state transition to have happened.
 func (h *Helper) WaitForCertificateNotReadyUpdate(cert *cmapi.Certificate, timeout time.Duration) (*cmapi.Certificate, error) {
 	result, err := e2eutil.WaitForCertificateConditionWithObservedGeneration(h.CMClient.CertmanagerV1().Certificates(cert.Namespace), cert.Name, cmapi.CertificateCondition{
 		Type:               cmapi.CertificateConditionReady,
@@ -90,6 +94,8 @@ func (h *Helper) WaitForCertificateNotReadyUpdate(cert *cmapi.Certificate, timeo
 	if err != nil {
 		return h.handleResult(cert.Namespace, cert.Name, result, "Not Ready", err)
 	}
+	// Making sure that the Certificate is stable (see #4239) by also waiting for the Issuing state to disappear.
+	// A certificate that has state Ready=False and Issuing not set, is stable and will not change without outside changes.
 	return h.waitForCertificateNotIssuing(cert.Namespace, cert.Name, timeout)
 }
 

--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -96,7 +96,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 
 				By("grabbing the corresponding secret")
 				var secret corev1.Secret
-				Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
+				Expect(f.CRClient.Get(context.Background(), secretName, &secret)).To(Succeed())
 
 				By("checking that all webhooks have a populated CA")
 				caData := secret.Data["ca.crt"]
@@ -158,11 +158,14 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				By("changing the name of the corresponding secret in the cert")
 				secretName := types.NamespacedName{Name: cert.Spec.SecretName, Namespace: f.Namespace.Name}
 				cert.Spec.DNSNames = append(cert.Spec.DNSNames, "something.com")
-				Eventually(func() error { return f.CRClient.Update(context.Background(), &cert) }, "10s", "2s").Should(Succeed())
+				Expect(f.CRClient.Update(context.Background(), &cert)).To(Succeed())
+
+				_, err := f.Helper().WaitForCertificateReadyUpdate(&cert, time.Second*30)
+				Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become updated")
 
 				By("grabbing the new secret")
 				var secret corev1.Secret
-				Eventually(func() error { return f.CRClient.Get(context.Background(), secretName, &secret) }, "10s", "2s").Should(Succeed())
+				Expect(f.CRClient.Get(context.Background(), secretName, &secret)).To(Succeed())
 
 				By("verifying that the hooks have the new data")
 				caData := secret.Data["ca.crt"]

--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -165,6 +165,27 @@ func WaitForCertificateCondition(client clientset.CertificateInterface, name str
 	return certificate, wrapErrorWithCertificateStatusCondition(client, pollErr, name, condition.Type)
 }
 
+// WaitForMissingCertificateCondition waits for the status of the named Certificate to NOT contain
+// a condition whose type and status matches the supplied one.
+func WaitForMissingCertificateCondition(client clientset.CertificateInterface, name string, condition v1.CertificateCondition, timeout time.Duration) (*v1.Certificate, error) {
+	var certificate *v1.Certificate = nil
+	pollErr := wait.PollImmediate(500*time.Millisecond, timeout,
+		func() (bool, error) {
+			log.Logf("Waiting for Certificate %v condition %v=%v to be missing", name, condition.Type, condition.Status)
+			certificate, err := client.Get(context.TODO(), name, metav1.GetOptions{})
+			if nil != err {
+				return false, fmt.Errorf("error getting Certificate %v: %v", name, err)
+			}
+			if apiutil.CertificateHasCondition(certificate, condition) {
+				log.Logf("Expected Certificate %v condition %v=%v to be missing but it has: %v", name, condition.Type, condition.Status, condition.ObservedGeneration, certificate.Status.Conditions)
+				return false, nil
+			}
+			return true, nil
+		},
+	)
+	return certificate, wrapErrorWithCertificateStatusCondition(client, pollErr, name, condition.Type)
+}
+
 // WaitForCertificateConditionWithObservedGeneration waits for the status of the named Certificate to contain
 // a condition whose type and status matches the supplied one.
 func WaitForCertificateConditionWithObservedGeneration(client clientset.CertificateInterface, name string, condition v1.CertificateCondition, timeout time.Duration) (*v1.Certificate, error) {


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR should resolve most of the flakes that look similar to "Operation cannot be fulfilled on certificates.cert-manager.io \"serving-certs\": the object has been modified; please apply your changes to the latest version and try again".
This flake is caused by the Issuing=True certificate condition that is removed by the issuing controller.
The best fix is to wait for the Issuing=True certificate condition to get removed when waiting for the certificate to become ready.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
/kind bug