### PR TITLE
Updates CertificateRequest design doc with maxPathLen

### DIFF
--- a/design/20190708.certificate-request-crd.md
+++ b/design/20190708.certificate-request-crd.md
@@ -144,6 +144,18 @@ type CertificateRequestSpec struct {
 	// implies that the 'signing' usage is set
 	// +optional
 	IsCA bool `json:"isCA,omitempty"`
+
+  // MaxPathLen requests that the pathLen in the requested certificate's
+  // basicConstraints be set by an issuer, which controls the maximum number of CA
+  // certificates which can appear in the chain issued by the requested
+  // certificate.  Not all issuers support MaxPathLen, and it will be left unset if
+  // unsupported. If a certificate's MaxPathLen is 0, then it cannot issue CA
+  // certificates; if MaxPathLen is n > 0, this certificate may issue a CA
+  // certificate, which in turn may issue a CA certificate only if n-1 is greater
+  // than zero. Most intermediate certificates will usually want to have a pathLen
+  // set to the smallest value possible. If omitted, no MaxPathLen will be
+  // requested for the issued certificate.
+  MaxPathLen *int32 `json:"isCA,omitempty"`
 }
 
 // CertificateStatus defines the observed state of CertificateRequest and


### PR DESCRIPTION
This PR updates the design for the CertificateRequest CRD to include the proposed `maxPathLen` field.

The related PR for this feature is here #4241 


```release-note
NONE
```
