### PR TITLE
Put Gateway-API support behind a feature-gate.

### DIFF
--- a/cmd/controller/app/BUILD.bazel
+++ b/cmd/controller/app/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/controller/certificates/trigger:go_default_library",
         "//pkg/controller/clusterissuers:go_default_library",
         "//pkg/controller/issuers:go_default_library",
+        "//pkg/feature:go_default_library",
         "//pkg/issuer/acme:go_default_library",
         "//pkg/issuer/acme/dns/util:go_default_library",
         "//pkg/issuer/ca:go_default_library",

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -52,12 +52,13 @@ import (
 	intscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
 	informers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
 	"github.com/jetstack/cert-manager/pkg/controller"
-	shimgw "github.com/jetstack/cert-manager/pkg/controller/certificate-shim/gateways"
 	"github.com/jetstack/cert-manager/pkg/controller/clusterissuers"
+	"github.com/jetstack/cert-manager/pkg/feature"
 	dnsutil "github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 	"github.com/jetstack/cert-manager/pkg/metrics"
 	"github.com/jetstack/cert-manager/pkg/util"
+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
 )
 
 const controllerAgentName = "cert-manager"
@@ -230,30 +231,24 @@ func buildControllerContext(ctx context.Context, opts *options.ControllerOptions
 		return nil, nil, fmt.Errorf("error creating kubernetes client: %s", err.Error())
 	}
 
-	// check if the gateway API CRDs are available
 	var gatewayAvailable bool
-	d := cl.Discovery()
-	resources, err := d.ServerResourcesForGroupVersion(gwapi.GroupVersion.String())
-	switch {
-	case apierrors.IsNotFound(err):
-		gatewayAvailable = false
-		log.Info("the Gateway API CRDs do not seem to be present, gateway-api functionality disabled")
-	case err != nil:
-		return nil, nil, fmt.Errorf("while checking if the Gateway API CRD is installed: %s", err.Error())
-	case len(resources.APIResources) == 0:
-		gatewayAvailable = false
-		log.Info("the Gateway API CRDs do not seem to be present, gateway-api functionality disabled")
-	default:
-		gatewayAvailable = true
-	}
-
-	// cert-manager will try watching the Gateway resources with an exponential
-	// back-off, which allows the user to install the CRDs after cert-manager
-	// itself. Let's let the user know that the CRDs have not been found yet.
-	if opts.EnabledControllers().Has(shimgw.ControllerName) {
-		if !gatewayAvailable {
-			log.Info("the Gateway API CRDs do not seem to be present, but the gateway-shim controller was " +
-				"manually enabled. please install the CRDs.")
+	// Check if the Gateway API feature gate was enabled
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
+		// check if the gateway API CRDs are available. If they are not found return an error
+		// which will cause cert-manager to crashloopbackoff
+		d := cl.Discovery()
+		resources, err := d.ServerResourcesForGroupVersion(gwapi.GroupVersion.String())
+		var GatewayAPINotAvailable = "the Gateway API CRDs do not seem to be present, but " + feature.ExperimentalGatewayAPISupport +
+			" is set to true. Please install the gateway-api CRDs."
+		switch {
+		case apierrors.IsNotFound(err):
+			return nil, nil, fmt.Errorf("%s (%w)", GatewayAPINotAvailable, err)
+		case err != nil:
+			return nil, nil, fmt.Errorf("while checking if the Gateway API CRD is installed: %w", err)
+		case len(resources.APIResources) == 0:
+			return nil, nil, fmt.Errorf("%s (found %d APIResources in %s)", GatewayAPINotAvailable, len(resources.APIResources), gwapi.GroupVersion.String())
+		default:
+			gatewayAvailable = true
 		}
 	}
 

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -194,7 +194,10 @@ func Run(opts *options.ControllerOptions, stopCh <-chan struct{}) error {
 	log.V(logf.DebugLevel).Info("starting shared informer factories")
 	ctx.SharedInformerFactory.Start(rootCtx.Done())
 	ctx.KubeSharedInformerFactory.Start(rootCtx.Done())
-	ctx.GWShared.Start(rootCtx.Done())
+
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
+		ctx.GWShared.Start(rootCtx.Done())
+	}
 
 	err = g.Wait()
 	if err != nil {

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -424,5 +424,10 @@ func (o *ControllerOptions) EnabledControllers() sets.String {
 		enabled = enabled.Insert(experimentalCertificateSigningRequestControllers...)
 	}
 
+	if utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalGatewayAPISupport) {
+		logf.Log.Info("enabling the sig-network Gateway API certificate-shim and HTTP-01 solver")
+		enabled = enabled.Insert(shimgatewaycontroller.ControllerName)
+	}
+
 	return enabled
 }

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -23,7 +23,7 @@ NAMESPACE="${NAMESPACE:-cert-manager}"
 # Release name to use with Helm
 RELEASE_NAME="${RELEASE_NAME:-cert-manager}"
 # Default feature gates to enable
