### PR TITLE
Install APIGroup once for multiple DNS providers

### DIFF
--- a/pkg/acme/webhook/apiserver/BUILD.bazel
+++ b/pkg/acme/webhook/apiserver/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -32,4 +32,19 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["apiserver_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/acme/webhook:go_default_library",
+        "//pkg/acme/webhook/apis/acme/v1alpha1:go_default_library",
+        "//pkg/acme/webhook/registry/challengepayload:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_apimachinery//pkg/runtime/schema:go_default_library",
+        "@io_k8s_apiserver//pkg/server:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+    ],
 )

--- a/pkg/acme/webhook/apiserver/apiserver_test.go
+++ b/pkg/acme/webhook/apiserver/apiserver_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	"k8s.io/client-go/rest"
+
+	"github.com/jetstack/cert-manager/pkg/acme/webhook"
+	whapi "github.com/jetstack/cert-manager/pkg/acme/webhook/apis/acme/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/acme/webhook/registry/challengepayload"
+)
+
+var (
+	_ webhook.Solver = noOpSolver{}
+)
+
+type noOpSolver struct {
+	name string
+}
+
+func (s noOpSolver) Name() string {
+	return s.name
+}
+
+func (s noOpSolver) Present(_ *whapi.ChallengeRequest) error {
+	return nil
+}
+
+func (s noOpSolver) CleanUp(_ *whapi.ChallengeRequest) error {
+	return nil
+}
+
+func (s noOpSolver) Initialize(_ *rest.Config, _ <-chan struct{}) error {
+	return nil
+}
+
+func newFakeRecommendedConfig() *genericapiserver.RecommendedConfig {
+	cfg := genericapiserver.NewRecommendedConfig(Codecs)
+	cfg.ExternalAddress = "192.168.10.4:443"
+	cfg.LoopbackClientConfig = &rest.Config{}
+	return cfg
+}
+
+func TestNewChallengeServer(t *testing.T) {
+	tests := map[string]struct {
+		cfg Config
+
+		expErr bool
+	}{
+		"Single solver": {
+			cfg: Config{
+				GenericConfig: newFakeRecommendedConfig(),
+				ExtraConfig: ExtraConfig{
+					SolverGroup: "test-solvers.cert-manager.io",
+					Solvers: []webhook.Solver{
+						noOpSolver{name: "solver-1"},
+					},
+				},
+				restConfig: &rest.Config{},
+			},
+			expErr: false,
+		},
+		"Multiple solvers": {
+			cfg: Config{
+				GenericConfig: newFakeRecommendedConfig(),
+				ExtraConfig: ExtraConfig{
+					SolverGroup: "test-solvers.cert-manager.io",
+					Solvers: []webhook.Solver{
+						noOpSolver{name: "solver-1"},
+						noOpSolver{name: "solver-2"},
+					},
+				},
+				restConfig: &rest.Config{},
+			},
+			expErr: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			server, err := test.cfg.Complete().New()
+			if test.expErr {
+				require.Error(t, err)
+				return
+			}
+
+			require.NoError(t, err)
+			for _, solver := range test.cfg.ExtraConfig.Solvers {
+				registeredKind := server.GenericAPIServer.EquivalentResourceRegistry.KindFor(
+					schema.GroupVersionResource{
+						Group:    test.cfg.ExtraConfig.SolverGroup,
+						Version:  "v1alpha1",
+						Resource: solver.Name(),
+					},
+					"",
+				)
+				expectedKind := challengepayload.NewREST(solver).
+					GroupVersionKind(schema.GroupVersion{
+						Group:   test.cfg.ExtraConfig.SolverGroup,
+						Version: "v1alpha1",
+					})
+				require.Equal(t, expectedKind, registeredKind)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

If we register multiple DNS providers while running the webhook server, it will cause an unexpected exit with `WebService with duplicate root path detected` error. 

This issue happens because the root path of each DNS provider is equal since they share the group name.

To resolve this issue, this commit installs APIGroup once for multiple DNS providers by extracting apiGroupInfo variable and InstallAPIGroup call from solver (DNS provider) loop in ChallengeServer constructor.

**Which issue this PR fixes**

None

**Special notes for your reviewer**:

None

**Release note**:

```release-note
Fix unexpected exit when multiple DNS providers are passed to `RunWebhookServer` 
```

/kind bug