### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest.go
@@ -21,7 +21,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -247,7 +246,7 @@ func (o *Options) Run(ctx context.Context, args []string) error {
 	if o.KeyFilename != "" {
 		keyFileName = o.KeyFilename
 	}
-	if err := ioutil.WriteFile(keyFileName, keyData, 0600); err != nil {
+	if err := os.WriteFile(keyFileName, keyData, 0600); err != nil {
 		return fmt.Errorf("error when writing private key to file: %w", err)
 	}
 	fmt.Fprintf(o.ErrOut, "Private key written to file %s\n", keyFileName)

--- a/cmd/ctl/pkg/create/certificaterequest/certificaterequest_test.go
+++ b/cmd/ctl/pkg/create/certificaterequest/certificaterequest_test.go
@@ -18,7 +18,6 @@ package certificaterequest
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -205,7 +204,7 @@ spec:
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			if err := ioutil.WriteFile("testfile.yaml", []byte(test.inputFileContent), 0644); err != nil {
+			if err := os.WriteFile("testfile.yaml", []byte(test.inputFileContent), 0644); err != nil {
 				t.Fatalf("error creating test file %#v", err)
 			}
 			defer os.Remove("testfile.yaml")

--- a/cmd/ctl/pkg/inspect/secret/util.go
+++ b/cmd/ctl/pkg/inspect/secret/util.go
@@ -24,7 +24,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -78,7 +78,7 @@ func checkOCSPValidCert(leafCert, issuerCert *x509.Certificate) (bool, error) {
 			return false, fmt.Errorf("error making HTTP request: %w", err)
 		}
 		defer httpResponse.Body.Close()
-		output, err := ioutil.ReadAll(httpResponse.Body)
+		output, err := io.ReadAll(httpResponse.Body)
 		if err != nil {
 			return false, fmt.Errorf("error reading HTTP body: %w", err)
 		}
@@ -102,7 +102,7 @@ func checkCRLValidCert(cert *x509.Certificate, url string) (bool, error) {
 		return false, fmt.Errorf("error getting HTTP response: %w", err)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return false, fmt.Errorf("error reading HTTP body: %w", err)
 	}

--- a/cmd/webhook/app/testing/testwebhook.go
+++ b/cmd/webhook/app/testing/testwebhook.go
@@ -24,7 +24,6 @@ import (
 	"crypto/x509/pkix"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"os"
@@ -67,7 +66,7 @@ func StartWebhookServer(t *testing.T, ctx context.Context, args []string) (Serve
 	fs.Parse(args)
 
 	var caPEM []byte
-	tempDir, err := ioutil.TempDir("", "webhook-tls-")
+	tempDir, err := os.MkdirTemp("", "webhook-tls-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,10 +78,10 @@ func StartWebhookServer(t *testing.T, ctx context.Context, args []string) (Serve
 		}
 
 		caPEM = ca
-		if err := ioutil.WriteFile(filepath.Join(tempDir, "tls.crt"), certificatePEM, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "tls.crt"), certificatePEM, 0644); err != nil {
 			t.Fatal(err)
 		}
-		if err := ioutil.WriteFile(filepath.Join(tempDir, "tls.key"), privateKeyPEM, 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(tempDir, "tls.key"), privateKeyPEM, 0644); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/controller/cainjector/setup.go
+++ b/pkg/controller/cainjector/setup.go
@@ -19,7 +19,7 @@ package cainjector
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 	"golang.org/x/sync/errgroup"
@@ -164,7 +164,7 @@ func dataFromSliceOrFile(data []byte, file string) ([]byte, error) {
 		return data, nil
 	}
 	if len(file) > 0 {
-		fileData, err := ioutil.ReadFile(file)
+		fileData, err := os.ReadFile(file)
 		if err != nil {
 			return []byte{}, err
 		}

--- a/pkg/internal/vault/vault_test.go
+++ b/pkg/internal/vault/vault_test.go
@@ -27,7 +27,7 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -254,7 +254,7 @@ func TestSign(t *testing.T) {
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
 				Response: &http.Response{
-					Body: ioutil.NopCloser(bytes.NewReader(bundleData))},
+					Body: io.NopCloser(bytes.NewReader(bundleData))},
 			}, nil),
 			expectedErr:  nil,
 			expectedCert: testLeafCertificate + testIntermediateCa,
@@ -268,7 +268,7 @@ func TestSign(t *testing.T) {
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
 				Response: &http.Response{
-					Body: ioutil.NopCloser(bytes.NewReader(rootBundleData))},
+					Body: io.NopCloser(bytes.NewReader(rootBundleData))},
 			}, nil),
 			expectedErr:  nil,
 			expectedCert: testLeafCertificate + testIntermediateCa,
@@ -282,7 +282,7 @@ func TestSign(t *testing.T) {
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
 				Response: &http.Response{
-					Body: ioutil.NopCloser(bytes.NewReader(bundleData))},
+					Body: io.NopCloser(bytes.NewReader(bundleData))},
 			}, nil),
 			expectedErr:  nil,
 			expectedCert: testLeafCertificate + testIntermediateCa,
