### PR TITLE
Fix kyverno images for CI

### DIFF
--- a/devel/addon/kyverno/install.sh
+++ b/devel/addon/kyverno/install.sh
@@ -36,7 +36,7 @@ IMAGE_TAG="v1.3.6"
 PRE_IMAGE_TAG="v1.3.6"
 
 require_image "ghcr.io/kyverno/kyverno:${IMAGE_TAG}" "//devel/addon/kyverno:bundle_${IMAGE_TAG}"
-require_image "ghcr.io/kyverno/kyverno:${PRE_IMAGE_TAG}" "//devel/addon/kyverno:bundle_${PRE_IMAGE_TAG}"
+require_image "ghcr.io/kyverno/kyvernopre:${PRE_IMAGE_TAG}" "//devel/addon/kyverno:pre_bundle_${PRE_IMAGE_TAG}"
 
 
 # Install latest version of Kyverno
@@ -50,7 +50,7 @@ helm upgrade \
   --create-namespace \
   --version "${CHART_VERSION}" \
   --set image.tag="${IMAGE_TAG}" \
-  --set initImage.tag="${IMAGE_TAG}" \
+  --set initImage.tag="${PRE_IMAGE_TAG}" \
   kyverno \
   kyverno/kyverno
 # Install cert-manager specific Pod security policy

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -66,7 +66,7 @@ def install():
         registry = "ghcr.io",
         repository = "kyverno/kyvernopre",
         tag = "v1.3.6",
-        digest = "sha256:e76fb71c59449bca1028724a88005652409b56efb90bbcdce56b0d083bda6568",
+        digest = "sha256:94fc7f204917a86dcdbc18977e843701854aa9f84c215adce36c26de2adf13df",
     )
 
     ## Fetch traefik for use during e2e tests.


### PR DESCRIPTION
This PR takes the first two commits from #4507 and commits them separately. This fixes an immediate problem where the installation of kyverno is just completely broken.

#4507 is still something we should do, but because of the [seccompProfile issue](https://github.com/jetstack/cert-manager/pull/4507#issuecomment-940786514) it'll take a little more work; this fix is needed now.

/kind cleanup

```release-note
NONE
```
