### PR TITLE
[release-1.4] Helm chart k8s compat update

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -8,7 +8,7 @@ to renew certificates at an appropriate time before expiry.
 
 ## Prerequisites
 
-- Kubernetes 1.11+
+- Kubernetes 1.16 - 1.21 (note that Kubernetes 1.22 and later will require at least cert-manager v1.5)
 
 ## Installing the Chart
 


### PR DESCRIPTION
Updates the helm chart for release-1.4 to highlight the correct version range it supports, and to point out that it won't work with
Kubernetes 1.22+

Part of #4076

/kind cleanup

```release-note
Clarify the exact supported kubernetes version range for cert-manager 1.4
```
