### PR TITLE
add krew automation for releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,12 @@
+name: release
+on:
+  release:
+    types: ["released"]
+jobs:
+  krewrelease:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.40

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,44 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: cert-manager
+spec:
+  version: {{ .TagName }}
+  homepage: https://github.com/jetstack/cert-manager
+  shortDescription: Manage cert-manager resources inside your cluster
+  description: |
+    The official plugin accompanying cert-manger, a Kubernetes add-on to
+    automate the management and issuance of TLS certificates. Allows for
+    direct interaction with cert-manager resources e.g. manual renewal of
+    Certificate resources.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-darwin-amd64.tar.gz" .TagName }}
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-linux-amd64.tar.gz" .TagName }}
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm
+    {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-linux-arm.tar.gz" .TagName }}
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: linux
+        arch: arm64
+    {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-linux-arm64.tar.gz" .TagName }}
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-windows-amd64.tar.gz" .TagName }}
+    bin: kubectl-cert_manager


### PR DESCRIPTION
The krew-release-bot action will use the `GITHUB_REF` envvar to detect the tag; that envvar is set to the tag corresponding to the release according to the [release event docs](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release).

The [release event](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release) is set to `released` so that it's not triggered on a prerelease (like a beta or alpha). The docs also state:

>  Note: The release event is not triggered for draft releases.

So we should be safe when doing our draft releases during the release process.

`.krew.yaml` was generated with [krew-release-bot-helper](https://rajatjindal.com/tools/krew-release-bot-helper/)

Fixes #4193 

/kind feature

```release-note
Add automatic krew plugin updating on successful cert-manager releases
```
