### PR TITLE
Fix chart prerequisites Kubernetes version

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -8,7 +8,7 @@ to renew certificates at an appropriate time before expiry.
 
 ## Prerequisites
 
-- Kubernetes 1.11+
+- Kubernetes 1.16+
 
 ## Installing the Chart
 


### PR DESCRIPTION
Make supported Kubernetes version in helm chart readme match: https://cert-manager.io/docs/installation/supported-releases/

fixes https://github.com/jetstack/cert-manager/issues/4076

```release-note
NONE
```
