### PR TITLE
Ginkgo skip/focus can be optionally passed in from CI

### DIFF
--- a/devel/run-e2e.sh
+++ b/devel/run-e2e.sh
@@ -26,6 +26,28 @@ SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 export REPO_ROOT="${SCRIPT_ROOT}/.."
 source "${SCRIPT_ROOT}/lib/lib.sh"
 
+GINKGO_SKIP=${GINKGO_SKIP:-}
+GINKGO_FOCUS=${GINKGO_FOCUS:-}
+
+# Skip Gateway tests for Kubernetes below v1.19
+if [[ "$K8S_VERSION" =~ 1\.16 ]] || [[ "$K8S_VERSION" =~ 1\.17 ]] || [[ "$K8S_VERSION" =~ 1\.18 ]]; then
+	echo "Kubernetes version ${K8S_VERSION}, skipping Gateway tests..."
+	if [[ -z "$GINKGO_SKIP" ]]; then
+		GINKGO_SKIP="Gateway"
+	else
+	# duplicates are ok
+	GINKGO_SKIP="${GINKGO_SKIP}|Gateway"
+	fi
+fi
+
+# GINKGO_FOCUS can be set to a regex matching ginkgo specs to run.
+# Example- 'export GINKGO_FOCUS='Gateway' (runs only test cases with 'Gateway' in name).
+if [[ -n "$GINKGO_FOCUS" ]]; then GINKGO_FOCUS="--ginkgo.focus=${GINKGO_FOCUS}"; fi
+
+# GINKGO_SKIP can be set to a regex matching ginkgo specs to skip. Example-
+# 'export GINKGO_SKIP="Venafi Cloud"' (skips all suites with 'Venafi Cloud' in the name).
+if  [[ -n "$GINKGO_SKIP" ]]; then GINKGO_SKIP="--ginkgo.skip=${GINKGO_SKIP}"; fi
+
 # Configure PATH to use bazel provided e2e tools
 setup_tools
 
@@ -38,19 +60,6 @@ mkdir -p "${REPO_ROOT}/_artifacts"
 # Build the e2e test binary
 bazel build //test/e2e:e2e.test
 
-# Gateway e2e tests are not supported on k8s <1.19
-# K8S_VERSION is exported in lib.sh
-
-echo "Using K8S_VERSION ${K8S_VERSION}"
-case "$K8S_VERSION" in
-  "1.16" | "1.17" | "1.18")
-    SKIP="Gateway"
-    echo "skipping Gateway e2e tests as K8S_VERSION is <1.19"
-    ;;
-  *)
-    SKIP=""
-esac
-
 # Run e2e tests
 ginkgo -nodes 10 -flakeAttempts ${FLAKE_ATTEMPTS:-1} \
 	$(bazel info bazel-genfiles)/test/e2e/e2e.test \
@@ -59,5 +68,6 @@ ginkgo -nodes 10 -flakeAttempts ${FLAKE_ATTEMPTS:-1} \
 	--report-dir="${ARTIFACTS:-$REPO_ROOT/_artifacts}" \
 	--acme-dns-server="$DNS_SERVER" \
 	--acme-ingress-ip="$INGRESS_IP" \
-	"--ginkgo.skip=${SKIP}" \
+	${GINKGO_SKIP:+"$GINKGO_SKIP"} \
+	${GINKGO_FOCUS:+"$GINKGO_FOCUS"} \
 	"$@"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -57,7 +57,7 @@ func TestE2E(t *testing.T) {
 	// Copied from https://github.com/kubernetes/kubernetes/blob/960e5e78255dd148d4dae49f62e729ea940f4f07/test/e2e/e2e.go#L103-L106
 	// See https://github.com/kubernetes/community/blob/master/contributors/devel/sig-testing/flaky-tests.md#quarantining-flakes
 	if len(ginkgoconfig.GinkgoConfig.FocusStrings) == 0 && len(ginkgoconfig.GinkgoConfig.SkipStrings) == 0 {
-		ginkgoconfig.GinkgoConfig.SkipStrings = []string{`\[Flaky\]|\[Feature:.+\]`}
+		ginkgoconfig.GinkgoConfig.SkipStrings = []string{`\[Flaky\]`}
 	}
 
 	if err := framework.DefaultConfig.Validate(); err != nil {

--- a/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
+++ b/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
@@ -32,7 +32,7 @@ import (
 	"github.com/jetstack/cert-manager/test/e2e/suite/conformance/certificates"
 )
 
-var _ = framework.ConformanceDescribe("[Feature:Issuers:Venafi:Cloud] Certificates", func() {
+var _ = framework.ConformanceDescribe("Certificates", func() {
 	// unsupportedFeatures is a list of features that are not supported by the
 	// Venafi Cloud issuer.
 	var unsupportedFeatures = featureset.NewFeatureSet(


### PR DESCRIPTION
This PR:

- allows for `GINKGO_SKIP`/`GINKGO_FOCUS` env vars to be passed from CI so particular tests can be skipped (see i.e AWS tests that are all marked as red since they cannot run the Gateway tests)
- Re-instates Venafi Cloud tests that should now be passing (they are already being run for `CertificateSigningRequest`s)

It does not change the existing way of skipping Gateway tests for k8s below `v1.19`.

Related PR- [testing#522](https://github.com/jetstack/testing/pull/552) where the `GINKGO_FOCUS`, `GINKGO_SKIP` env vars are used to ensure only specific test suites are run in aws tests.




```release-note
NONE
```


Signed-off-by: irbekrm <irbekrm@gmail.com>
