### PR TITLE
Bumps timeout to wait for cm api in upgrade test

### DIFF
--- a/hack/verify-upgrade.sh
+++ b/hack/verify-upgrade.sh
@@ -85,7 +85,7 @@ helm upgrade \
     "$HELM_CHART"
 
 # Wait for the cert-manager api to be available
-kubectl cert-manager check api --wait=1m -v
+kubectl cert-manager check api --wait=2m -v
 
 echo "Creating some cert-manager resources.."
 
@@ -110,7 +110,7 @@ helm upgrade \
     "$REPO_ROOT/bazel-bin/deploy/charts/cert-manager/cert-manager.tgz"
 
 # Wait for the cert-manager api to be available
-kubectl cert-manager check api --wait=1m -v
+kubectl cert-manager check api --wait=2m -v
 
 # Test that the existing cert-manager resources can still be retrieved
 kubectl get issuer/selfsigned-issuer cert/test1
@@ -155,7 +155,7 @@ kubectl wait \
 	--namespace "${NAMESPACE}"
 
 # Wait for the cert-manager api to be available
-kubectl cert-manager check api --wait=1m -v
+kubectl cert-manager check api --wait=2m -v
 
 # Create a cert-manager issuer and cert
 kubectl apply -f "${REPO_ROOT}/test/fixtures/cert-manager-resources.yaml" --selector=test="first"
@@ -192,7 +192,7 @@ until $rollout_cmd; do
 done
 
 # Wait for the cert-manager api to be available
-kubectl cert-manager check api --wait=1m -v
+kubectl cert-manager check api --wait=2m -v
 
 # Test that the existing cert-manager resources can still be retrieved
 kubectl get issuer/selfsigned-issuer cert/test1


### PR DESCRIPTION
This PR bumps timeout to wait for cert-manager API to become ready in upgrade test 1min -> 2min (we've seen a bunch of upgrade test failures recently https://testgrid.k8s.io/jetstack-cert-manager-master#ci-cert-manager-upgrade and #4579 ).

The lease duration is [1minute](https://github.com/jetstack/cert-manager/blob/master/cmd/util/defaults.go#L26), but I guess since it is retried [every 15s](https://github.com/jetstack/cert-manager/blob/master/cmd/util/defaults.go#L28), the actual period the cainjector is waiting to become leader after an upgrade can be longer, see logs below:

```
I1101 04:15:52.080481       1 leaderelection.go:248] attempting to acquire leader lease kube-system/cert-manager-cainjector-leader-election...
I1101 04:17:05.997851       1 leaderelection.go:258] successfully acquired lease kube-system/cert-manager-cainjector-leader-election
I1101 04:17:06.003849       1 recorder.go:103] cert-manager/events "msg"="Normal"  "message"="cert-manager-cainjector-69d555d79d-xtgbd_5b84ec06-6b59-4fcb-913d-00e9d71298e1 became leader" "object
```

It may be worth investigating whether we can speed this up a little more as this period after upgrade when cainjector is not leader yet is when users who don't use [the api checker](https://cert-manager.io/docs/installation/verify/) get webhook timeout errors when trying to apply cert-manager resources and we seem to get a lot of questions about that.


```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
