### PR TITLE
Add an option to create a kube 1.23 cluster

### DIFF
--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -45,6 +45,9 @@ elif [[ "$K8S_VERSION" =~ 1\.21 ]] ; then
   KIND_IMAGE_SHA=$KIND_IMAGE_SHA_K8S_121
 elif [[ "$K8S_VERSION" =~ 1\.22 ]] ; then
   KIND_IMAGE_SHA=$KIND_IMAGE_SHA_K8S_122
+elif [[ "$K8S_VERSION" =~ 1\.23 ]]; then
+  KIND_IMAGE_SHA="sha256:8c3e98c086ece02428518a474e752a9ed0bf51da0ee93a8e6c47ca0937d7904b"
+  KIND_IMAGE_REPO="eu.gcr.io/jetstack-build-infra-images/kind"
 else
   echo "Unrecognised/unsupported Kubernetes version '${K8S_VERSION}'! Aborting..."
   exit 1


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR allows to create a Kubernetes 1.23 kind cluster (using an image built from the latest alpha release of kube 1.23) for running cert-manager e2e tests.
This is needed so that we can start testing cert-manager against Kubernetes v1.23 which [will come out on 7th December](https://www.kubernetes.dev/resources/release/) and should be supported by cert-manager v1.7.

**Special notes for your reviewer**:

- To test run `K8S_VERSION=1.23 ./devel/cluster/create-kind.sh` then verify that the created cluster version with `kubectl version`
- Once this PR gets merged, I will create a Prow periodic and an Prow presubmit with kube version set to 1.23

```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
