### PR TITLE
Integration tests cleanup

### DIFF
--- a/cmd/webhook/app/testing/BUILD.bazel
+++ b/cmd/webhook/app/testing/BUILD.bazel
@@ -10,7 +10,9 @@ go_library(
         "//cmd/webhook/app/options:go_default_library",
         "//pkg/logs:go_default_library",
         "//pkg/util/pki:go_default_library",
+        "//pkg/webhook/server:go_default_library",
         "@com_github_spf13_pflag//:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/wait:go_default_library",
     ],
 )
 

--- a/pkg/api/testing/BUILD.bazel
+++ b/pkg/api/testing/BUILD.bazel
@@ -3,6 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = ["bazel.go"],
+    data = [
+        "//deploy/crds:crds.yaml",
+    ],
     importpath = "github.com/jetstack/cert-manager/pkg/api/testing",
     visibility = ["//visibility:public"],
 )

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -51,6 +51,8 @@ var (
 	// ConversionReview resources submitted to the webhook server.
 	// It is not used for performing validation, mutation or conversion.
 	defaultScheme = runtime.NewScheme()
+
+	ErrNotListening = errors.New("Server is not listening yet")
 )
 
 func init() {
@@ -227,7 +229,7 @@ func (s *Server) Run(stopCh <-chan struct{}) error {
 // Port returns the port number that the webhook listener is listening on
 func (s *Server) Port() (int, error) {
 	if s.listener == nil {
-		return 0, errors.New("Run() must be called before Port()")
+		return 0, ErrNotListening
 	}
 	tcpAddr, ok := s.listener.Addr().(*net.TCPAddr)
 	if !ok {

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -47,11 +47,11 @@ import (
 // certificate, ca, and private key is stored into the target Secret to
 // complete Issuing the Certificate.
 func TestIssuingController(t *testing.T) {
-	config, stopFn := framework.RunControlPlane(t)
-	defer stopFn()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
+
+	config, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
 
 	// Build, instantiate and run the issuing controller.
 	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
@@ -178,7 +178,7 @@ func TestIssuingController(t *testing.T) {
 	req.Status.CA = certPem
 	req.Status.Certificate = certPem
 	apiutil.SetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady, cmmeta.ConditionTrue, cmapi.CertificateRequestReasonIssued, "")
-	req, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(ctx, req, metav1.UpdateOptions{})
+	_, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(ctx, req, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -194,7 +194,7 @@ func TestIssuingController(t *testing.T) {
 
 	// Wait for the Certificate to have the 'Issuing' condition removed, and for
 	// the signed certificate, ca, and private key stored in the Secret.
-	err = wait.Poll(time.Millisecond*100, time.Second*5, func() (done bool, err error) {
+	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
 		crt, err = cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, crtName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Certificate resource, retrying: %v", err)
@@ -243,7 +243,7 @@ func TestIssuingController(t *testing.T) {
 		}
 
 		return true, nil
-	})
+	}, ctx.Done())
 
 	if err != nil {
 		t.Fatalf("Failed to wait for final state: %+v", crt)
@@ -251,11 +251,11 @@ func TestIssuingController(t *testing.T) {
 }
 
 func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
-	config, stopFn := framework.RunControlPlane(t)
-	defer stopFn()
-
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
+
+	config, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
 
 	// Build, instantiate and run the issuing controller.
 	kubeClient, factory, cmCl, cmFactory := framework.NewClients(t, config)
@@ -389,7 +389,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 	req.Status.CA = certPem
 	req.Status.Certificate = certPem
 	apiutil.SetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady, cmmeta.ConditionTrue, cmapi.CertificateRequestReasonIssued, "")
-	req, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(ctx, req, metav1.UpdateOptions{})
+	_, err = cmCl.CertmanagerV1().CertificateRequests(namespace).UpdateStatus(ctx, req, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,7 +405,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 
 	// Wait for the Certificate to have the 'Issuing' condition removed, and for
 	// the signed certificate, ca, and private key stored in the Secret.
-	err = wait.Poll(time.Millisecond*100, time.Second*5, func() (done bool, err error) {
+	err = wait.PollImmediateUntil(time.Millisecond*100, func() (done bool, err error) {
 		crt, err = cmCl.CertmanagerV1().Certificates(namespace).Get(ctx, crtName, metav1.GetOptions{})
 		if err != nil {
 			t.Logf("Failed to fetch Certificate resource, retrying: %v", err)
@@ -454,7 +454,7 @@ func TestIssuingController_PKCS8_PrivateKey(t *testing.T) {
 		}
 
 		return true, nil
-	})
+	}, ctx.Done())
 	if err != nil {
 		t.Fatalf("Failed to wait for final state: %+v", crt)
 	}

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -62,7 +62,10 @@ type CreateCRTest struct {
 // after the private key has been written to file and before the CR is successfully created.
 // Achieved by trying to create two CRs with the same name, storing the private key to two different files.
 func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
-	config, stopFn := framework.RunControlPlane(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	config, stopFn := framework.RunControlPlane(t, ctx)
 	defer stopFn()
 
 	// Build clients
@@ -74,8 +77,6 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 		cr5Name = "testcr-5"
 		ns1     = "testns-1"
 	)
-
-	ctx := context.TODO()
 
 	// Create Namespace
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1}}
@@ -122,7 +123,7 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 			// Now we try to create another CR with the same name, but storing the private key somewhere else
 			// This should break after writing private key to file and during creating CR
 			opts.KeyFilename = test.keyFilename
-			// Validating args and flagscontext.TODO()
+			// Validating args and flags
 			err = opts.Validate(test.inputArgs)
 			if err != nil {
 				t.Fatal(err)
@@ -160,11 +161,11 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 // TestCtlCreateCRSuccessful tests the behaviour in the case where the command successfully
 // creates the CR, including the --fetch-certificate logic.
 func TestCtlCreateCRSuccessful(t *testing.T) {
-	config, stopFn := framework.RunControlPlane(t)
-	defer stopFn()
+	rootCtx, cancelRoot := context.WithTimeout(context.Background(), time.Second*200)
+	defer cancelRoot()
 
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
-	defer cancel()
+	config, stopFn := framework.RunControlPlane(t, rootCtx)
+	defer stopFn()
 
 	// Build clients
 	kubernetesCl, _, cmCl, _ := framework.NewClients(t, config)
@@ -182,7 +183,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 	exampleCertificate := []byte(`LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUZUekNDQkRlZ0F3SUJBZ0lUQVBwOWhMUit2ODF2UTdpZSt6emxTMWY5MFRBTkJna3Foa2lHOXcwQkFRc0YKQURBaU1TQXdIZ1lEVlFRRERCZEdZV3RsSUV4RklFbHVkR1Z5YldWa2FXRjBaU0JZTVRBZUZ3MHlNREEyTXpBeApNelUyTkRoYUZ3MHlNREE1TWpneE16VTJORGhhTUNZeEpEQWlCZ05WQkFNVEcyaGhiM2hwWVc1bkxXZGpjQzVxClpYUnpkR0ZqYTJWeUxtNWxkRENDQVNJd0RRWUpLb1pJaHZjTkFRRUJCUUFEZ2dFUEFEQ0NBUW9DZ2dFQkFOTjIKTS9zZGtPazgvenJLbXNvMEE1SmxoUjRTQU9pTVhiWGZleEpvUzZ3b3krakszNVBCOUFDUDFQcllXR0diZjNYRwo1VngvZmRBSlNmdVFmL0NoZlRsa0kwQUYxUCsxUThhQU9BUXhKdU4ySVJxT0ErNlEwUTg2Vy9oZVFXbUdOUkI4CmxMcHQvWU9IV3NreHRqRDNmN3p1QXZZUkI1czFCZ3o2K2s1REF6d1pGNnlMMEtja1JpY3dFMHh3aisrZkcyeCsKdEpQb1AwdmliM0EzU0xySFhsRW5HbFdEL3ZSbkkrNkc1dFI2ZHJWbGcrcjhSRkFiYTJDc1VpTGFiM252Q2JqUQpDNG9xZWd1NklUNzk4R0thenBXbGw2b3M0SndQdFJnQzlvYS9FeklVanlWeStuRWhHU3pwSmlNQ0NZOS96b0daCmV1TGJ0M1lSdVVIaStiemludnNDQXdFQUFhT0NBbmd3Z2dKME1BNEdBMVVkRHdFQi93UUVBd0lGb0RBZEJnTlYKSFNVRUZqQVVCZ2dyQmdFRkJRY0RBUVlJS3dZQkJRVUhBd0l3REFZRFZSMFRBUUgvQkFJd0FEQWRCZ05WSFE0RQpGZ1FVRGZKNml2NlNoRlhzLzFrUTh5bmR1NGhTUEtrd0h3WURWUjBqQkJnd0ZvQVV3TXdEUnJsWUlNeGNjbkR6CjRTN0xJS2IxYURvd2R3WUlLd1lCQlFVSEFRRUVhekJwTURJR0NDc0dBUVVGQnpBQmhpWm9kSFJ3T2k4dmIyTnoKY0M1emRHY3RhVzUwTFhneExteGxkSE5sYm1OeWVYQjBMbTl5WnpBekJnZ3JCZ0VGQlFjd0FvWW5hSFIwY0RvdgpMMk5sY25RdWMzUm5MV2x1ZEMxNE1TNXNaWFJ6Wlc1amNubHdkQzV2Y21jdk1DWUdBMVVkRVFRZk1CMkNHMmhoCmIzaHBZVzVuTFdkamNDNXFaWFJ6ZEdGamEyVnlMbTVsZERCTUJnTlZIU0FFUlRCRE1BZ0dCbWVCREFFQ0FUQTMKQmdzckJnRUVBWUxmRXdFQkFUQW9NQ1lHQ0NzR0FRVUZCd0lCRmhwb2RIUndPaTh2WTNCekxteGxkSE5sYm1OeQplWEIwTG05eVp6Q0NBUVFHQ2lzR0FRUUIxbmtDQkFJRWdmVUVnZklBOEFCMkFMRE1nK1dsK1gxcnIzd0p6Q2hKCkJJY3F4K2lMRXl4alVMZkcvU2JoYkd4M0FBQUJjd1c3QXB3QUFBUURBRWN3UlFJaEFPai9nNm9ONjNTRnBqa00Ka3FmcjRDUlVzb0dWamZqQzN4MkRFdmR0RVZzNEFpQm05OTFzTHFHUzFJYksrM1VoemZzUDUvNTVjU2FpWkVPcwpwQmdVb1plb0l3QjJBTjJaTlB5bDV5U0F5VlpvZllFMG1RaEpza24zdFduWXg3eXJQMXpCODI1a0FBQUJjd1c3CkJJb0FBQVFEQUVjd1JRSWdVbTRDbW9hdDBIdTZaMUExcFRKbTc4WTRYaHZWcmJIQ3RYUUZaa0QweHZzQ0lRQ0IKbVBSTFFZS2RObUMyMXJLRW5hUjBBRjBZbS9ENEp6NjlhWTJUbEcwM1hqQU5CZ2txaGtpRzl3MEJBUXNGQUFPQwpBUUVBZHZoNFJuUGVaWEliazc3b2xjaTM0K0tZRmxCSUtDbFdUTkl3dXB5NlpGM0NYSlBzSjRQQWUvMGMzTVpaCkZSbDl4SHN2LzNESXZOaU5udkJSblRjdHJFMGp1V0cxYVlrWWIzaGRJMFVNcWlqUHNmc0doZW9LQnpRVDBoREcKRDFET0hPNXB5czQvNnp3NXk2TVMrdkoyVXY3aHlWem1PdldqaFp1c0xvUUZBcmpYY0ROY0puN3N2SkdOMXRFSgpZeUxHSk42SFpMV0xSeU8zdTBHYU9HQkk4SGRmc3JzbGVKaUk4b1ROaXdjaFZuekR1UUlLZFo0M040N0R5QlgwClpjTmplbElzeGtPSlhCUHJQVWJOaGltK1dNWjlicWxpUFZLamlhRUJFQ1BIaVRFK0Y2a3dkRkpkTktJZUVtL3UKR0JTRW5Zdmp2RWRJMzh4U1JWMXZDdDgxUUE9PQotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCi0tLS0tQkVHSU4gQ0VSVElGSUNBVEUtLS0tLQpNSUlFcXpDQ0FwT2dBd0lCQWdJUkFJdmhLZzVaUk8wOFZHUXg4SmRoVCtVd0RRWUpLb1pJaHZjTkFRRUxCUUF3CkdqRVlNQllHQTFVRUF3d1BSbUZyWlNCTVJTQlNiMjkwSUZneE1CNFhEVEUyTURVeU16SXlNRGMxT1ZvWERUTTIKTURVeU16SXlNRGMxT1Zvd0lqRWdNQjRHQTFVRUF3d1hSbUZyWlNCTVJTQkpiblJsY20xbFpHbGhkR1VnV0RFdwpnZ0VpTUEwR0NTcUdTSWIzRFFFQkFRVUFBNElCRHdBd2dnRUtBb0lCQVFEdFdLeVNEbjdyV1pjNWdnanozWkIwCjhqTzR4dGkzdXpJTmZENXNRN0xqN2h6ZXRVVCt3UW9iK2lYU1praG52eCtJdmRiWEY1L3l0OGFXUHBVS25QeW0Kb0x4c1lpSTVnUUJMeE5EekllYzBPSWFmbFdxQXIyOW03SjgrTk50QXBFTjhuWkZuZjNiaGVoWlc3QXhtUzFtMApablNzZEh3MEZ3K2JnaXhQZzJNUTlrOW9lZkZlcWErN0txZGx6NWJiclVZVjJ2b2x4aERGdG5JNE1oOEJpV0NOCnhESDFIaXpxK0dLQ2NIc2luRFpXdXJDcWRlci9hZkpCblFzK1NCU0w2TVZBcEh0K2QzNXpqQkQ5MmZPMkplNTYKZGhNZnpDZ09LWGVKMzQwV2hXM1RqRDF6cUxaWGVhQ3lVTlJuZk9tV1pWOG5FaHRIT0ZiVUNVN3IvS2tqTVpPOQpBZ01CQUFHamdlTXdnZUF3RGdZRFZSMFBBUUgvQkFRREFnR0dNQklHQTFVZEV3RUIvd1FJTUFZQkFmOENBUUF3CkhRWURWUjBPQkJZRUZNRE1BMGE1V0NETVhISnc4K0V1eXlDbTlXZzZNSG9HQ0NzR0FRVUZCd0VCQkc0d2JEQTAKQmdnckJnRUZCUWN3QVlZb2FIUjBjRG92TDI5amMzQXVjM1JuTFhKdmIzUXRlREV1YkdWMGMyVnVZM0o1Y0hRdQpiM0puTHpBMEJnZ3JCZ0VGQlFjd0FvWW9hSFIwY0RvdkwyTmxjblF1YzNSbkxYSnZiM1F0ZURFdWJHVjBjMlZ1ClkzSjVjSFF1YjNKbkx6QWZCZ05WSFNNRUdEQVdnQlRCSm5Ta2lrU2c1dm9nS05oY0k1cEZpQmg1NERBTkJna3EKaGtpRzl3MEJBUXNGQUFPQ0FnRUFCWVN1NElsK2ZJME1ZVTQyT1RtRWorMUhxUTVEdnlBZXlDQTZzR3VaZHdqRgpVR2VWT3YzTm5MeWZvZnVVT2pFYlk1aXJGQ0R0bnYrMGNrdWtVWk45bHo0UTJZaldHVXBXNFRUdTNpZVRzYUM5CkFGdkNTZ05ISnlXU1Z0V3ZCNVhEeHNxYXdsMUt6SHp6d3IxMzJiRjJydEd0YXpTcVZxSzlFMDdzR0hNQ2YrenAKRFFWRFZWR3RxWlBId1gzS3FVdGVmRTYyMWI4Ukk2VkNsNG9EMzBPbGY4cGp1ekc0SktCRlJGY2x6TFJqby9oNwpJa2tmalo4d0RhN2ZhT2pWWHg2bitlVVEyOWNJTUN6cjgvck5XSFM5cFlHR1FLSmlZMnhtVkM5aDEySDk5WHlmCnpXRTl2YjV6S1AzTVZHNm5lWDFoU2RvN1BFQWI5ZnFSaEhrcVZzcVV2SmxJUm12WHZWS1R3TkNQM2VDalJDQ0kKUFRBdmpWKzRuaTc4NmlYd3dGWU56OGwzUG1QTEN5UVhXR29obko4aUJtKzVuazdPMnluYVBWVzBVMlcrcHQydwpTVnV2ZERNNXpHdjJmOWx0TldVaVlaSEoxbW1POTdqU1kvNllmZE9VSDY2aVJ0UXREa0hCUmRrTkJzTWJEK0VtCjJUZ0JsZHRITlNKQmZCM3BtOUZibGdPY0owRlNXY1VEV0o3dk8wK05UWGxnclJvZlJUNnBWeXd6eFZvNmRORDAKV3pZbFRXZVVWc080MHhKcWhnVVFSRVI5WUxPTHhKME82QzhpMHhGeEFNS090U2RvZE1CM1JJd3Q3UkZRMHV5dApuNVo1TXFrWWhsTUkzSjF0UFJUcDFuRXQ5ZnlHc3BCT08wNWdpMTQ4UWFzcCszTitzdnFLb21vUWdsTm9BeFU9Ci0tLS0tRU5EIENFUlRJRklDQVRFLS0tLS0K`)
 
 	// Create Namespace
-	_, err := kubernetesCl.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1}}, metav1.CreateOptions{})
+	_, err := kubernetesCl.CoreV1().Namespaces().Create(rootCtx, &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns1}}, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -262,6 +263,9 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			ctx, cancel := context.WithTimeout(rootCtx, time.Second*20)
+			defer cancel()
+
 			streams, _, _, _ := genericclioptions.NewTestIOStreams()
 
 			cleanUpFunc := setupPathForTest(t)
@@ -293,14 +297,21 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 				// by the CLI command yet.
 				// Once it has been created, set the `status.certificate` and `Ready` condition so that the `--fetch-certificate`
 				// part of the command is able to proceed.
+				doneCh := make(chan struct{})
+				pollCtx, cancelPoll := context.WithCancel(ctx)
+				defer func() {
+					cancelPoll()
+					<-doneCh
+				}()
 				go func() {
-					err = wait.Poll(time.Second, 5*time.Minute, func() (done bool, err error) {
-						req, err = cmCl.CertmanagerV1().CertificateRequests(test.inputNamespace).Get(context.TODO(), test.inputArgs[0], metav1.GetOptions{})
+					defer close(doneCh)
+					err = wait.PollImmediateUntil(time.Second, func() (done bool, err error) {
+						req, err = cmCl.CertmanagerV1().CertificateRequests(test.inputNamespace).Get(pollCtx, test.inputArgs[0], metav1.GetOptions{})
 						if err != nil {
 							return false, nil
 						}
 						return true, nil
-					})
+					}, pollCtx.Done())
 					if err != nil {
 						t.Fatal("timeout when waiting for CertificateRequest to be created")
 					}
@@ -308,7 +319,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 					// CR has been created, try update status
 					req.Status.Conditions = test.crStatus.Conditions
 					req.Status.Certificate = test.crStatus.Certificate
-					req, err = cmCl.CertmanagerV1().CertificateRequests(test.inputNamespace).UpdateStatus(context.TODO(), req, metav1.UpdateOptions{})
+					req, err = cmCl.CertmanagerV1().CertificateRequests(test.inputNamespace).UpdateStatus(pollCtx, req, metav1.UpdateOptions{})
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/test/integration/ctl/ctl_install.go
+++ b/test/integration/ctl/ctl_install.go
@@ -75,7 +75,7 @@ func TestCtlInstall(t *testing.T) {
 			testApiServer, cleanup := install_framework.NewTestInstallApiServer(t)
 			defer cleanup()
 
-			ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 			defer cancel()
 
 			if test.prerun {

--- a/test/integration/ctl/ctl_renew_test.go
+++ b/test/integration/ctl/ctl_renew_test.go
@@ -37,11 +37,11 @@ import (
 // TestCtlRenew tests the renewal logic of the ctl CLI command against the
 // cert-manager Issuing controller.
 func TestCtlRenew(t *testing.T) {
-	config, stopFn := framework.RunControlPlane(t)
-	defer stopFn()
-
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
+
+	config, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
 
 	// Build clients
 	kubeClient, _, cmCl, _ := framework.NewClients(t, config)

--- a/test/integration/ctl/ctl_status_certificate_test.go
+++ b/test/integration/ctl/ctl_status_certificate_test.go
@@ -73,11 +73,11 @@ func generateCSR(t *testing.T) []byte {
 func TestCtlStatusCert(t *testing.T) {
 	testCSR := generateCSR(t)
 
-	config, stopFn := framework.RunControlPlane(t)
-	defer stopFn()
-
-	ctx, cancel := context.WithTimeout(context.TODO(), time.Second*20)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
 	defer cancel()
+
+	config, stopFn := framework.RunControlPlane(t, ctx)
+	defer stopFn()
 
 	// Build clients
 	kubernetesCl, _, cmCl, _ := framework.NewClients(t, config)
@@ -607,7 +607,7 @@ func createOrderOwnedByCR(cmCl versioned.Interface, ctx context.Context,
 	}
 
 	order.OwnerReferences = append(order.OwnerReferences, *metav1.NewControllerRef(req, cmapi.SchemeGroupVersion.WithKind("CertificateRequest")))
-	order, err = cmCl.AcmeV1().Orders(req.Namespace).Update(ctx, order, metav1.UpdateOptions{})
+	_, err = cmCl.AcmeV1().Orders(req.Namespace).Update(ctx, order, metav1.UpdateOptions{})
 	if err != nil {
 		return fmt.Errorf("Update Err: %v", err)
 	}
@@ -625,7 +625,7 @@ func createChallengesOwnedByOrder(cmCl versioned.Interface, ctx context.Context,
 		}
 
 		challenge.OwnerReferences = append(challenge.OwnerReferences, *metav1.NewControllerRef(order, cmacme.SchemeGroupVersion.WithKind("Order")))
-		challenge, err = cmCl.AcmeV1().Challenges(order.Namespace).Update(ctx, challenge, metav1.UpdateOptions{})
+		_, err = cmCl.AcmeV1().Challenges(order.Namespace).Update(ctx, challenge, metav1.UpdateOptions{})
 		if err != nil {
 			return fmt.Errorf("Update Err: %v", err)
 		}

--- a/test/integration/framework/BUILD.bazel
+++ b/test/integration/framework/BUILD.bazel
@@ -6,12 +6,6 @@ go_library(
         "apiserver.go",
         "helpers.go",
     ],
-    data = [
-        "//deploy/crds:crds.yaml",
-        "//hack/bin:com_coreos_etcd",
-        "//hack/bin:io_kubernetes_kube-apiserver",
-        "//hack/bin:kubectl",
-    ],
     importpath = "github.com/jetstack/cert-manager/test/integration/framework",
     visibility = ["//visibility:public"],
     deps = [
@@ -42,6 +36,7 @@ go_library(
         "@io_k8s_client_go//tools/record:go_default_library",
         "@io_k8s_kubectl//pkg/util/openapi:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/envtest:go_default_library",
     ],
 )
 

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/pem"
 	"strings"
 	"testing"
+	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -167,9 +168,13 @@ func TestValidationCertificateRequests(t *testing.T) {
 			cert := test.input.(*cmapi.CertificateRequest)
 			cert.SetGroupVersionKind(certGVK)
 
-			config, stop := framework.RunControlPlane(t)
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+			defer cancel()
+
+			config, stop := framework.RunControlPlane(t, ctx)
 			defer stop()
-			framework.WaitForOpenAPIResourcesToBeLoaded(t, config, certGVK)
+
+			framework.WaitForOpenAPIResourcesToBeLoaded(t, ctx, config, certGVK)
 
 			// create the object to get any errors back from the webhook
 			cl, err := client.New(config, client.Options{Scheme: api.Scheme})
@@ -177,7 +182,7 @@ func TestValidationCertificateRequests(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = cl.Create(context.Background(), cert)
+			err = cl.Create(ctx, cert)
 			if test.expectError != (err != nil) {
 				t.Errorf("unexpected error, exp=%t got=%v",
 					test.expectError, err)

--- a/test/integration/webhook/dynamic_authority_test.go
+++ b/test/integration/webhook/dynamic_authority_test.go
@@ -44,7 +44,10 @@ import (
 // Ensure that when the controller is running against an empty API server, it
 // creates and stores a new CA keypair.
 func TestDynamicAuthority_Bootstrap(t *testing.T) {
-	config, stop := framework.RunControlPlane(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	config, stop := framework.RunControlPlane(t, ctx)
 	defer stop()
 
 	kubeClient, _, _, _ := framework.NewClients(t, config)
@@ -52,7 +55,7 @@ func TestDynamicAuthority_Bootstrap(t *testing.T) {
 	namespace := "testns"
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,9 +81,8 @@ func TestDynamicAuthority_Bootstrap(t *testing.T) {
 	}()
 
 	cl := kubernetes.NewForConfigOrDie(config)
-	// allow the controller 5s to provision the Secret - this is far longer
-	// than it should ever take.
-	if err := wait.Poll(time.Millisecond*500, time.Second*5, authoritySecretReadyConditionFunc(t, cl, auth.SecretNamespace, auth.SecretName)); err != nil {
+	// allow the controller to provision the Secret
+	if err := wait.PollImmediateUntil(time.Millisecond*500, authoritySecretReadyConditionFunc(t, ctx, cl, auth.SecretNamespace, auth.SecretName), ctx.Done()); err != nil {
 		t.Errorf("Failed waiting for Secret to contain valid certificate: %v", err)
 		return
 	}
@@ -89,7 +91,10 @@ func TestDynamicAuthority_Bootstrap(t *testing.T) {
 // Ensures that when the controller is running and the CA Secret is deleted,
 // it is automatically recreated within a bounded amount of time.
 func TestDynamicAuthority_Recreates(t *testing.T) {
-	config, stop := framework.RunControlPlane(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	config, stop := framework.RunControlPlane(t, ctx)
 	defer stop()
 
 	kubeClient, _, _, _ := framework.NewClients(t, config)
@@ -97,7 +102,7 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 	namespace := "testns"
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -123,21 +128,19 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 	}()
 
 	cl := kubernetes.NewForConfigOrDie(config)
-	// allow the controller 5s to provision the Secret - this is far longer
-	// than it should ever take.
-	if err := wait.Poll(time.Millisecond*500, time.Second*5, authoritySecretReadyConditionFunc(t, cl, auth.SecretNamespace, auth.SecretName)); err != nil {
+	// allow the controller to provision the Secret
+	if err := wait.PollImmediateUntil(time.Millisecond*500, authoritySecretReadyConditionFunc(t, ctx, cl, auth.SecretNamespace, auth.SecretName), ctx.Done()); err != nil {
 		t.Errorf("Failed waiting for Secret to contain valid certificate: %v", err)
 		return
 	}
 
 	t.Logf("Secret resource has been provisioned, deleting to ensure it is recreated")
-	if err := cl.CoreV1().Secrets(auth.SecretNamespace).Delete(context.TODO(), auth.SecretName, metav1.DeleteOptions{}); err != nil {
+	if err := cl.CoreV1().Secrets(auth.SecretNamespace).Delete(ctx, auth.SecretName, metav1.DeleteOptions{}); err != nil {
 		t.Fatal(err)
 	}
 
-	// allow the controller 5s to provision the Secret again - this is far longer
-	// than it should ever take.
-	if err := wait.Poll(time.Millisecond*500, time.Second*5, authoritySecretReadyConditionFunc(t, cl, auth.SecretNamespace, auth.SecretName)); err != nil {
+	// allow the controller to provision the Secret again
+	if err := wait.PollImmediateUntil(time.Millisecond*500, authoritySecretReadyConditionFunc(t, ctx, cl, auth.SecretNamespace, auth.SecretName), ctx.Done()); err != nil {
 		t.Errorf("Failed waiting for Secret to be recreated: %v", err)
 		return
 	}
@@ -146,9 +149,9 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 // authoritySecretReadyConditionFunc will check a named Secret resource and
 // check if it contains a valid CA keypair used by the authority.
 // This can be used with the `k8s.io/apimachinery/pkg/util/wait` package.
-func authoritySecretReadyConditionFunc(t *testing.T, cl kubernetes.Interface, namespace, name string) wait.ConditionFunc {
+func authoritySecretReadyConditionFunc(t *testing.T, ctx context.Context, cl kubernetes.Interface, namespace, name string) wait.ConditionFunc {
 	return func() (done bool, err error) {
-		s, err := cl.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+		s, err := cl.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
 			t.Logf("Secret resource %s/%s does not yet exist, waiting...", namespace, name)
 			return false, nil

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -39,7 +39,10 @@ import (
 // Ensure that when the source is running against an apiserver, it bootstraps
 // a CA and signs a valid certificate.
 func TestDynamicSource_Bootstrap(t *testing.T) {
-	config, stop := framework.RunControlPlane(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	config, stop := framework.RunControlPlane(t, ctx)
 	defer stop()
 
 	kubeClient, _, _, _ := framework.NewClients(t, config)
@@ -47,7 +50,7 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 	namespace := "testns"
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +82,7 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 
 	// allow the controller 5s to provision the Secret - this is far longer
 	// than it should ever take.
-	if err := wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
+	if err := wait.PollImmediateUntil(time.Millisecond*500, func() (done bool, err error) {
 		cert, err := source.GetCertificate(nil)
 		if err == tls.ErrNotAvailable {
 			t.Logf("GetCertificate has no certificate available, waiting...")
@@ -93,7 +96,7 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 		}
 		t.Logf("Got non-nil certificate from dynamic source")
 		return true, nil
-	}); err != nil {
+	}, ctx.Done()); err != nil {
 		t.Errorf("Failed waiting for source to return a certificate: %v", err)
 		return
 	}
@@ -102,7 +105,10 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 // Ensure that when the source is running against an apiserver, it bootstraps
 // a CA and signs a valid certificate.
 func TestDynamicSource_CARotation(t *testing.T) {
-	config, stop := framework.RunControlPlane(t)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*40)
+	defer cancel()
+
+	config, stop := framework.RunControlPlane(t, ctx)
 	defer stop()
 
 	kubeClient, _, _, _ := framework.NewClients(t, config)
@@ -110,7 +116,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 	namespace := "testns"
 
 	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}
-	_, err := kubeClient.CoreV1().Namespaces().Create(context.TODO(), ns, metav1.CreateOptions{})
+	_, err := kubeClient.CoreV1().Namespaces().Create(ctx, ns, metav1.CreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -143,7 +149,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 	var serialNumber *big.Int
 	// allow the controller 5s to provision the Secret - this is far longer
 	// than it should ever take.
-	if err := wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
+	if err := wait.PollImmediateUntil(time.Millisecond*500, func() (done bool, err error) {
 		cert, err := source.GetCertificate(nil)
 		if err == tls.ErrNotAvailable {
 			t.Logf("GetCertificate has no certificate available, waiting...")
@@ -164,19 +170,19 @@ func TestDynamicSource_CARotation(t *testing.T) {
 
 		serialNumber = x509cert.SerialNumber
 		return true, nil
-	}); err != nil {
+	}, ctx.Done()); err != nil {
 		t.Errorf("Failed waiting for source to return a certificate: %v", err)
 		return
 	}
 
 	cl := kubernetes.NewForConfigOrDie(config)
-	if err := cl.CoreV1().Secrets(source.Authority.SecretNamespace).Delete(context.TODO(), source.Authority.SecretName, metav1.DeleteOptions{}); err != nil {
+	if err := cl.CoreV1().Secrets(source.Authority.SecretNamespace).Delete(ctx, source.Authority.SecretName, metav1.DeleteOptions{}); err != nil {
 		t.Fatalf("Failed to delete CA secret: %v", err)
 	}
 
 	// wait for the serving certificate to have a new serial number (which
 	// indicates it has been regenerated)
-	if err := wait.Poll(time.Millisecond*500, time.Second*5, func() (done bool, err error) {
+	if err := wait.PollImmediateUntil(time.Millisecond*500, func() (done bool, err error) {
 		cert, err := source.GetCertificate(nil)
 		if err == tls.ErrNotAvailable {
 			t.Logf("GetCertificate has no certificate available, waiting...")
@@ -201,7 +207,7 @@ func TestDynamicSource_CARotation(t *testing.T) {
 		}
 
 		return true, nil
-	}); err != nil {
+	}, ctx.Done()); err != nil {
 		t.Errorf("Failed waiting for source to return a certificate: %v", err)
 		return
 	}

--- a/test/internal/apiserver/BUILD.bazel
+++ b/test/internal/apiserver/BUILD.bazel
@@ -6,6 +6,11 @@ go_library(
         "apiserver.go",
         "envs.go",
     ],
+    data = [
+        "//hack/bin:com_coreos_etcd",
+        "//hack/bin:io_kubernetes_kube-apiserver",
+        "//hack/bin:kubectl",
+    ],
     importpath = "github.com/jetstack/cert-manager/test/internal/apiserver",
     visibility = ["//test:__subpackages__"],
     deps = [


### PR DESCRIPTION
**What this PR does / why we need it**:
The integration tests are still flaky and are hard to debug. This PR makes the tests use the correct context everywhere. The logic for adding cert-manager CRDs on startup has been updated also: now, no restart of the api-server is required.

BONUS: changed bazel to have build dependencies linked to the right files.
BONUS 2: the test-duration improved significantly by doing this cleanup:
before:
```
//test/integration/acme:go_default_test                                  PASSED in 31.5s
//test/integration/certificates:go_default_test                          PASSED in 149.5s
//test/integration/conversion:go_default_test                            PASSED in 126.1s
//test/integration/ctl:go_default_test                                   PASSED in 156.0s
//test/integration/validation:go_default_test                            PASSED in 153.3s
//test/integration/webhook:go_default_test                               PASSED in 100.0s
```

after:
```
//test/integration/acme:go_default_test                                  PASSED in 19.9s
//test/integration/certificates:go_default_test                          PASSED in 88.0s
//test/integration/conversion:go_default_test                            PASSED in 70.3s
//test/integration/ctl:go_default_test                                   PASSED in 104.5s
//test/integration/validation:go_default_test                            PASSED in 87.5s
//test/integration/webhook:go_default_test                               PASSED in 56.7s
```

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
```
/kind cleanup