### PR TITLE
Vault internal client should check health conn err before checking response status

### DIFF
--- a/pkg/internal/vault/vault.go
+++ b/pkg/internal/vault/vault.go
@@ -383,13 +383,25 @@ func (v *Vault) IsVaultInitializedAndUnsealed() error {
 	healthURL := path.Join("/v1", "sys", "health")
 	healthRequest := v.client.NewRequest("GET", healthURL)
 	healthResp, err := v.client.RawRequest(healthRequest)
+
+	if healthResp != nil {
+		defer healthResp.Body.Close()
+	}
+
 	// 429 = if unsealed and standby
 	// 472 = if disaster recovery mode replication secondary and active
 	// 473 = if performance standby
-	if err != nil && healthResp.StatusCode != 429 && healthResp.StatusCode != 472 && healthResp.StatusCode != 473 {
-		return err
+	if err != nil {
+		switch {
+		case healthResp == nil:
+			return err
+		case healthResp.StatusCode == 429, healthResp.StatusCode == 472, healthResp.StatusCode == 473:
+			return nil
+		default:
+			return fmt.Errorf("error calling Vault %s: %w", healthURL, err)
+		}
 	}
-	defer healthResp.Body.Close()
+
 	return nil
 }
 


### PR DESCRIPTION
/kind bug
/area vault
/milestone v1.6

/assign @irbekrm 
Fixes #4011 

```release-note
FIX: Prevent Vault Client from panicing when request to Vault health endpoint fails.
```

Should we consider this for backporting?