### PR TITLE
Fix regression in ACME HTTP-01 Ingress Solver introduced in v1.5.0

### DIFF
--- a/pkg/issuer/acme/http/ingress.go
+++ b/pkg/issuer/acme/http/ingress.go
@@ -358,7 +358,7 @@ func (s *Solver) cleanupIngresses(ctx context.Context, ch *cmacme.Challenge) err
 func ingressPath(token, serviceName string) networkingv1.HTTPIngressPath {
 	return networkingv1.HTTPIngressPath{
 		Path:     solverPathFn(token),
-		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeExact; return &s }(),
+		PathType: func() *networkingv1.PathType { s := networkingv1.PathTypeImplementationSpecific; return &s }(),
 		Backend: networkingv1.IngressBackend{
 			Service: &networkingv1.IngressServiceBackend{
 				Name: serviceName,


### PR DESCRIPTION
**What this PR does / why we need it**:

While upgrading from v1beta1 Ingress to v1 Ingress, the PathType was hardcoded to exact, which broke compatibility with Ingress-GCE.

This changes the PathType to ImplementationSpecific, which is the same behaviour as omitting it in a v1beta1 Ingress.

**Which issue this PR fixes**: fixes #4371 

**Special notes for your reviewer**:

For what it's worth, this means ingress-gce is not a valid Ingress controller, as controllers must support all 3 valid path types. 

**Release note**:

```release-note
Fix regression in Ingress PathType introduced in v1.5.0
```
