### PR TITLE
print timestamps during e2e tests

### DIFF
--- a/devel/ci-run-e2e.sh
+++ b/devel/ci-run-e2e.sh
@@ -28,15 +28,18 @@ SCRIPT_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 export REPO_ROOT="${SCRIPT_ROOT}/.."
 source "${SCRIPT_ROOT}/lib/lib.sh"
 
+# Install the "moreutils" package from your package manager to get ts
+check_tool ts
+
 # Configure PATH to use bazel provided e2e tools
-setup_tools
+setup_tools 2>&1 | ts "$TS_TIMESTAMP_FORMAT"
 
 # Ensure a running Kubernetes cluster
-"${SCRIPT_ROOT}/ci-cluster.sh"
+"${SCRIPT_ROOT}/ci-cluster.sh" 2>&1 | ts "$TS_TIMESTAMP_FORMAT"
 
 echo "Ensuring all e2e test dependencies are installed..."
-"${SCRIPT_ROOT}/setup-e2e-deps.sh"
+"${SCRIPT_ROOT}/setup-e2e-deps.sh" 2>&1 | ts "$TS_TIMESTAMP_FORMAT"
 
 echo "Running e2e test suite..."
 FLAKE_ATTEMPTS=2 "${SCRIPT_ROOT}/run-e2e.sh" \
-  "$@"
+  "$@" 2>&1 | ts "$TS_TIMESTAMP_FORMAT"

--- a/devel/lib/lib.sh
+++ b/devel/lib/lib.sh
@@ -35,6 +35,9 @@ export SERVICE_IP_PREFIX="${SERVICE_IP_PREFIX:-10.0.0}"
 export DNS_SERVER="${SERVICE_IP_PREFIX}.16"
 export INGRESS_IP="${SERVICE_IP_PREFIX}.15"
 
+# Timestamp format printed during e2e tests - see strftime(3)
+export TS_TIMESTAMP_FORMAT="[%Y-%m-%d %H:%M:%.S]"
+
 # setup_tools will build and set up the environment to use bazel-provided
 # versions of the tools required for development
 setup_tools() {


### PR DESCRIPTION
**What this PR does / why we need it**: 
We're investigating why our CI is so slow, so adding timestamps to the log output is the easiest way.

**Special notes for your reviewer**:
I considered adding `ts` to hack/tools, but it's a C program without releases so didn't want to add the bazel rules to build it.
Most of the log output goes to stderr, so I redirect it to stdout instead.

**Release note**:
```release-note
NONE
```

/kind flake