### PR TITLE
Helm values cleanup

### DIFF
--- a/cmd/cainjector/app/start.go
+++ b/cmd/cainjector/app/start.go
@@ -84,7 +84,7 @@ func (o *InjectorControllerOptions) AddFlags(fs *pflag.FlagSet) {
 		"The duration the clients should wait between attempting acquisition and renewal "+
 		"of a leadership. This is only applicable if leader election is enabled.")
 
-	fs.BoolVar(&o.EnablePprof, "enable-profiling", cmdutil.DefaultEnableProfiling, "Enable Go profiler (pprof) should be run.")
+	fs.BoolVar(&o.EnablePprof, "enable-profiling", cmdutil.DefaultEnableProfiling, "Enable profiling for cainjector")
 	fs.StringVar(&o.PprofAddr, "profiler-address", cmdutil.DefaultProfilerAddr, "Address of the Go profiler (pprof) if enabled. This should never be exposed on a public interface.")
 }
 

--- a/cmd/webhook/app/options/options.go
+++ b/cmd/webhook/app/options/options.go
@@ -76,7 +76,7 @@ func AddConfigFlags(fs *pflag.FlagSet, c *config.WebhookConfiguration) {
 		"Optional apiserver host address to connect to. If not specified, autoconfiguration "+
 		"will be attempted.")
 	fs.BoolVar(&c.EnablePprof, "enable-profiling", c.EnablePprof, ""+
-		"Enable profiling for controller.")
+		"Enable profiling for webhook.")
 	fs.StringVar(&c.PprofAddress, "profiler-address", c.PprofAddress,
 		"Address of the Go profiler (pprof). This should never be exposed on a public interface. If this flag is not set, the profiler is not run.")
 	tlsCipherPossibleValues := cliflag.TLSCipherPossibleValues()

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -85,9 +85,6 @@ serviceAccount:
 
 # Optional additional arguments
 extraArgs: []
-  # Use this flag to set a namespace that cert-manager will use to store
-  # supporting resources required for each ClusterIssuer (default is kube-system)
-  # - --cluster-resource-namespace=kube-system
   # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
   # - --enable-certificate-owner-ref=true
   # Use this flag to enabled or disable arbitrary controllers, for example, disable the CertificiateRequests approver

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -83,7 +83,8 @@ serviceAccount:
   # Automount API credentials for a Service Account.
   automountServiceAccountToken: true
 
-# Optional additional arguments
+# Additional command line flags to pass to cert-manager controller binary.
+# To see all available flags run docker run quay.io/jetstack/cert-manager-controller:<version> --help
 extraArgs: []
   # When this flag is enabled, secrets will be automatically removed when the certificate resource is deleted
   # - --enable-certificate-owner-ref=true
@@ -256,8 +257,11 @@ webhook:
   # Optional additional annotations to add to the webhook service
   # serviceAnnotations: {}
 
-  # Optional additional arguments for webhook
+  # Additional command line flags to pass to cert-manager webhook binary.
+  # To see all available flags run docker run quay.io/jetstack/cert-manager-webhook:<version> --help
   extraArgs: []
+  # Path to a file containing a WebhookConfiguration object used to configure the webhook
+  # - --config=<path-to-config-file>
 
   resources: {}
     # requests:
@@ -378,8 +382,11 @@ cainjector:
   # Optional additional annotations to add to the cainjector Pods
   # podAnnotations: {}
 
-  # Optional additional arguments for cainjector
+  # Additional command line flags to pass to cert-manager cainjector binary.
+  # To see all available flags run docker run quay.io/jetstack/cert-manager-cainjector:<version> --help
   extraArgs: []
+  # Enable profiling for cainjector
+  # - --enable-profiling=true
 
   resources: {}
     # requests:
@@ -451,7 +458,8 @@ startupapicheck:
   # Optional additional annotations to add to the startupapicheck Pods
   # podAnnotations: {}
 
-  # Optional additional arguments for startupapicheck
+  # Additional command line flags to pass to startupapicheck binary.
+  # To see all available flags run docker run quay.io/jetstack/cert-manager-ctl:<version> --help
   extraArgs: []
 
   resources: {}


### PR DESCRIPTION
**What this PR does / why we need it**:

This is a small helm values cleanup PR following #4698:

- removes the example where `--cluster-resource-namespace` flag is passed via extra args as there is already a top level helm value for the same flag
- adds some comments as to how users can view all available cert-manager component flags

```release-note
NONE
```

fixes #4698 

/kind cleanup
