### PR TITLE
The Vault issuer can now be given a serviceAccountRef

### DIFF
--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -79,6 +79,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
 
 ---
 

--- a/deploy/crds/crd-clusterissuers.yaml
+++ b/deploy/crds/crd-clusterissuers.yaml
@@ -1077,7 +1077,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -1094,6 +1093,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
@@ -2260,7 +2268,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -2277,6 +2284,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
@@ -3445,7 +3461,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -3462,6 +3477,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
@@ -4630,7 +4654,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -4647,6 +4670,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string

--- a/deploy/crds/crd-issuers.yaml
+++ b/deploy/crds/crd-issuers.yaml
@@ -1077,7 +1077,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -1094,6 +1093,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
@@ -2260,7 +2268,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -2277,6 +2284,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
@@ -3445,7 +3461,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -3462,6 +3477,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string
@@ -4630,7 +4654,6 @@ spec:
                           type: object
                           required:
                             - role
-                            - secretRef
                           properties:
                             mountPath:
                               description: The Vault mountPath here is the mount path to use when authenticating with Vault. For example, setting a value to `/v1/auth/foo`, will use the path `/v1/auth/foo/login` to authenticate with Vault. If unspecified, the default value "/v1/auth/kubernetes" will be used.
@@ -4647,6 +4670,15 @@ spec:
                                 key:
                                   description: The key of the entry in the Secret resource's `data` field to be used. Some instances of this field may be defaulted, in others it may be required.
                                   type: string
+                                name:
+                                  description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                  type: string
+                            serviceAccountRef:
+                              description: "A reference to a service account that will be used to request a bound token (also known as \"projected token\"). To be able to request a token, the service account token mounted in the cert-manager's Pod must be bound to a role containing the following rule: \n  apiGroups: [\"\"]  resources: [\"serviceaccounts/token\"]  verbs: [\"create\"]"
+                              type: object
+                              required:
+                                - name
+                              properties:
                                 name:
                                   description: 'Name of the resource being referred to. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                                   type: string

--- a/internal/apis/certmanager/identity/certificaterequests/certificaterequests.go
+++ b/internal/apis/certmanager/identity/certificaterequests/certificaterequests.go
@@ -40,7 +40,7 @@ func ValidateCreate(req *admissionv1.AdmissionRequest, obj runtime.Object) (fiel
 		el = append(el, field.Forbidden(fldPath.Child("uid"), "uid identity must be that of the requester"))
 	}
 	if cr.Spec.Username != req.UserInfo.Username {
-		el = append(el, field.Forbidden(fldPath.Child("username"), "username identity must be that of the requester"))
+		el = append(el, field.Forbidden(fldPath.Child("username"), "must be equal to the requestor '"+cr.Spec.Username+"'"))
 	}
 	if !util.EqualUnsorted(cr.Spec.Groups, req.UserInfo.Groups) {
 		el = append(el, field.Forbidden(fldPath.Child("groups"), "groups identity must be that of the requester"))

--- a/internal/apis/certmanager/types_issuer.go
+++ b/internal/apis/certmanager/types_issuer.go
@@ -233,8 +233,19 @@ type VaultKubernetesAuth struct {
 
 	// The required Secret field containing a Kubernetes ServiceAccount JWT used
 	// for authenticating with Vault. Use of 'ambient credentials' is not
-	// supported.
+	// supported. This field should not be set if serviceAccountRef is set.
 	SecretRef cmmeta.SecretKeySelector
+
+	// A reference to a service account that will be used to request a bound
+	// token (also known as "projected token"). This field should not be set if
+	// secretRef is set. To be able to request a token, the service account
+	// token mounted in the cert-manager's Pod must be bound to a role
+	// containing the following rule:
+	//
+	//  apiGroups: [""]
+	//  resources: ["serviceaccounts/token"]
+	//  verbs: ["create"]
+	ServiceAccountRef cmmeta.LocalObjectReference
 
 	// A required field containing the Vault Role to assume. A Role binds a
 	// Kubernetes ServiceAccount with a set of Vault policies.

--- a/internal/apis/certmanager/v1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1/zz_generated.conversion.go
@@ -1378,6 +1378,9 @@ func autoConvert_v1_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth(in *v
 	if err := internalapismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	if err := internalapismetav1.Convert_v1_LocalObjectReference_To_meta_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
+		return err
+	}
 	out.Role = in.Role
 	return nil
 }
@@ -1390,6 +1393,9 @@ func Convert_v1_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth(in *v1.Va
 func autoConvert_certmanager_VaultKubernetesAuth_To_v1_VaultKubernetesAuth(in *certmanager.VaultKubernetesAuth, out *v1.VaultKubernetesAuth, s conversion.Scope) error {
 	out.Path = in.Path
 	if err := internalapismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
+		return err
+	}
+	if err := internalapismetav1.Convert_meta_LocalObjectReference_To_v1_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
 		return err
 	}
 	out.Role = in.Role

--- a/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha2/zz_generated.conversion.go
@@ -1396,6 +1396,9 @@ func autoConvert_v1alpha2_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	if err := apismetav1.Convert_v1_LocalObjectReference_To_meta_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
+		return err
+	}
 	out.Role = in.Role
 	return nil
 }
