### PR TITLE
Regression: restore the previous service type defaulting behaviour

### DIFF
--- a/deploy/crds/crd-challenges.yaml
+++ b/deploy/crds/crd-challenges.yaml
@@ -389,7 +389,7 @@ spec:
                               additionalProperties:
                                 type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                         ingress:
                           description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -937,7 +937,7 @@ spec:
                                             description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                             type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                     selector:
                       description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -1346,7 +1346,7 @@ spec:
                               additionalProperties:
                                 type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP.
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                         ingress:
                           description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -1894,7 +1894,7 @@ spec:
                                             description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                             type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                     selector:
                       description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -2304,7 +2304,7 @@ spec:
                               additionalProperties:
                                 type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                         ingress:
                           description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -2852,7 +2852,7 @@ spec:
                                             description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                             type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                     selector:
                       description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -3262,7 +3262,7 @@ spec:
                               additionalProperties:
                                 type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                         ingress:
                           description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -3810,7 +3810,7 @@ spec:
                                             description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                             type: string
                             serviceType:
-                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                              description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                               type: string
                     selector:
                       description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -423,7 +423,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -971,7 +971,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -1592,7 +1592,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP.
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -2140,7 +2140,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -2763,7 +2763,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -3311,7 +3311,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -3934,7 +3934,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -4482,7 +4482,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -423,7 +423,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -971,7 +971,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -1592,7 +1592,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP.
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -2140,7 +2140,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -2763,7 +2763,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -3311,7 +3311,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.
@@ -3934,7 +3934,7 @@ spec:
                                     additionalProperties:
                                       type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                               ingress:
                                 description: The ingress based HTTP01 challenge solver will solve challenges by creating or modifying Ingress resources in order to route requests for '/.well-known/acme-challenge/XYZ' to 'challenge solver' pods that are provisioned by cert-manager for each Challenge to be completed.
@@ -4482,7 +4482,7 @@ spec:
                                                   description: Value is the taint value the toleration matches to. If the operator is Exists, the value should be empty, otherwise just a regular string.
                                                   type: string
                                   serviceType:
