### PR TITLE
[release-1.6] bump base images

### DIFF
--- a/build/images.bzl
+++ b/build/images.bzl
@@ -23,7 +23,7 @@ def define_base_images():
         name = "static_base",
         registry = "gcr.io",
         repository = "distroless/static",
-        digest = "sha256:fac888659ca3eb59f7d5dcb0d62540cc5c53615e2671062b36c815d000da8ef4"
+        digest = "sha256:49f33fac9328ac595cb74bd02e6a186414191c969de0d8be34e6307c185acb8e"
     )
     # Use 'dynamic' distroless image for modified cert-manager deployments that
     # are dynamically linked. (This is not the default and you probably don't
@@ -35,5 +35,5 @@ def define_base_images():
         name = "dynamic_base",
         registry = "gcr.io",
         repository = "distroless/base",
-        digest = "sha256:0530d193888bcd7bd0376c8b34178ea03ddb0b2b18caf265135b6d3a393c8d05"
+        digest = "sha256:eaddb8ca70848a43fab351226d9549a571f68d9427c53356114fedd3711b5d73"
     )


### PR DESCRIPTION
Backport of #4706 for release-1.6

This likely isn't worth doing a release for on its own, but it seems worth backporting so this is ready to go if we need to do another release of 1.6, which is currently scheduled to be supported until [Mar 30, 2022](https://cert-manager.io/docs/installation/supported-releases/#supported-releases)

/kind cleanup

```release-note
Bump base images to latest versions
```
