### PR TITLE
Order sync cleanup

### DIFF
--- a/pkg/controller/acmeorders/sync.go
+++ b/pkg/controller/acmeorders/sync.go
@@ -514,11 +514,11 @@ func (c *controller) finalizeOrder(ctx context.Context, cl acmecl.Interface, o *
 	// if it is already in the 'valid' state, as upon retry we will
 	// then retrieve the Certificate resource.
 	_, errUpdate := c.updateOrderStatus(ctx, cl, o)
-	if acmeErr, ok := err.(*acmeapi.Error); ok {
+	if acmeErr, ok := errUpdate.(*acmeapi.Error); ok {
 		if acmeErr.StatusCode >= 400 && acmeErr.StatusCode < 500 {
 			log.Error(err, "failed to update Order status due to a 4xx error, marking Order as failed")
 			c.setOrderState(&o.Status, string(cmacme.Errored))
-			o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", err)
+			o.Status.Reason = fmt.Sprintf("Failed to retrieve Order resource: %v", errUpdate)
 			return nil
 		}
 	}


### PR DESCRIPTION
**What this PR does / why we need it**:

- fixes a typo in `finalizeOrder` that caused an error to not be checked
- small refactor in orders controller `Sync` function to prevent ACME server being called twice in scenarios where an existing ACME Order needs to be retrieved to update a cert-manager `Order`'s status
- a few more test cases

**Special notes for your reviewer**:

- the extra ACME calls should have been maximum 1 extra per reconcile in a few scenarios only

```release-note
NONE
```
