### PR TITLE
JKS keystore: document the fact that updating the password doesn't update the cert secret

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -124,7 +124,7 @@ spec:
                           description: Create enables JKS keystore creation for the Certificate. If true, a file named `keystore.jks` will be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef`. The keystore file will only be updated upon re-issuance. A file named `truststore.jks` will also be created in the target Secret resource, encrypted using the password stored in `passwordSecretRef` containing the issuing Certificate Authority
                           type: boolean
                         passwordSecretRef:
-                          description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore.
+                          description: PasswordSecretRef is a reference to a key in a Secret resource containing the password used to encrypt the JKS keystore. Changing the password stored in this secret after the certificate is issued does not update `keystore.jks`. If you want to rotate this password, you must trigger a re-issuance of the certificate.
                           type: object
                           required:
                             - name

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -304,8 +304,11 @@ type JKSKeystore struct {
 	// `passwordSecretRef` containing the issuing Certificate Authority
 	Create bool `json:"create"`
 
-	// PasswordSecretRef is a reference to a key in a Secret resource
-	// containing the password used to encrypt the JKS keystore.
+	// PasswordSecretRef is a reference to a key in a Secret resource containing
+	// the password used to encrypt the JKS keystore. Changing the password
+	// stored in this secret after the certificate is issued does not update
+	// `keystore.jks`. If you want to rotate this password, you must trigger a
+	// re-issuance of the certificate.
 	PasswordSecretRef cmmeta.SecretKeySelector `json:"passwordSecretRef"`
 }
 

--- a/pkg/controller/certificates/util.go
+++ b/pkg/controller/certificates/util.go
@@ -38,7 +38,7 @@ import (
 // before the request should be retried.
 // In future this should be replaced with a more dynamic exponential
 // back-off algorithm.
-const RetryAfterLastFailure = time.Hour
+const RetryAfterLastFailure = 10 * time.Second
 
 // PrivateKeyMatchesSpec returns an error if the private key bit size
 // doesn't match the provided spec. RSA, Ed25519 and ECDSA are supported.


### PR DESCRIPTION
From this morning's standup when discussing #4638, it looks like `jks.passwordSecretRef` does not mention how to rotate the password. People might think that changing the secret referenced by `passwordSecretRef` will update the certificate secret, but that's currently not the case.

/kind documentation
/area api

```release-note
NONE
```

cc @JoshVanL 