### PR TITLE
Add goimports verification and skeleton ci presubmit check

### DIFF
--- a/hack/verify-goimports.sh
+++ b/hack/verify-goimports.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+goimports=$(realpath "$1")
+
+echo "+++ running goimports"
+output=$("$goimports" -l .)
+if [ ! -z "${output}" ]; then
+    echo "${output}"
+    echo "+++ goimports failed; run 'goimports -w .' to fix"
+    exit 1
+fi

--- a/make/Makefile
+++ b/make/Makefile
@@ -35,6 +35,7 @@ HOST_ARCH = $(shell $(GO) env GOARCH)
 
 include make/git.mk
 include make/tools.mk
+include make/ci.mk
 include make/base_images.mk
 include make/cmctl.mk
 include make/server.mk

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -1,0 +1,6 @@
+.PHONY: ci-presubmit
+ci-presubmit: verify-imports
+
+.PHONY: verify-imports
+verify-imports: bin/tools/goimports
+	./hack/verify-goimports.sh $<

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -16,6 +16,7 @@ KIND_VERSION=0.11.1
 COSIGN_VERSION=1.3.1
 CMREL_VERSION=a1e2bad95be9688794fd0571c4c40e88cccf9173
 K8S_RELEASE_NOTES_VERSION=0.7.0
+GOIMPORTS_VERSION=0.1.8
 YTT_VERSION=0.36.0
 YQ_VERSION=4.11.2
 
@@ -26,7 +27,7 @@ bin/scratch/tools:
 	@mkdir -p $@
 
 .PHONY: tools
-tools: bin/tools/helm bin/tools/kubectl bin/tools/kind bin/tools/cosign bin/tools/release-notes bin/tools/cmrel bin/tools/ytt bin/tools/yq
+tools: bin/tools/helm bin/tools/kubectl bin/tools/kind bin/tools/cosign bin/tools/cmrel bin/tools/release-notes bin/tools/goimports bin/tools/ytt bin/tools/yq
 
 ########
 # Helm #
@@ -108,6 +109,13 @@ bin/tools/cmrel: | bin/tools
 
 bin/tools/release-notes: | bin/tools
 	GOBIN=$(shell pwd)/$(dir $@) go install k8s.io/release/cmd/release-notes@v$(K8S_RELEASE_NOTES_VERSION)
+
+#############
+# goimports #
+#############
+
+bin/tools/goimports: | bin/tools
+	GOBIN=$(shell pwd)/$(dir $@) go install golang.org/x/tools/cmd/goimports@v$(GOIMPORTS_VERSION)
 
 #######
 # ytt #


### PR DESCRIPTION
This adds a step by which we can run `goimports` against the codebase.

It's also the first part of moving "testing" more generally from bazel to make. A lot of the existing steps are tied to bazel in some way, but since this is greenfield it's an easy place to start.

After this merges, we can add `make -f make/Makefile ci-presubmit` to the [presubmits](https://github.com/jetstack/testing/blob/master/config/jobs/cert-manager/cert-manager-presubmits.yaml).

Sort-of related to #4705

/kind feature

```release-note
Add goimports verification step for CI
```
