### PR TITLE
update trigger for gh action, add arm64 darwin for krew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,15 @@
 name: release
 on:
-  release:
-    types: ["released"]
+  push:
+    tags:
+      # this will trigger on "v2.0.0" but not on "v2.0.0-beta.0" or "v2.0.0-alpha.1"
+      - "v[0-9]+.[0-9]+.[0-9]+"
 jobs:
   krewrelease:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@master
-      - name: Update new version in krew-index
-        uses: rajatjindal/krew-release-bot@v0.0.40
+      - name: Update with new version in krew-index
+        # v0.0.40, referenced by hash
+        uses: rajatjindal/krew-release-bot@56925b62bacc2c652114d66a8256faaf0bf89fa9

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -20,6 +20,12 @@ spec:
     bin: kubectl-cert_manager
   - selector:
       matchLabels:
+        os: darwin
+        arch: arm64
+    {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-darwin-arm64.tar.gz" .TagName }}
+    bin: kubectl-cert_manager
+  - selector:
+      matchLabels:
         os: linux
         arch: amd64
     {{addURIAndSha "https://github.com/jetstack/cert-manager/releases/download/{{ .TagName }}/kubectl-cert_manager-linux-amd64.tar.gz" .TagName }}


### PR DESCRIPTION
Tested in a separate repo, this tag filter pattern won't trigger for our prereleases.

Also adds the arm64 darwin image to our `.krew.yaml`, and references the krew-release-bot by hash.

It's preferable to have the workflow be triggered on a release rather than a tag but unless I'm missing something that doesn't seem to be an easy thing to configure. 

/kind cleanup

```release-note
NONE
```
