### PR TITLE
Only consider running pods when determining version

### DIFF
--- a/pkg/util/versionchecker/fromservice.go
+++ b/pkg/util/versionchecker/fromservice.go
@@ -53,6 +53,10 @@ func (o *versionChecker) extractVersionFromService(
 	}
 
 	for _, pod := range pods.Items {
+		if pod.Status.Phase != corev1.PodRunning {
+			continue
+		}
+
 		if label := extractVersionFromLabels(pod.Labels); label != "" {
 			o.versionSources["webhookPodLabelVersion"] = label
 		}

--- a/pkg/util/versionchecker/getpodfromtemplate_test.go
+++ b/pkg/util/versionchecker/getpodfromtemplate_test.go
@@ -51,6 +51,9 @@ func getPodFromTemplate(template *v1.PodTemplateSpec, parentObject runtime.Objec
 			Name:         prefix + cmutil.RandStringRunes(5),
 			Finalizers:   desiredFinalizers,
 		},
+		Status: v1.PodStatus{
+			Phase: v1.PodRunning,
+		},
 	}
 	if controllerRef != nil {
 		pod.OwnerReferences = append(pod.OwnerReferences, *controllerRef)


### PR DESCRIPTION
Some clusters may have failed pods that are not garbage collected. These pods should not be considered when determining version numbers.

Signed-off-by: John Chadwick <86682572+johnwchadwick@users.noreply.github.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4614

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixed a bug that can cause `cmctl version` to erroneously display the wrong webhook pod versions when older failed pods are present. (#4616)
```
