### PR TITLE
CA chain fix without root

### DIFF
--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -222,6 +222,12 @@ func TestSign(t *testing.T) {
 		t.FailNow()
 	}
 
+	rootBundleData, err := bundlePEM(testIntermediateCa, testRootCa)
+	if err != nil {
+		t.Errorf("failed to encode root bundle for testing: %s", err)
+		t.FailNow()
+	}
+
 	tests := map[string]testSignT{
 		"a garbage csr should return err": {
 			csrPEM:       []byte("a bad csr"),
@@ -241,7 +247,7 @@ func TestSign(t *testing.T) {
 			expectedCA:   "",
 		},
 
-		"a good csr and good response should return a certificate": {
+		"a good csr and good response with no root should return a certificate with the intermediate in the chain and as the CA": {
 			csrPEM: csrPEM,
 			issuer: gen.Issuer("vault-issuer",
 				gen.SetIssuerVault(cmapi.VaultIssuer{}),
@@ -251,8 +257,22 @@ func TestSign(t *testing.T) {
 					Body: ioutil.NopCloser(bytes.NewReader(bundleData))},
 			}, nil),
 			expectedErr:  nil,
-			expectedCert: testLeafCertificate,
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testIntermediateCa,
+		},
+
+		"a good csr and good response with a root should return a certificate without the root in the chain but with the root as the CA": {
+			csrPEM: csrPEM,
+			issuer: gen.Issuer("vault-issuer",
+				gen.SetIssuerVault(cmapi.VaultIssuer{}),
+			),
+			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
+				Response: &http.Response{
+					Body: ioutil.NopCloser(bytes.NewReader(rootBundleData))},
+			}, nil),
+			expectedErr:  nil,
+			expectedCert: testLeafCertificate + testIntermediateCa,
+			expectedCA:   testRootCa,
 		},
 
 		"vault issuer with namespace specified": {
@@ -265,7 +285,7 @@ func TestSign(t *testing.T) {
 					Body: ioutil.NopCloser(bytes.NewReader(bundleData))},
 			}, nil),
 			expectedErr:  nil,
-			expectedCert: testLeafCertificate,
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testIntermediateCa,
 		},
 	}
@@ -321,7 +341,7 @@ func TestExtractCertificatesFromVaultCertificateSecret(t *testing.T) {
 	tests := map[string]testExtractCertificatesFromVaultCertT{
 		"when a Vault engine is a root CA": {
 			secret:       signedCertificateSecret(testIntermediateCa),
-			expectedCert: testLeafCertificate,
+			expectedCert: testLeafCertificate + testIntermediateCa,
 			expectedCA:   testIntermediateCa,
 		},
 		"when a Vault engine is an intermediate CA, and its parent is a root CA": {

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -258,14 +258,14 @@ func TestParseSingleCertificateChain(t *testing.T) {
 		expPEMBundle PEMBundle
 		expErr       bool
 	}{
-		"if single certificate passed, return single certificate": {
-			inputBundle:  root.pem,
-			expPEMBundle: PEMBundle{ChainPEM: root.pem},
-			expErr:       false,
-		},
 		"if two certificate chain passed in order, should return single ca and certificate": {
 			inputBundle:  joinPEM(intA1.pem, root.pem),
 			expPEMBundle: PEMBundle{ChainPEM: intA1.pem, CAPEM: root.pem},
+			expErr:       false,
+		},
+		"if two certificate chain passed with leaf and intermediate, should return both certs in chain with intermediate as CA": {
+			inputBundle:  joinPEM(leaf.pem, intA2.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem, intA2.pem), CAPEM: intA2.pem},
 			expErr:       false,
 		},
 		"if two certificate chain passed out of order, should return single ca and certificate": {
@@ -327,6 +327,21 @@ func TestParseSingleCertificateChain(t *testing.T) {
 		"if certificate chain does not have a root ca, should append all intermediates to ChainPEM and use the root-most cert as CAPEM": {
 			inputBundle:  joinPEM(intA1.pem, intA2.pem, leaf.pem),
 			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem, intA2.pem, intA1.pem), CAPEM: intA1.pem},
+			expErr:       false,
+		},
+		"if only a single leaf certificate was parsed, ChainPEM should contain a single leaf certificate and CAPEM should remain empty": {
+			inputBundle:  joinPEM(leaf.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem), CAPEM: nil},
+			expErr:       false,
+		},
+		"if only a single intermediate certificate was parsed, ChainPEM should contain a single intermediate certificate and CAPEM should remain empty": {
+			inputBundle:  joinPEM(intA1.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(intA1.pem), CAPEM: nil},
+			expErr:       false,
+		},
+		"if only a single root certificate was parsed, ChainPEM should contain a single root certificate and CAPEM should also contain that root": {
+			inputBundle:  joinPEM(root.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(root.pem), CAPEM: root.pem},
 			expErr:       false,
 		},
 	}

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -324,6 +324,11 @@ func TestParseSingleCertificateChain(t *testing.T) {
 			expPEMBundle: PEMBundle{},
 			expErr:       true,
 		},
+		"if certificate chain does not have a root ca, should append all intermediates to ChainPEM and use the root-most cert as CAPEM": {
+			inputBundle:  joinPEM(intA1.pem, intA2.pem, leaf.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem, intA2.pem, intA1.pem), CAPEM: intA1.pem},
+			expErr:       false,
+		},
 	}
 
 	for name, test := range tests {


### PR DESCRIPTION
This fixes the issue detailed [here](https://github.com/jetstack/cert-manager/pull/4195#issuecomment-887512357) in #4195. That PR focused on Vault, but this issue is actually more widely applicable; it's not valid to trim anything except a root certificate from a chain.

This is raised as a separate PR to be clear that it's widely applicable to all issuer types which use ParseSingleCertificateChain, and to speed development, aiming to merge before 1.5 and possibly cherry-pick into 1.4

/kind bug
/priority important-soon

```release-note
- Fix handling of chains which don't have a root in ParseSingleCertificateChain, and improve handling in situations where that function is passed a single certificate.
```
