### PR TITLE
The Issuer now becomes Ready=False when ingressClassName is not found

### DIFF
--- a/internal/ingress/ingress.go
+++ b/internal/ingress/ingress.go
@@ -78,13 +78,13 @@ type InternalIngressNamespaceLister interface {
 // API Versions available in the discovery client.
 func NewListerInformer(ctx *controller.Context) (InternalIngressLister, cache.SharedIndexInformer, error) {
 	switch {
-	case hasVersion(ctx.DiscoveryClient, networkingv1.SchemeGroupVersion.String()):
+	case HasVersion(ctx.DiscoveryClient, networkingv1.SchemeGroupVersion.String()):
 		return &v1Lister{
 				lister: ctx.KubeSharedInformerFactory.Networking().V1().Ingresses().Lister(),
 			},
 			ctx.KubeSharedInformerFactory.Networking().V1().Ingresses().Informer(),
 			nil
-	case hasVersion(ctx.DiscoveryClient, networkingv1beta1.SchemeGroupVersion.String()):
+	case HasVersion(ctx.DiscoveryClient, networkingv1beta1.SchemeGroupVersion.String()):
 		return &v1beta1Lister{
 				lister: ctx.KubeSharedInformerFactory.Networking().V1beta1().Ingresses().Lister(),
 			},
@@ -98,11 +98,11 @@ func NewListerInformer(ctx *controller.Context) (InternalIngressLister, cache.Sh
 // NewCreateUpdater returns an InternalIngressCreateUpdater configured for v1 or v1beta1 ingresses depending on the
 // versions available in the discovery client
 func NewCreateUpdater(ctx *controller.Context) (InternalIngressCreateUpdater, error) {
-	if hasVersion(ctx.DiscoveryClient, networkingv1.SchemeGroupVersion.String()) {
+	if HasVersion(ctx.DiscoveryClient, networkingv1.SchemeGroupVersion.String()) {
 		return &v1CreaterUpdater{
 			client: ctx.Client,
 		}, nil
-	} else if hasVersion(ctx.DiscoveryClient, networkingv1beta1.SchemeGroupVersion.String()) {
+	} else if HasVersion(ctx.DiscoveryClient, networkingv1beta1.SchemeGroupVersion.String()) {
 		return &v1beta1CreaterUpdater{
 			client: ctx.Client,
 		}, nil
@@ -111,7 +111,7 @@ func NewCreateUpdater(ctx *controller.Context) (InternalIngressCreateUpdater, er
 	}
 }
 
-func hasVersion(d discovery.DiscoveryInterface, GroupVersion string) bool {
+func HasVersion(d discovery.DiscoveryInterface, GroupVersion string) bool {
 	// check whether the GroupVersion is already known
 	knownVersions := knownAPIVersionCache.Load().(map[string]bool)
 	knownVersion, found := knownVersions[GroupVersion]


### PR DESCRIPTION
This PR partly fixes https://github.com/jetstack/cert-manager/issues/4537.

Since we added support for Ingress v1, we have slightly changed the semantics of the `class` field:

```yaml
apiVersion: cert-manager.io/v1
kind: Issuer
metadata:
  name: letsencrypt
spec:
  acme:
    email: mael+give-me-my-cluster@vls.dev
    server: https://acme-v02.api.letsencrypt.org/directory
    privateKeySecretRef:
      name: letsencrypt
    solvers:
      - http01:
          ingress:
            class: traefik # ⚠️
```

Before cert-manager 1.5.0, this field meant that the annotation `kubernetes.io/ingress.class` would be set on the v1beta1 Ingress used with the solver pod.

Since cert-manager 1.5.0, if your Kubernetes cluster is recent enough (1.21 and above), cert-manager creates an Ingress v1 instead. Since the annotation was deprecated with Ingress v1, it made sense for us to use the field `spec.ingressClassName` instead.

Unfortunately, this change is breaking: users who used to not have to create an IngressClass are now forced to create one and there is no indication that you should create one. As an example, I spent well over 2 hours this afternoon trying to understand why the solver Ingress wasn't being picked up by Traefik.

In this PR, I suggest that we mark the Issuer (and ClusterIssuer) "unready" when the `class` refers to an IngressClass that cannot be found. 

With this change, it will become easy to find the source of the issue by either looking at the CertificateRequest or the Issuer. For example, `cmctl` shows this:

```
$ cmctl status certificate example
...
Issuer:
  Name: letsencrypt
  Kind: Issuer
  Conditions:
    Ready: False, Reason: InvalidConfig, Message: the IngressClass "traefik" does not exist, please create it
CertificateRequest:
  Name: example-c8wzg
  Namespace: default
  Conditions:
    Approved: True, Reason: cert-manager.io, Message: Certificate request has been approved by cert-manager.io
  Ready: False, Reason: Pending, Message: Referenced issuer does not have a Ready status condition
  Events:
    Type    Reason           Age   From          Message
    ----    ------           ----  ----          -------
    Normal  cert-manager.io  39s   cert-manager  Certificate request has been approved by cert-manager.io
    Normal  IssuerNotReady   39s   cert-manager  Referenced issuer does not have a Ready status condition
```

With `kubectl get issuers`, it looks like this:

```sh
$ kubectl get issuer -owide
NAME          READY   STATUS                                                        AGE
letsencrypt   False   the IngressClass "traefik" does not exist, please create it   179m
```

A message also shows in the cert-manager logs:

```
E0107 16:44:13.263031 1687571 setup.go:111] cert-manager/issuers "msg"="no IngressClass found"
"error"="the IngressClass \"traefik\" does not exist, please create it"
```

The Issuer `Ready=False` looks like this:

```yaml
kind: Issuer
status:
  conditions:
  - message: the IngressClass "traefik" does not exist, please create it
    observedGeneration: 2
    reason: InvalidConfig
    status: "False"
    type: Ready
```

/kind feature
/area acme/http01

**Notes to the reviewer:**

- No tests have been written yet since I am looking for feedback on the idea at this point.
- Right now, Issuer objects are not reconciled when IngressClass objects are added/modified, which means you will have to force the reconciliation of your Issuer after getting `Ready=False`.
