### PR TITLE
issue 4189: keystore upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.14.0
 	github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible
+	github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/sergi/go-diff v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -839,6 +839,7 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible h1:Jd6xfriVlJ6hWPvYOE0Ni0QWcNTLRehfGPFxr3eSL80=
 github.com/pavel-v-chernykh/keystore-go v2.1.0+incompatible/go.mod h1:xlUlxe/2ItGlQyMTstqeDv9r3U4obH7xYd26TbDQutY=
+github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0 h1:xKxUVGoB9VJU+lgQLPN0KURjw+XCVVSpHfQEeyxk3zo=
 github.com/pavel-v-chernykh/keystore-go/v4 v4.1.0/go.mod h1:2ejgys4qY+iNVW1IittZhyRYA6MNv8TgM6VHqojbB9g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
+++ b/pkg/controller/certificates/internal/secretsmanager/keystore_test.go
@@ -23,13 +23,12 @@ import (
 	"fmt"
 	"testing"
 
-	jks "github.com/pavel-v-chernykh/keystore-go"
+	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
+	jks "github.com/pavel-v-chernykh/keystore-go/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"software.sslmate.com/src/go-pkcs12"
-
-	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
-	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 func mustGeneratePrivateKey(t *testing.T, encoding cmapi.PrivateKeyEncoding) []byte {
@@ -158,16 +157,19 @@ func TestEncodeJKSKeystore(t *testing.T) {
 					return
 				}
 				buf := bytes.NewBuffer(out)
-				ks, err := jks.Decode(buf, []byte("password"))
+				ks := jks.New()
+				err = ks.Load(buf, []byte("password"))
 				if err != nil {
 					t.Errorf("error decoding keystore: %v", err)
 					return
 				}
-				if ks["certificate"] == nil {
+
+				if !ks.IsPrivateKeyEntry("certificate") {
 					t.Errorf("no certificate data found in keystore")
 				}
-				if ks["ca"] != nil {
-					t.Errorf("unexpected ca data found in keystore")
+
+				if ks.IsTrustedCertificateEntry("ca") {
+					t.Errorf("unexpected ca data found in truststore")
 				}
 			},
 		},
@@ -180,16 +182,18 @@ func TestEncodeJKSKeystore(t *testing.T) {
 					t.Errorf("expected no error but got: %v", err)
 				}
 				buf := bytes.NewBuffer(out)
-				ks, err := jks.Decode(buf, []byte("password"))
+				ks := jks.New()
+				err = ks.Load(buf, []byte("password"))
 				if err != nil {
 					t.Errorf("error decoding keystore: %v", err)
 					return
 				}
-				if ks["certificate"] == nil {
+				if !ks.IsPrivateKeyEntry("certificate") {
 					t.Errorf("no certificate data found in keystore")
 				}
-				if ks["ca"] != nil {
-					t.Errorf("unexpected ca data found in keystore")
+
+				if ks.IsTrustedCertificateEntry("ca") {
+					t.Errorf("unexpected ca data found in truststore")
 				}
 			},
 		},
@@ -203,16 +207,17 @@ func TestEncodeJKSKeystore(t *testing.T) {
 					t.Errorf("expected no error but got: %v", err)
 				}
 				buf := bytes.NewBuffer(out)
-				ks, err := jks.Decode(buf, []byte("password"))
+				ks := jks.New()
+				err = ks.Load(buf, []byte("password"))
 				if err != nil {
 					t.Errorf("error decoding keystore: %v", err)
 					return
 				}
-				if ks["certificate"] == nil {
+				if !ks.IsPrivateKeyEntry("certificate") {
 					t.Errorf("no certificate data found in keystore")
 				}
-				if ks["ca"] == nil {
-					t.Errorf("no ca data found in keystore")
+				if !ks.IsTrustedCertificateEntry("ca") {
+					t.Errorf("no ca data found in truststore")
 				}
 			},
 		},


### PR DESCRIPTION
This PR is step 1 of a 2 step approach to allows the _usage of different passwords for the for the unlocking of a **Java keystore** and the **private key** contained within_:
1. upgrade [keystore-go](https://github.com/pavel-v-chernykh/keystore-go) to v4
2. add support for private key passwords to the cert-manager API

The PR fixes #4189

This PR should be followed by another one that implements no 2. above to be able to close #4189.