### PR TITLE
Adds an option to build k8s 1.22 kind cluster

### DIFF
--- a/devel/addon/ingressnginx/BUILD.bazel
+++ b/devel/addon/ingressnginx/BUILD.bazel
@@ -1,9 +1,19 @@
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 
+# Ingress image that works on Kubernetes v1.16 - v1.20
 container_bundle(
-    name = "bundle",
+    name = "bundle_v0.48.1",
     images = {
-        "k8s.gcr.io/ingress-nginx/controller:v0.46.0": "@io_kubernetes_ingress-nginx//image",
+        "k8s.gcr.io/ingress-nginx/controller:v0.48.1": "@io_kubernetes_ingress-nginx_old//image",
+    },
+    tags = ["manual"],
+)
+
+# Ingress image that works on Kubernetes v1.19 -> (including v1.22)
+container_bundle(
+    name = "bundle_v1.0.0-alpha.2",
+    images = {
+        "k8s.gcr.io/ingress-nginx/controller:v1.0.0-alpha.2": "@io_kubernetes_ingress-nginx_new//image",
     },
     tags = ["manual"],
 )

--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -39,12 +39,19 @@ IMAGE_TAG=""
 # Require helm available on PATH
 check_tool kubectl
 check_tool helm
+check_tool jq
 
 # We need to install different versions of Ingress depending on which version of
 # Kubernetes we are running as the NGINX Ingress controller does not have a
 # release where they would support both v1 and v1beta1 versions of networking API.
+# If running the setup script locally against Kubernetes v1.22, make sure to pass K8S_VERSION
+# K8S_VERSION=1.22 ./devel/setup-e2e-deps.sh for this to work.
 # TODO: Remove this once we no longer need to test against Kubernetes below v1.19.
-if [[ $K8S_VERSION =~ 1\.22 ]]; then
+
+# This allows running ./devel/setup-e2e-deps.sh locally against Kubernetes v1.22
+# without passing the K8S_VERSION env var.
+k8s_version=$(kubectl version -ojson | jq  -r '.serverVersion | "\(.major).\(.minor)"')
+if [[ $k8s_version =~ 1\.22 ]]; then
   IMAGE_TAG="v1.0.0-alpha.2"
 else
   IMAGE_TAG="v0.48.1"

--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -36,10 +36,12 @@ fi
 RELEASE_NAME="${RELEASE_NAME:-ingress-nginx}"
 IMAGE_TAG=""
 
-# Require helm available on PATH
+# Require helm, kubectl and jq available on PATH
 check_tool kubectl
 check_tool helm
-check_tool jq
+bazel build //hack/bin:jq
+bindir="$(bazel info bazel-bin)"
+export PATH="${bindir}/hack/bin/:$PATH"
 
 # We need to install different versions of Ingress depending on which version of
 # Kubernetes we are running as the NGINX Ingress controller does not have a

--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -69,7 +69,7 @@ helm repo update
 helm upgrade \
     --install \
     --wait \
-    --version 3.31.0 \
+    --version 3.34.0 \
     --namespace "${NAMESPACE}" \
     --set controller.image.digest="" \
     --set controller.image.tag="${IMAGE_TAG}" \

--- a/devel/addon/sample-external-issuer/install.sh
+++ b/devel/addon/sample-external-issuer/install.sh
@@ -21,7 +21,7 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
-SEI_VERSION="v0.1.0"
+SEI_VERSION="v0.1.1"
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_ROOT}/../../lib/lib.sh"

--- a/devel/addon/samplewebhook/chart/templates/apiservice.yaml
+++ b/devel/addon/samplewebhook/chart/templates/apiservice.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiregistration.k8s.io/v1beta1
+apiVersion: apiregistration.k8s.io/v1
 kind: APIService
 metadata:
   name: v1alpha1.{{ .Values.groupName }}

--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -47,6 +47,10 @@ elif [[ "$K8S_VERSION" =~ 1\.20 ]] ; then
   KIND_IMAGE_SHA="sha256:b40ecf8bcb188f6a0d0f5d406089c48588b75edc112c6f635d26be5de1c89040"
 elif [[ "$K8S_VERSION" =~ 1\.21 ]] ; then
   KIND_IMAGE_SHA="sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad"
