### PR TITLE
Allow helm chart verification in both bazel + make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,8 @@ verify_deps:
 # requires docker
 .PHONY: verify_chart
 verify_chart:
-	$(HACK_DIR)/verify-chart-version.sh
+	bazel build //deploy/charts/cert-manager
+	$(HACK_DIR)/verify-chart-version.sh bazel-bin/deploy/charts/cert-manager/cert-manager.tgz
 
 .PHONY: verify_upgrade
 verify_upgrade:

--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -18,15 +18,21 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
+if [ -z "${1:-}" ]; then
+	echo "usage: $0 <path to helm chart tarball>"
+	exit 1
+fi
+
+chart_tarball=$1
+
 chart_dir="deploy/charts/cert-manager"
 
-echo "Linting chart: ${chart_dir}"
+echo "Linting chart '${chart_tarball}' using internal dir '${chart_dir}'"
 
-bazel build //deploy/charts/cert-manager
 tmpdir="$(mktemp -d)"
 trap "rm -rf ${tmpdir}" EXIT
 
-tar -C "${tmpdir}" -xvf bazel-bin/deploy/charts/cert-manager/cert-manager.tgz
+tar -C "${tmpdir}" -xvf $chart_tarball
 
 if ! docker run -v "${tmpdir}":/workspace --workdir /workspace \
     quay.io/helmpack/chart-testing:v3.4.0 \

--- a/hack/verify-chart-version.sh
+++ b/hack/verify-chart-version.sh
@@ -35,7 +35,7 @@ trap "rm -rf ${tmpdir}" EXIT
 tar -C "${tmpdir}" -xvf $chart_tarball
 
 if ! docker run -v "${tmpdir}":/workspace --workdir /workspace \
-    quay.io/helmpack/chart-testing:v3.4.0 \
+    quay.io/helmpack/chart-testing:v3.5.0 \
     ct lint \
         --check-version-increment=false \
         --validate-maintainers=false \

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -1,6 +1,10 @@
 .PHONY: ci-presubmit
-ci-presubmit: verify-imports
+ci-presubmit: verify-imports verify-chart
 
 .PHONY: verify-imports
 verify-imports: bin/tools/goimports
 	./hack/verify-goimports.sh $<
+
+.PHONY: verify-chart
+verify-chart: bin/cert-manager-$(RELEASE_VERSION).tgz
+	./hack/verify-chart-version.sh $<


### PR DESCRIPTION
This slightly modifies our existing helm chart verification script to accept the location of a tarball containing the chart we're verifying.

That in turn allows us to more generally use the script for both validating the chart we build using make and the chart we build using bazel.

It also bumps the version of the docker image we use for verifying to the latest version, whose [release notes are here](https://github.com/helm/chart-testing/releases/tag/v3.5.0). Verification succeeds for both the make and bazel versions of the chart when run locally using v3.5.0.

Important: `make verify_chart` is the command called for chart verification in our [presubmits](https://github.com/jetstack/testing/blob/1347ee26d71fe2015a39077df563cdb5c3e00ec8/config/jobs/cert-manager/cert-manager-presubmits.yaml#L147-L185). 

(NB: I actually suspect we can remove the docker image now and use a locally-downloaded tool, but we can save that for another PR. See [this comment](https://github.com/jetstack/testing/blob/1347ee26d71fe2015a39077df563cdb5c3e00ec8/config/jobs/cert-manager/cert-manager-presubmits.yaml#L147-L149) on our presubmits for more info about why we use docker here)

/kind feature

```release-note
NONE
```
