### PR TITLE
Add a FullCertChain flag to support return full cer chain for k8s CSR CA issuer

### DIFF
--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -280,6 +280,9 @@ func buildControllerContext(ctx context.Context, stopCh <-chan struct{}, opts *o
 		SchedulerOptions: controller.SchedulerOptions{
 			MaxConcurrentChallenges: opts.MaxConcurrentChallenges,
 		},
+		CertificateSigningRequestOptions: controller.CertificateSigningRequestOptions{
+			FullCertChain: opts.FullCertChain,
+		},
 	}, kubeCfg, nil
 }
 

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -111,6 +111,9 @@ type ControllerOptions struct {
 	// CertificateRequest -> Order. Slice of string literals that are
 	// treated as prefixes for annotation keys.
 	CopiedAnnotationPrefixes []string
+
+	//Return full Certchain including root cert for k8s CSRs
+	FullCertChain bool
 }
 
 const (
@@ -122,7 +125,7 @@ const (
 	defaultClusterResourceNamespace = "kube-system"
 	defaultNamespace                = ""
 
-	defaultLeaderElect                 = true
+	defaultFullCertChain               = false
 	defaultLeaderElectionNamespace     = "kube-system"
 	defaultLeaderElectionLeaseDuration = 60 * time.Second
 	defaultLeaderElectionRenewDeadline = 40 * time.Second
@@ -258,9 +261,8 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Namespace, "namespace", defaultNamespace, ""+
 		"If set, this limits the scope of cert-manager to a single namespace and ClusterIssuers are disabled. "+
 		"If not specified, all namespaces will be watched")
-	fs.BoolVar(&s.LeaderElect, "leader-elect", true, ""+
-		"If true, cert-manager will perform leader election between instances to ensure no more "+
-		"than one instance of cert-manager operates at a time")
+	fs.BoolVar(&s.FullCertChain, "full-cert-chain", false, ""+
+		"If true, cert-manager will return the full cert chain which includes the root cert for k8s certificateSigningRequest")
 	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", defaultLeaderElectionNamespace, ""+
 		"Namespace used to perform leader election. Only used if leader election is enabled")
 	fs.DurationVar(&s.LeaderElectionLeaseDuration, "leader-election-lease-duration", defaultLeaderElectionLeaseDuration, ""+

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -88,6 +88,7 @@ type Context struct {
 	IngressShimOptions
 	CertificateOptions
 	SchedulerOptions
+	CertificateSigningRequestOptions
 }
 
 type IssuerOptions struct {
@@ -161,4 +162,9 @@ type SchedulerOptions struct {
 	// MaxConcurrentChallenges determines the maximum number of challenges that can be
 	// scheduled as 'processing' at once.
 	MaxConcurrentChallenges int
+}
+
+type CertificateSigningRequestOptions struct {
+	// return the full cert chain which includes the root cert for k8s certificateSigningRequest
+	FullCertChain bool
 }


### PR DESCRIPTION
hide leader-elec flag and a FullCertChain flag to support return full cert chain for k8s CSR CA issuer. Full cert chain is needed , for example istio will extract root cert from the full cert chain. 

**What this PR does / why we need it**:

- hide leader-elec flag as it is supposed to be true as always.
- Add a `full-cert-chain` flag to support return the full cert chain which includes the root cert for k8s certificateSigningRequest and make it as false by default.


**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
- hide leader-elec flag as it is supposed to be true as always.
- Add a `full-cert-chain` flag to support return the full cert chain which includes the root cert for k8s certificateSigningRequest and make it as false by default.
```