+elif [[ "$K8S_VERSION" =~ 1\.22 ]] ; then
+  KIND_IMAGE_SHA="sha256:0d32eba8eb762fde6e8e92dbb92811c327add2f7f3c8d6206f9f668a3ae1dee7"
+  # Override KIND_IMAGE_REPO set in devel/lib/lib.sh till there is a 1.22 image in kindest/node.
+  KIND_IMAGE_REPO="eu.gcr.io/jetstack-build-infra-images/kind"
 else
   echo "Unrecognised Kubernetes version '${K8S_VERSION}'! Aborting..."
   exit 1

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -39,7 +39,7 @@ export INGRESS_IP="${SERVICE_IP_PREFIX}.15"
 # versions of the tools required for development
 setup_tools() {
   check_bazel
-  bazel build //hack/bin:helm //hack/bin:kind //hack/bin:kubectl //devel/bin:ginkgo
+  bazel build //hack/bin:helm //hack/bin:kind //hack/bin:kubectl //hack/bin:jq //devel/bin:ginkgo
   if [[ "$IS_OPENSHIFT" == "true" ]] ; then
     bazel build //hack/bin:oc3
   fi
@@ -47,6 +47,7 @@ setup_tools() {
   export HELM="${bindir}/hack/bin/helm"
   export KIND="${bindir}/hack/bin/kind"
   export OC3="${bindir}/hack/bin/oc3"
+  export JQ="${bindir}/hack/bin/jq"
   export KUBECTL="${bindir}/hack/bin/kubectl"
   export KUSTOMIZE="${bindir}/hack/bin/kustomize"
   export GINKGO="${bindir}/devel/bin/ginkgo"

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -35,13 +35,23 @@ def install():
 
     ## Fetch nginx-ingress for use during e2e tests
     ## You can change the version of nginx-ingress used for tests by changing the
-    ## 'tag' field in this rule
+    ## 'tag' and 'digest' fields in these rules.
+    ## The digest here is the digest of a platform-specific image, so it will not
+    ## match the manifest list digest in ingress-nginx release notes- you will
+    ## have to find the value by other means.
     container_pull(
-        name = "io_kubernetes_ingress-nginx",
+        name = "io_kubernetes_ingress-nginx_old",
         registry = "k8s.gcr.io",
         repository = "ingress-nginx/controller",
-        tag = "v0.41.2",
-        digest = "sha256:e11b7d264cac4cfc7566b78bb150c94168ea4612a4e9769ca549eb03469db906",
+        tag = "v0.48.1",
+        digest = "sha256:dcc2d529a9cb95408ba9896639382793fb84361ef43cee9195f264c321e6b638",
+    )
+    container_pull(
+        name = "io_kubernetes_ingress-nginx_new",
+        registry = "k8s.gcr.io",
+        repository = "ingress-nginx/controller",
+        tag = "v1.0.0-alpha.2",
+        digest = "sha256:90f417ffd979f6493ea302f6757763365263d2f8112447139dffa97d927f5dfb"
     )
 
     ## Fetch vault for use during e2e tests


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR:
- adds an option to create an e2e test kind cluster with Kubernetes v1.22 (using `eu.gcr.io/jetstack-build-infra-images/kind:v1.22.0-beta.2` kind image)
This option would be triggered by the optional Prow presubmit `pull-cert-manager-e2e-v1-22` that's going to be added in [testing#536](https://github.com/jetstack/testing/pull/536).

- Bumps NGINX Ingress versions for e2e tests: with Kubernetes `v1.16` -  `v1.21` it now installs ingress controller image `v0.48.1`, Helm chart `v3.34.0`.  With Kubernetes v1.22 ingress controller image `v1.0.0-alpha.2`, Helm chart `v3.34.0`

- Bumps version of sample external issuer used in e2e tests `v0.1.0` -> `v0.1.1`



**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup

Signed-off-by: irbekrm <irbekrm@gmail.com>
