### PR TITLE
Correctly print conditions during tests

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -158,7 +158,7 @@ func WaitForCertificateCondition(client clientset.CertificateInterface, name str
 				return false, fmt.Errorf("error getting Certificate %v: %v", name, err)
 			}
 			if !apiutil.CertificateHasCondition(certificate, condition) {
-				log.Logf("Expected Certificate %v condition %v=%v but it has: %v", name, condition.Type, condition.Status, condition.ObservedGeneration, certificate.Status.Conditions)
+				log.Logf("Expected Certificate %v condition %v=%v but it has: %v", name, condition.Type, condition.Status, certificate.Status.Conditions)
 				return false, nil
 			}
 			return true, nil
@@ -179,7 +179,7 @@ func WaitForMissingCertificateCondition(client clientset.CertificateInterface, n
 				return false, fmt.Errorf("error getting Certificate %v: %v", name, err)
 			}
 			if apiutil.CertificateHasCondition(certificate, condition) {
-				log.Logf("Expected Certificate %v condition %v=%v to be missing but it has: %v", name, condition.Type, condition.Status, condition.ObservedGeneration, certificate.Status.Conditions)
+				log.Logf("Expected Certificate %v condition %v=%v to be missing but it has: %v", name, condition.Type, condition.Status, certificate.Status.Conditions)
 				return false, nil
 			}
 			return true, nil


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**
Current the tests output:
```
Expected Certificate serving-certs condition Ready=True but it has: 0
```
Instead the conditions should be printed.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note

```
/kind bug