### PR TITLE
Fixes a bug where a previous failed CertificateRequest was picked up during next issuance

### DIFF
--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -243,10 +243,10 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		log.V(logf.ErrorLevel).Info("Certificate does not have an issuing condition")
 		return nil
 	}
-	// If the CertificateRequest for this revision has failed, but before the
-	// Issuing condition was set on the Certificate, then it must be a
-	// failed CertificateRequest from previous issuance for the same
-	// revision. Leave it to certificate-requests controller to delete the
+	// If the CertificateRequest for this revision failed before the
+	// Issuing condition was last updated on the Certificate, then it must be a
+	// failed CertificateRequest from the previous issuance for the same
+	// revision. Leave it to the certificate-requests controller to delete the
 	// CertificateRequest and create a new one.
 	if req.Status.FailureTime != nil &&
 		req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) && crReadyCond.Reason == cmapi.CertificateRequestReasonFailed {

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -244,8 +244,8 @@ func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi
 			return nil, nil
 		}
 		// If the Issuing condition on the Certificate is newer than the
-		// failure time on CertificateRequest it means that the
-		// CertificateRequest failed during previous issuance (for the
+		// failure time on CertificateRequest, it means that the
+		// CertificateRequest failed during the previous issuance (for the
 		// same revision). If it is a CertificateRequest that failed
 		// during the previous issuance, then it should be deleted so
 		// that we create a new one for this issuance.

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller.go
@@ -198,7 +198,7 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 		return err
 	}
 
-	requests, err = c.deleteCurrentFailedRequests(ctx, requests...)
+	requests, err = c.deleteCurrentFailedRequests(ctx, crt, requests...)
 	if err != nil {
 		return err
 	}
@@ -220,33 +220,43 @@ func (c *controller) ProcessItem(ctx context.Context, key string) error {
 	return c.createNewCertificateRequest(ctx, crt, pk, nextRevision, nextPrivateKeySecret.Name)
 }
 
