### PR TITLE
Change admissionregistration.k8s.io v1beta1 to v1 in integration tests

### DIFF
--- a/test/integration/conversion/conversion_test.go
+++ b/test/integration/conversion/conversion_test.go
@@ -120,7 +120,40 @@ func TestConversion(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: v1alpha3.CertificateRequestSpec{
-					CSRPEM: testCSR,
+					CSRPEM:   testCSR,
+					Username: "admin",
+					Groups:   []string{"system:masters", "system:authenticated"},
+					IssuerRef: cmmeta.ObjectReference{
+						Name: "issuername",
+					},
+				},
+			},
+		},
+		"should convert CertificateRequest from v1alpha2 to v1": {
+			input: &v1alpha2.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1alpha2.CertificateRequestSpec{
+					CSRPEM:   testCSR,
+					Username: "some-user",
+					Groups:   []string{"some-group"},
+					IssuerRef: cmmeta.ObjectReference{
+						Name: "issuername",
+					},
+				},
+			},
+			targetGVK: v1.SchemeGroupVersion.WithKind("CertificateRequest"),
+			output: &v1.CertificateRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test",
+					Namespace: "default",
+				},
+				Spec: v1.CertificateRequestSpec{
+					Request:  testCSR,
+					Username: "admin",
+					Groups:   []string{"system:masters", "system:authenticated"},
 					IssuerRef: cmmeta.ObjectReference{
 						Name: "issuername",
 					},

--- a/test/integration/framework/BUILD.bazel
+++ b/test/integration/framework/BUILD.bazel
@@ -22,7 +22,7 @@ go_library(
         "//pkg/client/informers/externalversions:go_default_library",
         "//pkg/controller:go_default_library",
         "//test/internal/apiserver:go_default_library",
-        "@io_k8s_api//admissionregistration/v1beta1:go_default_library",
+        "@io_k8s_api//admissionregistration/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions:go_default_library",
         "@io_k8s_apiextensions_apiserver//pkg/apis/apiextensions/install:go_default_library",

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -219,8 +219,9 @@ func getValidatingWebhookConfig(url string, caPEM []byte) client.Object {
 						},
 					},
 				},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffects,
+				FailurePolicy:           &failurePolicy,
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}
@@ -256,8 +257,9 @@ func getMutatingWebhookConfig(url string, caPEM []byte) client.Object {
 						},
 					},
 				},
-				FailurePolicy: &failurePolicy,
-				SideEffects:   &sideEffects,
+				FailurePolicy:           &failurePolicy,
+				SideEffects:             &sideEffects,
+				AdmissionReviewVersions: []string{"v1"},
 			},
 		},
 	}

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -25,7 +25,7 @@ import (
 	"strings"
 	"testing"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
 	apiextensionsinstall "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install"
 	v1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -192,27 +192,27 @@ func crdsToRuntimeObjects(in []*v1.CustomResourceDefinition) []client.Object {
 }
 
 func getValidatingWebhookConfig(url string, caPEM []byte) client.Object {
-	failurePolicy := admissionregistrationv1beta1.Fail
-	sideEffects := admissionregistrationv1beta1.SideEffectClassNone
+	failurePolicy := admissionregistrationv1.Fail
+	sideEffects := admissionregistrationv1.SideEffectClassNone
 	validateURL := fmt.Sprintf("%s/validate", url)
-	webhook := admissionregistrationv1beta1.ValidatingWebhookConfiguration{
+	webhook := admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cert-manager-webhook",
 		},
-		Webhooks: []admissionregistrationv1beta1.ValidatingWebhook{
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
 			{
 				Name: "webhook.cert-manager.io",
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					URL:      &validateURL,
 					CABundle: caPEM,
 				},
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{
+				Rules: []admissionregistrationv1.RuleWithOperations{
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{
-							admissionregistrationv1beta1.Create,
-							admissionregistrationv1beta1.Update,
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
 						},
-						Rule: admissionregistrationv1beta1.Rule{
+						Rule: admissionregistrationv1.Rule{
 							APIGroups:   []string{"cert-manager.io", "acme.cert-manager.io"},
 							APIVersions: []string{"*"},
 							Resources:   []string{"*/*"},
@@ -229,27 +229,27 @@ func getValidatingWebhookConfig(url string, caPEM []byte) client.Object {
 }
 
 func getMutatingWebhookConfig(url string, caPEM []byte) client.Object {
-	failurePolicy := admissionregistrationv1beta1.Fail
-	sideEffects := admissionregistrationv1beta1.SideEffectClassNone
+	failurePolicy := admissionregistrationv1.Fail
+	sideEffects := admissionregistrationv1.SideEffectClassNone
 	validateURL := fmt.Sprintf("%s/mutate", url)
-	webhook := admissionregistrationv1beta1.MutatingWebhookConfiguration{
+	webhook := admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cert-manager-webhook",
 		},
-		Webhooks: []admissionregistrationv1beta1.MutatingWebhook{
+		Webhooks: []admissionregistrationv1.MutatingWebhook{
 			{
 				Name: "webhook.cert-manager.io",
-				ClientConfig: admissionregistrationv1beta1.WebhookClientConfig{
+				ClientConfig: admissionregistrationv1.WebhookClientConfig{
 					URL:      &validateURL,
 					CABundle: caPEM,
 				},
-				Rules: []admissionregistrationv1beta1.RuleWithOperations{
+				Rules: []admissionregistrationv1.RuleWithOperations{
 					{
-						Operations: []admissionregistrationv1beta1.OperationType{
-							admissionregistrationv1beta1.Create,
-							admissionregistrationv1beta1.Update,
+						Operations: []admissionregistrationv1.OperationType{
+							admissionregistrationv1.Create,
+							admissionregistrationv1.Update,
 						},
-						Rule: admissionregistrationv1beta1.Rule{
+						Rule: admissionregistrationv1.Rule{
 							APIGroups:   []string{"cert-manager.io", "acme.cert-manager.io"},
 							APIVersions: []string{"*"},
 							Resources:   []string{"*/*"},


### PR DESCRIPTION
Changes admissionregistration.k8s.io from v1beta1 to v1 in integration tests as they are no longer served in 1.22. v1 has been available since 1.16.

https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122

With the changes to controller-runtime, our client to the api-server used for integration tests now has real user info :)

The conversion integration tests have been updated to now reflect the inclusion of the user info fields in the CertificateRequests after they have been plumbed through the webhook.

/milestone v1.5
/kind cleanup

```release-note
NONE
```