-                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP (default).
+                                    description: Optional service type for Kubernetes solver service. Supported values are NodePort or ClusterIP. If unset, defaults to NodePort.
                                     type: string
                           selector:
                             description: Selector selects a set of DNSNames on the Certificate resource that should be solved using this challenge solver. If not specified, the solver will be treated as the 'default' solver with the lowest priority, i.e. if any other solver has a more specific match, it will be used instead.

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -217,7 +217,7 @@ type ACMEChallengeSolverHTTP01 struct {
 
 type ACMEChallengeSolverHTTP01Ingress struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
@@ -250,7 +250,7 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 // routing to an ACME challenge solver pod.
 type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 

--- a/pkg/apis/acme/v1alpha2/types_issuer.go
+++ b/pkg/apis/acme/v1alpha2/types_issuer.go
@@ -216,7 +216,7 @@ type ACMEChallengeSolverHTTP01 struct {
 
 type ACMEChallengeSolverHTTP01Ingress struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
@@ -247,7 +247,7 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 
 type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 

--- a/pkg/apis/acme/v1alpha3/types_issuer.go
+++ b/pkg/apis/acme/v1alpha3/types_issuer.go
@@ -216,7 +216,7 @@ type ACMEChallengeSolverHTTP01 struct {
 
 type ACMEChallengeSolverHTTP01Ingress struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
@@ -247,7 +247,7 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 
 type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP.
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 

--- a/pkg/apis/acme/v1beta1/types_issuer.go
+++ b/pkg/apis/acme/v1beta1/types_issuer.go
@@ -215,7 +215,7 @@ type ACMEChallengeSolverHTTP01 struct {
 
 type ACMEChallengeSolverHTTP01Ingress struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 
@@ -246,7 +246,7 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 
 type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// Optional service type for Kubernetes solver service. Supported values
-	// are NodePort or ClusterIP (default).
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 

--- a/pkg/internal/apis/acme/types_issuer.go
+++ b/pkg/internal/apis/acme/types_issuer.go
@@ -196,7 +196,9 @@ type ACMEChallengeSolverHTTP01 struct {
 }
 
 type ACMEChallengeSolverHTTP01Ingress struct {
-	// Optional service type for Kubernetes solver service
+	// Optional service type for Kubernetes solver service. Supported values
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
+	// +optional
 	ServiceType corev1.ServiceType
 
 	// The ingress class to use when creating Ingress resources to solve ACME
@@ -221,7 +223,8 @@ type ACMEChallengeSolverHTTP01Ingress struct {
 }
 
 type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
-	// Optional service type for Kubernetes solver service
+	// Optional service type for Kubernetes solver service. Supported values
+	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
 	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
 

--- a/pkg/issuer/acme/http/service.go
+++ b/pkg/issuer/acme/http/service.go
@@ -129,7 +129,9 @@ func buildService(ch *cmacme.Challenge) (*corev1.Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	service.Spec.Type = serviceType
+	if serviceType != "" {
+		service.Spec.Type = serviceType
+	}
 
 	return service, nil
 }

--- a/pkg/issuer/acme/http/service_test.go
+++ b/pkg/issuer/acme/http/service_test.go
@@ -162,6 +162,238 @@ func TestEnsureService(t *testing.T) {
 				}
 			},
 		},
+		"http-01 ingress challenge without a service type should default to NodePort": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "test.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				expectedService, err := buildService(s.Challenge)
+				if err != nil {
+					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
+				}
+				// create a reactor that fails the test if a service is created
+				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
+					// clear service name as we don't know it yet in the expectedService
+					service.Name = ""
+					if !reflect.DeepEqual(service, expectedService) {
+						t.Errorf("Expected %v to equal %v", service, expectedService)
+					}
+					return false, ret, nil
+				})
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				resp := args[0].(*v1.Service)
+				err := args[1]
+				if resp == nil && err == nil {
+					t.Errorf("unexpected service = nil")
+					t.Fail()
+					return
+				}
+				services, err := s.Solver.serviceLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("unexpected error listing services: %v", err)
+					t.Fail()
+					return
+				}
+				if len(services) != 1 {
+					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(services[0], resp) {
+					t.Errorf("Expected %v to equal %v", services[0], resp)
+				}
+				if services[0].Spec.Type != v1.ServiceTypeNodePort {
+					t.Errorf("Blank service type should default to NodePort, but was %q", services[0].Spec.Type)
+				}
+			},
+			Err: false,
+		},
+		"http-01 ingress challenge with a service type specified should end up on the generated solver service": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "test.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+								ServiceType: v1.ServiceTypeClusterIP,
+							},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				expectedService, err := buildService(s.Challenge)
+				if err != nil {
+					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
+				}
+				// create a reactor that fails the test if a service is created
+				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
+					// clear service name as we don't know it yet in the expectedService
+					service.Name = ""
+					if !reflect.DeepEqual(service, expectedService) {
+						t.Errorf("Expected %v to equal %v", service, expectedService)
+					}
+					return false, ret, nil
+				})
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				resp := args[0].(*v1.Service)
+				err := args[1]
+				if resp == nil && err == nil {
+					t.Errorf("unexpected service = nil")
+					t.Fail()
+					return
+				}
+				services, err := s.Solver.serviceLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("unexpected error listing services: %v", err)
+					t.Fail()
+					return
+				}
+				if len(services) != 1 {
+					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(services[0], resp) {
+					t.Errorf("Expected %v to equal %v", services[0], resp)
+				}
+				if services[0].Spec.Type != v1.ServiceTypeClusterIP {
+					t.Errorf("expected service type %q, but was %q", v1.ServiceTypeClusterIP, services[0].Spec.Type)
+				}
+			},
+			Err: false,
+		},
+		"http-01 gateway httpRoute challenge without a service type should default to NodePort": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "test.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				expectedService, err := buildService(s.Challenge)
+				if err != nil {
+					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
+				}
+				// create a reactor that fails the test if a service is created
+				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
+					// clear service name as we don't know it yet in the expectedService
+					service.Name = ""
+					if !reflect.DeepEqual(service, expectedService) {
+						t.Errorf("Expected %v to equal %v", service, expectedService)
+					}
+					return false, ret, nil
+				})
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				resp := args[0].(*v1.Service)
+				err := args[1]
+				if resp == nil && err == nil {
+					t.Errorf("unexpected service = nil")
+					t.Fail()
+					return
+				}
+				services, err := s.Solver.serviceLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("unexpected error listing services: %v", err)
+					t.Fail()
+					return
+				}
+				if len(services) != 1 {
+					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(services[0], resp) {
+					t.Errorf("Expected %v to equal %v", services[0], resp)
+				}
+				if services[0].Spec.Type != v1.ServiceTypeNodePort {
+					t.Errorf("Blank service type should default to NodePort, but was \"%s\"", services[0].Spec.Type)
+				}
+			},
+			Err: false,
+		},
+		"http-01 gateway httpRoute challenge with a service type specified should end up on the generated solver service": {
+			Challenge: &cmacme.Challenge{
+				Spec: cmacme.ChallengeSpec{
+					DNSName: "test.com",
+					Solver: cmacme.ACMEChallengeSolver{
+						HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+							GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
+								ServiceType: v1.ServiceTypeClusterIP,
+							},
+						},
+					},
+				},
+			},
+			PreFn: func(t *testing.T, s *solverFixture) {
+				expectedService, err := buildService(s.Challenge)
+				if err != nil {
+					t.Errorf("expectedService returned an error whilst building test fixture: %v", err)
+				}
+				// create a reactor that fails the test if a service is created
+				s.Builder.FakeKubeClient().PrependReactor("create", "services", func(action coretesting.Action) (handled bool, ret runtime.Object, err error) {
+					service := action.(coretesting.CreateAction).GetObject().(*v1.Service)
+					// clear service name as we don't know it yet in the expectedService
+					service.Name = ""
+					if !reflect.DeepEqual(service, expectedService) {
+						t.Errorf("Expected %v to equal %v", service, expectedService)
+					}
+					return false, ret, nil
+				})
+
+				s.Builder.Sync()
+			},
+			CheckFn: func(t *testing.T, s *solverFixture, args ...interface{}) {
+				resp := args[0].(*v1.Service)
+				err := args[1]
+				if resp == nil && err == nil {
+					t.Errorf("unexpected service = nil")
+					t.Fail()
+					return
+				}
+				services, err := s.Solver.serviceLister.List(labels.NewSelector())
+				if err != nil {
+					t.Errorf("unexpected error listing services: %v", err)
+					t.Fail()
+					return
+				}
+				if len(services) != 1 {
+					t.Errorf("unexpected %d services in lister: %+v", len(services), services)
+					t.Fail()
+					return
+				}
+				if !reflect.DeepEqual(services[0], resp) {
+					t.Errorf("Expected %v to equal %v", services[0], resp)
+				}
+				if services[0].Spec.Type != v1.ServiceTypeClusterIP {
+					t.Errorf("expected service type %q, but was %q", v1.ServiceTypeClusterIP, services[0].Spec.Type)
+				}
+			},
+			Err: false,
+		},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:
Prior to v1.5.0, not setting the service type on an Ingress solver meant that cert-manager created a NodePort service. This was accidentally changed to empty (ClusterIP) in 1.5.

This PR restores the previous behaviour and adds a test to ensure this doesn't happen again.

**Which issue this PR fixes**: fixes #4370 

**Release note**:
```release-note
Fixed the HTTP-01 solver creating ClusterIP instead of NodePort services by default.
```
