### PR TITLE
Installs v1 ingress-nginx for e2e tests against kube 1.23

### DIFF
--- a/devel/addon/ingressnginx/BUILD.bazel
+++ b/devel/addon/ingressnginx/BUILD.bazel
@@ -1,19 +1,21 @@
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 
-# Ingress image that works on Kubernetes v1.16 - v1.20
+# Ingress image that works on Kubernetes older than v1.22
+# Image version can be bumped in test/e2e/images.bzl
 container_bundle(
-    name = "bundle_v0.48.1",
+    name = "bundle_pre_networking_v1",
     images = {
-        "k8s.gcr.io/ingress-nginx/controller:v0.48.1": "@io_kubernetes_ingress-nginx_old//image",
+        "k8s.gcr.io/ingress-nginx/controller:v0.49.3": "@io_kubernetes_ingress-nginx_old//image",
     },
     tags = ["manual"],
 )
 
-# Ingress image that works on Kubernetes v1.19 -> (including v1.22)
+# Ingress image that works on Kubernetes v1.19+
+# Image version can be bumped in test/e2e/images.bzl
 container_bundle(
-    name = "bundle_v1.0.2",
+    name = "bundle",
     images = {
-        "k8s.gcr.io/ingress-nginx/controller:v1.0.2": "@io_kubernetes_ingress-nginx_new//image",
+        "k8s.gcr.io/ingress-nginx/controller:v1.1.0": "@io_kubernetes_ingress-nginx_new//image",
     },
     tags = ["manual"],
 )

--- a/test/e2e/images.bzl
+++ b/test/e2e/images.bzl
@@ -42,15 +42,15 @@ def install():
         name = "io_kubernetes_ingress-nginx_old",
         registry = "k8s.gcr.io",
         repository = "ingress-nginx/controller",
-        tag = "v0.48.1",
-        digest = "sha256:dcc2d529a9cb95408ba9896639382793fb84361ef43cee9195f264c321e6b638",
+        tag = "v0.49.3",
+        digest = "sha256:c47ed90d1685cb6e3b556353d7afb2aced2be7095066edfc90dd81f3e9014747"
     )
     container_pull(
         name = "io_kubernetes_ingress-nginx_new",
         registry = "k8s.gcr.io",
         repository = "ingress-nginx/controller",
-        tag = "v1.0.2",
-        digest = "sha256:8c0abb209aaef63631d1c85add422ca51848ccee2f87aea06558d37bda1c8e91",
+        tag = "v1.1.0",
+        digest = "sha256:7464dc90abfaa084204176bcc0728f182b0611849395787143f6854dc6c38c85"
     )
 
     container_pull(


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR ensures that v1 version of nginx-ingress is used for cert-manager e2e tests against Kubernetes v1.23. Also bumps the nginx-ingress image versions.



**Special notes for your reviewer**:

The ingress-nginx release notes actually suggest [Kubernetes v1.18 is not supported even for the (latest known) pre-v1 nginx-ingress releases](https://github.com/kubernetes/ingress-nginx#support-versions-table), but it seems to work

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
