### PR TITLE
DRAFT / WIP: Pathlen verification on CA issuance

### DIFF
--- a/deploy/crds/crd-certificaterequests.yaml
+++ b/deploy/crds/crd-certificaterequests.yaml
@@ -130,6 +130,11 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 uid:
                   description: UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.
                   type: string
@@ -299,6 +304,11 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 uid:
                   description: UID contains the uid of the user that created the CertificateRequest. Populated by the cert-manager webhook on creation and immutable.
                   type: string
@@ -466,6 +476,11 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 request:
                   description: The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.
                   type: string
@@ -637,6 +652,11 @@ spec:
                     name:
                       description: Name of the resource being referred to.
                       type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 request:
                   description: The PEM-encoded x509 certificate signing request to be submitted to the CA for signing.
                   type: string

--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -192,6 +192,11 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate. Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 organization:
                   description: Organization is a list of organizations to be used on the Certificate.
                   type: array
@@ -509,6 +514,11 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate. Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 privateKey:
                   description: Options to control private keys used for the Certificate.
                   type: object
@@ -813,6 +823,11 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate. Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 privateKey:
                   description: Options to control private keys used for the Certificate.
                   type: object
@@ -1132,6 +1147,11 @@ spec:
                             name:
                               description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                               type: string
+                maxPathLen:
+                  description: MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0, this certificate may issue a CA certificate, which in turn may issue a CA certificate only if n-1 is greater than zero. Most intermediate certificates will usually want to have a pathLen set to the smallest value possible. If omitted, no MaxPathLen will be requested for the issued certificate. Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+                  type: integer
+                  format: int32
+                  minimum: 0
                 privateKey:
                   description: Options to control private keys used for the Certificate.
                   type: object

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -163,6 +163,19 @@ type CertificateSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer,
+	// which controls the maximum number of CA certificates which can appear in the chain issued by
+	// this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1/types_certificaterequest.go
@@ -102,6 +102,18 @@ type CertificateRequestSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by
+	// an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by
+	// the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// If usages are set they SHOULD be encoded inside the CSR spec
 	// Defaults to `digital signature` and `key encipherment` if not specified.

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -271,6 +271,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -425,6 +430,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))

--- a/pkg/apis/certmanager/v1alpha2/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificate.go
@@ -160,6 +160,19 @@ type CertificateSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer,
+	// which controls the maximum number of CA certificates which can appear in the chain issued by
+	// this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha2/types_certificaterequest.go
@@ -100,6 +100,18 @@ type CertificateRequestSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by
+	// an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by
+	// the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -271,6 +271,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -430,6 +435,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))

--- a/pkg/apis/certmanager/v1alpha3/types_certificate.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificate.go
@@ -158,6 +158,19 @@ type CertificateSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer,
+	// which controls the maximum number of CA certificates which can appear in the chain issued by
+	// this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1alpha3/types_certificaterequest.go
@@ -100,6 +100,18 @@ type CertificateRequestSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by
+	// an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by
+	// the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
@@ -271,6 +271,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -425,6 +430,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))

--- a/pkg/apis/certmanager/v1beta1/types_certificate.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificate.go
@@ -159,6 +159,19 @@ type CertificateSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer,
+	// which controls the maximum number of CA certificates which can appear in the chain issued by
+	// this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
+++ b/pkg/apis/certmanager/v1beta1/types_certificaterequest.go
@@ -101,6 +101,18 @@ type CertificateRequestSpec struct {
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
 
+	// MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by
+	// an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by
+	// the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	// +optional

--- a/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
@@ -271,6 +271,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -425,6 +430,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -370,11 +370,12 @@ func (c *controller) createNewCertificateRequest(ctx context.Context, crt *cmapi
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(crt, certificateGvk)},
 		},
 		Spec: cmapi.CertificateRequestSpec{
-			Duration:  crt.Spec.Duration,
-			IssuerRef: crt.Spec.IssuerRef,
-			Request:   csrPEM.Bytes(),
-			IsCA:      crt.Spec.IsCA,
-			Usages:    crt.Spec.Usages,
+			Duration:   crt.Spec.Duration,
+			IssuerRef:  crt.Spec.IssuerRef,
+			Request:    csrPEM.Bytes(),
+			IsCA:       crt.Spec.IsCA,
+			MaxPathLen: crt.Spec.MaxPathLen,
+			Usages:     crt.Spec.Usages,
 		},
 	}
 

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -559,6 +559,7 @@ func TestProcessItem(t *testing.T) {
 			},
 		},
 	}
