### PR TITLE
Improve API doc: updating keyUsages does not trigger a cert re-issuance

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -252,7 +252,7 @@ spec:
                   items:
                     type: string
                 usages:
-                  description: Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified.
+                  description: Usages is the set of x509 usages that are requested for the certificate. Defaults to `digital signature` and `key encipherment` if not specified. Note that changing `usages` does not trigger a re-issuance of the certificate.
                   type: array
                   items:
                     description: 'KeyUsage specifies valid usage contexts for keys. See: https://tools.ietf.org/html/rfc5280#section-4.2.1.3      https://tools.ietf.org/html/rfc5280#section-4.2.1.12 Valid KeyUsage values are as follows: "signing", "digital signature", "content commitment", "key encipherment", "key agreement", "data encipherment", "cert sign", "crl sign", "encipher only", "decipher only", "any", "server auth", "client auth", "code signing", "email protection", "s/mime", "ipsec end system", "ipsec tunnel", "ipsec user", "timestamping", "ocsp signing", "microsoft sgc", "netscape sgc"'

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -162,6 +162,8 @@ type CertificateSpec struct {
 
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
+	// Note that changing `usages` does not trigger a re-issuance of the
+	// certificate.
 	// +optional
 	Usages []KeyUsage `json:"usages,omitempty"`
 

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -160,6 +160,8 @@ type CertificateSpec struct {
 
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
+	// Note that changing `usages` does not trigger a re-issuance of the
+	// certificate.
 	// +optional
 	Usages []KeyUsage `json:"usages,omitempty"`
 

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -161,6 +161,8 @@ type CertificateSpec struct {
 
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
+	// Note that changing `usages` does not trigger a re-issuance of the
+	// certificate.
 	// +optional
 	Usages []KeyUsage `json:"usages,omitempty"`
 

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -165,6 +165,8 @@ type CertificateSpec struct {
 
 	// Usages is the set of x509 usages that are requested for the certificate.
 	// Defaults to `digital signature` and `key encipherment` if not specified.
+	// Note that changing `usages` does not trigger a re-issuance of the
+	// certificate.
 	// +optional
 	Usages []KeyUsage `json:"usages,omitempty"`
 


### PR DESCRIPTION
Currently, cert-manager does not re-issue a certificate when the `spec.keyUsage` is changed. Until we do fix this limitation, I suggest that we document this unexpected behaviour. This has been raised in #4459 and detailed in https://github.com/jetstack/cert-manager/issues/4245#issuecomment-920010215.

Closes https://github.com/jetstack/cert-manager/issues/4459.

/kind documentation
/area api


```release-note
NONE
```
