### PR TITLE
Add a specific link to the LICENSES file in the repo

### DIFF
--- a/make/licenses.mk
+++ b/make/licenses.mk
@@ -14,7 +14,7 @@ bin/scratch/license.yaml: hack/boilerplate/boilerplate.sh.txt | bin/scratch
 # which presumably nobody will ever read or care about. Instead, just add a little footnote pointing
 # to the cert-manager repo in case anybody actually decides that they care.
 bin/scratch/license-footnote.yaml: | bin/scratch
-	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/jetstack/cert-manager" > $@
+	@echo -e "# To view licenses for cert-manager dependencies, see the LICENSES file in the\n# cert-manager repo: https://github.com/jetstack/cert-manager/blob/$(GITCOMMIT)/LICENSES" > $@
 
 bin/scratch/cert-manager.license: bin/scratch/license.yaml bin/scratch/license-footnote.yaml | bin/scratch
 	cat $^ > $@


### PR DESCRIPTION
As suggested by @munnerz [on slack](https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1639739884409500?thread_ts=1639739346.406900&cid=CDEQJ0Q8M)

This adds a link to the specific LICENSES file for a commit when we're doing a build. It won't be constantly re-run locally (because the `bin/scratch/license-footnote.yaml` target doesn't depend on `$(GITCOMMIT)` in any way) but since we build actual releases from scratch it should do nicely for those.

```release-note
NONE
```
