### PR TITLE
Add startup api check job PSP

### DIFF
--- a/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}-psp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+rules:
+- apiGroups: ['policy']
+  resources: ['podsecuritypolicies']
+  verbs:     ['use']
+  resourceNames:
+  - {{ template "startupapicheck.fullname" . }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups: ['policy']
   resources: ['podsecuritypolicies']

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -10,6 +10,10 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
+  {{- if .Values.startupapicheck.rbac.annotations }}
+  annotations:
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}-psp
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "startupapicheck.fullname" . }}-psp
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "startupapicheck.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
@@ -1,0 +1,49 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.podSecurityPolicy.enabled }}
+apiVersion: policy/v1beta1
+kind: PodSecurityPolicy
+metadata:
+  name: {{ template "startupapicheck.fullname" . }}
+  labels:
+    app: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/name: {{ include "startupapicheck.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: "startupapicheck"
+    {{- include "labels" . | nindent 4 }}
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName:  'docker/default'
+    {{- if .Values.global.podSecurityPolicy.useAppArmor }}
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
+    {{- end }}
+spec:
+  privileged: false
+  allowPrivilegeEscalation: false
+  allowedCapabilities: []  # default set of capabilities are implicitly allowed
+  volumes:
+  - 'projected'
+  - 'secret'
+  - 'downwardAPI'
+  hostNetwork: false
+  hostIPC: false
+  hostPID: false
+  runAsUser:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+  seLinux:
+    rule: 'RunAsAny'
+  supplementalGroups:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+  fsGroup:
+    rule: 'MustRunAs'
+    ranges:
+    - min: 1000
+      max: 1000
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
@@ -26,6 +26,7 @@ spec:
   allowedCapabilities: []  # default set of capabilities are implicitly allowed
   volumes:
   - 'projected'
+  - 'secret'
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
@@ -17,14 +17,15 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     {{- end }}
+    {{- if .Values.startupapicheck.rbac.annotations }}
+    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+    {{- end }}
 spec:
   privileged: false
   allowPrivilegeEscalation: false
   allowedCapabilities: []  # default set of capabilities are implicitly allowed
   volumes:
   - 'projected'
-  - 'secret'
-  - 'downwardAPI'
   hostNetwork: false
   hostIPC: false
   hostPID: false

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -463,6 +463,7 @@ startupapicheck:
     pullPolicy: IfNotPresent
 
   rbac:
+    # annotations for the startup API Check job RBAC and PSP resources
     annotations:
       helm.sh/hook: post-install
       helm.sh/hook-weight: "-5"

--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -25,13 +25,16 @@ chart_dir="deploy/charts/cert-manager"
 echo "Linting chart: ${chart_dir}"
 
 bazel build //deploy/charts/cert-manager
-tmpdir="$(mktemp -d -p "${REPO_ROOT}")"
+case $(uname) in
+    Darwin) tmpdir="$(mktemp -d)";;
+    *)      tmpdir="$(mktemp -d -p "${REPO_ROOT}")";;
+esac
 trap "rm -rf ${tmpdir}" EXIT
 
 tar -C "${tmpdir}" -xvf bazel-bin/deploy/charts/cert-manager/cert-manager.tgz
 
-if ! docker run -v ${tmpdir}:/workspace --workdir /workspace \
-    quay.io/helmpack/chart-testing:v3.0.0-beta.2 \
+if ! docker run -v "${tmpdir}":/workspace --workdir /workspace \
+    quay.io/helmpack/chart-testing:v3.4.0 \
     ct lint \
         --check-version-increment=false \
         --validate-maintainers=false \

--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -18,17 +18,12 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly REPO_ROOT=$(git rev-parse --show-toplevel)
-
 chart_dir="deploy/charts/cert-manager"
 
 echo "Linting chart: ${chart_dir}"
 
 bazel build //deploy/charts/cert-manager
-case $(uname) in
-    Darwin) tmpdir="$(mktemp -d)";;
-    *)      tmpdir="$(mktemp -d -p "${REPO_ROOT}")";;
-esac
+tmpdir="$(mktemp -d)"
 trap "rm -rf ${tmpdir}" EXIT
 
 tar -C "${tmpdir}" -xvf bazel-bin/deploy/charts/cert-manager/cert-manager.tgz


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the PSP and related RBAC resources for the Startup API Check job, new job in 1.5.0 but missing these resources.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4361 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Pod Security Policy for startup api check job
```
