### PR TITLE
Run krew automation workflow on create rather than push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: release
 on:
-  push:
+  create:
     tags:
       # this will trigger on "v2.0.0" but not on "v2.0.0-beta.0" or "v2.0.0-alpha.1"
       - "v[0-9]+.[0-9]+.[0-9]+"


### PR DESCRIPTION
Haven't yet confirmed that this works as expected and the docs aren't to be trusted, so WIP for now

/kind cleanup

```release-note
NONE
```
