### PR TITLE
Update and verify scripts can be run from darwin-arm64

### DIFF
--- a/devel/addon/ingressnginx/install.sh
+++ b/devel/addon/ingressnginx/install.sh
@@ -36,10 +36,10 @@ fi
 RELEASE_NAME="${RELEASE_NAME:-ingress-nginx}"
 IMAGE_TAG=""
 
-# Require helm, kubectl and jq available on PATH
+# Require helm, kubectl and yq available on PATH
 check_tool kubectl
 check_tool helm
-bazel build //hack/bin:jq
+bazel build //hack/bin:yq
 bindir="$(bazel info bazel-bin)"
 export PATH="${bindir}/hack/bin/:$PATH"
 
@@ -52,7 +52,7 @@ export PATH="${bindir}/hack/bin/:$PATH"
 
 # This allows running ./devel/setup-e2e-deps.sh locally against Kubernetes v1.22
 # without passing the K8S_VERSION env var.
-k8s_version=$(kubectl version -ojson | jq  -r '.serverVersion | "\(.major).\(.minor)"')
+k8s_version=$(kubectl version -oyaml | yq e '.serverVersion | .major +"."+ .minor' -)
 if [[ $k8s_version =~ 1\.22 ]]; then
   IMAGE_TAG="v1.0.0-alpha.2"
 else

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -39,7 +39,7 @@ export INGRESS_IP="${SERVICE_IP_PREFIX}.15"
 # versions of the tools required for development
 setup_tools() {
   check_bazel
-  bazel build //hack/bin:helm //hack/bin:kind //hack/bin:kubectl //hack/bin:jq //devel/bin:ginkgo
+  bazel build //hack/bin:helm //hack/bin:kind //hack/bin:kubectl //devel/bin:ginkgo
   if [[ "$IS_OPENSHIFT" == "true" ]] ; then
     bazel build //hack/bin:oc3
   fi
@@ -47,7 +47,6 @@ setup_tools() {
   export HELM="${bindir}/hack/bin/helm"
   export KIND="${bindir}/hack/bin/kind"
   export OC3="${bindir}/hack/bin/oc3"
-  export JQ="${bindir}/hack/bin/jq"
   export KUBECTL="${bindir}/hack/bin/kubectl"
   export KUSTOMIZE="${bindir}/hack/bin/kustomize"
   export GINKGO="${bindir}/devel/bin/ginkgo"

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -10,8 +10,6 @@ GOROOT = "@go_sdk//:files"
 
 GOFMT = "@go_sdk//:bin/gofmt"
 
-JQ = "//hack/bin:jq"
-
 YQ = "//hack/bin:yq"
 
 CONTROLLER_GEN = "@io_k8s_sigs_controller_tools//cmd/controller-gen"
@@ -73,7 +71,6 @@ sh_binary(
         "$(location %s)" % GO,
         "$(location %s)" % GAZELLE,
         "$(location %s)" % KAZEL,
-        "$(location %s)" % JQ,
         "$(location :update-bazel)",
         "$(location :update-deps-licenses)",
     ],
@@ -81,7 +78,6 @@ sh_binary(
         GAZELLE,
         GO,
         KAZEL,
-        JQ,
         ":update-bazel",
         ":update-deps-licenses",
     ],
@@ -95,7 +91,6 @@ sh_test(
         "$(location %s)" % GO,
         "$(location %s)" % GAZELLE,
         "$(location %s)" % KAZEL,
-        "$(location %s)" % JQ,
         "$(location :update-bazel)",
         "$(location :update-deps-licenses)",
     ],
@@ -104,7 +99,6 @@ sh_test(
         GAZELLE,
         GO,
         KAZEL,
-        JQ,
         ":update-bazel",
         ":update-deps-licenses",
         "@//:all-srcs",
@@ -117,11 +111,9 @@ sh_binary(
     srcs = ["update-deps-licenses.sh"],
     args = [
         "$(location %s)" % GO,
-        "$(location %s)" % JQ,
     ],
     data = [
         GO,
-        JQ,
     ],
 )
 
@@ -131,13 +123,11 @@ sh_test(
     args = [
         "$(location :update-deps-licenses)",
         "$(location %s)" % GO,
-        "$(location %s)" % JQ,
     ],
     data = [
         GAZELLE,
         GO,
         KAZEL,
-        JQ,
         ":update-deps-licenses",
         "@//:all-srcs",
     ],

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -3,17 +3,6 @@ package(default_visibility = ["//visibility:public"])
 load("@io_k8s_repo_infra//defs:run_in_workspace.bzl", "workspace_binary")
 
 genrule(
-    name = "fetch_jq",
-    srcs = select({
-        ":darwin": ["@jq_osx//file"],
-        ":k8": ["@jq_linux//file"],
-    }),
-    outs = ["jq"],
-    cmd = "cp $(SRCS) $@",
-    visibility = ["//visibility:public"],
-)
-
-genrule(
     name = "fetch_helm",
     srcs = select({
         ":darwin": ["@helm_darwin//:file"],

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -17,6 +17,7 @@ genrule(
     name = "fetch_helm",
     srcs = select({
         ":darwin": ["@helm_darwin//:file"],
+        ":darwin_arm": ["@helm_darwin_arm//:file"],
         ":k8": ["@helm_linux//:file"],
     }),
     outs = ["helm"],
@@ -61,6 +62,7 @@ genrule(
     name = "fetch_kubectl",
     srcs = select({
         ":darwin": ["@kubectl_1_22_darwin//file"],
+        ":darwin_arm": ["@kubectl_1_22_darwin_arm//file"],
         ":k8": ["@kubectl_1_22_linux//file"],
     }),
     outs = ["kubectl"],
@@ -129,6 +131,7 @@ genrule(
     name = "fetch_kind",
     srcs = select({
         ":darwin": ["@kind_darwin//file"],
+        ":darwin_arm": ["@kind_darwin_arm//file"],
         ":k8": ["@kind_linux//file"],
     }),
     outs = ["kind"],
@@ -148,6 +151,7 @@ genrule(
     name = "fetch_ytt",
     srcs = select({
         ":darwin": ["@ytt_darwin//file"],
+        ":darwin_arm": ["@ytt_darwin_arm//file"],
         ":k8": ["@ytt_linux//file"],
     }),
     outs = ["ytt"],
@@ -158,6 +162,7 @@ genrule(
     name = "fetch_yq",
     srcs = select({
         ":darwin": ["@yq_darwin//file"],
+        ":darwin_arm": ["@yq_darwin_arm//file"],
         ":k8": ["@yq_linux//file"],
     }),
     outs = ["yq"],
@@ -173,6 +178,12 @@ config_setting(
 config_setting(
     name = "darwin",
     values = {"host_cpu": "darwin"},
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "darwin_arm",
+    values = {"host_cpu": "darwin_arm64"},
     visibility = ["//visibility:private"],
 )
 

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -83,17 +83,6 @@ genrule(
 )
 
 genrule(
-    name = "fetch_buildozer",
-    srcs = select({
-        ":darwin": ["@buildozer_darwin//file"],
-        ":k8": ["@buildozer_linux//file"],
-    }),
-    outs = ["buildozer"],
-    cmd = "cp $(SRCS) $@",
-    visibility = ["//visibility:public"],
-)
-
-genrule(
     name = "fetch_kazel",
     srcs = ["@io_k8s_repo_infra//cmd/kazel"],
     outs = ["kazel"],

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -151,8 +151,8 @@ def install_bazel_tools():
 
 # Install Helm targets
 def install_helm():
-    ## Fetch helm & tiller for use in template generation and testing
-    ## You can bump the version of Helm & Tiller used during e2e tests by tweaking
+    ## Fetch helm for use in template generation and testing
+    ## You can bump the version of Helm used during e2e tests by tweaking
     ## the version numbers in these rules.
     http_archive(
         name = "helm_darwin",
@@ -164,6 +164,22 @@ filegroup(
     name = "file",
     srcs = [
         "darwin-amd64/helm",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
+    http_archive(
+        name = "helm_darwin_arm",
+        sha256 = "a50b499dbd0bbec90761d50974bf1e67cc6d503ea20d03b4a1275884065b7e9e",
+        urls = ["https://get.helm.sh/helm-v3.6.3-darwin-arm64.tar.gz"],
+        build_file_content =
+            """
+filegroup(
+    name = "file",
+    srcs = [
+        "darwin-arm64/helm",
     ],
     visibility = ["//visibility:public"],
 )
@@ -191,15 +207,22 @@ def install_kubectl():
     http_file(
         name = "kubectl_1_22_darwin",
         executable = 1,
-        sha256 = "2b5214a01a9595e4f2b8f30c556136c5b93351f6677d07858ee1acf92cc14249",
-        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/darwin/amd64/kubectl"],
+        sha256 = "00bb3947ac6ff15690f90ee1a732d0a9a44360fc7743dbfee4cba5a8f6a31413",
+        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/darwin/amd64/kubectl"],
+    )
+
+    http_file(
+        name = "kubectl_1_22_darwin_arm",
+        executable = 1,
+        sha256 = "c81a314ab7f0827a5376f8ffd6d47f913df046275d44c562915a822229819d77",
+        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/darwin/arm64/kubectl"],
     )
 
     http_file(
         name = "kubectl_1_22_linux",
         executable = 1,
-        sha256 = "703e70d49b82271535bc66bc7bd469a58c11d47f188889bd37101c9772f14fa1",
-        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.22.0/bin/linux/amd64/kubectl"],
+        sha256 = "78178a8337fc6c76780f60541fca7199f0f1a2e9c41806bded280a4a5ef665c9",
+        urls = ["https://storage.googleapis.com/kubernetes-release/release/v1.22.1/bin/linux/amd64/kubectl"],
     )
 
 
@@ -231,6 +254,13 @@ def install_kind():
     )
 
     http_file(
+        name = "kind_darwin_arm",
+        executable = 1,
+        sha256 = "4f019c578600c087908ac59dd0c4ce1791574f153a70608adb372d5abc58cd47",
+        urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-darwin-arm64"],
+    )
+
+    http_file(
         name = "kind_linux",
         executable = 1,
         sha256 = "949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491",
@@ -243,15 +273,22 @@ def install_ytt():
     http_file(
         name = "ytt_darwin",
         executable = 1,
-        sha256 = "a874395924e670f2c89160efeffc35b94a9bcf4e515e49935cb1ceb22be7f08a",
-        urls = ["https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.34.0/ytt-darwin-amd64"],
+        sha256 = "9662e3f8e30333726a03f7a5ae6231fbfb2cebb6c1aa3f545b253d7c695487e6",
+        urls = ["https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.36.0/ytt-darwin-amd64"],
+    )
+
+    http_file(
+        name = "ytt_darwin_arm",
+        executable = 1,
+        sha256 = "c970b2c13d4059f0bee3bf3ceaa09bd0674a62c24550453d90b284d885a06b7b",
+        urls = ["https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.36.0/ytt-darwin-arm64"],
     )
 
     http_file(
         name = "ytt_linux",
         executable = 1,
-        sha256 = "49741ac5540fc64da8566f3d1c9538f4f0fec22c62b8ba83e5e3d8efb91ee170",
-        urls = ["https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.34.0/ytt-linux-amd64"],
+        sha256 = "d81ecf6c47209f6ac527e503a6fd85e999c3c2f8369e972794047bddc7e5fbe2",
+        urls = ["https://github.com/vmware-tanzu/carvel-ytt/releases/download/v0.36.0/ytt-linux-amd64"],
     )
 
 # yq is jq for yaml
@@ -261,6 +298,13 @@ def install_yq():
         executable = 1,
         sha256 = "5af6162d858b1adc4ad23ef11dff19ede5565d8841ac611b09500f6741ff7f46",
         urls = ["https://github.com/mikefarah/yq/releases/download/v4.11.2/yq_darwin_amd64"],
+    )
+
+    http_file(
+        name = "yq_darwin_arm",
+        executable = 1,
+        sha256 = "665ae1af7c73866cba74dd878c12ac49c091b66e46c9ed57d168b43955f5dd69",
+        urls = ["https://github.com/mikefarah/yq/releases/download/v4.12.0/yq_darwin_arm64"],
     )
 
     http_file(

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -18,7 +18,6 @@ load("@bazel_gazelle//:deps.bzl", "go_repository")
 def install():
     install_misc()
     install_integration_test_dependencies()
-    install_bazel_tools()
     install_staticcheck()
     install_helm()
     install_kubectl()
@@ -130,23 +129,6 @@ filegroup(
     visibility = ["//visibility:public"],
 )
 """,
-    )
-
-# Install additional tools for Bazel management
-def install_bazel_tools():
-    ## Install buildozer, for mass-editing BUILD files
-    http_file(
-        name = "buildozer_darwin",
-        executable = 1,
-        sha256 = "972944bbd15a20d1527695ba805ca7e7f98c3381c8f521359791e0016f079713",
-        urls = ["https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildozer-darwin-amd64"],
-    )
-
-    http_file(
-        name = "buildozer_linux",
-        executable = 1,
-        sha256 = "082aea1df38fe30ce41d955a2cbf309cae8ec386507e0c10cc16f0d9a93e151f",
-        urls = ["https://github.com/bazelbuild/buildtools/releases/download/4.0.1/buildozer-linux-amd64"],
     )
 
 # Install Helm targets

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -16,7 +16,6 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive"
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 def install():
-    install_misc()
     install_integration_test_dependencies()
     install_staticcheck()
     install_helm()

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -68,21 +68,6 @@ filegroup(
 """,
     )
 
-def install_misc():
-    http_file(
-        name = "jq_linux",
-        executable = 1,
-        sha256 = "af986793a515d500ab2d35f8d2aecd656e764504b789b66d7e1a0b727a124c44",
-        urls = ["https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"],
-    )
-
-    http_file(
-        name = "jq_osx",
-        executable = 1,
-        sha256 = "5c0a0a3ea600f302ee458b30317425dd9632d1ad8882259fcaf4e9b868b2b1ef",
-        urls = ["https://github.com/stedolan/jq/releases/download/jq-1.6/jq-osx-amd64"],
-    )
-
 # Install dependencies used by the controller-runtime integration test framework
 # Use these links to check for new versions:
 # https://console.developers.google.com/storage/kubebuilder-tools/

--- a/hack/update-deps-licenses.sh
+++ b/hack/update-deps-licenses.sh
@@ -52,7 +52,7 @@ fi
 go=$(realpath "$1")
 export PATH=$(dirname "$go"):$PATH
 
-shift 2
+shift 1
 REPO_ROOT="$BUILD_WORKSPACE_DIRECTORY"
 LICENSE_ROOT="$REPO_ROOT"
 

--- a/hack/update-deps-licenses.sh
+++ b/hack/update-deps-licenses.sh
@@ -50,7 +50,6 @@ else
 fi
 
 go=$(realpath "$1")
-jq=$(realpath "$2")
 export PATH=$(dirname "$go"):$PATH
 
 shift 2
@@ -163,12 +162,6 @@ export GOFLAGS=-mod=mod
 if (( BASH_VERSINFO[0] < 4 )); then
   echo
   echo "ERROR: Bash v4+ required."
-  # Extra help for OSX
-  if [[ "$(uname -s)" == "Darwin" ]]; then
-    echo
-    echo "Ensure you are up to date on the following packages:"
-    echo "$ brew install md5sha1sum bash jq"
-  fi
   echo
   exit 9
 fi
@@ -240,7 +233,7 @@ only_contains_submodules () {
 }
 
 # Loop through every vendored package
-for PACKAGE in $("$go" list -m -json all | "$jq" -r .Path | sort -f); do
+for PACKAGE in $("$go" list -m -f '{{.Path}}' all | sort -f); do
   if [[ -e "staging/src/${PACKAGE}" ]]; then
     echo "${PACKAGE} is a staging package, skipping" >&2
     continue

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -40,16 +40,14 @@ go=$(realpath "$1")
 export PATH=$(dirname "$go"):$PATH
 gazelle=$(realpath "$2")
 kazel=$(realpath "$3")
-jq=$(realpath "$4")
 update_bazel=(
-  $(realpath "$5")
+  $(realpath "$4")
   "$gazelle"
   "$kazel"
 )
 update_deps_licenses=(
-  $(realpath "$6")
+  $(realpath "$5")
   "$go"
-  "$jq"
 )
 
 shift 6

--- a/hack/update-deps.sh
+++ b/hack/update-deps.sh
@@ -50,7 +50,7 @@ update_deps_licenses=(
   "$go"
 )
 
-shift 6
+shift 5
 
 cd "$BUILD_WORKSPACE_DIRECTORY"
 trap 'echo "FAILED" >&2' ERR

--- a/hack/verify-deps-licenses.sh
+++ b/hack/verify-deps-licenses.sh
@@ -47,12 +47,6 @@ tmpfiles=$TEST_TMPDIR/files
   "$@"
 )
 
-(
-  # Remove the platform/binary for gazelle and kazel
-  jq=$(dirname "$3")
-  rm -rf {.,"$tmpfiles"}/{"$jq"}
-)
-
 # Avoid diff -N so we handle empty files correctly
 diff=$(diff -upr \
   -x ".git" \

--- a/hack/verify-staticcheck.sh
+++ b/hack/verify-staticcheck.sh
@@ -18,6 +18,10 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+# This script is currently not run as part of any automated tests.
+# https://github.com/jetstack/cert-manager/pull/3037#issue-440523030
+# It will also currently only work on linux/amd64, darwin/amd64.
+
 REPO_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../" > /dev/null && pwd )"
 
 # See https://staticcheck.io/docs/checks

--- a/hack/verify-upgrade.sh
+++ b/hack/verify-upgrade.sh
@@ -29,9 +29,9 @@ kube::version::last_published_release
 LATEST_RELEASE="${KUBE_LAST_RELEASE}"
 CURRENT_VERSION="${KUBE_GIT_VERSION}"
 
-# Ensure helm, kind, kubectl, ytt, jq are available
+# Ensure helm, kind, kubectl, ytt are available
 echo "Building the required tools.."
-bazel build //hack/bin:helm //hack/bin:kind //hack/bin:ytt //hack/bin:jq //hack/bin:kubectl //hack/bin:kubectl-cert_manager
+bazel build //hack/bin:helm //hack/bin:kind //hack/bin:ytt //hack/bin:kubectl //hack/bin:kubectl-cert_manager
 bindir="$(bazel info bazel-bin)"
 export PATH="${bindir}/hack/bin/:$PATH"
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR adds a [new Bazel `config_setting`](https://docs.bazel.build/versions/main/configurable-attributes.html) `darwin_arm` that gets selected when host's cpu is `darwin_arm64`  to download darwin/arm builds of tools we use in various scripts.

This _should_ allow darwin/arm users to run all the `./hack/update-*` and `./hack/verify-*` scripts except for the staticcheck one.

This will not yet allow darwin/arm users to run `bazel test //...` because the `kube-apiserver` and `etcd` are still currently downloaded only for linux/amd, darwin/amd. [There are no darwin/arm builds for those](https://console.cloud.google.com/storage/browser/kubebuilder-tools;tab=objects?prefix=&forceOnObjectsSortingFiltering=false).  We may be able to build those directly by importing them in [`./hack/bin/tools.go`](https://github.com/jetstack/cert-manager/blob/master/hack/bin/tools.go), but will then need to ensure ourselves that the versions are compatible. Also the [`etcd` build script](https://github.com/etcd-io/etcd/blob/main/build.sh) seems to do a bunch of things. Perhaps we should try to PR darwin/arm release building upstream?

**Special notes for your reviewer**:
- I have removed `jq` as there is no darwin/arm build released for it and we can use `yq` for the same
- I have removed `buildozer` as it appears to be unused
- `./hack/verify-staticcheck.sh` is not yet runnable on darwin/arm, but this is not run as part of automated tests
- It is possible to verify that the correct tools would be downloaded by running i.e `bazel build --host_cpu=darwin_arm64 //hack/bin:kubectl` and then checking the file at `bazel-bin/hack/bin/kubectl`, but it would be great if someone on M1 could try running `./hack/update-all.sh` and the `./hack/verify-*` scripts before approving this PR


**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

/kind cleanup