+
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			// Create and initialise a new unit test builder

--- a/pkg/internal/apis/certmanager/types_certificate.go
+++ b/pkg/internal/apis/certmanager/types_certificate.go
@@ -146,6 +146,19 @@ type CertificateSpec struct {
 	// This will automatically add the `cert sign` usage to the list of `usages`.
 	IsCA bool
 
+	// MaxPathLen requests that the pathLen in the certificate's basicConstraints be set by an issuer,
+	// which controls the maximum number of CA certificates which can appear in the chain issued by
+	// this certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// Changing MaxPathLen won't trigger re-issuance of a certificate. Use `kubectl cert-manager renew` for that.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	Usages []KeyUsage

--- a/pkg/internal/apis/certmanager/types_certificaterequest.go
+++ b/pkg/internal/apis/certmanager/types_certificaterequest.go
@@ -91,6 +91,18 @@ type CertificateRequestSpec struct {
 	// This will automatically add the `cert sign` usage to the list of `usages`.
 	IsCA bool
 
+	// MaxPathLen requests that the pathLen in the requested certificate's basicConstraints be set by
+	// an issuer, which controls the maximum number of CA certificates which can appear in the chain issued by
+	// the requested certificate. Not all issuers support MaxPathLen, and it will be left unset if unsupported.
+	// If a certificate's MaxPathLen is 0, then it cannot issue CA certificates; if MaxPathLen is n > 0,
+	// this certificate may issue a CA certificate, which in turn may issue a CA certificate only if
+	// n-1 is greater than zero.
+	// Most intermediate certificates will usually want to have a pathLen set to the smallest value possible.
+	// If omitted, no MaxPathLen will be requested for the issued certificate.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	MaxPathLen *int32 `json:"maxPathLen,omitempty"`
+
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
 	Usages []KeyUsage

--- a/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -693,6 +693,7 @@ func autoConvert_v1_CertificateRequestSpec_To_certmanager_CertificateRequestSpec
 	}
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -713,6 +714,7 @@ func autoConvert_certmanager_CertificateRequestSpec_To_v1_CertificateRequestSpec
 	}
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -798,6 +800,7 @@ func autoConvert_v1_CertificateSpec_To_certmanager_CertificateSpec(in *v1.Certif
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
@@ -829,6 +832,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1_CertificateSpec(in *certmanag
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*v1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))

--- a/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -685,6 +685,7 @@ func autoConvert_v1alpha2_CertificateRequestSpec_To_certmanager_CertificateReque
 	}
 	// WARNING: in.CSRPEM requires manual conversion: does not exist in peer-type
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -700,6 +701,7 @@ func autoConvert_certmanager_CertificateRequestSpec_To_v1alpha2_CertificateReque
 	}
 	// WARNING: in.Request requires manual conversion: does not exist in peer-type
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1alpha2.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -789,6 +791,7 @@ func autoConvert_v1alpha2_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	// WARNING: in.KeySize requires manual conversion: does not exist in peer-type
 	// WARNING: in.KeyAlgorithm requires manual conversion: does not exist in peer-type
@@ -839,6 +842,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha2_CertificateSpec(in *cer
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1alpha2.KeyUsage)(unsafe.Pointer(&in.Usages))
 	if in.PrivateKey != nil {
 		in, out := &in.PrivateKey, &out.PrivateKey

--- a/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -685,6 +685,7 @@ func autoConvert_v1alpha3_CertificateRequestSpec_To_certmanager_CertificateReque
 	}
 	// WARNING: in.CSRPEM requires manual conversion: does not exist in peer-type
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -700,6 +701,7 @@ func autoConvert_certmanager_CertificateRequestSpec_To_v1alpha3_CertificateReque
 	}
 	// WARNING: in.Request requires manual conversion: does not exist in peer-type
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1alpha3.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -788,6 +790,7 @@ func autoConvert_v1alpha3_CertificateSpec_To_certmanager_CertificateSpec(in *v1a
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	// WARNING: in.KeySize requires manual conversion: does not exist in peer-type
 	// WARNING: in.KeyAlgorithm requires manual conversion: does not exist in peer-type
@@ -838,6 +841,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1alpha3_CertificateSpec(in *cer
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1alpha3.KeyUsage)(unsafe.Pointer(&in.Usages))
 	if in.PrivateKey != nil {
 		in, out := &in.PrivateKey, &out.PrivateKey

--- a/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/pkg/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -693,6 +693,7 @@ func autoConvert_v1beta1_CertificateRequestSpec_To_certmanager_CertificateReques
 	}
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -713,6 +714,7 @@ func autoConvert_certmanager_CertificateRequestSpec_To_v1beta1_CertificateReques
 	}
 	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1beta1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID
