### PR TITLE
Clouldflare: Show API error messages (e.g., invalid access token)

### DIFF
--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -10,6 +10,7 @@ package cloudflare
 
 import (
 	"encoding/json"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -109,7 +110,25 @@ func TestFindNearestZoneForFQDN(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, zone, DNSZone{ID: "1a23cc4567b8def91a01c23a456e78cd", Name: "sub.domain.com"})
+}
 
+func TestFindNearestZoneForFQDNInvalidToken(t *testing.T) {
+	dnsProvider := new(DNSProviderMock)
+
+	noResult := []byte(`[]`)
+
+	dnsProvider.On("makeRequest", "GET", "/zones?name=_acme-challenge.test.sub.domain.com", mock.Anything).Maybe().Return(noResult, nil)
+	dnsProvider.On("makeRequest", "GET", "/zones?name=test.sub.domain.com", mock.Anything).Maybe().Return(noResult, nil)
+	dnsProvider.On("makeRequest", "GET", "/zones?name=sub.domain.com", mock.Anything).Maybe().Return(noResult, nil)
+	dnsProvider.On("makeRequest", "GET", "/zones?name=domain.com", mock.Anything).Return(noResult,
+		fmt.Errorf(`while attempting to find Zones for domain _acme-challenge.test.sub.domain.com
+while querying the Cloudflare API for GET "/zones?name=_acme-challenge.test.sub.domain.com"
+	 Error: 9109: Invalid access token`))
+
+	_, err := FindNearestZoneForFQDN(dnsProvider, "_acme-challenge.test.sub.domain.com.")
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid access token")
 }
 
 func TestCloudFlarePresent(t *testing.T) {

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare_test.go
@@ -42,8 +42,9 @@ func (c *DNSProviderMock) makeRequest(method, uri string, body io.Reader) (json.
 func init() {
 	cflareEmail = os.Getenv("CLOUDFLARE_EMAIL")
 	cflareAPIKey = os.Getenv("CLOUDFLARE_API_KEY")
+	cflareAPIToken = os.Getenv("CLOUDFLARE_API_TOKEN")
 	cflareDomain = os.Getenv("CLOUDFLARE_DOMAIN")
-	if len(cflareEmail) > 0 && len(cflareAPIKey) > 0 && len(cflareDomain) > 0 {
+	if len(cflareEmail) > 0 && (len(cflareAPIKey) > 0 || len(cflareAPIToken) > 0) && len(cflareDomain) > 0 {
 		cflareLiveTest = true
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Error messages (e.g., invalid access token) returned by the Cloudflare API were being swallowed with a blanket and misleading message ("Found no Zones for domain ..."). This PR exposes the last network or API error message from the request/response to the user in the form:
```
while attempting to find Zones for domain _acme-challenge.sub.domain.
while querying the Cloudflare API for GET "/zones?name=_acme-challenge.sub.domain"
         Error: 9109: Invalid access token
```

This PR also allows live testing using a Cloudflare API token (which are more tightly scoped than API keys). 

**Special notes for your reviewer**:

Probably not the best way to do this, but I'm a golang newbie and didn't want to dive in to completely re-writing error handling for the whole module.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Expose error messages (e.g., invalid access token) from the Cloudflare API to users; allow live testing using Cloudflare API token (not just key).
```
