### PR TITLE
Cleanup helm templates & fix empty 'resources' in deployment

### DIFF
--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -58,7 +58,7 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{- define "webhook.caRef" -}}
-{{ .Release.Namespace}}/{{ template "webhook.fullname" . }}-ca
+{{ .Release.Namespace }}/{{ template "webhook.fullname" . }}-ca
 {{- end -}}
 
 {{/*

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cainjector.enabled -}}
+{{- if .Values.cainjector.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "cainjector"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.cainjector.deploymentAnnotations }}
+  {{- with .Values.cainjector.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.cainjector.deploymentAnnotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.cainjector.replicaCount }}
@@ -23,7 +23,7 @@ spec:
       app.kubernetes.io/component: "cainjector"
   {{- with .Values.cainjector.strategy }}
   strategy:
-    {{- . | toYaml | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -33,21 +33,21 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "cainjector"
         {{- include "labels" . | nindent 8 }}
-{{- if .Values.cainjector.podLabels }}
-{{ toYaml .Values.cainjector.podLabels | indent 8 }}
-{{- end }}
-      {{- if .Values.cainjector.podAnnotations }}
+        {{- with .Values.cainjector.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.cainjector.podAnnotations }}
       annotations:
-{{ toYaml .Values.cainjector.podAnnotations | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "cainjector.serviceAccountName" . }}
-      {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- with .Values.global.priorityClassName }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if .Values.cainjector.securityContext}}
+      {{- with .Values.cainjector.securityContext }}
       securityContext:
-{{ toYaml .Values.cainjector.securityContext | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -71,30 +71,32 @@ spec:
           - --leader-election-retry-period={{ .retryPeriod }}
           {{- end }}
           {{- end }}
-          {{- if .Values.cainjector.extraArgs }}
-{{ toYaml .Values.cainjector.extraArgs | indent 10 }}
+          {{- with .Values.cainjector.extraArgs }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          {{- if .Values.cainjector.containerSecurityContext }}
+          {{- with .Values.cainjector.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.cainjector.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.cainjector.resources }}
           resources:
-{{ toYaml .Values.cainjector.resources | indent 12 }}
-    {{- with .Values.cainjector.nodeSelector }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.cainjector.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.cainjector.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cainjector.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.cainjector.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cainjector.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- end -}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -52,7 +52,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.cainjector.image }}
-          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.cainjector.image.pullPolicy }}
           args:

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cainjector.enabled -}}
+{{- if .Values.cainjector.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cainjector.enabled -}}
+{{- if .Values.cainjector.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/charts/cert-manager/templates/cainjector-psp.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cainjector.enabled -}}
+{{- if .Values.cainjector.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -47,5 +47,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-rbac.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.global.rbac.create -}}
+{{- if .Values.cainjector.enabled }}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -110,5 +110,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "cainjector.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-serviceaccount.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.cainjector.enabled -}}
-{{- if .Values.cainjector.serviceAccount.create -}}
+{{- if .Values.cainjector.enabled }}
+{{- if .Values.cainjector.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.cainjector.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "cainjector.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.cainjector.serviceAccount.annotations }}
+  {{- with .Values.cainjector.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.cainjector.serviceAccount.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app: {{ include "cainjector.name" . }}
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "cainjector"
     {{- include "labels" . | nindent 4 }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -72,7 +72,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.image }}
-          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.deploymentAnnotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.deploymentAnnotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
@@ -22,7 +22,7 @@ spec:
       app.kubernetes.io/component: "controller"
   {{- with .Values.strategy }}
   strategy:
-    {{- . | toYaml | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -32,12 +32,12 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "controller"
         {{- include "labels" . | nindent 8 }}
-{{- if .Values.podLabels }}
-{{ toYaml .Values.podLabels | indent 8 }}
-{{- end }}
-      {{- if .Values.podAnnotations }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.podAnnotations }}
       annotations:
-{{ toYaml .Values.podAnnotations | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if and .Values.prometheus.enabled (not .Values.prometheus.servicemonitor.enabled) }}
       {{- if not .Values.podAnnotations }}
@@ -49,25 +49,25 @@ spec:
       {{- end }}
     spec:
       serviceAccountName: {{ template "cert-manager.serviceAccountName" . }}
-      {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- with .Values.global.priorityClassName }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       {{- $enabledDefined := gt (len (keys (pick .Values.securityContext "enabled"))) 0 }}
       {{- $legacyEnabledExplicitlyOff := and $enabledDefined (not .Values.securityContext.enabled) }}
       {{- if and .Values.securityContext (not $legacyEnabledExplicitlyOff) }}
       securityContext:
-        {{- if .Values.securityContext.enabled -}}
+        {{- if .Values.securityContext.enabled }}
         {{/* support legacy securityContext.enabled and its two parameters */}}
         fsGroup: {{ default 1001 .Values.securityContext.fsGroup }}
         runAsUser: {{ default 1001 .Values.securityContext.runAsUser }}
