### PR TITLE
Flakiness: iterate over a slice instead of iterating over a map

### DIFF
--- a/pkg/controller/certificate-shim/BUILD.bazel
+++ b/pkg/controller/certificate-shim/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "//test/unit/gen:go_default_library",
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//networking/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",


### PR DESCRIPTION
To reproduce the flakiness that is fixed in this commit, you can run:

```sh
go test ./pkg/... -run "TestSync/gateway-shim/if_a_Gateway_contains_two_.*" -count 10
```

While working on https://github.com/jetstack/cert-manager/pull/4293, we found that, since #4158, one of the unit tests was flaky:

```
I0803 17:14:34.151059 3741895 reflector.go:225] Stopping reflector *v1.Certificate (10ms) from pkg/mod/k8s.io/client-go@v0.21.2/tools/cache/reflector.go:167
--- FAIL: TestSync (0.14s)
  --- FAIL: TestSync/gateway-shim/if_a_Gateway_contains_two_listeners_with_different_Secret_names,_it_should_create_two_Certificates (0.13s)
  sync_test.go:2450: got unexpected events:
  exp='[Normal CreateCertificate Successfully created Certificate "foo-example-com-tls" Normal CreateCertificate Successfully created Certificate "bar-example-com-tls"]'
  got='[Normal CreateCertificate Successfully created Certificate "bar-example-com-tls" Normal CreateCertificate Successfully created Certificate "foo-example-com-tls"]'
```

At first, we thought that it was due to the fact that we were (wrongly) expecting the events to come in a deterministic order (i.e., the events arrive in the order they are sent), and we were looking at using [`EqualUnsorted`](https://github.com/jetstack/cert-manager/blob/master/pkg/util/util.go#L56) instead of `EqualSorted` to check the events in [`AllEventsCalled`](https://github.com/jetstack/cert-manager/blob/3b50d78ae40cf410595c6943ade3b4bdd1aa4f43/pkg/controller/test/context_builder.go#L227).

But then, we found that this indeterminism was coming from the fact that we store the Gateway TLS hostnames in a map in [sync.go](https://github.com/jetstack/cert-manager/blob/be8079b5046c1e10d5eb8d812c2260f5bea33f4e/pkg/controller/certificate-shim/sync.go#L313):

```go
tlsHosts := make(map[corev1.ObjectReference][]string)
for secretRef, hosts := range tlsHosts {
    // Undeterministic order!
}
```

This PR introduces fixes the indeterminism.