### PR TITLE
Re-organise and extend path loading logic to make it easier to run integration tests using Delve/GoLand

### DIFF
--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -16,6 +16,7 @@ filegroup(
         "//internal/apis/config/webhook:all-srcs",
         "//internal/apis/meta:all-srcs",
         "//internal/ingress:all-srcs",
+        "//internal/test/paths:all-srcs",
         "//internal/vault:all-srcs",
     ],
     tags = ["automanaged"],

--- a/internal/apis/acme/install/BUILD.bazel
+++ b/internal/apis/acme/install/BUILD.bazel
@@ -45,8 +45,8 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//internal/apis/acme/fuzzer:go_default_library",
+        "//internal/test/paths:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/api/testing:go_default_library",
         "@com_github_munnerz_crd_schema_fuzz//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/apitesting/roundtrip:go_default_library",
     ],

--- a/internal/apis/acme/install/pruning_test.go
+++ b/internal/apis/acme/install/pruning_test.go
@@ -22,8 +22,8 @@ import (
 	crdfuzz "github.com/munnerz/crd-schema-fuzz"
 
 	acmefuzzer "github.com/jetstack/cert-manager/internal/apis/acme/fuzzer"
+	apitesting "github.com/jetstack/cert-manager/internal/test/paths"
 	"github.com/jetstack/cert-manager/pkg/api"
-	apitesting "github.com/jetstack/cert-manager/pkg/api/testing"
 )
 
 func TestPruneTypes(t *testing.T) {

--- a/internal/apis/certmanager/install/BUILD.bazel
+++ b/internal/apis/certmanager/install/BUILD.bazel
@@ -47,8 +47,8 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//internal/apis/certmanager/fuzzer:go_default_library",
+        "//internal/test/paths:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/api/testing:go_default_library",
         "@com_github_munnerz_crd_schema_fuzz//:go_default_library",
         "@io_k8s_apimachinery//pkg/api/apitesting/roundtrip:go_default_library",
     ],