@@ -798,6 +800,7 @@ func autoConvert_v1beta1_CertificateSpec_To_certmanager_CertificateSpec(in *v1be
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]certmanager.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*certmanager.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))
@@ -834,6 +837,7 @@ func autoConvert_certmanager_CertificateSpec_To_v1beta1_CertificateSpec(in *cert
 		return err
 	}
 	out.IsCA = in.IsCA
+	out.MaxPathLen = (*int32)(unsafe.Pointer(in.MaxPathLen))
 	out.Usages = *(*[]v1beta1.KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.PrivateKey = (*v1beta1.CertificatePrivateKey)(unsafe.Pointer(in.PrivateKey))
 	out.EncodeUsagesInRequest = (*bool)(unsafe.Pointer(in.EncodeUsagesInRequest))

--- a/pkg/internal/apis/certmanager/validation/BUILD.bazel
+++ b/pkg/internal/apis/certmanager/validation/BUILD.bazel
@@ -70,6 +70,7 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/pkg/internal/apis/certmanager/validation/certificate.go
+++ b/pkg/internal/apis/certmanager/validation/certificate.go
@@ -82,9 +82,11 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 	if crt.Duration != nil || crt.RenewBefore != nil {
 		el = append(el, ValidateDuration(crt, fldPath)...)
 	}
+
 	if len(crt.Usages) > 0 {
 		el = append(el, validateUsages(crt, fldPath)...)
 	}
+
 	if crt.RevisionHistoryLimit != nil && *crt.RevisionHistoryLimit < 1 {
 		el = append(el, field.Invalid(fldPath.Child("revisionHistoryLimit"), *crt.RevisionHistoryLimit, "must not be less than 1"))
 	}
@@ -95,6 +97,16 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 		}
 		if len(crt.SecretTemplate.Annotations) > 0 {
 			el = append(el, validateSecretTemplateAnnotations(crt, fldPath)...)
+		}
+	}
+
+	if crt.MaxPathLen != nil {
+		if !crt.IsCA {
+			el = append(el, field.Required(fldPath.Child("isCA"), "must set isCA to true when maxPathLen is set"))
+		}
+
+		if *crt.MaxPathLen < 0 {
+			el = append(el, field.Invalid(fldPath.Child("maxPathLen"), *crt.MaxPathLen, "maxPathLen must be either null, zero or a positive integer"))
 		}
 	}
 

--- a/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/pkg/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -271,6 +271,11 @@ func (in *CertificateRequestSpec) DeepCopyInto(out *CertificateRequestSpec) {
 		*out = make([]byte, len(*in))
 		copy(*out, *in)
 	}
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))
@@ -425,6 +430,11 @@ func (in *CertificateSpec) DeepCopyInto(out *CertificateSpec) {
 		(*in).DeepCopyInto(*out)
 	}
 	out.IssuerRef = in.IssuerRef
