### PR TITLE
Add fuzzing unit tests for JKS passwords

### DIFF
--- a/pkg/controller/certificates/internal/secretsmanager/BUILD.bazel
+++ b/pkg/controller/certificates/internal/secretsmanager/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//pkg/controller/test:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/unit/gen:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
         "@com_github_pavel_v_chernykh_keystore_go_v4//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
@@ -47,6 +48,8 @@ go_test(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//testing:go_default_library",
         "@io_k8s_utils//clock/testing:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
+        "@org_golang_x_sync//semaphore:go_default_library",
     ],
 )
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Following #4563, this adds a fuzzing unit test to our keystore function to ensure we can encode keystores with random passwords of varying lengths.

Tested before upgrading keystore-go:
```
=== RUN   TestManyPasswordLengths
    keystore_test.go:423: couldn't encode JKS Keystore with password ÛƓD (length 5): password must be at least 6 characters: short password
    keystore_test.go:409: internal error while testing JKS Keystore password lengths: context canceled
--- FAIL: TestManyPasswordLengths (0.35s)

FAIL
```

Tested after upgrading keystore-go:

```
=== RUN   TestManyPasswordLengths
--- PASS: TestManyPasswordLengths (0.79s)
PASS
```

**Special notes for your reviewer**:
There doesn't appear to be any e2e test for keystores (!). I will add one ASAP.

**Release note**:
```release-note
NONE
```
