### PR TITLE
Mark integration / e2e test files with a build tag

### DIFF
--- a/internal/apis/acme/install/BUILD.bazel
+++ b/internal/apis/acme/install/BUILD.bazel
@@ -43,6 +43,9 @@ go_test(
         "//deploy/crds:templated_files",
     ],
     embed = [":go_default_library"],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//internal/apis/acme/fuzzer:go_default_library",
         "//internal/test/paths:go_default_library",

--- a/internal/apis/acme/install/pruning_test.go
+++ b/internal/apis/acme/install/pruning_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/internal/apis/certmanager/install/BUILD.bazel
+++ b/internal/apis/certmanager/install/BUILD.bazel
@@ -45,6 +45,9 @@ go_test(
         "//deploy/crds:templated_files",
     ],
     embed = [":go_default_library"],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//internal/apis/certmanager/fuzzer:go_default_library",
         "//internal/test/paths:go_default_library",

--- a/internal/apis/certmanager/install/pruning_test.go
+++ b/internal/apis/certmanager/install/pruning_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/pkg/issuer/acme/dns/rfc2136/BUILD.bazel
+++ b/pkg/issuer/acme/dns/rfc2136/BUILD.bazel
@@ -31,6 +31,9 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":go_default_library"],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/apis/acme/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",

--- a/pkg/issuer/acme/dns/rfc2136/provider_test.go
+++ b/pkg/issuer/acme/dns/rfc2136/provider_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/pkg/util/versionchecker/BUILD.bazel
+++ b/pkg/util/versionchecker/BUILD.bazel
@@ -31,6 +31,9 @@ go_test(
     ],
     embed = [":go_default_library"],
     embedsrcs = ["//pkg/util/versionchecker/testdata:test_manifests.tar"],  # keep
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/util:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",

--- a/pkg/util/versionchecker/versionchecker_test.go
+++ b/pkg/util/versionchecker/versionchecker_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2021 The cert-manager Authors.
 