-func (c *controller) deleteCurrentFailedRequests(ctx context.Context, reqs ...*cmapi.CertificateRequest) ([]*cmapi.CertificateRequest, error) {
-	log := logf.FromContext(ctx)
+func (c *controller) deleteCurrentFailedRequests(ctx context.Context, crt *cmapi.Certificate, reqs ...*cmapi.CertificateRequest) ([]*cmapi.CertificateRequest, error) {
+	log := logf.FromContext(ctx).WithValues("Certificate", crt.Name)
 	var remaining []*cmapi.CertificateRequest
 	for _, req := range reqs {
 		log = logf.WithRelatedResource(log, req)
+
 		// Check if there are any 'current' CertificateRequests that
 		// failed during the previous issuance cycle. Those should be
 		// deleted so that a new one gets created and the issuance is
 		// re-tried. In practice no more than one CertificateRequest is
 		// expected at this point.
-		cond := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
-		if cond == nil || cond.Status != cmmeta.ConditionFalse || cond.Reason != cmapi.CertificateRequestReasonFailed {
+		crReadyCond := apiutil.GetCertificateRequestCondition(req, cmapi.CertificateRequestConditionReady)
+		if crReadyCond == nil || crReadyCond.Status != cmmeta.ConditionFalse || crReadyCond.Reason != cmapi.CertificateRequestReasonFailed {
 			remaining = append(remaining, req)
 			continue
 		}
-		// TODO: once we have implemented exponential back off for
-		// Certificate failures, this should be changed accordingly.
-		now := c.clock.Now()
-		durationSinceFailure := now.Sub(cond.LastTransitionTime.Time)
-		if durationSinceFailure >= certificates.RetryAfterLastFailure {
+
+		certIssuingCond := apiutil.GetCertificateCondition(crt, cmapi.CertificateConditionIssuing)
+		if certIssuingCond == nil {
+			// This should never happen
+			log.V(logf.ErrorLevel).Info("Certificate does not have Issuing condition")
+			return nil, nil
+		}
+		// If the Issuing condition on the Certificate is newer than the
+		// failure time on CertificateRequest it means that the
+		// CertificateRequest failed during previous issuance (for the
+		// same revision). If it is a CertificateRequest that failed
+		// during the previous issuance, then it should be deleted so
+		// that we create a new one for this issuance.
+		if req.Status.FailureTime.Before(certIssuingCond.LastTransitionTime) {
+			log.V(logf.DebugLevel).Info("Found a failed CertificateRequest for previous issuance of this revision, deleting...")
 			if err := c.client.CertmanagerV1().CertificateRequests(req.Namespace).Delete(ctx, req.Name, metav1.DeleteOptions{}); err != nil {
 				return nil, err
 			}
 			continue
 		}
 		remaining = append(remaining, req)
-
 	}
 	return remaining, nil
 }

--- a/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
+++ b/pkg/controller/certificates/requestmanager/requestmanager_controller_test.go
@@ -605,9 +605,7 @@ func TestProcessItem(t *testing.T) {
 			if test.secrets != nil {
 				builder.KubeObjects = append(builder.KubeObjects, test.secrets...)
 			}
-			for _, req := range test.requests {
-				builder.CertManagerObjects = append(builder.CertManagerObjects, req)
-			}
+			builder.CertManagerObjects = append(builder.CertManagerObjects, test.requests...)
 			builder.Init()
 
 			// Register informers used by the controller using the registration wrapper


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR fixes a bug where after a certificate request fails and the next one succeeds, the `Certificate`'s 'Ready' condition remains false and the contents of the `Secret` are not updated.

See  #4642 for detailed bug description and instructions how to reproduce it.

**Which issue this PR fixes** 
 fixes #4642 

**Special notes for your reviewer**:

This bug was caused by a race condition where during an issuance where the _previous_ issuance failed, the failed `CertificateRequest` gets picked up by the issuing controller and used to update `Certificate`'s status.
This issue is fixed in https://github.com/jetstack/cert-manager/pull/4688/commits/ff67b2a9a0bc5e1520c875496fbd728b915ca738 by making the issuing controller compare timestamp on the `Issuing` condition on the `Certificate` and the failure time on the `CertificateRequest` and ignore the `CertificateRequest` if it has failed _before_ the `Issuing` condition was set on the `Certificate` as this means that it belongs to previous issuance.

Additionally, this PR also changes the way how `certificates-request-manager` controller determines if it should delete a failed `CertificateRequest` for this revision (see #4130 for context). Previously there was a check that the failure happened at least 1 hour (default backoff period) ago. This would mean that if a user runs `cmctl renew` command earlier, the failed `CertificateRequest` won't get deleted so I've changed this to check that the `CertificateRequest` has failed _before_ the `Issuing` condition was applied to the `Certificate`.

Looking at the timestamps is not the most reliable way how to determine if an action should be performed and resource statuses can be lost i.e after a backup and restore. However, in this case, the first step would always be to apply 'Issuing' condition to the `Certificate` in the trigger controller which is done after looking at the contents of the `Secret`. I cannot think of other edge cases.

**Verify the fix** (with Venafi TPP issuer):

1. Create a TPP zone with policy that does not allow private key reuse
2. Create a TPP issuer and a Certificate with spec.privateKey.rotationPolicy set to 'Never' (default)
3. Observe successful issuance (Certificate becomes ready)
4. Force renewal i.e by changing DNS names on Certificate
5. Observe that cert's 'Ready' condition becomes false and there is a failed CertificateRequest
6. Modify TPP zone to allow private key reuse
7. Force renewal using cmctl renew
8. Observe a new successfull `CertificateRequest` and `Certificate`'s Ready condition set to true

(See [here](https://github.com/jetstack/cert-manager/issues/4642#:~:text=Reproduce%20with%20a%20Venafi%20TPP%20issuer%3A) for how to reproduce the bug)

**Alternative approaches**:

Same alternative approaches as those in the description of #4130 and same reasons as to why they weren't chosen

**Related PRs**:
#4130

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fixes a bug where a previous failed CertificateRequest was picked up during the next issuance. Thanks to @MattiasGees for raising the issue and help with debugging!
```

/kind bug

