### PR TITLE
Add timestamps to bazel build output

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,4 @@
 # Include git version info
 build --workspace_status_command hack/build/print-workspace-status.sh
+# Show timestamps with each bazel message
+build --show_timestamps


### PR DESCRIPTION
Add timestamps to bazel output to make it easier to see which steps take a long time.

Supplants #4421 

```release-note
NONE
```