### PR TITLE
Pipes in the feature gates from environment to e2e binary

### DIFF
--- a/devel/run-e2e.sh
+++ b/devel/run-e2e.sh
@@ -48,6 +48,9 @@ if [[ -n "$GINKGO_FOCUS" ]]; then GINKGO_FOCUS="--ginkgo.focus=${GINKGO_FOCUS}";
 # 'export GINKGO_SKIP="Venafi Cloud"' (skips all suites with 'Venafi Cloud' in the name).
 if  [[ -n "$GINKGO_SKIP" ]]; then GINKGO_SKIP="--ginkgo.skip=${GINKGO_SKIP}"; fi
 
+# Default feature gates to enable
+FEATURE_GATES="${FEATURE_GATES:-ExperimentalCertificateSigningRequestControllers=true,ExperimentalGatewayAPISupport=true}"
+
 # Configure PATH to use bazel provided e2e tools
 setup_tools
 
@@ -68,6 +71,7 @@ ginkgo -nodes 10 -flakeAttempts ${FLAKE_ATTEMPTS:-1} \
 	--report-dir="${ARTIFACTS:-$REPO_ROOT/_artifacts}" \
 	--acme-dns-server="$DNS_SERVER" \
 	--acme-ingress-ip="$INGRESS_IP" \
+	--feature-gates="${FEATURE_GATES}" \
 	${GINKGO_SKIP:+"$GINKGO_SKIP"} \
 	${GINKGO_FOCUS:+"$GINKGO_FOCUS"} \
 	"$@"

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -34,6 +34,8 @@ import (
 	_ "github.com/jetstack/cert-manager/test/e2e/suite"
 )
 
+var featureGates string
+
 func init() {
 	logs.InitLogs(flag.CommandLine)
 	framework.DefaultConfig.AddFlags(flag.CommandLine)
@@ -46,7 +48,6 @@ func init() {
 	ginkgoconfig.GinkgoConfig.RandomizeAllSpecs = true
 
 	wait.ForeverTestTimeout = time.Second * 60
-
 }
 
 func TestE2E(t *testing.T) {

--- a/test/e2e/framework/config/BUILD.bazel
+++ b/test/e2e/framework/config/BUILD.bazel
@@ -19,6 +19,8 @@ go_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/feature:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
         "@io_k8s_apimachinery//pkg/util/errors:go_default_library",
         "@io_k8s_client_go//tools/clientcmd:go_default_library",
     ],

--- a/test/e2e/suite/conformance/certificatesigningrequests/BUILD.bazel
+++ b/test/e2e/suite/conformance/certificatesigningrequests/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/apis/experimental/v1alpha1:go_default_library",
         "//pkg/feature:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/framework/helper/featureset:go_default_library",
         "//test/e2e/framework/helper/validation:go_default_library",

--- a/test/e2e/suite/conformance/certificatesigningrequests/suite.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/suite.go
@@ -19,14 +19,12 @@ package certificatesigningrequests
 import (
 	"crypto"
 	"fmt"
-	"os"
-	"strings"
 
 	. "github.com/onsi/ginkgo"
 	certificatesv1 "k8s.io/api/certificates/v1"
 
 	"github.com/jetstack/cert-manager/pkg/feature"
-	"github.com/jetstack/cert-manager/pkg/util"
+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/framework/helper/featureset"
 )
@@ -111,8 +109,7 @@ func (s *Suite) it(f *framework.Framework, name string, fn func(string), require
 		return
 	}
 	It(name, func() {
-		fgs := os.Getenv("FEATURE_GATES")
-		if !util.Contains(strings.Split(fgs, ","), string(feature.ExperimentalCertificateSigningRequestControllers)+"=true") {
+		if !utilfeature.DefaultFeatureGate.Enabled(feature.ExperimentalCertificateSigningRequestControllers) {
 			framework.Skipf("skipping CertificateSigningRequest controller test since FEATURE_GATE %s is not enabled",
 				feature.ExperimentalCertificateSigningRequestControllers)
 		}


### PR DESCRIPTION
Since https://github.com/jetstack/testing/pull/612 merged, we are no longer running e2e tests that predicate on string matches against the feature flag env var and the feature name- namely CertificateSigningRequests. This PR registers the feature gate flag on the e2e suite binary and pipes them in from the test script.

Since the feature gates package uses pflag which is incompatible (or extremely tedious to get working properly!) with ginkgo, we simply register a golang flag, copy the resulting value to a pflag set once parsed, then register it with the feature gate map.

This should get the feature gate tests running correctly.

```release-note
Cleanup: Pipe feature gate flag to the e2e binary. Test against shared Feature Gate map for feature enabled and whether they should be tested against.
```

/milestone v1.7
/kind cleanup