### PR TITLE
Add Certificate RenewBefore prometheus metrics

### DIFF
--- a/cmd/ctl/pkg/status/certificate/certificate_test.go
+++ b/cmd/ctl/pkg/status/certificate/certificate_test.go
@@ -83,8 +83,8 @@ func TestCRInfoString(t *testing.T) {
 		"CR with no condition output correct": {
 			cr: &cmapi.CertificateRequest{Status: cmapi.CertificateRequestStatus{Conditions: []cmapi.CertificateRequestCondition{}}},
 			expOutput: `CertificateRequest:
-  Name: 
-  Namespace: 
+  Name:
+  Namespace:
   Conditions:
     No Conditions set
   Events:  <none>
@@ -97,8 +97,8 @@ func TestCRInfoString(t *testing.T) {
 						{Type: cmapi.CertificateRequestConditionReady, Status: cmmeta.ConditionTrue, Message: "example"},
 					}}},
 			expOutput: `CertificateRequest:
-  Name: 
-  Namespace: 
+  Name:
+  Namespace:
   Conditions:
     Ready: True, Reason: , Message: example
   Events:  <none>
@@ -109,7 +109,7 @@ func TestCRInfoString(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			actualOutput := (&CertificateStatus{}).withCR(test.cr, nil, test.err).CRStatus.String()
-			if strings.TrimSpace(actualOutput) != strings.TrimSpace(test.expOutput) {
+			if strings.ReplaceAll(actualOutput, " \n", "\n") != strings.ReplaceAll(test.expOutput, " \n", "\n") {
 				t.Errorf("Unexpected output; expected: \n%s\nactual: \n%s", test.expOutput, actualOutput)
 			}
 		})
@@ -235,7 +235,7 @@ MA6koCR/K23HZfML8vT6lcHvQJp9XXaHRIe9NX/M/2f6VpfO7JjKWLou5k5a
 					gen.SetCertificateNamespace(ns),
 					gen.SetCertificateNotAfter(metav1.Time{Time: timestamp}),
 					gen.SetCertificateNotBefore(metav1.Time{Time: timestamp}),
-					gen.SetCertificateRenewalTIme(metav1.Time{Time: timestamp}),
+					gen.SetCertificateRenewalTime(metav1.Time{Time: timestamp}),
 					gen.SetCertificateStatusCondition(cmapi.CertificateCondition{Type: cmapi.CertificateConditionReady,
 						Status: cmmeta.ConditionTrue, Message: "Certificate is up to date and has not expired"}),
 					gen.SetCertificateDNSNames("example.com"),

--- a/pkg/metrics/acme.go
+++ b/pkg/metrics/acme.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
 // certificate_expiration_timestamp_seconds{name, namespace}
-// certificate_renew_before_seconds{name, namespace}
+// certificate_renewal_timestamp_seconds{name, namespace}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}

--- a/pkg/metrics/acme.go
+++ b/pkg/metrics/acme.go
@@ -17,6 +17,7 @@ limitations under the License.
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
 // certificate_expiration_timestamp_seconds{name, namespace}
+// certificate_renew_before_seconds{name, namespace}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -35,7 +35,7 @@ import (
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 )
 
-// UpdateCertificate will update that Certificate metric with expiry and Ready
+// UpdateCertificate will update that Certificate metric with expiry, renewBefore and Ready
 // condition.
 func (m *Metrics) UpdateCertificate(ctx context.Context, crt *cmapi.Certificate) {
 	key, err := cache.MetaNamespaceKeyFunc(crt)

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
 // certificate_expiration_timestamp_seconds{name, namespace}
-// certificate_renew_before_seconds{name, namespace}
+// certificate_renewal_timestamp_seconds{name, namespace}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
@@ -47,7 +47,7 @@ func (m *Metrics) UpdateCertificate(ctx context.Context, crt *cmapi.Certificate)
 
 	m.updateCertificateStatus(key, crt)
 	m.updateCertificateExpiry(ctx, key, crt)
-	m.updateCertificateRenewBefore(crt)
+	m.updateCertificateRenewalTime(crt)
 }
 
 // updateCertificateExpiry updates the expiry time of a certificate
@@ -63,15 +63,18 @@ func (m *Metrics) updateCertificateExpiry(ctx context.Context, key string, crt *
 		"namespace": crt.Namespace}).Set(expiryTime)
 }
 
