### PR TITLE
rerun git tags command when //:version changes

### DIFF
--- a/pkg/util/versionchecker/testdata/BUILD.bazel
+++ b/pkg/util/versionchecker/testdata/BUILD.bazel
@@ -1,8 +1,9 @@
-# Clone empty version of cert-manager repo and list all tags
+# List all tags of cert-manager repo
 genrule(
     name = "git_tags",
     outs = [":git_tags.txt"],
     cmd = "git ls-remote -t --refs https://github.com/jetstack/cert-manager.git | awk '{print $$2;}' | sed 's/refs\\/tags\\///' | sed -n '/v1.0.0/,$$p' > $@",
+    stamp = 1,  # make sure we re-run if 'bazel-out/stable-status.txt' changes (more frequent would also be ok, but is difficult with bazel)
 )
 
 genrule(


### PR DESCRIPTION
**What this PR does / why we need it**:
The `git_tags` genrule generates other outputs depending on the released git tags for cert-manager.
Bazel however, thinks that this genrule can be cached (no `srcs` attribute & no changes to the rule).
This fix adds the `stamp = 1` option to the `git_tags` genrule, this option makes sure that the rule is re-run when `bazel-out/stable-status.txt` changes (more info: https://docs.bazel.build/versions/main/user-manual.html#workspace_status).

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #
fixes https://github.com/jetstack/cert-manager/issues/4350

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```
/kind bug