@@ -1408,6 +1411,9 @@ func Convert_v1alpha2_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth(in 
 func autoConvert_certmanager_VaultKubernetesAuth_To_v1alpha2_VaultKubernetesAuth(in *certmanager.VaultKubernetesAuth, out *v1alpha2.VaultKubernetesAuth, s conversion.Scope) error {
 	out.Path = in.Path
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
+		return err
+	}
+	if err := apismetav1.Convert_meta_LocalObjectReference_To_v1_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
 		return err
 	}
 	out.Role = in.Role

--- a/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1alpha3/zz_generated.conversion.go
@@ -1395,6 +1395,9 @@ func autoConvert_v1alpha3_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	if err := apismetav1.Convert_v1_LocalObjectReference_To_meta_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
+		return err
+	}
 	out.Role = in.Role
 	return nil
 }
@@ -1407,6 +1410,9 @@ func Convert_v1alpha3_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth(in 
 func autoConvert_certmanager_VaultKubernetesAuth_To_v1alpha3_VaultKubernetesAuth(in *certmanager.VaultKubernetesAuth, out *v1alpha3.VaultKubernetesAuth, s conversion.Scope) error {
 	out.Path = in.Path
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
+		return err
+	}
+	if err := apismetav1.Convert_meta_LocalObjectReference_To_v1_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
 		return err
 	}
 	out.Role = in.Role

--- a/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
+++ b/internal/apis/certmanager/v1beta1/zz_generated.conversion.go
@@ -1388,6 +1388,9 @@ func autoConvert_v1beta1_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth(
 	if err := apismetav1.Convert_v1_SecretKeySelector_To_meta_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
 		return err
 	}
+	if err := apismetav1.Convert_v1_LocalObjectReference_To_meta_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
+		return err
+	}
 	out.Role = in.Role
 	return nil
 }