+	if in.MaxPathLen != nil {
+		in, out := &in.MaxPathLen, &out.MaxPathLen
+		*out = new(int32)
+		**out = **in
+	}
 	if in.Usages != nil {
 		in, out := &in.Usages, &out.Usages
 		*out = make([]KeyUsage, len(*in))

--- a/pkg/util/pki/BUILD.bazel
+++ b/pkg/util/pki/BUILD.bazel
@@ -36,6 +36,8 @@ go_test(
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@io_k8s_api//certificates/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -389,10 +389,10 @@ func GenerateTemplateFromCSRPEMWithUsages(csrPEM []byte, duration time.Duration,
 }
 
 // SignCertificate returns a signed *x509.Certificate given a template
-// *x509.Certificate crt and an issuer.
+// *x509.Certificate certificate and an issuer.
 // publicKey is the public key of the signee, and signerKey is the private
 // key of the signer.
-// It returns a PEM encoded copy of the Certificate as well as a *x509.Certificate
+// It returns a PEM encoded copy of the Certificate as well as an *x509.Certificate
 // which can be used for reading the encoded values.
 func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, publicKey crypto.PublicKey, signerKey interface{}) ([]byte, *x509.Certificate, error) {
 	derBytes, err := x509.CreateCertificate(rand.Reader, template, issuerCert, publicKey, signerKey)
@@ -415,10 +415,11 @@ func SignCertificate(template *x509.Certificate, issuerCert *x509.Certificate, p
 	return pemBytes.Bytes(), cert, err
 }
 
-// SignCSRTemplate signs a certificate template usually based upon a CSR. This
+// SignCSRTemplate signs a certificate template, which is usually based upon a CSR. This
 // function expects all fields to be present in the certificate template,
-// including it's public key.
-// It returns the PEM bundle containing certificate data and the CA data, encoded in PEM format.
+// including its public key.
+// It returns a PEM bundle containing certificate data along with any available chain
+// certificates which were passed in caCerts.
 func SignCSRTemplate(caCerts []*x509.Certificate, caKey crypto.Signer, template *x509.Certificate) (PEMBundle, error) {
 	if len(caCerts) == 0 {
 		return PEMBundle{}, errors.New("no CA certificates given to sign CSR template")

--- a/pkg/util/pki/parse_test.go
+++ b/pkg/util/pki/parse_test.go
@@ -288,6 +288,11 @@ func TestParseSingleCertificateChain(t *testing.T) {
 			expPEMBundle: PEMBundle{ChainPEM: joinPEM(leaf.pem, intA2.pem, intA1.pem), CAPEM: root.pem},
 			expErr:       false,
 		},
+		"if only CAs are passed, should still output the best chain possible": {
+			inputBundle:  joinPEM(root.pem, intA2.pem, intA1.pem),
+			expPEMBundle: PEMBundle{ChainPEM: joinPEM(intA2.pem, intA1.pem), CAPEM: root.pem},
+			expErr:       false,
+		},
 		"if certificate chain has two certs with the same CN, shouldn't affect output": {
 			// see https://github.com/jetstack/cert-manager/issues/4142
 			inputBundle:  joinPEM(leafInterCN.pem, intA1.pem, intA2.pem, root.pem),

--- a/test/e2e/framework/helper/featureset/featureset.go
+++ b/test/e2e/framework/helper/featureset/featureset.go
@@ -157,4 +157,8 @@ const (
 	// LongDomainFeatureSet denotes whether the target issuer is able to sign
 	// a certificate that defines a long domain
 	LongDomainFeatureSet Feature = "LongDomain"
+
+	// MaxPathLenFeature denotes whether the issuer is able to set the pathLen
+	// basicConstraint on signed certificates.
+	MaxPathLenFeature Feature = "MaxPathLen"
 )

--- a/test/e2e/framework/helper/validation/certificates/certificates.go
+++ b/test/e2e/framework/helper/validation/certificates/certificates.go
@@ -360,7 +360,23 @@ func ExpectValidBasicConstraints(certificate *cmapi.Certificate, secret *corev1.
 		return fmt.Errorf("Expected CA basicConstraint to be %v, but got %v", certificate.Spec.IsCA, cert.IsCA)
 	}
 
-	// TODO: also validate pathLen
+	if certificate.Spec.MaxPathLen != nil {
+		expectedPathLen := int(*certificate.Spec.MaxPathLen)
+		expectPathLenZero := (expectedPathLen == 0)
+
+		if cert.MaxPathLen != expectedPathLen {
+			return fmt.Errorf("Expected pathLen basicConstraints to be %v, but got %v", expectedPathLen, cert.MaxPathLen)
+		}
+
+		if cert.MaxPathLenZero != expectPathLenZero {
+			return fmt.Errorf("Expected MaxPathLenZero on certificate to be %v, but got %v", expectPathLenZero, cert.MaxPathLenZero)
+		}
+	}
+
+	// It would an improvement to check here that cert.BasicConstraintsValid is true, but this is only set by
+	// x509.ParseCertificate when there _is_ a basicConstraints extension on the cert.
+	// Some issuers don't add the extension, so we can't check this generally without first parsing the cert's extensions manually
+	// to see if there was a basicConstraints extension added.
 
 	return nil
 }

--- a/test/e2e/suite/conformance/certificates/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificates/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",
         "@io_k8s_client_go//util/retry:go_default_library",
+        "@io_k8s_utils//pointer:go_default_library",
     ],
 )
 

--- a/test/e2e/suite/conformance/certificates/external/external.go
+++ b/test/e2e/suite/conformance/certificates/external/external.go
@@ -45,6 +45,7 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		featureset.SaveCAToSecret,
 		featureset.Ed25519FeatureSet,
 		featureset.IssueCAFeature,
+		featureset.MaxPathLenFeature,
 	)
 
 	issuerBuilder := newIssuerBuilder("Issuer")

