### PR TITLE
Updates the kind cluster for v1.22 to v1.22.0-rc.0

### DIFF
--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -48,7 +48,7 @@ elif [[ "$K8S_VERSION" =~ 1\.20 ]] ; then
 elif [[ "$K8S_VERSION" =~ 1\.21 ]] ; then
   KIND_IMAGE_SHA="sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad"
 elif [[ "$K8S_VERSION" =~ 1\.22 ]] ; then
-  KIND_IMAGE_SHA="sha256:0d32eba8eb762fde6e8e92dbb92811c327add2f7f3c8d6206f9f668a3ae1dee7"
+  KIND_IMAGE_SHA="sha256:fa600aa4b8234235e141fab085126e2a72c3d8f05eed44d38bf343091c51d192"
   # Override KIND_IMAGE_REPO set in devel/lib/lib.sh till there is a 1.22 image in kindest/node.
   KIND_IMAGE_REPO="eu.gcr.io/jetstack-build-infra-images/kind"
 else


### PR DESCRIPTION
See:

https://console.cloud.google.com/gcr/images/jetstack-build-infra-images/EU/kind@sha256:fa600aa4b8234235e141fab085126e2a72c3d8f05eed44d38bf343091c51d192/details?tab=info

```release-note
NONE
```
