### PR TITLE
Fix a cainjector E2E test flake

### DIFF
--- a/test/e2e/suite/serving/cainjector.go
+++ b/test/e2e/suite/serving/cainjector.go
@@ -91,7 +91,7 @@ var _ = framework.CertManagerDescribe("CA Injector", func() {
 				cert.Namespace = f.Namespace.Name
 				Expect(f.CRClient.Create(context.Background(), cert)).To(Succeed())
 
-				_, err := f.Helper().WaitForCertificateReady(f.Namespace.Name, "serving-certs", time.Second*30)
+				_, err := f.Helper().WaitForCertificateReadyUpdate(cert, time.Second*30)
 				Expect(err).NotTo(HaveOccurred(), "failed to wait for Certificate to become Ready")
 
 				By("grabbing the corresponding secret")


### PR DESCRIPTION
In https://github.com/jetstack/cert-manager/pull/4234 there were intermittent test failures in the cainjector E2E tests:
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/4234/pull-cert-manager-e2e-v1-21/1422524737686343681
 * https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/jetstack_cert-manager/4234/pull-cert-manager-e2e-v1-21/1421109702468571136

I reproduced the failure locally, but only after rebasing that branch on origin/master, which brings in https://github.com/jetstack/cert-manager/pull/4239

Maybe if we also check the  Ready condition observed generation after first creating the certificate, it will help avoid the chance of the Certificate still being processed while when we attempt to modify the certificate in the test.

**Release note**:
```release-note
NONE
```
