### PR TITLE
[WIP] Make the cobra tool generate markdown with Hugo headers

### DIFF
--- a/tools/cobra/main.go
+++ b/tools/cobra/main.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// Contains functionality to generate markdown docs for cert-manager components.
 package main
 
 import (
@@ -21,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -33,6 +35,17 @@ import (
 	ctlcmd "github.com/jetstack/cert-manager/cmd/ctl/cmd"
 	webhookcmd "github.com/jetstack/cert-manager/cmd/webhook/app"
 )
+
+// Header template to be prepended to each markdown file. This is so that the
+// files are suited for committing to cert-manager/website.
+const headerTemplate = `---
+title: %s
+linkTitle: %s
+weight: 960
+type: "docs"
+---
+
+`
 
 func main() {
 	if err := run(os.Args); err != nil {
@@ -73,7 +86,7 @@ func run(args []string) error {
 			return err
 		}
 
-		if err := doc.GenMarkdownTree(c, dir); err != nil {
+		if err := doc.GenMarkdownTreeCustom(c, dir, header, linkHandler); err != nil {
 			return err
 		}
 	}
@@ -95,4 +108,14 @@ func ensureDirectory(dir string) error {
 	}
 
 	return nil
+}
+
+func header(filename string) string {
+	name := strings.TrimSuffix(filepath.Base(filename), ".md")
+	return fmt.Sprintf(headerTemplate, name, name)
+}
+
+// We don't need custom link processing so this function is a no-op.
+func linkHandler(s string) string {
+	return s
 }

--- a/tools/cobra/main_test.go
+++ b/tools/cobra/main_test.go
@@ -49,7 +49,7 @@ func TestRun(t *testing.T) {
 		},
 		"if directory given, should write docs": {
 			input:   []string{"cobra", filepath.Join(rootDir, "foo")},
-			expDirs: []string{"foo/ca-injector", "foo/cert-manager-controller", "foo/cert-manager"},
+			expDirs: []string{"foo/ca-injector", "foo/cert-manager-controller", "foo/cert-manager", "foo/acmesolver", "foo/webhook"},
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR makes the script in tools/cobra output markdown files with Hugo header so that they can be committed directly to the cert-manager website from CI.
It also removes markdown file generation for kubectl plugin, since that is already documented elsewhere.
See the output in https://github.com/cert-manager/website/pull/660


**Special notes for your reviewer**:

This does make the script very website specific- the alternatives that I considered was moving this whole script to its own repo.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
