### PR TITLE
Revert the `Forget` call that was happening on every Certificates and Orders sync

### DIFF
--- a/pkg/controller/acmeorders/controller.go
+++ b/pkg/controller/acmeorders/controller.go
@@ -158,13 +158,6 @@ func NewController(
 }
 
 func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	// We don't want to leak goroutines, so let's remove this key from the
-	// scheduled queue in case it has been scheduled. We only need to
-	// un-schedule the key for 'Deleted' events, but ProcessItem does not allow
-	// us to distinguish between 'Added', 'Updated' and 'Deleted'. Note that
-	// there is no unit test around this.
-	c.scheduledWorkQueue.Forget(key)
-
 	log := logf.FromContext(ctx)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {

--- a/pkg/controller/certificates/trigger/trigger_controller.go
+++ b/pkg/controller/certificates/trigger/trigger_controller.go
@@ -124,13 +124,6 @@ func NewController(
 }
 
 func (c *controller) ProcessItem(ctx context.Context, key string) error {
-	// We don't want to leak goroutines, so let's remove this key from the
-	// scheduled queue in case it has been scheduled. We only need to
-	// un-schedule the key for 'Deleted' events, but ProcessItem does not allow
-	// us to distinguish between 'Added', 'Updated' and 'Deleted'. Note that
-	// there is no unit test around this.
-	c.scheduledWorkQueue.Forget(key)
-
 	log := logf.FromContext(ctx).WithValues("key", key)
 	ctx = logf.NewContext(ctx, log)
 	namespace, name, err := cache.SplitMetaNamespaceKey(key)

--- a/pkg/scheduler/scheduler.go
+++ b/pkg/scheduler/scheduler.go
@@ -23,6 +23,36 @@ import (
 	"k8s.io/utils/clock"
 )
 
+// We are writting our own time.AfterFunc to be able to mock the clock. The
+// cancel function can be called concurrently.
+func afterFunc(c clock.Clock, d time.Duration, f func()) (cancel func()) {
+	t := c.NewTimer(d)
+	cancelCh := make(chan struct{})
+	cancelOnce := sync.Once{}
+	cancel = func() {
+		t.Stop()
+		cancelOnce.Do(func() {
+			close(cancelCh)
+		})
+	}
+
+	go func() {
+		defer cancel()
+
+		select {
+		case <-t.C():
+			// We don't need to check whether the channel has returned a zero
+			// value since t.C is never closed as per the timer.Stop
+			// documentation.
+			f()
+		case <-cancelCh:
+			return
+		}
+	}()
+
+	return cancel
+}
+
 // ProcessFunc is a function to process an item in the work queue.
 type ProcessFunc func(interface{})
 
@@ -87,35 +117,4 @@ func (s *scheduledWorkQueue) Forget(obj interface{}) {
 		cancel()
 		delete(s.work, obj)
 	}
-}
-
-// We are writting our own time.AfterFunc to be able to mock the clock. The
-// cancel function can be called concurrently.
-func afterFunc(c clock.Clock, d time.Duration, f func()) (cancel func()) {
-	t := c.NewTimer(d)
-
-	// The caller expects `cancel` to stop the goroutine. Since `t.C` is not
-	// closed after calling `t.Stop`, we need to create our own `cancelCh`
-	// channel to stop the goroutine.
-	cancelCh := make(chan struct{})
-	cancelOnce := sync.Once{}
-	cancel = func() {
-		t.Stop()
-		cancelOnce.Do(func() {
-			close(cancelCh)
-		})
-	}
-
-	go func() {
-		defer cancel()
-
-		select {
-		case <-t.C():
-			f()
-		case <-cancelCh:
-			return
-		}
-	}()
-
-	return cancel
 }


### PR DESCRIPTION
~~As [pointed out](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1627484902047400?thread_ts=1627481906.043900&cid=CDEQJ0Q8M) by @munnerz, we feel not very confident in back-porting #4233 knowing that `Forget` is called on all three event types (`Deleted`, `Updated`, `Added`). We had [a discussion](https://github.com/jetstack/cert-manager/pull/4233/files#r675442778) about that with @irbekrm. I changed this in f03d48f, where the only event on why we run `Forget` is `Deleted`.~~

## Why are we reverting 641960b?

After tonight's biweekly dev meeting, @wallrj asked the team why we would not accept backporting the `Forget` fix (641960b) in 1.4.2 and 1.3.2 but still accept it in 1.5.

The team agrees on the fact that it needs more testing (since it is not tested at all). I thus suggest we revert the untested `Forget` change that was merged.

The "Forget" memory leak that we are reverting now is the cause of a tiny fraction of the overall memory leakage that was fixed in the PR in the scheduler itself.  Reverting this means that some goroutines will be leaked, but only when a Certificate gets removed and never recreated with the same name.

## Which commit should still be backported to 1.4.2 and 1.3.2?

Only 2 out of the 3 commits of #4233 should be backported in that order:

1. eb947f9
2. 8e87263

/release-note-none
/kind cleanup