### PR TITLE
Remove t.Fatal from goroutine

### DIFF
--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -70,11 +70,11 @@ func TestMetricsController(t *testing.T) {
 	}
 	server := metricsHandler.NewServer(ln, false)
 
-	doneCh := make(chan struct{})
+	errCh := make(chan error)
 	go func() {
-		defer close(doneCh)
+		defer close(errCh)
 		if err := server.Serve(ln); err != http.ErrServerClosed {
-			t.Fatal(err)
+			errCh <- err
 		}
 	}()
 	defer func() {
@@ -84,7 +84,10 @@ func TestMetricsController(t *testing.T) {
 		if err := server.Shutdown(shutdownCtx); err != nil {
 			t.Fatal(err)
 		}
-		<-doneCh
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 
 	ctrl, queue, mustSync := controllermetrics.NewController(factory, cmFactory, metricsHandler)

--- a/test/integration/webhook/dynamic_authority_test.go
+++ b/test/integration/webhook/dynamic_authority_test.go
@@ -67,16 +67,19 @@ func TestDynamicAuthority_Bootstrap(t *testing.T) {
 		Log:             logtesting.TestLogger{T: t},
 	}
 	stopCh := make(chan struct{})
-	doneCh := make(chan struct{})
+	errCh := make(chan error)
 	defer func() {
 		close(stopCh)
-		<-doneCh
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 	// run the dynamic authority controller in the background
 	go func() {
-		defer close(doneCh)
+		defer close(errCh)
 		if err := auth.Run(stopCh); err != nil && !errors.Is(err, context.Canceled) {
-			t.Fatalf("Unexpected error running authority: %v", err)
+			errCh <- fmt.Errorf("Unexpected error running authority: %v", err)
 		}
 	}()
 
@@ -114,16 +117,19 @@ func TestDynamicAuthority_Recreates(t *testing.T) {
 		Log:             logtesting.TestLogger{T: t},
 	}
 	stopCh := make(chan struct{})
-	doneCh := make(chan struct{})
+	errCh := make(chan error)
 	defer func() {
 		close(stopCh)
-		<-doneCh
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 	// run the dynamic authority controller in the background
 	go func() {
-		defer close(doneCh)
+		defer close(errCh)
 		if err := auth.Run(stopCh); err != nil && !errors.Is(err, context.Canceled) {
-			t.Fatalf("Unexpected error running authority: %v", err)
+			errCh <- fmt.Errorf("Unexpected error running authority: %v", err)
 		}
 	}()
 

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -67,16 +68,19 @@ func TestDynamicSource_Bootstrap(t *testing.T) {
 		Log: log,
 	}
 	stopCh := make(chan struct{})
-	doneCh := make(chan struct{})
+	errCh := make(chan error)
 	defer func() {
 		close(stopCh)
-		<-doneCh
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 	// run the dynamic authority controller in the background
 	go func() {
-		defer close(doneCh)
+		defer close(errCh)
 		if err := source.Run(stopCh); err != nil && !errors.Is(err, context.Canceled) {
-			t.Fatalf("Unexpected error running source: %v", err)
+			errCh <- fmt.Errorf("Unexpected error running source: %v", err)
 		}
 	}()
 
@@ -133,16 +137,19 @@ func TestDynamicSource_CARotation(t *testing.T) {
 		Log: log,
 	}
 	stopCh := make(chan struct{})
-	doneCh := make(chan struct{})
+	errCh := make(chan error)
 	defer func() {
 		close(stopCh)
-		<-doneCh
+		err := <-errCh
+		if err != nil {
+			t.Fatal(err)
+		}
 	}()
 	// run the dynamic authority controller in the background
 	go func() {
-		defer close(doneCh)
+		defer close(errCh)
 		if err := source.Run(stopCh); err != nil && !errors.Is(err, context.Canceled) {
-			t.Fatalf("Unexpected error running source: %v", err)
+			errCh <- fmt.Errorf("Unexpected error running source: %v", err)
 		}
 	}()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR is addressing go vet's issues with t.Fatal executed from goroutines

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4499

**Special notes for your reviewer**:
For this issue I addressed the changes to go vet's problematic `t.Fatal` calls in two ways:

The first way is inside plain test functions (those starting with `Test`) where I use a channel to send/receive the eventual error if raised inside the goroutine. The difference with the code before is that `t.Fatal` will not trigger as soon as the error is spotted but at the end of the test.

The second way is inside the other functions (not starting with `Test` but still used in the tests) where I just plainly replaced it with a `panic` as in those contexts it may be more helpful to stop the execution right when the error happens.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Hello, thanks for letting me having a go on this. I have used the special notes section to explain a bit the logic I used to replace the go vet's problematic calls to `t.Fatal`. Please let me know your feedback so that I can check with you the best way to fix this issue.
Cheers,
Michele
