### PR TITLE
Adds a warning about sidecar proxy for startup check job

### DIFF
--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -402,6 +402,11 @@ cainjector:
 
 # This startupapicheck is a Helm post-install hook that waits for the webhook
 # endpoints to become available.
+# The check is implemented using a Kubernetes Job- if you are injecting mesh
+# sidecar proxies into cert-manager pods, you probably want to ensure that they
+# are not injected into this Job's pod. Otherwise the installation may time out
+# due to the Job never being completed because the sidecar proxy does not exit.
+# See https://github.com/jetstack/cert-manager/pull/4414 for context.
 startupapicheck:
   enabled: true
 


### PR DESCRIPTION
**What this PR does / why we need it**:

See #4405 for context- if a sidecar proxy (i.e for linkerd, istio etc) is injected into startupapicheck Job's pod, the installation will time out because the proxy container is not going to exit so the Job will never complete.
This is a known problem, see i.e [istio#11659](https://github.com/istio/istio/issues/11659), [linkerd#1869](https://github.com/linkerd/linkerd2/issues/1869). The solution at least in Linkerd's case appears to be to send a shutdown signal to the proxy- I don't think it would make sense for our startup process to attempt to do this as we don't know in what setup it may be deployed.
So the solution would be for the users to ensure that a proxy sidecar doesn't get injected to the Job's pod. If they normally inject them via pod annotations/labels then they should just not apply the annotations to the Job's pod. If they use namespace labelling for proxy injection and cannot turn it off for a specific pod then the solution would be to disable the startup check.

**Special notes for your reviewer**:

I've tested by deploying manually that with both Istio and Linkerd cert-manager Helm installations will time out if there is a proxy injected to the Job's pod. 

I am not sure how common this kind of setup is- if it appears that this kind of issue is hit often then we could add an FAQ or a note to installation docs about this.


```release-note
NONE
```
Signed-off-by: irbekrm <irbekrm@gmail.com>

 fixes #4405 

/kind cleanup