### PR TITLE
Add support for building all Bazel targets on M1 macs

### DIFF
--- a/build/platforms.bzl
+++ b/build/platforms.bzl
@@ -46,7 +46,7 @@ CLIENT_PLATFORMS = {
 
 TEST_PLATFORMS = {
     "linux": ["amd64"],
-    "darwin": ["amd64"],
+    "darwin": ["amd64", "arm64"],
 }
 
 # Helper which produces the ALL_PLATFORMS dictionary, currently composed of

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -18,6 +18,7 @@ genrule(
     name = "com_coreos_etcd",
     srcs = select({
         ":darwin": ["@kubebuilder-tools_darwin_amd64//:etcd"],
+        ":darwin_arm": ["@kubebuilder-tools_darwin_amd64//:etcd"],
         ":k8": ["@kubebuilder-tools_linux_amd64//:etcd"],
     }),
     outs = ["etcd"],
@@ -29,6 +30,7 @@ genrule(
     name = "co_honnef_go_tools_staticcheck",
     srcs = select({
         ":darwin": ["@co_honnef_go_tools_staticcheck_osx//:file"],
+        ":darwin_arm": ["@co_honnef_go_tools_staticcheck_osx//:file"],
         ":k8": ["@co_honnef_go_tools_staticcheck_linux//:file"],
     }),
     outs = ["staticcheck"],
@@ -40,6 +42,7 @@ genrule(
     name = "io_kubernetes_kube-apiserver",
     srcs = select({
         ":darwin": ["@kubebuilder-tools_darwin_amd64//:kube-apiserver"],
+        ":darwin_arm": ["@kubebuilder-tools_darwin_amd64//:kube-apiserver"],
         ":k8": ["@kubebuilder-tools_linux_amd64//:kube-apiserver"],
     }),
     outs = ["kube-apiserver"],
@@ -64,6 +67,8 @@ genrule(
     name = "fetch_oc3",
     srcs = select({
         ":k8": ["@oc_3_11_linux//:file"],
+        ":darwin": ["@oc_3_11_mac//:file"],
+        ":darwin_arm": ["@oc_3_11_mac//:file"],
     }),
     outs = ["oc3"],
     cmd = "cp $(SRCS) $@",

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -54,7 +54,7 @@ filegroup(
 
     http_archive(
         name = "co_honnef_go_tools_staticcheck_osx",
-        sha256 = "03b100561e3bc14db0b3b4004b102a00cb0197938d23cc40193f269f7b246d2d",
+        sha256 = "7fb41768b8e68aaad397f666d7d5eb9c31abcc4180b5cb6fa7d091cef987eb77",
         urls = ["https://github.com/dominikh/go-tools/releases/download/2021.1/staticcheck_darwin_amd64.tar.gz"],
         build_file_content = """
 filegroup(
@@ -204,6 +204,21 @@ filegroup(
      name = "file",
      srcs = [
         "openshift-origin-client-tools-v3.11.0-0cbc58b-linux-64bit/oc",
+     ],
+     visibility = ["//visibility:public"],
+)
+    """,
+    )
+    http_archive(
+        name = "oc_3_11_mac",
+        sha256 = "75d58500aec1a2cee9473dfa826c81199669dbc0f49806e31a13626b5e4cfcf0",
+        urls = ["https://github.com/openshift/origin/releases/download/v3.11.0/openshift-origin-client-tools-v3.11.0-0cbc58b-mac.zip"],
+        build_file_content =
+         """
+filegroup(
+     name = "file",
+     srcs = [
+        "oc",
      ],
      visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds support for running `bazel build //...` and `bazel test //...` on M1 macs successfully. This requires Bazel version v4.2.1 to work, or otherwise requires a full Xcode installation alongside Bazel v4.1.x.

**Which issue this PR fixes**: fixes #3804

**Special notes for your reviewer**:

For any binaries that _don't_ offer a darwin/arm64 build, I've just used the darwin/amd64 version instead on the assumption that Rosetta 2 is installed/available.

I've also noticed some issues with `verify-errexit` that I can't seem to place.. I don't _think_ this is specific to M1, though I've not had chance to test yet :)

**Release note**:
```release-note
Add support for building & developing on M1 macs
```
