### PR TITLE
Don't wait for hooks in kubectl cert-manager x install integration test (part 2)

### DIFF
--- a/cmd/ctl/pkg/install/install.go
+++ b/cmd/ctl/pkg/install/install.go
@@ -231,9 +231,16 @@ func (o *InstallOptions) runInstall(ctx context.Context) (*release.Release, erro
 	o.client.DryRun = false     // Apply DryRun cli flags
 	o.client.ClientOnly = false // Perform install against cluster
 
-	o.client.Wait = o.Wait          // Wait for resources to be ready
-	o.client.Atomic = o.Wait        // If part of the install fails (& we are waiting), all resource installs are reverted;
-	o.client.DisableHooks = !o.Wait // Disable hooks if wait is disabled
+	o.client.Wait = o.Wait // Wait for resources to be ready
+	// If part of the install fails and the Atomic option is set to True,
+	// all resource installs are reverted. Atomic cannot be enabled without
+	// waiting (if Atomic=True is set, the value for Wait is overwritten with True),
+	// so only enable Atomic if we are waiting.
+	o.client.Atomic = o.Wait
+	// The cert-manager chart currently has only a startupapicheck hook,
+	// if waiting is disabled, this hook should be disabled too; otherwise
+	// the hook will still wait for the installation to succeed.
+	o.client.DisableHooks = !o.Wait
 
 	chartValues[installCRDsFlagName] = false // Do not render CRDs, as this might cause problems when uninstalling using helm
 

--- a/test/internal/util/paths.go
+++ b/test/internal/util/paths.go
@@ -21,6 +21,9 @@ import (
 	"path/filepath"
 )
 
+// GetTestPath returns the path for bazel golang test dependencies
+// These dependencies are set in the go_test data attribute in the BUILD.bazel file
+// see: https://github.com/bazelbuild/rules_go/blob/master/go/core.rst#go_test -> data attribute
 func GetTestPath(path ...string) string {
 	return filepath.Join(append([]string{os.Getenv("RUNFILES_DIR"), "com_github_jetstack_cert_manager"}, path...)...)
 }


### PR DESCRIPTION
Integration tests are failing with a timeout error due to newly released Helm chart.
The integration test is performed against a fake kubernetes api-server, and the test only checks if the resources are created correctly.
The resources are not used to really deploy cert-manager in the tests, that is why we have to disable the post-install checks.
The newly-added post-install Helm hook in the v1.5 release was not yet disabled in the test; this causes a timeout error.

This PR disables the post-install Helm hook for the integration test.
Also included: use local chart instead of published chart in the integration test -> this should prevent this problem in the future

part 1: #4342

```release-note
NONE
```

/kind bug