### PR TITLE
Fix mistakenly changed CRDs for v1beta1

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -2033,7 +2033,7 @@ spec:
                       description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
                       type: object
                       properties:
-                        acmedns:
+                        acmeDNS:
                           description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
                           type: object
                           required:
@@ -2101,7 +2101,7 @@ spec:
                                   type: string
                             serviceConsumerDomain:
                               type: string
-                        azuredns:
+                        azureDNS:
                           description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
                           type: object
                           required:
@@ -2139,7 +2139,7 @@ spec:
                             tenantID:
                               description: when specifying ClientID and ClientSecret then this field is also needed
                               type: string
-                        clouddns:
+                        cloudDNS:
                           description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                           type: object
                           required:

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -2492,7 +2492,7 @@ spec:
                             description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
                             type: object
                             properties:
-                              acmedns:
+                              acmeDNS:
                                 description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
                                 type: object
                                 required:
@@ -2560,7 +2560,7 @@ spec:
                                         type: string
                                   serviceConsumerDomain:
                                     type: string
-                              azuredns:
+                              azureDNS:
                                 description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
                                 type: object
                                 required:
@@ -2598,7 +2598,7 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
-                              clouddns:
+                              cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
                                 required:

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -2492,7 +2492,7 @@ spec:
                             description: Configures cert-manager to attempt to complete authorizations by performing the DNS01 challenge flow.
                             type: object
                             properties:
-                              acmedns:
+                              acmeDNS:
                                 description: Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage DNS01 challenge records.
                                 type: object
                                 required:
@@ -2560,7 +2560,7 @@ spec:
                                         type: string
                                   serviceConsumerDomain:
                                     type: string
-                              azuredns:
+                              azureDNS:
                                 description: Use the Microsoft Azure DNS API to manage DNS01 challenge records.
                                 type: object
                                 required:
@@ -2598,7 +2598,7 @@ spec:
                                   tenantID:
                                     description: when specifying ClientID and ClientSecret then this field is also needed
                                     type: string
-                              clouddns:
+                              cloudDNS:
                                 description: Use the Google Cloud DNS API to manage DNS01 challenge records.
                                 type: object
                                 required:

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -340,7 +340,7 @@ type ACMEChallengeSolverDNS01 struct {
 
 	// Use the Google Cloud DNS API to manage DNS01 challenge records.
 	// +optional
-	CloudDNS *ACMEIssuerDNS01ProviderCloudDNS `json:"clouddns,omitempty"`
+	CloudDNS *ACMEIssuerDNS01ProviderCloudDNS `json:"cloudDNS,omitempty"`
 
 	// Use the Cloudflare API to manage DNS01 challenge records.
 	// +optional
@@ -352,7 +352,7 @@ type ACMEChallengeSolverDNS01 struct {
 
 	// Use the Microsoft Azure DNS API to manage DNS01 challenge records.
 	// +optional
-	AzureDNS *ACMEIssuerDNS01ProviderAzureDNS `json:"azuredns,omitempty"`
+	AzureDNS *ACMEIssuerDNS01ProviderAzureDNS `json:"azureDNS,omitempty"`
 
 	// Use the DigitalOcean DNS API to manage DNS01 challenge records.
 	// +optional
@@ -361,7 +361,7 @@ type ACMEChallengeSolverDNS01 struct {
 	// Use the 'ACME DNS' (https://github.com/joohoi/acme-dns) API to manage
 	// DNS01 challenge records.
 	// +optional
-	AcmeDNS *ACMEIssuerDNS01ProviderAcmeDNS `json:"acmedns,omitempty"`
+	AcmeDNS *ACMEIssuerDNS01ProviderAcmeDNS `json:"acmeDNS,omitempty"`
 
 	// Use RFC2136 ("Dynamic Updates in the Domain Name System") (https://datatracker.ietf.org/doc/rfc2136/)
 	// to manage DNS01 challenge records.


### PR DESCRIPTION
As reported in #4352 

/kind bug

```release-note
Fix CRDs which were accidentally changed in cert-manager v1.5.0
```
