### PR TITLE
Make leader election defaults consistent

### DIFF
--- a/cmd/cainjector/app/BUILD.bazel
+++ b/cmd/cainjector/app/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/cainjector/app",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/util:go_default_library",
         "//pkg/api:go_default_library",
         "//pkg/controller/cainjector:go_default_library",
         "//pkg/logs:go_default_library",

--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -29,6 +29,7 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	cmdutil "github.com/jetstack/cert-manager/cmd/util"
 	"github.com/jetstack/cert-manager/pkg/api"
 	"github.com/jetstack/cert-manager/pkg/controller/cainjector"
 	logf "github.com/jetstack/cert-manager/pkg/logs"
@@ -55,23 +56,22 @@ func (o *InjectorControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"If set, this limits the scope of cainjector to a single namespace. "+
 		"If set, cainjector will not update resources with certificates outside of the "+
 		"configured namespace.")
-	fs.BoolVar(&o.LeaderElect, "leader-elect", true, ""+
+	fs.BoolVar(&o.LeaderElect, "leader-elect", cmdutil.DefaultLeaderElect, ""+
 		"If true, cainjector will perform leader election between instances to ensure no more "+
 		"than one instance of cainjector operates at a time")
-	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", "", ""+
-		"Namespace used to perform leader election (defaults to controller's namespace). "+
-		"Only used if leader election is enabled")
-	fs.DurationVar(&o.LeaseDuration, "leader-election-lease-duration", 15*time.Second, ""+
+	fs.StringVar(&o.LeaderElectionNamespace, "leader-election-namespace", cmdutil.DefaultLeaderElectionNamespace, ""+
+		"Namespace used to perform leader election. Only used if leader election is enabled")
+	fs.DurationVar(&o.LeaseDuration, "leader-election-lease-duration", cmdutil.DefaultLeaderElectionLeaseDuration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
 		"slot. This is effectively the maximum duration that a leader can be stopped "+
 		"before it is replaced by another candidate. This is only applicable if leader "+
 		"election is enabled.")
-	fs.DurationVar(&o.RenewDeadline, "leader-election-renew-deadline", 10*time.Second, ""+
+	fs.DurationVar(&o.RenewDeadline, "leader-election-renew-deadline", cmdutil.DefaultLeaderElectionRenewDeadline, ""+
 		"The interval between attempts by the acting master to renew a leadership slot "+
 		"before it stops leading. This must be less than or equal to the lease duration. "+
 		"This is only applicable if leader election is enabled.")
-	fs.DurationVar(&o.RetryPeriod, "leader-election-retry-period", 2*time.Second, ""+
+	fs.DurationVar(&o.RetryPeriod, "leader-election-retry-period", cmdutil.DefaultLeaderElectionRetryPeriod, ""+
 		"The duration the clients should wait between attempting acquisition and renewal "+
 		"of a leadership. This is only applicable if leader election is enabled.")
 }

--- a/cmd/controller/app/options/BUILD.bazel
+++ b/cmd/controller/app/options/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/cmd/controller/app/options",
     visibility = ["//visibility:public"],
     deps = [
+        "//cmd/util:go_default_library",
         "//pkg/apis/certmanager:go_default_library",
         "//pkg/controller/acmechallenges:go_default_library",
         "//pkg/controller/acmeorders:go_default_library",

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -25,6 +25,7 @@ import (
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/sets"
 
+	cmdutil "github.com/jetstack/cert-manager/cmd/util"
 	cm "github.com/jetstack/cert-manager/pkg/apis/certmanager"
 	challengescontroller "github.com/jetstack/cert-manager/pkg/controller/acmechallenges"
 	orderscontroller "github.com/jetstack/cert-manager/pkg/controller/acmeorders"
@@ -122,12 +123,6 @@ const (
 	defaultClusterResourceNamespace = "kube-system"
 	defaultNamespace                = ""
 
-	defaultLeaderElect                 = true
-	defaultLeaderElectionNamespace     = "kube-system"
-	defaultLeaderElectionLeaseDuration = 60 * time.Second
-	defaultLeaderElectionRenewDeadline = 40 * time.Second
-	defaultLeaderElectionRetryPeriod   = 15 * time.Second
-
 	defaultClusterIssuerAmbientCredentials = true
 	defaultIssuerAmbientCredentials        = false
 
@@ -223,11 +218,11 @@ func NewControllerOptions() *ControllerOptions {
 		KubernetesAPIQPS:                  defaultKubernetesAPIQPS,
 		KubernetesAPIBurst:                defaultKubernetesAPIBurst,
 		Namespace:                         defaultNamespace,
-		LeaderElect:                       defaultLeaderElect,
-		LeaderElectionNamespace:           defaultLeaderElectionNamespace,
-		LeaderElectionLeaseDuration:       defaultLeaderElectionLeaseDuration,
-		LeaderElectionRenewDeadline:       defaultLeaderElectionRenewDeadline,
-		LeaderElectionRetryPeriod:         defaultLeaderElectionRetryPeriod,
+		LeaderElect:                       cmdutil.DefaultLeaderElect,
+		LeaderElectionNamespace:           cmdutil.DefaultLeaderElectionNamespace,
+		LeaderElectionLeaseDuration:       cmdutil.DefaultLeaderElectionLeaseDuration,
+		LeaderElectionRenewDeadline:       cmdutil.DefaultLeaderElectionRenewDeadline,
+		LeaderElectionRetryPeriod:         cmdutil.DefaultLeaderElectionRetryPeriod,
 		controllers:                       defaultEnabledControllers,
 		ClusterIssuerAmbientCredentials:   defaultClusterIssuerAmbientCredentials,
 		IssuerAmbientCredentials:          defaultIssuerAmbientCredentials,
@@ -258,22 +253,22 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 	fs.StringVar(&s.Namespace, "namespace", defaultNamespace, ""+
 		"If set, this limits the scope of cert-manager to a single namespace and ClusterIssuers are disabled. "+
 		"If not specified, all namespaces will be watched")
-	fs.BoolVar(&s.LeaderElect, "leader-elect", true, ""+
+	fs.BoolVar(&s.LeaderElect, "leader-elect", cmdutil.DefaultLeaderElect, ""+
 		"If true, cert-manager will perform leader election between instances to ensure no more "+
 		"than one instance of cert-manager operates at a time")
-	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", defaultLeaderElectionNamespace, ""+
+	fs.StringVar(&s.LeaderElectionNamespace, "leader-election-namespace", cmdutil.DefaultLeaderElectionNamespace, ""+
 		"Namespace used to perform leader election. Only used if leader election is enabled")
-	fs.DurationVar(&s.LeaderElectionLeaseDuration, "leader-election-lease-duration", defaultLeaderElectionLeaseDuration, ""+
+	fs.DurationVar(&s.LeaderElectionLeaseDuration, "leader-election-lease-duration", cmdutil.DefaultLeaderElectionLeaseDuration, ""+
 		"The duration that non-leader candidates will wait after observing a leadership "+
 		"renewal until attempting to acquire leadership of a led but unrenewed leader "+
 		"slot. This is effectively the maximum duration that a leader can be stopped "+
 		"before it is replaced by another candidate. This is only applicable if leader "+
 		"election is enabled.")
-	fs.DurationVar(&s.LeaderElectionRenewDeadline, "leader-election-renew-deadline", defaultLeaderElectionRenewDeadline, ""+
+	fs.DurationVar(&s.LeaderElectionRenewDeadline, "leader-election-renew-deadline", cmdutil.DefaultLeaderElectionRenewDeadline, ""+
 		"The interval between attempts by the acting master to renew a leadership slot "+
 		"before it stops leading. This must be less than or equal to the lease duration. "+
 		"This is only applicable if leader election is enabled.")
-	fs.DurationVar(&s.LeaderElectionRetryPeriod, "leader-election-retry-period", defaultLeaderElectionRetryPeriod, ""+
+	fs.DurationVar(&s.LeaderElectionRetryPeriod, "leader-election-retry-period", cmdutil.DefaultLeaderElectionRetryPeriod, ""+
 		"The duration the clients should wait between attempting acquisition and renewal "+
 		"of a leadership. This is only applicable if leader election is enabled.")
 

--- a/cmd/util/BUILD.bazel
+++ b/cmd/util/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "context.go",
+        "defaults.go",
         "exit.go",
         "signal.go",
         "signal_posix.go",

--- a/cmd/util/defaults.go
+++ b/cmd/util/defaults.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"time"
+)
+
+const (
+	DefaultLeaderElect                 = true
+	DefaultLeaderElectionNamespace     = "kube-system"
+	DefaultLeaderElectionLeaseDuration = 60 * time.Second
+	DefaultLeaderElectionRenewDeadline = 40 * time.Second
+	DefaultLeaderElectionRetryPeriod   = 15 * time.Second
+)


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed in #2362, this makes the defaults for leader election parameters consistent across controllers

**Which issue this PR fixes**

I don’t think it actually fixes #2362, but it can help mitigate cainjector crashing due to apiserver being slow.

**Special notes for your reviewer**:

**Release note**:

```release-note
The defaults for leader election parameters are now consistent across cert-manager and cainjector.
```