--- a/internal/apis/certmanager/install/pruning_test.go
+++ b/internal/apis/certmanager/install/pruning_test.go
@@ -22,8 +22,8 @@ import (
 	crdfuzz "github.com/munnerz/crd-schema-fuzz"
 
 	cmfuzzer "github.com/jetstack/cert-manager/internal/apis/certmanager/fuzzer"
+	apitesting "github.com/jetstack/cert-manager/internal/test/paths"
 	"github.com/jetstack/cert-manager/pkg/api"
-	apitesting "github.com/jetstack/cert-manager/pkg/api/testing"
 )
 
 func TestPruneTypes(t *testing.T) {

--- a/internal/test/paths/BUILD.bazel
+++ b/internal/test/paths/BUILD.bazel
@@ -2,12 +2,15 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "go_default_library",
-    srcs = ["bazel.go"],
+    srcs = [
+        "bazel.go",
+        "paths.go",
+    ],
     data = [
         "//deploy/crds:crds.yaml",
     ],
-    importpath = "github.com/jetstack/cert-manager/pkg/api/testing",
-    visibility = ["//visibility:public"],
+    importpath = "github.com/jetstack/cert-manager/internal/test/paths",
+    visibility = ["//:__subpackages__"],
 )
 
 filegroup(

--- a/internal/test/paths/bazel.go
+++ b/internal/test/paths/bazel.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testing
+package paths
 
 import (
 	"fmt"
@@ -42,10 +42,7 @@ func PathForCRD(t *testing.T, name string) string {
 
 func CRDDirectory(t *testing.T) string {
 	runfiles := os.Getenv("RUNFILES_DIR")
-	// BAZEL_BIN_DIR allows the developer to set a path to the bazel bin directory.
-	// This allows for the tests to be ran outside of Bazel, for example with Delve
-	// the Bazel bin directory still needs to be generated using Bazel.
-	bazelDir := os.Getenv("BAZEL_BIN_DIR")
+	bazelDir := BazelBinDir
 	if runfiles == "" && bazelDir == "" {
 		t.Fatalf("integration tests can only run within 'bazel test' environment or have BAZEL_BIN_DIR set")
 	}

--- a/internal/test/paths/bazel.go
+++ b/internal/test/paths/bazel.go
@@ -41,17 +41,15 @@ func PathForCRD(t *testing.T, name string) string {
 }
 
 func CRDDirectory(t *testing.T) string {
-	runfiles := os.Getenv("RUNFILES_DIR")
 	bazelDir := BazelBinDir
-	if runfiles == "" && bazelDir == "" {
-		t.Fatalf("integration tests can only run within 'bazel test' environment or have BAZEL_BIN_DIR set")
-	}
-	var path string
-	if bazelDir != "" {
-		path = filepath.Join(bazelDir, "deploy", "crds")
-	} else {
+	path := filepath.Join(bazelDir, "deploy", "crds")
+
+	// prefer RUNFILES_DIR if set
+	runfiles := os.Getenv("RUNFILES_DIR")
+	if runfiles != "" {
 		path = filepath.Join(runfiles, "com_github_jetstack_cert_manager", "deploy", "crds")
 	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/test/paths/paths.go
+++ b/internal/test/paths/paths.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package paths
+
+import (
+	"path/filepath"
+	"runtime"
+)
+
+var (
+	_, b, _, _ = runtime.Caller(0)
+
+	// ModuleRootDir is the filesystem path to the root of the repository.
+	ModuleRootDir = filepath.Join(filepath.Dir(b), "../../..")
+
+	// BazelBinDir is the filesystem path to the bazel-bin directory within the
+	// root of the repository.
+	// This will not be accessible when running within the bazel sandbox, but
+	// is useful for reading bazel files when running commands with `go test`.
+	BazelBinDir = filepath.Join(ModuleRootDir, "bazel-bin")
+)

--- a/pkg/api/BUILD.bazel
+++ b/pkg/api/BUILD.bazel
@@ -38,7 +38,6 @@ filegroup(
     name = "all-srcs",
     srcs = [
         ":package-srcs",
-        "//pkg/api/testing:all-srcs",
         "//pkg/api/util:all-srcs",
     ],
     tags = ["automanaged"],

--- a/test/integration/framework/BUILD.bazel
+++ b/test/integration/framework/BUILD.bazel
@@ -11,8 +11,8 @@ go_library(
     deps = [
         "//cmd/webhook/app:go_default_library",
         "//cmd/webhook/app/testing:go_default_library",
+        "//internal/test/paths:go_default_library",
         "//pkg/api:go_default_library",
-        "//pkg/api/testing:go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",
         "//pkg/client/informers/externalversions:go_default_library",
         "//pkg/controller:go_default_library",

--- a/test/integration/framework/apiserver.go
+++ b/test/integration/framework/apiserver.go
@@ -40,8 +40,8 @@ import (
 
 	"github.com/jetstack/cert-manager/cmd/webhook/app"
 	webhooktesting "github.com/jetstack/cert-manager/cmd/webhook/app/testing"
+	"github.com/jetstack/cert-manager/internal/test/paths"
 	"github.com/jetstack/cert-manager/pkg/api"
-	apitesting "github.com/jetstack/cert-manager/pkg/api/testing"
 	"github.com/jetstack/cert-manager/pkg/webhook/handlers"
 	"github.com/jetstack/cert-manager/test/internal/apiserver"
 )
@@ -75,7 +75,7 @@ func WithWebhookConversionHandler(handler handlers.ConversionHook) RunControlPla
 
 func RunControlPlane(t *testing.T, ctx context.Context, optionFunctions ...RunControlPlaneOption) (*rest.Config, StopFunc) {
 	options := &controlPlaneOptions{
-		crdsDir: pointer.StringPtr(apitesting.CRDDirectory(t)),
+		crdsDir: pointer.StringPtr(paths.CRDDirectory(t)),
 	}
 
 	for _, f := range optionFunctions {

--- a/test/internal/apiserver/BUILD.bazel
+++ b/test/internal/apiserver/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/jetstack/cert-manager/test/internal/apiserver",
     visibility = ["//test:__subpackages__"],
     deps = [
+        "//internal/test/paths:go_default_library",
         "//test/internal/util:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/envtest:go_default_library",
     ],

--- a/test/internal/apiserver/envs.go
+++ b/test/internal/apiserver/envs.go
@@ -20,7 +20,9 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 
+	"github.com/jetstack/cert-manager/internal/test/paths"
 	"github.com/jetstack/cert-manager/test/internal/util"
 )
 
@@ -45,11 +47,21 @@ Either re-run this test or set the %s environment variable.`, bin, key))
 }
 
 func getPath(name string, path ...string) (string, error) {
+	// Check to see if we are running in a `bazel test` environment and if so,
+	// use the RUNFILES_DIR environment variable to find dependencies.
 	bazelPath := util.GetTestPath(path...)
 	p, err := exec.LookPath(bazelPath)
 	if err == nil {
 		return p, nil
 	}
 
+	// Check for a bazel-bin directory which may contain the test dependencies
+	nextBazelPath := filepath.Join(append([]string{paths.BazelBinDir}, path...)...)
+	p, err = exec.LookPath(nextBazelPath)
+	if err == nil {
+		return p, nil
+	}
+
+	// Otherwise check the users PATH
 	return exec.LookPath(name)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Prior to this change, running integration tests using anything other than Bazel would fail unless environment variables pointing the integration test framework to copies of the binaries needed were set.

This PR adds additional checks into the path loading logic to attempt to load these binaries from the `bazel-bin` directory if it exists. This means that once a user has run `bazel build //hack/bin/...` (or has indirectly caused these targets to be built by running or building other targets), IDEs like Goland will be able to run these tests like normal without any additional configuration changes by the user.

**Release note**:
```release-note
NONE
```

/kind cleanup
/area testing