--- a/test/e2e/suite/conformance/certificates/tests.go
+++ b/test/e2e/suite/conformance/certificates/tests.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
+	"k8s.io/utils/pointer"
 
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
@@ -123,6 +124,33 @@ func (s *Suite) Define() {
 			err = f.Helper().ValidateCertificate(f.Namespace.Name, "testcert", validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
 			Expect(err).NotTo(HaveOccurred())
 		}, featureset.IssueCAFeature)
+
+		s.it(f, "should issue a CA certificate with the CA and pathLen basicConstraints set", func(issuerRef cmmeta.ObjectReference) {
+			testCertificate := &cmapi.Certificate{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testcert",
+					Namespace: f.Namespace.Name,
+				},
+				Spec: cmapi.CertificateSpec{
+					SecretName: "testcert-tls",
+					IsCA:       true,
+					MaxPathLen: pointer.Int32(2),
+					IssuerRef:  issuerRef,
+					DNSNames:   []string{e2eutil.RandomSubdomain(s.DomainSuffix)},
+				},
+			}
+			By("Creating a Certificate")
+			err := f.CRClient.Create(ctx, testCertificate)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for the Certificate to be issued...")
+			_, err = f.Helper().WaitForCertificateReady(f.Namespace.Name, "testcert", time.Minute*5)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Validating the issued Certificate...")
+			err = f.Helper().ValidateCertificate(f.Namespace.Name, "testcert", validation.CertificateSetForUnsupportedFeatureSet(s.UnsupportedFeatures)...)
+			Expect(err).NotTo(HaveOccurred())
+		}, featureset.IssueCAFeature, featureset.MaxPathLenFeature)
 
 		s.it(f, "should issue an ECDSA, defaulted certificate for a single distinct DNS Name", func(issuerRef cmmeta.ObjectReference) {
 			testCertificate := &cmapi.Certificate{

--- a/test/e2e/suite/conformance/certificates/vault/vault_approle.go
+++ b/test/e2e/suite/conformance/certificates/vault/vault_approle.go
@@ -47,6 +47,7 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		// Vault does not support signing using Ed25519
 		featureset.Ed25519FeatureSet,
 		featureset.IssueCAFeature,
+		featureset.MaxPathLenFeature,
 	)
 
 	provisioner := new(vaultAppRoleProvisioner)

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -52,6 +52,7 @@ var _ = framework.ConformanceDescribe("Certificates", func() {
 		// Venafi seems to only support SSH Ed25519 keys
 		featureset.Ed25519FeatureSet,
 		featureset.IssueCAFeature,
+		featureset.MaxPathLenFeature,
 	)
 
 	provisioner := new(venafiProvisioner)

--- a/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
+++ b/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
@@ -49,6 +49,7 @@ var _ = framework.ConformanceDescribe("[Feature:Issuers:Venafi:Cloud] Certificat
 		// Venafi seems to only support SSH Ed25519 keys
 		featureset.Ed25519FeatureSet,
 		featureset.IssueCAFeature,
+		featureset.MaxPathLenFeature,
 	)
 
 	provisioner := new(venafiProvisioner)


### PR DESCRIPTION
:warning:  DO NOT MERGE - DRAFT :warning: 

This shouldn't be merged until after #4241  - it depends on that PR being merged first. The only relevant commit here is the last one.

/kind feature
/priority important-soon

```release-note
Attempt to verify that a CA doesn't violate a pathLen basicConstraint imposed by any of the issuers in its chain where possible when issuing a CA.
```