-        {{- else -}}
+        {{- else }}
         {{/* this is the way forward: support an arbitrary yaml block */}}
-{{ toYaml .Values.securityContext | indent 8 }}
+        {{- toYaml .Values.securityContext | nindent 8 }}
         {{- end }}
       {{- end }}
-      {{- if .Values.volumes }}
+      {{- with .Values.volumes }}
       volumes:
-{{ toYaml .Values.volumes | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -76,29 +76,29 @@ spec:
           {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           args:
-        {{- if .Values.global.logLevel }}
+          {{- if .Values.global.logLevel }}
           - --v={{ .Values.global.logLevel }}
-        {{- end }}
-        {{- if .Values.clusterResourceNamespace }}
+          {{- end }}
+          {{- if .Values.clusterResourceNamespace }}
           - --cluster-resource-namespace={{ .Values.clusterResourceNamespace }}
-        {{- else }}
+          {{- else }}
           - --cluster-resource-namespace=$(POD_NAMESPACE)
-        {{- end }}
-        {{- with .Values.global.leaderElection }}
+          {{- end }}
+          {{- with .Values.global.leaderElection }}
           - --leader-election-namespace={{ .namespace }}
-        {{- if .leaseDuration }}
+          {{- if .leaseDuration }}
           - --leader-election-lease-duration={{ .leaseDuration }}
-        {{- end }}
-        {{- if .renewDeadline }}
+          {{- end }}
+          {{- if .renewDeadline }}
           - --leader-election-renew-deadline={{ .renewDeadline }}
-        {{- end }}
-        {{- if .retryPeriod }}
+          {{- end }}
+          {{- if .retryPeriod }}
           - --leader-election-retry-period={{ .retryPeriod }}
-        {{- end }}
-        {{- end }}
-        {{- if .Values.extraArgs }}
-{{ toYaml .Values.extraArgs | indent 10 }}
-        {{- end }}
+          {{- end }}
+          {{- end }}
+          {{- with .Values.extraArgs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           {{- with .Values.ingressShim }}
           {{- if .defaultIssuerName }}
           - --default-issuer-name={{ .defaultIssuerName }}
@@ -116,52 +116,54 @@ spec:
           ports:
           - containerPort: 9402
             protocol: TCP
-          {{- if .Values.containerSecurityContext }}
+          {{- with .Values.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if .Values.volumeMounts }}
+          {{- with .Values.volumeMounts }}
           volumeMounts:
-{{ toYaml .Values.volumeMounts | indent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-        {{- if .Values.extraEnv }}
-{{ toYaml .Values.extraEnv | indent 10 }}
-        {{- end }}
-          {{- if .Values.http_proxy }}
+          {{- with .Values.extraEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          {{- with .Values.http_proxy }}
           - name: HTTP_PROXY
-            value: {{ .Values.http_proxy }}
+            value: {{ . }}
           {{- end }}
-          {{- if .Values.https_proxy }}
+          {{- with .Values.https_proxy }}
           - name: HTTPS_PROXY
-            value: {{ .Values.https_proxy }}
+            value: {{ . }}
           {{- end }}
-          {{- if .Values.no_proxy }}
+          {{- with .Values.no_proxy }}
           - name: NO_PROXY
-            value: {{ .Values.no_proxy }}
+            value: {{ . }}
           {{- end }}
+          {{- with .Values.resources }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
-    {{- with .Values.nodeSelector }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- if .Values.podDnsPolicy }}
-      dnsPolicy: {{ .Values.podDnsPolicy }}
-{{- end }}
-{{- if .Values.podDnsConfig }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.podDnsPolicy }}
+      dnsPolicy: {{ . }}
+      {{- end }}
+      {{- with .Values.podDnsConfig }}
       dnsConfig:
-{{ toYaml .Values.podDnsConfig | indent 8 }}
-{{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/cert-manager/templates/rbac.yaml
+++ b/deploy/charts/cert-manager/templates/rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbac.create -}}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -10,20 +10,20 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
-{{- if .Values.serviceLabels }}
-{{ toYaml .Values.serviceLabels | indent 4 }}
-{{- end }}
-{{- if .Values.serviceAnnotations }}
+    {{- with .Values.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAnnotations }}
   annotations:
-    {{ toYaml .Values.serviceAnnotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:
-    - protocol: TCP
-      port: 9402
-      name: tcp-prometheus-servicemonitor
-      targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
+  - protocol: TCP
+    port: 9402
+    name: tcp-prometheus-servicemonitor
+    targetPort: {{ .Values.prometheus.servicemonitor.targetPort }}
   selector:
     app.kubernetes.io/name: {{ include "cert-manager.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/deploy/charts/cert-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/serviceaccount.yaml
@@ -1,16 +1,17 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "cert-manager.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.serviceAccount.annotations }}
+  {{- with .Values.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.serviceAccount.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app: {{ include "cert-manager.name" . }}

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- include "labels" . | nindent 4 }}
     prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
     {{- with .Values.prometheus.servicemonitor.labels }}
-    {{- toYaml . | nindent 4}}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   jobLabel: {{ template "cert-manager.fullname" . }}

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -15,9 +15,9 @@ metadata:
     app.kubernetes.io/component: "controller"
     {{- include "labels" . | nindent 4 }}
     prometheus: {{ .Values.prometheus.servicemonitor.prometheusInstance }}
-{{- if .Values.prometheus.servicemonitor.labels }}
-{{ toYaml .Values.prometheus.servicemonitor.labels | indent 4}}
-{{- end }}
+    {{- with .Values.prometheus.servicemonitor.labels }}
+    {{- toYaml . | nindent 4}}
+    {{- end }}
 spec:
   jobLabel: {{ template "cert-manager.fullname" . }}
   selector:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -44,7 +44,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.startupapicheck.image }}
-          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.startupapicheck.image.pullPolicy }}
           args:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.startupapicheck.enabled }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.startupapicheck.jobAnnotations }}
+  {{- with .Values.startupapicheck.jobAnnotations }}
   annotations:
-{{ toYaml .Values.startupapicheck.jobAnnotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
@@ -24,22 +24,22 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "startupapicheck"
         {{- include "labels" . | nindent 8 }}
-{{- if .Values.startupapicheck.podLabels }}
-{{ toYaml .Values.startupapicheck.podLabels | indent 8 }}
-{{- end }}
-      {{- if .Values.startupapicheck.podAnnotations }}
+        {{- with .Values.startupapicheck.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.startupapicheck.podAnnotations }}
       annotations:
-{{ toYaml .Values.startupapicheck.podAnnotations | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       restartPolicy: OnFailure
       serviceAccountName: {{ template "startupapicheck.serviceAccountName" . }}
-      {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- with .Values.global.priorityClassName }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if .Values.startupapicheck.securityContext}}
+      {{- with .Values.startupapicheck.securityContext }}
       securityContext:
-{{ toYaml .Values.startupapicheck.securityContext | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}
@@ -51,25 +51,27 @@ spec:
           - check
           - api
           - --wait={{ .Values.startupapicheck.timeout }}
-          {{- if .Values.startupapicheck.extraArgs }}
-{{ toYaml .Values.startupapicheck.extraArgs | indent 10 }}
+          {{- with .Values.startupapicheck.extraArgs }}
+          {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- if .Values.startupapicheck.containerSecurityContext }}
+          {{- with .Values.startupapicheck.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.startupapicheck.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with .Values.startupapicheck.resources }}
           resources:
-{{ toYaml .Values.startupapicheck.resources | indent 12 }}
-    {{- with .Values.startupapicheck.nodeSelector }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.startupapicheck.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.startupapicheck.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.startupapicheck.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-{{- end -}}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.startupapicheck.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.startupapicheck.rbac.annotations }}
+  {{- with .Values.startupapicheck.rbac.annotations }}
   annotations:
-    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
 - apiGroups: ['policy']

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp-clusterrolebinding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.startupapicheck.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -10,9 +10,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.startupapicheck.rbac.annotations }}
+  {{- with .Values.startupapicheck.rbac.annotations }}
   annotations:
-    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-psp.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.startupapicheck.enabled }}
 {{- if .Values.global.podSecurityPolicy.enabled }}
 apiVersion: policy/v1beta1
 kind: PodSecurityPolicy
@@ -17,8 +17,8 @@ metadata:
     apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
     apparmor.security.beta.kubernetes.io/defaultProfileName:  'runtime/default'
     {{- end }}
-    {{- if .Values.startupapicheck.rbac.annotations }}
-    {{ toYaml .Values.startupapicheck.rbac.annotations | nindent 4 }}
+    {{- with .Values.startupapicheck.rbac.annotations }}
+    {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   privileged: false
@@ -47,5 +47,5 @@ spec:
     ranges:
     - min: 1000
       max: 1000
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-rbac.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.startupapicheck.enabled -}}
-{{- if .Values.global.rbac.create -}}
+{{- if .Values.startupapicheck.enabled }}
+{{- if .Values.global.rbac.create }}
 # create certificate role
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -12,15 +12,14 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.startupapicheck.rbac.annotations }}
+  {{- with .Values.startupapicheck.rbac.annotations }}
   annotations:
-{{ toYaml .Values.startupapicheck.rbac.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 rules:
   - apiGroups: ["cert-manager.io"]
     resources: ["certificates"]
     verbs: ["create"]
-
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -33,9 +32,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.startupapicheck.rbac.annotations }}
+  {{- with .Values.startupapicheck.rbac.annotations }}
   annotations:
-{{ toYaml .Values.startupapicheck.rbac.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -45,5 +44,5 @@ subjects:
   - kind: ServiceAccount
     name: {{ template "startupapicheck.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-serviceaccount.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.startupapicheck.enabled -}}
-{{- if .Values.startupapicheck.serviceAccount.create -}}
+{{- if .Values.startupapicheck.enabled }}
+{{- if .Values.startupapicheck.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.startupapicheck.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "startupapicheck.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.startupapicheck.serviceAccount.annotations }}
+  {{- with .Values.startupapicheck.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.startupapicheck.serviceAccount.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app: {{ include "startupapicheck.name" . }}
@@ -16,8 +16,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "startupapicheck"
     {{- include "labels" . | nindent 4 }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
 {{- end }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -9,9 +9,9 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "webhook"
     {{- include "labels" . | nindent 4 }}
-  {{- if .Values.webhook.deploymentAnnotations }}
+  {{- with .Values.webhook.deploymentAnnotations }}
   annotations:
-{{ toYaml .Values.webhook.deploymentAnnotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   replicas: {{ .Values.webhook.replicaCount }}
@@ -22,7 +22,7 @@ spec:
       app.kubernetes.io/component: "webhook"
   {{- with .Values.webhook.strategy }}
   strategy:
-    {{- . | toYaml | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   template:
     metadata:
@@ -32,21 +32,21 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         app.kubernetes.io/component: "webhook"
         {{- include "labels" . | nindent 8 }}
-{{- if .Values.webhook.podLabels }}
-{{ toYaml .Values.webhook.podLabels | indent 8 }}
-{{- end }}
-      {{- if .Values.webhook.podAnnotations }}
+        {{- with .Values.webhook.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.webhook.podAnnotations }}
       annotations:
-{{ toYaml .Values.webhook.podAnnotations | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       serviceAccountName: {{ template "webhook.serviceAccountName" . }}
-      {{- if .Values.global.priorityClassName }}
-      priorityClassName: {{ .Values.global.priorityClassName | quote }}
+      {{- with .Values.global.priorityClassName }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
-      {{- if .Values.webhook.securityContext}}
+      {{- with .Values.webhook.securityContext }}
       securityContext:
-{{ toYaml .Values.webhook.securityContext | indent 8 }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- if .Values.webhook.hostNetwork }}
       hostNetwork: true
@@ -65,9 +65,9 @@ spec:
           - --dynamic-serving-ca-secret-namespace=$(POD_NAMESPACE)
           - --dynamic-serving-ca-secret-name={{ template "webhook.fullname" . }}-ca
           - --dynamic-serving-dns-names={{ template "webhook.fullname" . }},{{ template "webhook.fullname" . }}.{{ .Release.Namespace }},{{ template "webhook.fullname" . }}.{{ .Release.Namespace }}.svc{{ if .Values.webhook.url.host }},{{ .Values.webhook.url.host }}{{ end }}
-        {{- if .Values.webhook.extraArgs }}
-{{ toYaml .Values.webhook.extraArgs | indent 10 }}
-        {{- end }}
+          {{- with .Values.webhook.extraArgs }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
           ports:
           - name: https
             protocol: TCP
@@ -92,26 +92,29 @@ spec:
             timeoutSeconds: {{ .Values.webhook.readinessProbe.timeoutSeconds }}
             successThreshold: {{ .Values.webhook.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.webhook.readinessProbe.failureThreshold }}
-          {{- if .Values.webhook.containerSecurityContext }}
+          {{- with .Values.webhook.containerSecurityContext }}
           securityContext:
-            {{- toYaml .Values.webhook.containerSecurityContext | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           env:
           - name: POD_NAMESPACE
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
+          {{- with .Values.webhook.resources }}
           resources:
-{{ toYaml .Values.webhook.resources | indent 12 }}
-    {{- with .Values.webhook.nodeSelector }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      {{- with .Values.webhook.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.webhook.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.webhook.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.webhook.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -54,7 +54,7 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.webhook.image }}
-          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{.digest}}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ default $.Chart.AppVersion .tag }} {{- end -}}"
           {{- end }}
           imagePullPolicy: {{ .Values.webhook.image.pullPolicy }}
           args:

--- a/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-mutating-webhook.yaml
@@ -10,9 +10,9 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     cert-manager.io/inject-ca-from-secret: "{{ .Release.Namespace }}/{{ template "webhook.fullname" . }}-ca"
-  {{- if .Values.webhook.mutatingWebhookConfigurationAnnotations }}
-{{ toYaml .Values.webhook.mutatingWebhookConfigurationAnnotations | indent 4 }}
-  {{- end }}
+    {{- with .Values.webhook.mutatingWebhookConfigurationAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 webhooks:
   - name: webhook.cert-manager.io
     rules:

--- a/deploy/charts/cert-manager/templates/webhook-psp.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-psp.yaml
@@ -27,11 +27,11 @@ spec:
   - 'secret'
   - 'downwardAPI'
   hostNetwork: {{ .Values.webhook.hostNetwork }}
-  {{ if .Values.webhook.hostNetwork }}
+  {{- if .Values.webhook.hostNetwork }}
   hostPorts:
   - max: {{ .Values.webhook.securePort }}
     min: {{ .Values.webhook.securePort }}
-  {{ end }}
+  {{- end }}
   hostIPC: false
   hostPID: false
   runAsUser:

--- a/deploy/charts/cert-manager/templates/webhook-rbac.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-rbac.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.global.rbac.create -}}
+{{- if .Values.global.rbac.create }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -80,4 +80,4 @@ subjects:
   kind: ServiceAccount
   name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
-{{- end -}}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -9,17 +9,17 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "webhook"
     {{- include "labels" . | nindent 4 }}
-{{- if .Values.webhook.serviceLabels }}
-{{ toYaml .Values.webhook.serviceLabels | indent 4 }}
-{{- end }}
-{{- if .Values.webhook.serviceAnnotations }}
+    {{- with .Values.webhook.serviceLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.webhook.serviceAnnotations }}
   annotations:
-    {{ toYaml .Values.webhook.serviceAnnotations | indent 4 }}
-{{- end }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.webhook.serviceType }}
-  {{- if .Values.webhook.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.webhook.loadBalancerIP }}
+  {{- with .Values.webhook.loadBalancerIP }}
+  loadBalancerIP: {{ . }}
   {{- end }}
   ports:
   - name: https

--- a/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-serviceaccount.yaml
@@ -1,13 +1,13 @@
-{{- if .Values.webhook.serviceAccount.create -}}
+{{- if .Values.webhook.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.webhook.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ template "webhook.serviceAccountName" . }}
   namespace: {{ .Release.Namespace | quote }}
-  {{- if .Values.webhook.serviceAccount.annotations }}
+  {{- with .Values.webhook.serviceAccount.annotations }}
   annotations:
-{{ toYaml .Values.webhook.serviceAccount.annotations | indent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
   labels:
     app: {{ include "webhook.name" . }}
@@ -15,7 +15,8 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name }}
     app.kubernetes.io/component: "webhook"
     {{- include "labels" . | nindent 4 }}
-{{- if .Values.global.imagePullSecrets }}
-imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 2 }}
-{{- end -}}
-{{- end -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-validating-webhook.yaml
@@ -10,9 +10,9 @@ metadata:
     {{- include "labels" . | nindent 4 }}
   annotations:
     cert-manager.io/inject-ca-from-secret: "{{ .Release.Namespace }}/{{ template "webhook.fullname" . }}-ca"
-  {{- if .Values.webhook.validatingWebhookConfigurationAnnotations }}
-{{ toYaml .Values.webhook.validatingWebhookConfigurationAnnotations | indent 4 }}
-  {{- end }}
+    {{- with .Values.webhook.validatingWebhookConfigurationAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 webhooks:
   - name: webhook.cert-manager.io
     namespaceSelector:

--- a/devel/addon/samplewebhook/chart/templates/deployment.yaml
+++ b/devel/addon/samplewebhook/chart/templates/deployment.yaml
@@ -51,21 +51,23 @@ spec:
             - name: certs
               mountPath: /tls
               readOnly: true
+          {{- with .Values.resources }}
           resources:
-{{ toYaml .Values.resources | indent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
         - name: certs
           secret:
             secretName: {{ include "example-webhook.servingCertificate" . }}
-    {{- with .Values.nodeSelector }}
+      {{- with .Values.nodeSelector }}
       nodeSelector:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.affinity }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
       affinity:
-{{ toYaml . | indent 8 }}
-    {{- end }}
-    {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
       tolerations:
-{{ toYaml . | indent 8 }}
-    {{- end }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}


### PR DESCRIPTION
**What this PR does / why we need it**:
Apply more consistent helm style in templates.
Fixes wrong renders when 'resources' field is empty https://github.com/jetstack/cert-manager/pull/4209#discussion_r706397410 -> should be only functional change in this PR

**Release note**:
```release-note
NONE
```
