### PR TITLE
Allow Certificate secretTemplates to set the cert-manager.io/allow-d…

### DIFF
--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -186,7 +186,7 @@ func validateSecretTemplateAnnotations(crt *internalcmapi.CertificateSpec, fldPa
 
 	secretTemplateAnnotationsPath := fldPath.Child("secretTemplate", "annotations")
 	for a := range crt.SecretTemplate.Annotations {
-		if strings.HasPrefix(a, "cert-manager.io/") {
+		if strings.HasPrefix(a, "cert-manager.io/") && a != "cert-manager.io/allow-direct-injection" {
 			el = append(el, field.Invalid(secretTemplateAnnotationsPath, a, "cert-manager.io/* annotations are not allowed"))
 		}
 	}

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -671,9 +671,10 @@ func TestValidateCertificate(t *testing.T) {
 					SecretName: "abc",
 					SecretTemplate: &internalcmapi.CertificateSecretTemplate{
 						Annotations: map[string]string{
-							"app.com/valid":                    "valid",
-							"cert-manager.io/alt-names":        "example.com",
-							"cert-manager.io/certificate-name": "selfsigned-cert",
+							"app.com/valid":                          "valid",
+							"cert-manager.io/alt-names":              "example.com",
+							"cert-manager.io/certificate-name":       "selfsigned-cert",
+							"cert-manager.io/allow-direct-injection": "true",
 						},
 					},
 					IssuerRef: cmmeta.ObjectReference{


### PR DESCRIPTION
Allow Certificate secretTemplates to set the cert-manager.io/allow-direct-injection annotation

Signed-off-by: Brian Dunnigan <brian@boxboat.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #4621 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Allow Certificate secretTemplates to set the cert-manager.io/allow-direct-injection annotation
```
