### PR TITLE
Match upstream boilerplate verification for files w/ go:build

### DIFF
--- a/hack/verify_boilerplate.py
+++ b/hack/verify_boilerplate.py
@@ -192,13 +192,11 @@ def get_regexs():
     regexs["year"] = re.compile('YEAR')
     # dates can be 2014, 2015, 2016 or 2017, company holder names can be anything
     regexs["date"] = re.compile(get_dates())
-    # strip //go:build \n// +build \n\n build constraints We are currently using
-    # Go 1.17 where two forms of build constraints ('go:build', '+build') are
-    # added to files. This will need to change when we upgrade to a version of
-    # Go which only uses the 'go:build' format
-    # See https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md
+    # strip the following build constraints/tags:
+    # //go:build
+    # // +build \n\n
     regexs["go_build_constraints"] = re.compile(
-        r"^(//go:build.*\n// \+build.*\n)+\n", re.MULTILINE)
+        r"^(//(go:build| \+build).*\n)+\n", re.MULTILINE)
     # strip #!.* from shell/python scripts
     regexs["shebang"] = re.compile(r"^(#!.*\n)\n*", re.MULTILINE)
     return regexs


### PR DESCRIPTION
The regex being replaced doesn't match files which only contain `//go:build` although as of go 1.17 (which we require for cert-manager) that seems [totally valid](https://go.googlesource.com/proposal/+/master/design/draft-gobuild.md).

This commit updates the regex to match upstream k8s, which is the original source of the boilerplate verification script in any case.

See the [upstream](https://github.com/kubernetes/kubernetes/blob/47ff335d4c678f8ebe12369055d4b3806d0fb9f4/hack/boilerplate/boilerplate.py#L219-L223) version of the script for more details

/kind feature

```release-note
NONE
```