--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -29,6 +29,9 @@ go_test(
     name = "go_default_test",
     srcs = ["e2e_test.go"],
     embed = [":go_default_library"],
+    gotags = [
+        "e2e_test",
+    ],
     tags = ["manual"],  # 'bazel test //...' should not run e2e tests
     deps = [
         "//pkg/logs:go_default_library",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/acme/BUILD.bazel
+++ b/test/integration/acme/BUILD.bazel
@@ -3,6 +3,9 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 go_test(
     name = "go_default_test",
     srcs = ["orders_controller_test.go"],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/acme/accounts/test:go_default_library",
         "//pkg/acme/client:go_default_library",

--- a/test/integration/acme/orders_controller_test.go
+++ b/test/integration/acme/orders_controller_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/certificates/BUILD.bazel
+++ b/test/integration/certificates/BUILD.bazel
@@ -8,6 +8,9 @@ go_test(
         "revisionmanager_controller_test.go",
         "trigger_controller_test.go",
     ],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/api/util:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",

--- a/test/integration/certificates/issuing_controller_test.go
+++ b/test/integration/certificates/issuing_controller_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/certificates/revisionmanager_controller_test.go
+++ b/test/integration/certificates/revisionmanager_controller_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/certificates/trigger_controller_test.go
+++ b/test/integration/certificates/trigger_controller_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/conversion/BUILD.bazel
+++ b/test/integration/conversion/BUILD.bazel
@@ -6,6 +6,9 @@ go_test(
     data = [
         "//pkg/webhook/handlers/testdata/apis/testgroup/crds:all-srcs",
     ],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/webhook/handlers:go_default_library",
         "//pkg/webhook/handlers/testdata/apis/testgroup/install:go_default_library",

--- a/test/integration/conversion/conversion_test.go
+++ b/test/integration/conversion/conversion_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/ctl/BUILD.bazel
+++ b/test/integration/ctl/BUILD.bazel
@@ -12,6 +12,9 @@ go_test(
         "//deploy/charts/cert-manager:cert-manager.tgz",
     ],
     embed = [":go_default_library"],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//cmd/ctl/pkg/convert:go_default_library",
         "//cmd/ctl/pkg/create/certificaterequest:go_default_library",

--- a/test/integration/ctl/ctl_convert_test.go
+++ b/test/integration/ctl/ctl_convert_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/ctl/ctl_create_cr_test.go
+++ b/test/integration/ctl/ctl_create_cr_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/ctl/ctl_install.go
+++ b/test/integration/ctl/ctl_install.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2021 The cert-manager Authors.
 

--- a/test/integration/ctl/ctl_renew_test.go
+++ b/test/integration/ctl/ctl_renew_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/ctl/ctl_status_certificate_test.go
+++ b/test/integration/ctl/ctl_status_certificate_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/validation/BUILD.bazel
+++ b/test/integration/validation/BUILD.bazel
@@ -17,6 +17,9 @@ filegroup(
 go_test(
     name = "go_default_test",
     srcs = ["certificaterequest_test.go"],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/api:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",

--- a/test/integration/validation/certificaterequest_test.go
+++ b/test/integration/validation/certificaterequest_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/webhook/BUILD.bazel
+++ b/test/integration/webhook/BUILD.bazel
@@ -6,6 +6,9 @@ go_test(
         "dynamic_authority_test.go",
         "dynamic_source_test.go",
     ],
+    gotags = [
+        "integration_test",
+    ],
     deps = [
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/webhook/authority:go_default_library",

--- a/test/integration/webhook/dynamic_authority_test.go
+++ b/test/integration/webhook/dynamic_authority_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 

--- a/test/integration/webhook/dynamic_source_test.go
+++ b/test/integration/webhook/dynamic_source_test.go
@@ -1,3 +1,5 @@
+//go:build integration_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 


### PR DESCRIPTION
## Notes for Reviewer

See my [comments](https://github.com/jetstack/cert-manager/pull/4565#issuecomment-1006759949) [below](https://github.com/jetstack/cert-manager/pull/4565#issuecomment-1006778371) about prow's reporting of tests.

This PR should be a no-op for all of our bazel-based tests. They should still be run in exactly the same way. Verifying that they do run the same way is IMO the most important part of reviewing this PR.

## Overview

This PR adds `go:build` tags to every test I can find which has an external dependency - i.e. one which breaks or fails on a clean checkout of the repo when running `go test ./...`, or else everything under `test/integration` and `test/e2e`. The e2e tests are tagged differently.

This will enable us to use `go test` for all types of tests. Currently `go test` will panic due to missing dependencies if run without bazel magic happening.

This is part of the [migration to make](https://github.com/jetstack/cert-manager/issues/4712).

---

<details>
<summary>Unrelated notes, might be of interest but not needed for reviewing this PR</summary>
Mostly for interest, the following is useful analysing runtimes of tests, the following will list in `tests.txt` all tests ordered by time taken in seconds:

```bash
go test -count=1 -json ./pkg/...  > tests.json
jq -r '. | select(.Action == "pass") | [(.Elapsed|tostring), .Package] | join(" ")' < tests.json | sort -rn | uniq > tests.txt
```

Note that the output varies based on how the tests are specified:

```console
# testing a specific file ignores the build tag, but build tags in dependencies are respected leading to a failure to build
$ go test -count=1 ./test/integration/webhook/dynamic_authority_test.go
# command-line-arguments
package command-line-arguments (test)
        imports github.com/jetstack/cert-manager/test/integration/framework: build constraints exclude all Go files in ...
FAIL    command-line-arguments [setup failed]
FAIL
exit code 1
# testing using ... respects build tags and therefore acts as though there aren't any go files here at all
$ go test -count=1 ./test/integration/webhook/...
go: warning: "./test/integration/webhook/..." matched no packages
no packages to test
exit code 1
```

</details>

---

/kind cleanup

```release-note
Adds go:build tags to integration and e2e tests
```
