### PR TITLE
Removes deprecated dns01-self-check-nameservers flag

### DIFF
--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -323,11 +323,6 @@ func (s *ControllerOptions) AddFlags(fs *pflag.FlagSet) {
 			"environments, where access to authoritative nameservers is restricted. "+
 			"Enabling this option could cause the DNS01 self check to take longer "+
 			"due to caching performed by the recursive nameservers.")
-	fs.StringSliceVar(&s.DNS01RecursiveNameservers, "dns01-self-check-nameservers",
-		[]string{}, "A list of comma separated dns server endpoints used for "+
-			"DNS01 check requests. This should be a list containing host and port, "+
-			"for example 8.8.8.8:53,8.8.4.4:53")
-	fs.MarkDeprecated("dns01-self-check-nameservers", "Deprecated in favour of dns01-recursive-nameservers")
 
 	fs.BoolVar(&s.EnableCertificateOwnerRef, "enable-certificate-owner-ref", defaultEnableCertificateOwnerRef, ""+
 		"Whether to set the certificate resource as an owner of secret where the tls certificate is stored. "+


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Removes the `dns01-self-check-nameservers` flag that was deprecated a couple years ago in https://github.com/jetstack/cert-manager/pull/1184

**Special notes for your reviewer**:

The flag was deprecated, so it would not have appeared to anyone runing `--help` on controller binary and if it had been used, a warning would have been displayed.
The flag _was_ still being used to set the `DNSRecursiveNameservers` value, which is also being set by the `dns01-recursive-nameservers` flag. If anyone still used the deprecated flag, this would be breaking change.

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Breaking change: removes the deprecated `dns01-self-check-nameservers` flag. Use `--dns01-recursive-nameservers` instead.
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