-// updateCertificateRenewBefore updates the renew before duration of a certificate
-func (m *Metrics) updateCertificateRenewBefore(crt *cmapi.Certificate) {
-	renewBefore := crt.Spec.RenewBefore
+// updateCertificateRenewalTime updates the renew before duration of a certificate
+func (m *Metrics) updateCertificateRenewalTime(crt *cmapi.Certificate) {
+	renewalTime := 0.0
 
-	if renewBefore != nil {
-		m.certificateRenewBeforeSeconds.With(prometheus.Labels{
-			"name":      crt.Name,
-			"namespace": crt.Namespace}).Set(renewBefore.Seconds())
+	if crt.Status.RenewalTime != nil {
+		renewalTime = float64(crt.Status.RenewalTime.Unix())
 	}
+
+	m.certificateRenewalTimeSeconds.With(prometheus.Labels{
+		"name":      crt.Name,
+		"namespace": crt.Namespace}).Set(renewalTime)
+
 }
 
 // updateCertificateStatus will update the metric for that Certificate
@@ -113,7 +116,7 @@ func (m *Metrics) RemoveCertificate(key string) {
 	}
 
 	m.certificateExpiryTimeSeconds.DeleteLabelValues(name, namespace)
-	m.certificateRenewBeforeSeconds.DeleteLabelValues(name, namespace)
+	m.certificateRenewalTimeSeconds.DeleteLabelValues(name, namespace)
 	for _, condition := range readyConditionStatuses {
 		m.certificateReadyStatus.DeleteLabelValues(name, namespace, string(condition))
 	}

--- a/pkg/metrics/certificates.go
+++ b/pkg/metrics/certificates.go
@@ -35,7 +35,7 @@ import (
 	logf "github.com/jetstack/cert-manager/pkg/logs"
 )
 
-// UpdateCertificate will update that Certificate metric with expiry, renewBefore and Ready
+// UpdateCertificate will update the given Certificate's metrics for its expiry, renewal, and status
 // condition.
 func (m *Metrics) UpdateCertificate(ctx context.Context, crt *cmapi.Certificate) {
 	key, err := cache.MetaNamespaceKeyFunc(crt)

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -150,7 +150,7 @@ func TestCertificateMetrics(t *testing.T) {
 					Type:   cmapi.CertificateConditionReady,
 					Status: cmmeta.ConditionTrue,
 				}),
-				gen.SetCertificateRenewalTIme(metav1.Time{
+				gen.SetCertificateRenewalTime(metav1.Time{
 					Time: time.Unix(2208988804, 0),
 				}),
 			),
@@ -208,8 +208,9 @@ func TestCertificateCache(t *testing.T) {
 			Type:   cmapi.CertificateConditionReady,
 			Status: cmmeta.ConditionUnknown,
 		}),
-		gen.SetCertificateRenewBefore(1e11),
-	)
+		gen.SetCertificateRenewalTime(metav1.Time{
+			Time: time.Unix(100, 0),
+		}))
 	crt2 := gen.Certificate("crt2",
 		gen.SetCertificateUID("uid-2"),
 		gen.SetCertificateNotAfter(metav1.Time{
@@ -219,7 +220,9 @@ func TestCertificateCache(t *testing.T) {
 			Type:   cmapi.CertificateConditionReady,
 			Status: cmmeta.ConditionTrue,
 		}),
-		gen.SetCertificateRenewBefore(2e11),
+		gen.SetCertificateRenewalTime(metav1.Time{
+			Time: time.Unix(200, 0),
+		}),
 	)
 	crt3 := gen.Certificate("crt3",
 		gen.SetCertificateUID("uid-3"),
@@ -230,7 +233,9 @@ func TestCertificateCache(t *testing.T) {
 			Type:   cmapi.CertificateConditionReady,
 			Status: cmmeta.ConditionFalse,
 		}),
-		gen.SetCertificateRenewBefore(3e11),
+		gen.SetCertificateRenewalTime(metav1.Time{
+			Time: time.Unix(300, 0),
+		}),
 	)
 
 	// Observe all three Certificate metrics

--- a/pkg/metrics/certificates_test.go
+++ b/pkg/metrics/certificates_test.go
@@ -37,9 +37,9 @@ const expiryMetadata = `
 	# TYPE certmanager_certificate_expiration_timestamp_seconds gauge
 `
 
-const renewBeforeMetadata = `
-	# HELP certmanager_certificate_renew_before_seconds The number of seconds before expiration time the certificate should renew.
-	# TYPE certmanager_certificate_renew_before_seconds gauge
+const renewalTimeMetadata = `
+	# HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
+	# TYPE certmanager_certificate_renewal_timestamp_seconds gauge
 `
 
 const readyMetadata = `