-FEATURE_GATES="${FEATURE_GATES:-ExperimentalCertificateSigningRequestControllers=true}"
+FEATURE_GATES="${FEATURE_GATES:-ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true}"
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_ROOT}/../../lib/lib.sh"
@@ -66,7 +66,7 @@ helm upgrade \
     --set startupapicheck.image.tag="${APP_VERSION}" \
     --set installCRDs=true \
     --set featureGates="${FEATURE_GATES:-}" \
-    --set "extraArgs={--dns01-recursive-nameservers=${SERVICE_IP_PREFIX}.16:53,--dns01-recursive-nameservers-only=true,--controllers=*\,gateway-shim}" \
+    --set "extraArgs={--dns01-recursive-nameservers=${SERVICE_IP_PREFIX}.16:53,--dns01-recursive-nameservers-only=true}" \
     "$RELEASE_NAME" \
     "$REPO_ROOT/bazel-bin/deploy/charts/cert-manager/cert-manager.tgz"
 

--- a/devel/addon/certmanager/install.sh
+++ b/devel/addon/certmanager/install.sh
@@ -23,7 +23,7 @@ NAMESPACE="${NAMESPACE:-cert-manager}"
 # Release name to use with Helm
 RELEASE_NAME="${RELEASE_NAME:-cert-manager}"
 # Default feature gates to enable
-FEATURE_GATES="${FEATURE_GATES:-ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true}"
+FEATURE_GATES="${FEATURE_GATES:-ExperimentalCertificateSigningRequestControllers=true\\,ExperimentalGatewayAPISupport=true}"
 
 SCRIPT_ROOT=$(dirname "${BASH_SOURCE}")
 source "${SCRIPT_ROOT}/../../lib/lib.sh"

--- a/devel/run-e2e.sh
+++ b/devel/run-e2e.sh
@@ -44,7 +44,7 @@ bazel build //test/e2e:e2e.test
 echo "Using K8S_VERSION ${K8S_VERSION}"
 case "$K8S_VERSION" in
   "1.16" | "1.17" | "1.18")
-    SKIP="--ginkgo.skip=Gateway"
+    SKIP="Gateway"
     echo "skipping Gateway e2e tests as K8S_VERSION is <1.19"
     ;;
   *)
@@ -59,5 +59,5 @@ ginkgo -nodes 10 -flakeAttempts ${FLAKE_ATTEMPTS:-1} \
 	--report-dir="${ARTIFACTS:-$REPO_ROOT/_artifacts}" \
 	--acme-dns-server="$DNS_SERVER" \
 	--acme-ingress-ip="$INGRESS_IP" \
-	"${SKIP}" \
+	"--ginkgo.skip=${SKIP}" \
 	"$@"

--- a/pkg/feature/features.go
+++ b/pkg/feature/features.go
@@ -34,16 +34,23 @@ const (
 	// ExperimentalCertificateSigningRequestControllers enables all CertificateSigningRequest
 	// controllers that sign Kubernetes CertificateSigningRequest resources
 	ExperimentalCertificateSigningRequestControllers featuregate.Feature = "ExperimentalCertificateSigningRequestControllers"
+
+	// alpha: v1.5.0
+	//
+	// ExperimentalGatewayAPISupport enables the gateway-shim controller and adds support for
+	// the Gateway API to the HTTP-01 challenge solver.
+	ExperimentalGatewayAPISupport featuregate.Feature = "ExperimentalGatewayAPISupport"
 )
 
 func init() {
-	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultKubernetesFeatureGates))
+	runtime.Must(utilfeature.DefaultMutableFeatureGate.Add(defaultCertManagerFeatureGates))
 }
 
-// defaultKubernetesFeatureGates consists of all known Kubernetes-specific feature keys.
+// defaultCertManagerFeatureGates consists of all known cert-manager feature keys.
 // To add a new feature, define a key for it above and add it here. The features will be
-// available throughout Kubernetes binaries.
-var defaultKubernetesFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
+// available on the cert-manager controller binary.
+var defaultCertManagerFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ValidateCAA: {Default: false, PreRelease: featuregate.Alpha},
 	ExperimentalCertificateSigningRequestControllers: {Default: false, PreRelease: featuregate.Alpha},
+	ExperimentalGatewayAPISupport:                    {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
After discussion in the stand-up and on slack, the gateway-api support is now gated behind `--feature-gate=ExperimentalGatewayAPISupport=true`

**What this PR does / why we need it**:

Adds an alpha-level feature gate for enabling the gateway-shim and the gateway HTTPRoute ACME HTTP-01 challenge solver.

**Special notes for your reviewer**:

The cert-manager controller will now crash with the following error if the feature gate is enabled but the gateway API CRDs are not installed: `the Gateway API CRDs do not seem to be present, but ExperimentalGatewayAPISupport is set to true. Please install the gateway-api CRDs.`


**Release note**:
```release-note
Support for the sig-network Gateway API is gated behind the --feature-gates=ExperimentalGatewayAPISupport=true command line flag on the cert-manager controller
```

/kind feature