### PR TITLE
cmctl status was fetching v1beta1 orders instead of v1

### DIFF
--- a/cmd/ctl/pkg/status/certificate/BUILD.bazel
+++ b/cmd/ctl/pkg/status/certificate/BUILD.bazel
@@ -12,7 +12,7 @@ go_library(
         "//cmd/ctl/pkg/build:go_default_library",
         "//cmd/ctl/pkg/factory:go_default_library",
         "//cmd/ctl/pkg/status/util:go_default_library",
-        "//pkg/apis/acme/v1beta1:go_default_library",
+        "//pkg/apis/acme/v1:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/ctl:go_default_library",
@@ -50,7 +50,7 @@ go_test(
     srcs = ["certificate_test.go"],
     embed = [":go_default_library"],
     deps = [
-        "//pkg/apis/acme/v1beta1:go_default_library",
+        "//pkg/apis/acme/v1:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//test/unit/gen:go_default_library",

--- a/cmd/ctl/pkg/status/certificate/certificate.go
+++ b/cmd/ctl/pkg/status/certificate/certificate.go
@@ -34,7 +34,7 @@ import (
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/build"
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/factory"
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1beta1"
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmclient "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	"github.com/jetstack/cert-manager/pkg/ctl"
@@ -327,7 +327,7 @@ func findMatchingCR(cmClient cmclient.Interface, ctx context.Context, crt *cmapi
 // If one found returns the Order
 // If multiple found or error occurs when listing Orders, returns error
 func findMatchingOrder(cmClient cmclient.Interface, ctx context.Context, req *cmapi.CertificateRequest) (*cmacme.Order, error) {
-	orders, err := cmClient.AcmeV1beta1().Orders(req.Namespace).List(ctx, metav1.ListOptions{})
+	orders, err := cmClient.AcmeV1().Orders(req.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -377,7 +377,7 @@ func getGenericIssuer(cmClient cmclient.Interface, ctx context.Context, crt *cma
 // findMatchingChallenges tries to find Challenges that are owned by order.
 // If none found returns empty slice.
 func findMatchingChallenges(cmClient cmclient.Interface, ctx context.Context, order *cmacme.Order) ([]*cmacme.Challenge, error) {
-	challenges, err := cmClient.AcmeV1beta1().Challenges(order.Namespace).List(ctx, metav1.ListOptions{})
+	challenges, err := cmClient.AcmeV1().Challenges(order.Namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/ctl/pkg/status/certificate/certificate_test.go
+++ b/cmd/ctl/pkg/status/certificate/certificate_test.go
@@ -28,7 +28,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1beta1"
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
 	"github.com/jetstack/cert-manager/test/unit/gen"

--- a/cmd/ctl/pkg/status/certificate/types.go
+++ b/cmd/ctl/pkg/status/certificate/types.go
@@ -29,7 +29,7 @@ import (
 	"k8s.io/kubectl/pkg/describe"
 
 	"github.com/jetstack/cert-manager/cmd/ctl/pkg/status/util"
-	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1beta1"
+	cmacme "github.com/jetstack/cert-manager/pkg/apis/acme/v1"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	"github.com/jetstack/cert-manager/pkg/util/pki"
 )


### PR DESCRIPTION
`cmctl` should now be able to display the orders when running

```
cmctl status certificate ...
```

Fixes https://github.com/jetstack/cert-manager/issues/4568.

```release-note
Fixes an issue in `cmctl` that prevented displaying the Order resource with cert-manager
1.6 when running `cmctl status certificate`.
```



/kind bug