### PR TITLE
[release-1.5] Fix flaky test by using EqualUnsorted to compare Events

### DIFF
--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -224,7 +224,7 @@ func (b *Builder) AllReactorsCalled() error {
 
 func (b *Builder) AllEventsCalled() error {
 	var errs []error
-	if !util.EqualSorted(b.ExpectedEvents, b.Events()) {
+	if !util.EqualUnsorted(b.ExpectedEvents, b.Events()) {
 		errs = append(errs, fmt.Errorf("got unexpected events, exp='%s' got='%s'",
 			b.ExpectedEvents, b.Events()))
 	}


### PR DESCRIPTION
This is a manual cherry-pick of 5d91f0a3c47af743b22f315b1b15c7c4db2a86c8

It should fix the release-previous CI flakes.

```release-note
NONE
```