@@ -1400,6 +1403,9 @@ func Convert_v1beta1_VaultKubernetesAuth_To_certmanager_VaultKubernetesAuth(in *
 func autoConvert_certmanager_VaultKubernetesAuth_To_v1beta1_VaultKubernetesAuth(in *certmanager.VaultKubernetesAuth, out *v1beta1.VaultKubernetesAuth, s conversion.Scope) error {
 	out.Path = in.Path
 	if err := apismetav1.Convert_meta_SecretKeySelector_To_v1_SecretKeySelector(&in.SecretRef, &out.SecretRef, s); err != nil {
+		return err
+	}
+	if err := apismetav1.Convert_meta_LocalObjectReference_To_v1_LocalObjectReference(&in.ServiceAccountRef, &out.ServiceAccountRef, s); err != nil {
 		return err
 	}
 	out.Role = in.Role

--- a/internal/apis/certmanager/zz_generated.deepcopy.go
+++ b/internal/apis/certmanager/zz_generated.deepcopy.go
@@ -865,6 +865,7 @@ func (in *VaultIssuer) DeepCopy() *VaultIssuer {
 func (in *VaultKubernetesAuth) DeepCopyInto(out *VaultKubernetesAuth) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.ServiceAccountRef = in.ServiceAccountRef
 	return
 }
 

--- a/internal/vault/BUILD.bazel
+++ b/internal/vault/BUILD.bazel
@@ -10,6 +10,9 @@ go_library(
         "//pkg/util/pki:go_default_library",
         "@com_github_hashicorp_vault_api//:go_default_library",
         "@com_github_hashicorp_vault_sdk//helper/certutil:go_default_library",
+        "@io_k8s_api//authentication/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
     ],
 )

--- a/pkg/apis/certmanager/v1/types_issuer.go
+++ b/pkg/apis/certmanager/v1/types_issuer.go
@@ -260,7 +260,19 @@ type VaultKubernetesAuth struct {
 	// The required Secret field containing a Kubernetes ServiceAccount JWT used
 	// for authenticating with Vault. Use of 'ambient credentials' is not
 	// supported.
-	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
+	// +optional
+	SecretRef cmmeta.SecretKeySelector `json:"secretRef,omitempty"`
+
+	// A reference to a service account that will be used to request a bound
+	// token (also known as "projected token"). To be able to request a token,
+	// the service account token mounted in the cert-manager's Pod must be bound
+	// to a role containing the following rule:
+	//
+	//  apiGroups: [""]
+	//  resources: ["serviceaccounts/token"]
+	//  verbs: ["create"]
+	// +optional
+	ServiceAccountRef cmmeta.LocalObjectReference `json:"serviceAccountRef,omitempty"`
 
 	// A required field containing the Vault Role to assume. A Role binds a
 	// Kubernetes ServiceAccount with a set of Vault policies.

--- a/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1/zz_generated.deepcopy.go
@@ -865,6 +865,7 @@ func (in *VaultIssuer) DeepCopy() *VaultIssuer {
 func (in *VaultKubernetesAuth) DeepCopyInto(out *VaultKubernetesAuth) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.ServiceAccountRef = in.ServiceAccountRef
 	return
 }
 

--- a/pkg/apis/certmanager/v1alpha2/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha2/types_issuer.go
@@ -256,7 +256,19 @@ type VaultKubernetesAuth struct {
 	// The required Secret field containing a Kubernetes ServiceAccount JWT used
 	// for authenticating with Vault. Use of 'ambient credentials' is not
 	// supported.
-	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
+	// +optional
+	SecretRef cmmeta.SecretKeySelector `json:"secretRef,omitempty"`
+
+	// A reference to a service account that will be used to request a bound
+	// token (also known as "projected token"). To be able to request a token,
+	// the service account token mounted in the cert-manager's Pod must be bound
+	// to a role containing the following rule:
+	//
+	//  apiGroups: [""]
+	//  resources: ["serviceaccounts/token"]
+	//  verbs: ["create"]
+	// +optional
+	ServiceAccountRef cmmeta.LocalObjectReference `json:"serviceAccountRef,omitempty"`
 
 	// A required field containing the Vault Role to assume. A Role binds a
 	// Kubernetes ServiceAccount with a set of Vault policies.

--- a/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha2/zz_generated.deepcopy.go
@@ -870,6 +870,7 @@ func (in *VaultIssuer) DeepCopy() *VaultIssuer {
 func (in *VaultKubernetesAuth) DeepCopyInto(out *VaultKubernetesAuth) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.ServiceAccountRef = in.ServiceAccountRef
 	return
 }
 

--- a/pkg/apis/certmanager/v1alpha3/types_issuer.go
+++ b/pkg/apis/certmanager/v1alpha3/types_issuer.go
@@ -256,7 +256,19 @@ type VaultKubernetesAuth struct {
 	// The required Secret field containing a Kubernetes ServiceAccount JWT used
 	// for authenticating with Vault. Use of 'ambient credentials' is not
 	// supported.
-	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
+	// +optional
+	SecretRef cmmeta.SecretKeySelector `json:"secretRef,omitempty"`
+
+	// A reference to a service account that will be used to request a bound
+	// token (also known as "projected token"). To be able to request a token,
+	// the service account token mounted in the cert-manager's Pod must be bound
+	// to a role containing the following rule:
+	//
+	//  apiGroups: [""]
+	//  resources: ["serviceaccounts/token"]
+	//  verbs: ["create"]
+	// +optional
+	ServiceAccountRef cmmeta.LocalObjectReference `json:"serviceAccountRef,omitempty"`
 
 	// A required field containing the Vault Role to assume. A Role binds a
 	// Kubernetes ServiceAccount with a set of Vault policies.

--- a/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1alpha3/zz_generated.deepcopy.go
@@ -865,6 +865,7 @@ func (in *VaultIssuer) DeepCopy() *VaultIssuer {
 func (in *VaultKubernetesAuth) DeepCopyInto(out *VaultKubernetesAuth) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.ServiceAccountRef = in.ServiceAccountRef
 	return
 }
 

--- a/pkg/apis/certmanager/v1beta1/types_issuer.go
+++ b/pkg/apis/certmanager/v1beta1/types_issuer.go
@@ -258,7 +258,19 @@ type VaultKubernetesAuth struct {
 	// The required Secret field containing a Kubernetes ServiceAccount JWT used
 	// for authenticating with Vault. Use of 'ambient credentials' is not
 	// supported.
-	SecretRef cmmeta.SecretKeySelector `json:"secretRef"`
+	// +optional
+	SecretRef cmmeta.SecretKeySelector `json:"secretRef,omitempty"`
+
+	// A reference to a service account that will be used to request a bound
+	// token (also known as "projected token"). To be able to request a token,
+	// the service account token mounted in the cert-manager's Pod must be bound
+	// to a role containing the following rule:
+	//
+	//  apiGroups: [""]
+	//  resources: ["serviceaccounts/token"]
+	//  verbs: ["create"]
+	// +optional
+	ServiceAccountRef cmmeta.LocalObjectReference `json:"serviceAccountRef,omitempty"`
 
 	// A required field containing the Vault Role to assume. A Role binds a
 	// Kubernetes ServiceAccount with a set of Vault policies.

--- a/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
+++ b/pkg/apis/certmanager/v1beta1/zz_generated.deepcopy.go
@@ -865,6 +865,7 @@ func (in *VaultIssuer) DeepCopy() *VaultIssuer {
 func (in *VaultKubernetesAuth) DeepCopyInto(out *VaultKubernetesAuth) {
 	*out = *in
 	out.SecretRef = in.SecretRef
+	out.ServiceAccountRef = in.ServiceAccountRef
 	return
 }
 

--- a/pkg/controller/certificaterequests/vault/BUILD.bazel
+++ b/pkg/controller/certificaterequests/vault/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/issuer:go_default_library",
         "//pkg/logs:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
     ],
 )

--- a/pkg/controller/certificatesigningrequests/vault/BUILD.bazel
+++ b/pkg/controller/certificatesigningrequests/vault/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes:go_default_library",
         "@io_k8s_client_go//kubernetes/typed/certificates/v1:go_default_library",
         "@io_k8s_client_go//listers/core/v1:go_default_library",
         "@io_k8s_client_go//tools/record:go_default_library",


### PR DESCRIPTION
| ⚠️ I paused this PR due to the security concerns with regards to the RBAC rules required by this PR |
|-|

As detailed in #4144, the Vault issuer is only able to use a Secret in order to use the "Kubernetes authentication" method. The downside to this service account Secret token is that it has the default JWT is "kubernetes/serviceaccount" (along with the fact that the token is not bound to a particular pod and has no expiry).

With the new `serviceAccountRef` field, cert-manager now requests the token on behalf of the pod in order to authenticate with Vault.

I manually tested the feature on these environments:

- kind cluster (Kubernetes 1.21) with an internal Vault running as a deployment.
- EKS cluster (Kubernetes 1.20) with an internal Vault running as a deployment.

**Still to be done:**

- [ ] Unit tests,
- [ ] End-to-end tests,
- [ ] Documentation on the website.

**Notes to the reviewer:**

1. No token rotation is done here, which might become a problem since a TokenRequest API call to the apiserver is made every time the Vault client is created, which happens every time a resync of a CertificateRequest referencing a Vault issuer.
2. This approach requires cert-manager to be given even more permissions.
2. The expiry is currently hardcoded to 2 hours.
3. The audience is currently hardcoded to `vault`.
4. I had to change the `vault.auth.kubernetes.secretRef` from mandatory to optional; I don't think that's a breaking change since I am relaxing constraints.

**UPDATE:** another idea, suggested in https://github.com/jetstack/cert-manager/issues/2345, is to reuse cert-manager's own token to do the authentication. I don't know what are the security implications of this yet.

**If you want to test this feature, here are the steps:**

```sh
./devel/addon/certmanager/install.sh
helm upgrade --install vault hashicorp/vault --set server.dev.enabled=true --set global.tlsDisable=true --wait
kubectl wait --for=condition=Ready pod vault-0

kubectl exec vault-0 -i -- vault secrets enable pki
kubectl exec vault-0 -i -- vault secrets tune -max-lease-ttl=175200h pki
kubectl exec vault-0 -i -- vault write pki/root/generate/internal common_name=example.com key_type=ec key_bits=256 ttl=175200h
kubectl exec vault-0 -i -- vault write pki/config/urls \
    issuing_certificates="http://vault.default:8200/v1/pki/ca" \
    url_distribution_points="http://vault.default:8200/v1/pki/crl"
kubectl exec vault-0 -i -- vault write pki/roles/vault-sa allowed_domains=cluster.local allow_subdomains=true max_ttl=48h key_type=ec key_bits=256

kubectl exec vault-0 -i -- vault auth enable kubernetes
kubectl exec vault-0 -i -- sh -c 'vault write auth/kubernetes/config \
   token_reviewer_jwt="$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)" \
   kubernetes_host="https://$KUBERNETES_PORT_443_TCP_ADDR:443" \
   kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt \
   issuer=https://kubernetes.default.svc.cluster.local'

kubectl exec vault-0 -i -- vault policy write vault-sa - <<EOF
path "pki*"                 { capabilities = ["read", "list"] }
path "pki/roles/vault-sa"   { capabilities = ["create", "update"] }
path "pki/sign/vault-sa"    { capabilities = ["create", "update"] }
path "pki/issue/vault-sa"   { capabilities = ["create"] }
EOF
kubectl exec vault-0 -i -- vault write auth/kubernetes/role/vault-sa bound_service_account_names=vault-sa bound_service_account_namespaces=default policies=vault-sa ttl=20m
```

Then, create an issuer and a certificate:

```sh
kubectl apply -f- <<EOF
apiVersion: v1
kind: ServiceAccount
metadata:
  name: vault-sa
---
apiVersion: v1
kind: Secret
metadata:
  name: vault-sa-secret
  annotations:
    kubernetes.io/service-account.name: vault-sa
type: kubernetes.io/service-account-token
---
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: vault-issuer
spec:
  vault:
    path: pki/sign/vault-sa
    server: http://vault.default.svc.cluster.local:8200
    auth:
      kubernetes:
        role: vault-sa
        mountPath: /v1/auth/kubernetes
        serviceAccountRef:
          name: vault-sa # ✨
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: example-com
spec:
  secretName: example-com-tls
  issuerRef:
    name: vault-issuer
  commonName: example.cluster.local
  dnsNames:
  - example.cluster.local
  privateKey:
    algorithm: ECDSA
EOF
```

/kind feature
/area vault

```release-note
The Vault issuer can now be used with projected tokens instead of a service account Secret.
```
