### PR TITLE
Add help entry for build and release_tars in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,6 +59,7 @@ help:
 	### Build targets
 	#
 	# clean              - removes the entire output base tree, stops the Bazel server and removes test artifacts
+	# build              - build a binary of the cert-manager kubectl plugin and build docker images for all components
 	# controller         - build a binary of the 'controller'
 	# cainjector         - build a binary of the 'cainjector'
 	# webhook            - build a binary of the 'webhook'
@@ -68,10 +69,9 @@ help:
 	# images_push        - pushes docker images to the target registry
 	# crds               - runs the update-crds script to ensure that generated CRDs are up to date
 	# cluster            - creates a Kubernetes cluster for testing in CI (KIND by default)
+	# release_tars       - build the release tar files.
 	#
-	# Image targets can be run with optional args DOCKER_REGISTRY and APP_VERSION:
-	#
-	# All image targets can be run with optional args DOCKER_REGISTRY, APP_VERSION, PLATFORM
+	# All image targets can be run with optional args DOCKER_REGISTRY, APP_VERSION, PLATFORM:
 	#
 	# make images DOCKER_REGISTRY=quay.io/yourusername APP_VERSION=v0.11.0-dev.my-feature PLATFORM=@io_bazel_rules_go//go/toolchain:linux_arm64
 	#


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

While looking into [issue 3648](https://github.com/jetstack/cert-manager/issues/3648) I've found that `build` and `release_tars` are not mentioned in `make help`


**Special notes for your reviewer**:

Comments get outdated pretty fast. Another solution for `make help` that is super powerful is here: [Alacritty's Makefile Help](https://github.com/alacritty/alacritty/blob/master/Makefile#L29-L30). It moves the comments closer to the targets.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
No code change.
