### PR TITLE
[release-1.5] Bump base images to latest versions

### DIFF
--- a/build/images.bzl
+++ b/build/images.bzl
@@ -23,7 +23,7 @@ def define_base_images():
         name = "static_base",
         registry = "gcr.io",
         repository = "distroless/static",
-        digest = "sha256:aadea1b1f16af043a34491eec481d0132479382096ea34f608087b4bef3634be"
+        digest = "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4"
     )
     # Use 'dynamic' distroless image for modified cert-manager deployments that
     # are dynamically linked. (This is not the default and you probably don't
@@ -35,5 +35,5 @@ def define_base_images():
         name = "dynamic_base",
         registry = "gcr.io",
         repository = "distroless/base",
-        digest = "sha256:ba7a315f86771332e76fa9c3d423ecfdbb8265879c6f1c264d6fff7d4fa460a4"
+        digest = "sha256:0530d193888bcd7bd0376c8b34178ea03ddb0b2b18caf265135b6d3a393c8d05"
     )


### PR DESCRIPTION
Backport from #4588, done manually because of a merge conflict

/kind cleanup

```release-note
NONE
```
