### PR TITLE
Fix renewalTime skew issue

### DIFF
--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -307,6 +307,16 @@ func RenewalTime(notBefore, notAfter time.Time, renewBeforeOverride *metav1.Dura
 
 	// 2. Calculate when a cert should be renewed
 
+	// Truncate the renewal time to nearest second. This is important
+	// because the renewal time also gets stored on Certificate's status
+	// where it is truncated to the nearest second. We use the renewal time
+	// from Certificate's status to determine when the Certificate will be
+	// added to the queue to be renewed, but then re-calculate whether it
+	// needs to be renewed _now_ using this function- so returning a
+	// non-truncated value here would potentially cause Certificates to be
+	// re-queued for renewal earlier than the calculated renewal time thus
+	// causing Certificates to not be automatically renewed. See
+	// https://github.com/jetstack/cert-manager/pull/4399.
 	rt := metav1.NewTime(notAfter.Add(-1 * renewBefore).Truncate(time.Second))
 	return &rt
 }

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -307,6 +307,6 @@ func RenewalTime(notBefore, notAfter time.Time, renewBeforeOverride *metav1.Dura
 
 	// 2. Calculate when a cert should be renewed
 
-	rt := metav1.NewTime(notAfter.Add(-1 * renewBefore))
+	rt := metav1.NewTime(notAfter.Add(-1 * renewBefore).Truncate(time.Second))
 	return &rt
 }

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -302,7 +302,7 @@ func TestRenewalTime(t *testing.T) {
 		renewBeforeOverride *metav1.Duration
 		expectedRenewalTime *metav1.Time
 	}
-	now := time.Now()
+	now := time.Now().Truncate(time.Second)
 	tests := map[string]scenario{
 		"short lived cert, spec.renewBefore is not set": {
 			notBefore:           now,

--- a/pkg/controller/certificates/util_test.go
+++ b/pkg/controller/certificates/util_test.go
@@ -343,6 +343,15 @@ func TestRenewalTime(t *testing.T) {
 			renewBeforeOverride: &metav1.Duration{Duration: time.Hour * 24},
 			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Minute * 3)}, // renew in 3 minutes
 		},
+		// This test case is here to guard against an earlier bug where
+		// a non-truncated renewal time returned from this function
+		// caused certs to not be renewed.
+		// See https://github.com/jetstack/cert-manager/pull/4399
+		"certificate's duration is skewed by a second": {
+			notBefore:           now,
+			notAfter:            now.Add(time.Hour * 24).Add(time.Second * -1),
+			expectedRenewalTime: &metav1.Time{Time: now.Add(time.Hour * 16).Add(time.Second * -1)},
+		},
 	}
 	for n, s := range tests {
 		t.Run(n, func(t *testing.T) {


### PR DESCRIPTION
See #4345 and [Slack](https://kubernetes.slack.com/archives/C4NV3DWUC/p1628851369196000) for context.

It appears like in cases where a certificate has a slightly skewed duration, the certs don't get renewed.
This seems to happen because the renewal time value on the `Certificate` is truncated to the nearest second, whereas [the function we use to calculate renewal time](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/util.go#L293-L312), returns a value to higher precision.
We use the truncated renewal time from the certificate's status when we re-queue `Certificate` for renewal [here](https://github.com/jetstack/cert-manager/blob/master/pkg/controller/certificates/trigger/trigger_controller.go#L168), but then when it has been popped from the queue at the set renewal time, we [re-calculate the renewal time using our custom function](https://github.com/jetstack/cert-manager/blob/38ab6f4bddabaac6ba46451f52c8720ed02e6831/pkg/controller/certificates/trigger/policies/policies.go#L216) so we get the higher precison value, which in case of a skewed duration will be some micro/milli/nano-seconds _later_ from the current time, so [we determine that the cert does not need re-issuing _now_](https://github.com/jetstack/cert-manager/blob/38ab6f4bddabaac6ba46451f52c8720ed02e6831/pkg/controller/certificates/trigger/policies/policies.go#L219). After that the `Certificate` will also not get re-queued again since that part looks at the renewal time on the `Certificate`'s status and [determines that it is being re-issued _now_](https://github.com/jetstack/cert-manager/blob/38ab6f4bddabaac6ba46451f52c8720ed02e6831/pkg/controller/certificates/trigger/trigger_controller.go#L251).

I have reproduced this issue by modifying the self-signed issuer to issue certs with skewed duration (the different second values for `notAfter`, `notBefore`):
```
  notAfter: "2021-08-20T14:23:10Z"
  notBefore: "2021-08-20T13:23:11Z"
  renewalTime: "2021-08-20T14:03:10Z"
```
In this case the `renewalTime` returned by our function that calculates renewal time is `2021-08-20 14:03:10.333333334 +0000 UTC"=null` which is 0.333333334s later than the `renewalTime` read from `Certificate`'s status.
I verified that once this fix is applied, the renewal happens as expected.


**What this PR does / why we need it**:
This PR truncates the renewalTime returned by `RenewalTime` function to the nearest second, so it will always be the same value as that stored on `Certificate`'s status.

**Special notes for your reviewer**:
- This issue could have also been fixed by re-calculating the renewal time also when re-scheduling, but I think this would be extra work and isn't needed
- We recalculate the renewal time when determining whether cert needs re-issuing now since `v1.3.0` - see #3665 in short it is needed to prevent multiple issuances when readiness controller has not _yet_ updated renewal time on certificate's status just after an issuance

```release-note
Fixes renewal time issue for certs with skewed duration period.
```

 fixes #4345 

Signed-off-by: irbekrm <irbekrm@gmail.com>

/kind bug