### PR TITLE
Bump to build with go1.17

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -31,7 +31,7 @@ go_rules_dependencies()
 
 go_register_toolchains(
     nogo = "@//hack/build:nogo_vet",
-    version = "1.16.6",
+    version = "1.17",
 )
 
 ## Load gazelle and dependencies

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jetstack/cert-manager
 
-go 1.16
+go 1.17
 
 // This fork allows us to add alternative certificate chains for ACME see
 // https://github.com/cert-manager/crypto#cert-manager-fork-of-golangxcrypto .


### PR DESCRIPTION
/kind cleanup

```release-note
Build cert-manager with go 1.17
```
