### PR TITLE
Fix manually specified Certificate and CertificateRequest versions

### DIFF
--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -118,7 +118,7 @@ func TestSign(t *testing.T) {
 	}
 
 	rootTmpl := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -79,7 +79,7 @@ func generateCSR(t *testing.T, secretKey crypto.Signer, sigAlg x509.SignatureAlg
 
 func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
 	tmpl := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/controller/certificaterequests/venafi/venafi_test.go
+++ b/pkg/controller/certificaterequests/venafi/venafi_test.go
@@ -90,7 +90,7 @@ func TestSign(t *testing.T) {
 	}
 
 	rootTmpl := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -78,7 +78,7 @@ func generateCSR(t *testing.T, secretKey crypto.Signer, sigAlg x509.SignatureAlg
 
 func generateSelfSignedCACert(t *testing.T, key crypto.Signer, name string) (*x509.Certificate, []byte) {
 	tmpl := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          big.NewInt(0),
 		Subject: pkix.Name{

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -211,7 +211,10 @@ func GenerateCSR(crt *v1.Certificate) (*x509.CertificateRequest, error) {
 	}
 
 	return &x509.CertificateRequest{
-		Version:            3,
+		// Version 0 is the only one defined in the PKCS#10 standard, RFC2986.
+		// This value isn't used by Go at the time of writing.
+		// https://datatracker.ietf.org/doc/html/rfc2986#section-4
+		Version:            0,
 		SignatureAlgorithm: sigAlgo,
 		PublicKeyAlgorithm: pubKeyAlgo,
 		Subject: pkix.Name{
@@ -301,7 +304,11 @@ func GenerateTemplate(crt *v1.Certificate) (*x509.Certificate, error) {
 	}
 
 	return &x509.Certificate{
-		Version:               3,
+		// Version must be 2 according to RFC5280.
+		// A version value of 2 confusingly means version 3.
+		// This value isn't used by Go at the time of writing.
+		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    pubKeyAlgo,
@@ -369,7 +376,11 @@ func GenerateTemplateFromCSRPEMWithUsages(csrPEM []byte, duration time.Duration,
 	}
 
 	return &x509.Certificate{
-		Version:               csr.Version,
+		// Version must be 2 according to RFC5280.
+		// A version value of 2 confusingly means version 3.
+		// This value isn't used by Go at the time of writing.
+		// https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    csr.PublicKeyAlgorithm,

--- a/pkg/util/pki/csr_test.go
+++ b/pkg/util/pki/csr_test.go
@@ -422,7 +422,8 @@ func TestGenerateCSR(t *testing.T) {
 		{
 			name: "Generate CSR from certificate with only DNS",
 			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{DNSNames: []string{"example.org"}}},
-			want: &x509.CertificateRequest{Version: 3,
+			want: &x509.CertificateRequest{
+				Version:            0,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
 				DNSNames:           []string{"example.org"},
@@ -432,7 +433,8 @@ func TestGenerateCSR(t *testing.T) {
 		{
 			name: "Generate CSR from certificate with only CN",
 			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org"}},
-			want: &x509.CertificateRequest{Version: 3,
+			want: &x509.CertificateRequest{
+				Version:            0,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
 				Subject:            pkix.Name{CommonName: "example.org"},
@@ -442,7 +444,8 @@ func TestGenerateCSR(t *testing.T) {
 		{
 			name: "Generate CSR from certificate with extended key usages",
 			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", Usages: []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageIPsecEndSystem}}},
-			want: &x509.CertificateRequest{Version: 3,
+			want: &x509.CertificateRequest{
+				Version:            0,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
 				Subject:            pkix.Name{CommonName: "example.org"},
@@ -452,7 +455,8 @@ func TestGenerateCSR(t *testing.T) {
 		{
 			name: "Generate CSR from certificate with double signing key usages",
 			crt:  &cmapi.Certificate{Spec: cmapi.CertificateSpec{CommonName: "example.org", Usages: []cmapi.KeyUsage{cmapi.UsageDigitalSignature, cmapi.UsageKeyEncipherment, cmapi.UsageSigning}}},
-			want: &x509.CertificateRequest{Version: 3,
+			want: &x509.CertificateRequest{
+				Version:            0,
 				SignatureAlgorithm: x509.SHA256WithRSA,
 				PublicKeyAlgorithm: x509.RSA,
 				Subject:            pkix.Name{CommonName: "example.org"},
@@ -575,7 +579,7 @@ func TestSignCSRTemplate(t *testing.T) {
 		pk, err := GenerateECPrivateKey(256)
 		require.NoError(t, err)
 		tmpl := &x509.Certificate{
-			Version:               3,
+			Version:               2,
 			BasicConstraintsValid: true,
 			SerialNumber:          big.NewInt(0),
 			Subject: pkix.Name{

--- a/pkg/util/pki/generate_test.go
+++ b/pkg/util/pki/generate_test.go
@@ -255,7 +255,7 @@ func signTestCert(key crypto.Signer) *x509.Certificate {
 	}
 
 	template := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		SignatureAlgorithm:    x509.SHA256WithRSA,
@@ -318,7 +318,6 @@ func TestPublicKeyMatchesCertificateRequest(t *testing.T) {
 	}
 
 	template := &x509.CertificateRequest{
-		Version: 3,
 		// SignatureAlgorithm: sigAlgo,
 		Subject: pkix.Name{
 			CommonName: "cn",

--- a/pkg/util/pki/kube_test.go
+++ b/pkg/util/pki/kube_test.go
@@ -79,7 +79,7 @@ func TestGenerateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               0,
+				Version:               2,
 				BasicConstraintsValid: true,
 				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,
@@ -112,7 +112,7 @@ func TestGenerateTemplateFromCertificateSigningRequest(t *testing.T) {
 				gen.SetCertificateSigningRequestRequest(csr),
 			),
 			expCertificate: &x509.Certificate{
-				Version:               0,
+				Version:               2,
 				BasicConstraintsValid: true,
 				SerialNumber:          nil,
 				PublicKeyAlgorithm:    x509.RSA,

--- a/pkg/webhook/authority/authority.go
+++ b/pkg/webhook/authority/authority.go
@@ -339,7 +339,7 @@ func (d *DynamicAuthority) regenerateCA(ctx context.Context, s *corev1.Secret) e
 		return err
 	}
 	cert := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.ECDSA,

--- a/pkg/webhook/server/tls/dynamic_source.go
+++ b/pkg/webhook/server/tls/dynamic_source.go
@@ -224,6 +224,7 @@ func (f *DynamicSource) regenerateCertificate(nextRenew chan<- time.Time) error 
 
 	// create the certificate template to be signed
 	template := &x509.Certificate{
+		Version:            2,
 		PublicKeyAlgorithm: x509.ECDSA,
 		PublicKey:          pk.Public(),
 		DNSNames:           f.DNSNames,

--- a/pkg/webhook/server/tls/file_source_test.go
+++ b/pkg/webhook/server/tls/file_source_test.go
@@ -174,7 +174,7 @@ func generatePrivateKeyAndCertificate(t *testing.T, serial string) ([]byte, []by
 		t.Fatal(err)
 	}
 	cert := &x509.Certificate{
-		Version:               3,
+		Version:               2,
 		BasicConstraintsValid: true,
 		SerialNumber:          serialNumber,
 		PublicKeyAlgorithm:    x509.RSA,


### PR DESCRIPTION
Basically all modern X.509 certs are version 3, but confusingly to specify "version 3" in an encoded cert, the version number is actually 2.

For PKCS#10 CSRs, the only valid version is 1, which again confusingly has the value "0" when encoded.

This was incorrect in many places, including one place in which the version number on a CSR was used as a certificate's version number, when the two are entirely unrelated.

Go ignores these values, so there's no functional changes here; still, it's better to be accurate.

Go ignoring CSR version and specifying 0: https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/crypto/x509/x509.go;l=1958

Go ignoring Certificate version and specifying 2: https://cs.opensource.google/go/go/+/refs/tags/go1.17:src/crypto/x509/x509.go;l=1534

PKCS#10 CSR specification in RFC 2986 section 4.1: https://datatracker.ietf.org/doc/html/rfc2986#section-4

> version is the version number, for compatibility with future revisions of this document.  It shall be 0 for this version of the standard.

X.509 Cert specification in RFC 5280 section 4.1.2.1: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.1

> When extensions are used, as expected in this profile, version MUST be 3 (value is 2).

/kind cleanup

```release-note
Fix manually specified PKCS#10 CSR and X.509 Certificate version numbers (although these were ignored in practice)
```
