### PR TITLE
Use the official kind image for testing against Kubernetes v1.22

### DIFF
--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -48,9 +48,7 @@ elif [[ "$K8S_VERSION" =~ 1\.20 ]] ; then
 elif [[ "$K8S_VERSION" =~ 1\.21 ]] ; then
   KIND_IMAGE_SHA="sha256:fae9a58f17f18f06aeac9772ca8b5ac680ebbed985e266f711d936e91d113bad"
 elif [[ "$K8S_VERSION" =~ 1\.22 ]] ; then
-  KIND_IMAGE_SHA="sha256:2e335fce9c7b1d9be39042e46dc604264143c349f56cd7f566b03d0ccb7bd5e2"
-  # Override KIND_IMAGE_REPO set in devel/lib/lib.sh till there is a 1.22 image in kindest/node.
-  KIND_IMAGE_REPO="eu.gcr.io/jetstack-build-infra-images/kind"
+  KIND_IMAGE_SHA="sha256:f97edf7f7ed53c57762b24f90a34fad101386c5bd4d93baeb45449557148c717"
 else
   echo "Unrecognised Kubernetes version '${K8S_VERSION}'! Aborting..."
   exit 1


### PR DESCRIPTION






**What this PR does / why we need it**:

This PR makes the script that spins up kind cluster for tests use the official kind image for Kubernetes v1.22 instead of our own build as there now is one available.




**Special notes for your reviewer**:

Once this gets merged it might make sense to run v1.22 tests by default on presubmits instead of v1.21.

```release-note
NONE
```

/kind cleanup

Signed-off-by: irbekrm <irbekrm@gmail.com>