@@ -504,7 +504,7 @@ func TestSetToken(t *testing.T) {
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
 				Response: &http.Response{
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						strings.NewReader(
 							`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-roleapp-token"}}`),
 					),
@@ -611,7 +611,7 @@ func TestSetToken(t *testing.T) {
 			),
 			fakeClient: vaultfake.NewFakeClient().WithRawRequest(&vault.Response{
 				Response: &http.Response{
-					Body: ioutil.NopCloser(
+					Body: io.NopCloser(
 						strings.NewReader(
 							`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"}}`),
 					),
@@ -1007,7 +1007,7 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 			client: vaultfake.NewFakeClient().WithRawRequest(
 				&vault.Response{
 					Response: &http.Response{
-						Body: ioutil.NopCloser(
+						Body: io.NopCloser(
 							strings.NewReader(
 								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{}}`),
 						),
@@ -1024,7 +1024,7 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 			client: vaultfake.NewFakeClient().WithRawRequest(
 				&vault.Response{
 					Response: &http.Response{
-						Body: ioutil.NopCloser(
+						Body: io.NopCloser(
 							strings.NewReader(
 								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"}}`),
 						),
@@ -1041,7 +1041,7 @@ func TestRequestTokenWithAppRoleRef(t *testing.T) {
 			client: vaultfake.NewFakeClient().WithRawRequest(
 				&vault.Response{
 					Response: &http.Response{
-						Body: ioutil.NopCloser(
+						Body: io.NopCloser(
 							strings.NewReader(
 								`{"request_id":"","lease_id":"","lease_duration":0,"renewable":false,"data":null,"warnings":null,"data":{"id":"my-token"},"auth":{"client_token":"my-client-token"}}`),
 						),

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -12,7 +12,6 @@ package clouddns
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -104,7 +103,7 @@ func NewDNSProviderServiceAccount(project string, saFile string, dns01Nameserver
 		return nil, fmt.Errorf("Google Cloud Service Account file missing")
 	}
 
-	dat, err := ioutil.ReadFile(saFile)
+	dat, err := os.ReadFile(saFile)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to read Service Account file: %v", err)
 	}

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -287,7 +287,7 @@ func testReachability(ctx context.Context, url *url.URL, key string) error {
 	}
 
 	defer response.Body.Close()
-	presentedKey, err := ioutil.ReadAll(response.Body)
+	presentedKey, err := io.ReadAll(response.Body)
 	if err != nil {
 		log.V(logf.DebugLevel).Info("failed to decode response body", "error", err)
 		return fmt.Errorf("failed to read response body: %v", err)

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -21,7 +21,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"time"
@@ -280,7 +280,7 @@ func (s *Server) handle(inner handleFunc) func(w http.ResponseWriter, req *http.
 	return func(w http.ResponseWriter, req *http.Request) {
 		defer req.Body.Close()
 
-		data, err := ioutil.ReadAll(req.Body)
+		data, err := io.ReadAll(req.Body)
 		if err != nil {
 			s.Log.Error(err, "failed to read request body")
 			w.WriteHeader(http.StatusBadRequest)

--- a/pkg/webhook/server/tls/file_source.go
+++ b/pkg/webhook/server/tls/file_source.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"crypto/tls"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"sync"
 	"time"
 
@@ -125,12 +125,12 @@ func (f *FileCertificateSource) Healthy() bool {
 // updateCertificateFromDisk will read private key and certificate data from
 // disk and update the cached tls.Certificate if the data on disk has changed.
 func (f *FileCertificateSource) updateCertificateFromDisk() error {
-	keyData, err := ioutil.ReadFile(f.KeyPath)
+	keyData, err := os.ReadFile(f.KeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read keyPath: %w", err)
 	}
 
-	certData, err := ioutil.ReadFile(f.CertPath)
+	certData, err := os.ReadFile(f.CertPath)
 	if err != nil {
 		return fmt.Errorf("failed to read certPath: %w", err)
 	}

--- a/pkg/webhook/server/tls/file_source_test.go
+++ b/pkg/webhook/server/tls/file_source_test.go
@@ -20,7 +20,6 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"io/ioutil"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -35,7 +34,7 @@ import (
 )
 
 func TestFileSource_ReadsFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-filesource-readsfile-")
+	dir, err := os.MkdirTemp("", "test-filesource-readsfile-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -85,7 +84,7 @@ func TestFileSource_ReadsFile(t *testing.T) {
 }
 
 func TestFileSource_UpdatesFile(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-filesource-updatesfile-")
+	dir, err := os.MkdirTemp("", "test-filesource-updatesfile-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/acme/dns/options.go
+++ b/test/acme/dns/options.go
@@ -19,7 +19,7 @@ package dns
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -59,7 +59,7 @@ func applyDefaults(f *fixture) {
 	}
 	if f.jsonConfig == nil {
 		if f.kubectlManifestsPath != "" {
-			d, err := ioutil.ReadFile(f.kubectlManifestsPath + "/config.json")
+			d, err := os.ReadFile(f.kubectlManifestsPath + "/config.json")
 			if err == nil {
 				f.jsonConfig = &apiextensionsv1.JSON{
 					Raw: d,

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -74,7 +73,7 @@ var _ = ginkgo.SynchronizedAfterSuite(func() {},
 				continue
 			}
 
-			err = ioutil.WriteFile(outPath, []byte(v), 0644)
+			err = os.WriteFile(outPath, []byte(v), 0644)
 			if err != nil {
 				log.Logf("Failed to write log file: %v", err)
 				continue

--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -19,7 +19,7 @@ package chart
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path"
@@ -93,7 +93,7 @@ func (c *Chart) Setup(cfg *config.Config) error {
 		return fmt.Errorf("--helm-binary-path must be set")
 	}
 
-	c.home, err = ioutil.TempDir("", "helm-chart-install")
+	c.home, err = os.MkdirTemp("", "helm-chart-install")
 	if err != nil {
 		return err
 	}
@@ -179,7 +179,7 @@ func (c *Chart) getHelmVersion() (string, error) {
 		return "", err
 	}
 
-	outBytes, err := ioutil.ReadAll(out)
+	outBytes, err := io.ReadAll(out)
 	if err != nil {
 		return "", err
 	}

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -19,7 +19,7 @@ package certificates
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -121,7 +121,7 @@ func TestMetricsController(t *testing.T) {
 			return err
 		}
 
-		output, err := ioutil.ReadAll(resp.Body)
+		output, err := io.ReadAll(resp.Body)
 		if err != nil {
 			return err
 		}

--- a/test/integration/ctl/ctl_convert_test.go
+++ b/test/integration/ctl/ctl_convert_test.go
@@ -18,7 +18,7 @@ package ctl
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"k8s.io/cli-runtime/pkg/genericclioptions"
@@ -144,7 +144,7 @@ func TestCtlConvert(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			expOutput, err := ioutil.ReadFile(test.expOutputFile)
+			expOutput, err := os.ReadFile(test.expOutputFile)
 			if err != nil {
 				t.Fatalf("%s: %s", test.expOutputFile, err)
 			}

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -145,7 +144,7 @@ func TestCtlCreateCRBeforeCRIsCreated(t *testing.T) {
 			}
 
 			// Check the file where the private key is stored
-			keyData, err := ioutil.ReadFile(test.expKeyFilename)
+			keyData, err := os.ReadFile(test.expKeyFilename)
 			if err != nil {
 				t.Errorf("error when reading file storing private key: %v", err)
 			}
@@ -342,7 +341,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 			}
 
 			// Check the file where the private key is stored
-			keyData, err := ioutil.ReadFile(test.expKeyFilename)
+			keyData, err := os.ReadFile(test.expKeyFilename)
 			if err != nil {
 				t.Errorf("error when reading file storing private key: %v", err)
 			}
@@ -370,7 +369,7 @@ func TestCtlCreateCRSuccessful(t *testing.T) {
 			// If the expected error message is the one below, we skip checking
 			// because no certificate will have been written to file
 			if test.fetchCert && test.expErrMsg != "error when waiting for CertificateRequest to be signed: timed out waiting for the condition" {
-				certData, err := ioutil.ReadFile(test.expCertFilename)
+				certData, err := os.ReadFile(test.expCertFilename)
 				if err != nil {
 					t.Errorf("error when reading file storing private key: %v", err)
 				}
@@ -401,7 +400,7 @@ func setupPathForTest(t *testing.T) func() {
 	}
 
 	// Create tmp directory and cd into it to store private key files
-	tmpDir, err := ioutil.TempDir("", "tmp-ctl-test-*")
+	tmpDir, err := os.MkdirTemp("", "tmp-ctl-test-*")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -19,7 +19,6 @@ package framework
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -150,7 +149,7 @@ func readCustomResourcesAtPath(t *testing.T, path string) []*v1.CustomResourceDe
 }
 
 func readCRDsAtPath(codec runtime.Codec, converter runtime.ObjectConvertor, path string) ([]*v1.CustomResourceDefinition, error) {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}

--- a/tools/cobra/main_test.go
+++ b/tools/cobra/main_test.go
@@ -17,14 +17,13 @@ limitations under the License.
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestRun(t *testing.T) {
-	rootDir, err := ioutil.TempDir(os.TempDir(), "cert-manager-cobra")
+	rootDir, err := os.MkdirTemp(os.TempDir(), "cert-manager-cobra")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.

**Which issue this PR fixes**:
N/A

**Special notes for your reviewer**:
No breaking change introduced.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
refactor: move from io/ioutil to io and os package
```
/kind cleanup