### PR TITLE
[Helm Chart] Add optional service annotations

### DIFF
--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -4,6 +4,10 @@ kind: Service
 metadata:
   name: {{ template "cert-manager.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
+{{- with .Values.serviceAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
     app: {{ include "cert-manager.name" . }}
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -3,6 +3,10 @@ kind: Service
 metadata:
   name: {{ template "webhook.fullname" . }}
   namespace: {{ .Release.Namespace | quote }}
+{{- with .Values.webhook.serviceAnnotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
   labels:
     app: {{ include "webhook.name" . }}
     app.kubernetes.io/name: {{ include "webhook.name" . }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -140,6 +140,9 @@ volumeMounts: []
 
 podLabels: {}
 
+# Optional annotations to add to the controller Service
+# serviceAnnotations: {}
+
 # Optional additional labels to add to the controller Service
 # serviceLabels: {}
 

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -232,6 +232,9 @@ webhook:
   # Optional additional annotations to add to the webhook Pods
   # podAnnotations: {}
 
+  # Optional additional annotations to add to the webhook Service
+  # serviceAnnotations: {}
+
   # Optional additional annotations to add to the webhook MutatingWebhookConfiguration
   # mutatingWebhookConfigurationAnnotations: {}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add optional annotations to the Kubernetes Service created by the helm chart.  Annotations are helpful for [human service discovery](https://kubernetes.io/blog/2021/04/20/annotating-k8s-for-humans/).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: None

**Special notes for your reviewer**: none

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Added helm value `.Values.serviceAnnotations`
```