@@ -50,7 +50,7 @@ const readyMetadata = `
 func TestCertificateMetrics(t *testing.T) {
 	type testT struct {
 		crt                                                *cmapi.Certificate
-		expectedExpiry, expectedReady, expectedRenewBefore string
+		expectedExpiry, expectedReady, expectedRenewalTime string
 	}
 	tests := map[string]testT{
 		"certificate with expiry and ready status": {
@@ -72,6 +72,9 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 1
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
+			expectedRenewalTime: `
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+`,
 		},
 
 		"certificate with no expiry and no status should give an expiry of 0 and Unknown status": {
@@ -85,6 +88,9 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="False",name="test-certificate",namespace="test-ns"} 0
         certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 0
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
+`,
+			expectedRenewalTime: `
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
 `,
 		},
 
@@ -107,6 +113,9 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 0
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
+			expectedRenewalTime: `
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+`,
 		},
 		"certificate with expiry and status Unknown should give an expiry and Unknown status": {
 			crt: gen.Certificate("test-certificate",
@@ -127,6 +136,9 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 0
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 1
 `,
+			expectedRenewalTime: `
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 0
+`,
 		},
 		"certificate with expiry and ready status and renew before": {
 			crt: gen.Certificate("test-certificate",
@@ -138,7 +150,9 @@ func TestCertificateMetrics(t *testing.T) {
 					Type:   cmapi.CertificateConditionReady,
 					Status: cmmeta.ConditionTrue,
 				}),
-				gen.SetCertificateRenewBefore(time.Duration(1e9)),
+				gen.SetCertificateRenewalTIme(metav1.Time{
+					Time: time.Unix(2208988804, 0),
+				}),
 			),
 			expectedExpiry: `
 	certmanager_certificate_expiration_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
@@ -148,8 +162,8 @@ func TestCertificateMetrics(t *testing.T) {
         certmanager_certificate_ready_status{condition="True",name="test-certificate",namespace="test-ns"} 1
         certmanager_certificate_ready_status{condition="Unknown",name="test-certificate",namespace="test-ns"} 0
 `,
-			expectedRenewBefore: `
-		certmanager_certificate_renew_before_seconds{name="test-certificate",namespace="test-ns"} 1
+			expectedRenewalTime: `
+		certmanager_certificate_renewal_timestamp_seconds{name="test-certificate",namespace="test-ns"} 2.208988804e+09
 `,
 		},
 	}
@@ -165,9 +179,9 @@ func TestCertificateMetrics(t *testing.T) {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}
 
-			if err := testutil.CollectAndCompare(m.certificateRenewBeforeSeconds,
-				strings.NewReader(renewBeforeMetadata+test.expectedRenewBefore),
-				"certmanager_certificate_renew_before_seconds",
+			if err := testutil.CollectAndCompare(m.certificateRenewalTimeSeconds,
+				strings.NewReader(renewalTimeMetadata+test.expectedRenewalTime),
+				"certmanager_certificate_renewal_timestamp_seconds",
 			); err != nil {
 				t.Errorf("unexpected collecting result:\n%s", err)
 			}
@@ -252,13 +266,13 @@ func TestCertificateCache(t *testing.T) {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}
 
-	if err := testutil.CollectAndCompare(m.certificateRenewBeforeSeconds,
-		strings.NewReader(renewBeforeMetadata+`
-        certmanager_certificate_renew_before_seconds{name="crt1",namespace="default-unit-test-ns"} 100
-        certmanager_certificate_renew_before_seconds{name="crt2",namespace="default-unit-test-ns"} 200
-        certmanager_certificate_renew_before_seconds{name="crt3",namespace="default-unit-test-ns"} 300
+	if err := testutil.CollectAndCompare(m.certificateRenewalTimeSeconds,
+		strings.NewReader(renewalTimeMetadata+`
+        certmanager_certificate_renewal_timestamp_seconds{name="crt1",namespace="default-unit-test-ns"} 100
+        certmanager_certificate_renewal_timestamp_seconds{name="crt2",namespace="default-unit-test-ns"} 200
+        certmanager_certificate_renewal_timestamp_seconds{name="crt3",namespace="default-unit-test-ns"} 300
 `),
-		"certmanager_certificate_renew_before_seconds",
+		"certmanager_certificate_renewal_timestamp_seconds",
 	); err != nil {
 		t.Errorf("unexpected collecting result:\n%s", err)
 	}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,6 +17,7 @@ limitations under the License.
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
 // certificate_expiration_timestamp_seconds{name, namespace}
+// certificate_renew_before_seconds{name, namespace}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
@@ -55,6 +56,7 @@ type Metrics struct {
 
 	clockTimeSeconds                 prometheus.CounterFunc
 	certificateExpiryTimeSeconds     *prometheus.GaugeVec
+	certificateRenewBeforeSeconds    *prometheus.GaugeVec
 	certificateReadyStatus           *prometheus.GaugeVec
 	acmeClientRequestDurationSeconds *prometheus.SummaryVec
 	acmeClientRequestCount           *prometheus.CounterVec
@@ -81,6 +83,15 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 				Namespace: namespace,
 				Name:      "certificate_expiration_timestamp_seconds",
 				Help:      "The date after which the certificate expires. Expressed as a Unix Epoch Time.",
+			},
+			[]string{"name", "namespace"},
+		)
+
+		certificateRenewBeforeSeconds = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "certificate_renew_before_seconds",
+				Help:      "The number of seconds before expiration time the certificate should renew.",
 			},
 			[]string{"name", "namespace"},
 		)
@@ -136,6 +147,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 
 		clockTimeSeconds:                 clockTimeSeconds,
 		certificateExpiryTimeSeconds:     certificateExpiryTimeSeconds,
+		certificateRenewBeforeSeconds:    certificateRenewBeforeSeconds,
 		certificateReadyStatus:           certificateReadyStatus,
 		acmeClientRequestCount:           acmeClientRequestCount,
 		acmeClientRequestDurationSeconds: acmeClientRequestDurationSeconds,
@@ -149,6 +161,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 func (m *Metrics) NewServer(ln net.Listener, enablePprof bool) *http.Server {
 	m.registry.MustRegister(m.clockTimeSeconds)
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
+	m.registry.MustRegister(m.certificateRenewBeforeSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)
 	m.registry.MustRegister(m.acmeClientRequestDurationSeconds)
 	m.registry.MustRegister(m.acmeClientRequestCount)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -17,7 +17,7 @@ limitations under the License.
 // Package metrics contains global structures related to metrics collection
 // cert-manager exposes the following metrics:
 // certificate_expiration_timestamp_seconds{name, namespace}
-// certificate_renew_before_seconds{name, namespace}
+// certificate_renewal_timestamp_seconds{name, namespace}
 // certificate_ready_status{name, namespace, condition}
 // acme_client_request_count{"scheme", "host", "path", "method", "status"}
 // acme_client_request_duration_seconds{"scheme", "host", "path", "method", "status"}
@@ -56,7 +56,7 @@ type Metrics struct {
 
 	clockTimeSeconds                 prometheus.CounterFunc
 	certificateExpiryTimeSeconds     *prometheus.GaugeVec
-	certificateRenewBeforeSeconds    *prometheus.GaugeVec
+	certificateRenewalTimeSeconds    *prometheus.GaugeVec
 	certificateReadyStatus           *prometheus.GaugeVec
 	acmeClientRequestDurationSeconds *prometheus.SummaryVec
 	acmeClientRequestCount           *prometheus.CounterVec
@@ -87,10 +87,10 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 			[]string{"name", "namespace"},
 		)
 
-		certificateRenewBeforeSeconds = prometheus.NewGaugeVec(
+		certificateRenewalTimeSeconds = prometheus.NewGaugeVec(
 			prometheus.GaugeOpts{
 				Namespace: namespace,
-				Name:      "certificate_renew_before_seconds",
+				Name:      "certificate_renewal_timestamp_seconds",
 				Help:      "The number of seconds before expiration time the certificate should renew.",
 			},
 			[]string{"name", "namespace"},
@@ -147,7 +147,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 
 		clockTimeSeconds:                 clockTimeSeconds,
 		certificateExpiryTimeSeconds:     certificateExpiryTimeSeconds,
-		certificateRenewBeforeSeconds:    certificateRenewBeforeSeconds,
+		certificateRenewalTimeSeconds:    certificateRenewalTimeSeconds,
 		certificateReadyStatus:           certificateReadyStatus,
 		acmeClientRequestCount:           acmeClientRequestCount,
 		acmeClientRequestDurationSeconds: acmeClientRequestDurationSeconds,
@@ -161,7 +161,7 @@ func New(log logr.Logger, c clock.Clock) *Metrics {
 func (m *Metrics) NewServer(ln net.Listener, enablePprof bool) *http.Server {
 	m.registry.MustRegister(m.clockTimeSeconds)
 	m.registry.MustRegister(m.certificateExpiryTimeSeconds)
-	m.registry.MustRegister(m.certificateRenewBeforeSeconds)
+	m.registry.MustRegister(m.certificateRenewalTimeSeconds)
 	m.registry.MustRegister(m.certificateReadyStatus)
 	m.registry.MustRegister(m.acmeClientRequestDurationSeconds)
 	m.registry.MustRegister(m.acmeClientRequestCount)

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -158,7 +158,6 @@ func TestMetricsController(t *testing.T) {
 		gen.SetCertificateCommonName(crtName),
 		gen.SetCertificateNamespace(namespace),
 		gen.SetCertificateUID("uid-1"),
-		gen.SetCertificateRenewBefore(time.Duration(3e11)),
 	)
 
 	crt, err = cmClient.CertmanagerV1().Certificates(namespace).Create(ctx, crt, metav1.CreateOptions{})
@@ -175,9 +174,9 @@ certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="t
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 1
-# HELP certmanager_certificate_renew_before_seconds The number of seconds before expiration time the certificate should renew.
-# TYPE certmanager_certificate_renew_before_seconds gauge
-certmanager_certificate_renew_before_seconds{name="testcrt",namespace="testns"} 300
+# HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
+# TYPE certmanager_certificate_renewal_timestamp_seconds gauge
+certmanager_certificate_renewal_timestamp_seconds{name="testcrt",namespace="testns"} 0
 ` + clockMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
@@ -194,6 +193,9 @@ certmanager_controller_sync_call_count{controller="metrics_test"} 1
 			Status: cmmeta.ConditionTrue,
 		},
 	}
+	crt.Status.RenewalTime = &metav1.Time{
+		Time: time.Unix(100, 0),
+	}
 	_, err = cmClient.CertmanagerV1().Certificates(namespace).UpdateStatus(ctx, crt, metav1.UpdateOptions{})
 	if err != nil {
 		t.Fatal(err)
@@ -208,9 +210,9 @@ certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="t
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 1
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 0
-# HELP certmanager_certificate_renew_before_seconds The number of seconds before expiration time the certificate should renew.
-# TYPE certmanager_certificate_renew_before_seconds gauge
-certmanager_certificate_renew_before_seconds{name="testcrt",namespace="testns"} 300
+# HELP certmanager_certificate_renewal_timestamp_seconds The number of seconds before expiration time the certificate should renew.
+# TYPE certmanager_certificate_renewal_timestamp_seconds gauge
+certmanager_certificate_renewal_timestamp_seconds{name="testcrt",namespace="testns"} 100
 ` + clockMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -158,6 +158,7 @@ func TestMetricsController(t *testing.T) {
 		gen.SetCertificateCommonName(crtName),
 		gen.SetCertificateNamespace(namespace),
 		gen.SetCertificateUID("uid-1"),
+		gen.SetCertificateRenewBefore(time.Duration(3e11)),
 	)
 
 	crt, err = cmClient.CertmanagerV1().Certificates(namespace).Create(ctx, crt, metav1.CreateOptions{})
@@ -174,6 +175,9 @@ certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="t
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 1
+# HELP certmanager_certificate_renew_before_seconds The number of seconds before expiration time the certificate should renew.
+# TYPE certmanager_certificate_renew_before_seconds gauge
+certmanager_certificate_renew_before_seconds{name="testcrt",namespace="testns"} 300
 ` + clockMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter
@@ -204,6 +208,9 @@ certmanager_certificate_expiration_timestamp_seconds{name="testcrt",namespace="t
 certmanager_certificate_ready_status{condition="False",name="testcrt",namespace="testns"} 0
 certmanager_certificate_ready_status{condition="True",name="testcrt",namespace="testns"} 1
 certmanager_certificate_ready_status{condition="Unknown",name="testcrt",namespace="testns"} 0
+# HELP certmanager_certificate_renew_before_seconds The number of seconds before expiration time the certificate should renew.
+# TYPE certmanager_certificate_renew_before_seconds gauge
+certmanager_certificate_renew_before_seconds{name="testcrt",namespace="testns"} 300
 ` + clockMetric + `
 # HELP certmanager_controller_sync_call_count The number of sync() calls made by a controller.
 # TYPE certmanager_controller_sync_call_count counter

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -172,7 +172,7 @@ func SetCertificateNotBefore(p metav1.Time) CertificateModifier {
 	}
 }
 
-func SetCertificateRenewalTIme(p metav1.Time) CertificateModifier {
+func SetCertificateRenewalTime(p metav1.Time) CertificateModifier {
 	return func(crt *v1.Certificate) {
 		crt.Status.RenewalTime = &p
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adds an additional RenewBefore metric to certificates. This allows for finer grained alerting of certificate issues. If a certificate has not been renewed before its RenewBefore time an alert can be triggered. This is helpful for clusters where certificates may have different lifetimes.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Add Certificate RenewBefore prometheus metrics
```
