### PR TITLE
Adds the ACME client middleware when create an ACME account

### DIFF
--- a/pkg/acme/accounts/BUILD.bazel
+++ b/pkg/acme/accounts/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/acme/client:go_default_library",
+        "//pkg/acme/client/middleware:go_default_library",
         "//pkg/acme/util:go_default_library",
         "//pkg/apis/acme/v1:go_default_library",
         "//pkg/metrics:go_default_library",

--- a/pkg/acme/accounts/client.go
+++ b/pkg/acme/accounts/client.go
@@ -26,6 +26,7 @@ import (
 	acmeapi "golang.org/x/crypto/acme"
 
 	acmecl "github.com/jetstack/cert-manager/pkg/acme/client"
+	"github.com/jetstack/cert-manager/pkg/acme/client/middleware"
 	acmeutil "github.com/jetstack/cert-manager/pkg/acme/util"
 	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	"github.com/jetstack/cert-manager/pkg/metrics"
@@ -39,13 +40,13 @@ var _ NewClientFunc = NewClient
 
 // NewClient is an implementation of NewClientFunc that returns a real ACME client.
 func NewClient(client *http.Client, config cmacme.ACMEIssuer, privateKey *rsa.PrivateKey) acmecl.Interface {
-	return &acmeapi.Client{
+	return middleware.NewLogger(&acmeapi.Client{
 		Key:          privateKey,
 		HTTPClient:   client,
 		DirectoryURL: config.Server,
 		UserAgent:    util.CertManagerUserAgent,
 		RetryBackoff: acmeutil.RetryBackoff,
-	}
+	})
 }
 
 // BuildHTTPClient returns a instrumented HTTP client to be used by the ACME


### PR DESCRIPTION
At some point we removed the ACME logging middlware to the client factory. This was important for me when trying to debug what calls cert-manager was making to ACME servers and in which order.

This PR re-adds to logging wrapper to all new ACME client, which logs at trace level.

/milestone v1.6

```release-note
Adds middleware logging back to ACME client for debugging
```
