### PR TITLE
Remove json tags from internal API types.

### DIFF
--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -192,7 +192,7 @@ type ACMEChallengeSolverHTTP01 struct {
 	// create HTTPRoutes with the specified labels in the same namespace as the challenge.
 	// This solver is experimental, and fields / behaviour may change in the future.
 	// +optional
-	GatewayHTTPRoute *ACMEChallengeSolverHTTP01GatewayHTTPRoute `json:"gatewayHTTPRoute,omitempty"`
+	GatewayHTTPRoute *ACMEChallengeSolverHTTP01GatewayHTTPRoute
 }
 
 type ACMEChallengeSolverHTTP01Ingress struct {
@@ -226,12 +226,12 @@ type ACMEChallengeSolverHTTP01GatewayHTTPRoute struct {
 	// Optional service type for Kubernetes solver service. Supported values
 	// are NodePort or ClusterIP. If unset, defaults to NodePort.
 	// +optional
-	ServiceType corev1.ServiceType `json:"serviceType,omitempty"`
+	ServiceType corev1.ServiceType
 
 	// The labels that cert-manager will use when creating the temporary
 	// HTTPRoute needed for solving the HTTP-01 challenge. These labels
 	// must match the label selector of at least one Gateway.
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string
 }
 
 type ACMEChallengeSolverHTTP01IngressPodTemplate struct {
@@ -270,11 +270,11 @@ type ACMEChallengeSolverHTTP01IngressPodSpec struct {
 	Tolerations []corev1.Toleration
 
 	// If specified, the pod's priorityClassName.
-	PriorityClassName string `json:"priorityClassName,omitempty"`
+	PriorityClassName string
 
 	// If specified, the pod's service account
 	// +optional
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
+	ServiceAccountName string
 }
 
 type ACMEChallengeSolverHTTP01IngressTemplate struct {

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -170,7 +170,7 @@ type CertificateSpec struct {
 	// and signed certificate chain to be written to this Certificate's target
 	// Secret. This is an Alpha Feature and is only enabled with the
 	// `--feature-gates=AdditionalCertificateOutputFormats=true` option.
-	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
+	AdditionalOutputFormats []CertificateAdditionalOutputFormat
 }
 
 // CertificatePrivateKey contains configuration options for private keys
@@ -241,7 +241,7 @@ const (
 type CertificateAdditionalOutputFormat struct {
 	// Type is the name of the format type that should be written to the
 	// Certificate's target Secret.
-	Type CertificateOutputFormatType `json:"type"`
+	Type CertificateOutputFormatType
 }
 
 // Denotes how private keys should be generated or sourced when a Certificate
@@ -437,9 +437,9 @@ const (
 type CertificateSecretTemplate struct {
 	// Annotations is a key value map to be copied to the target Kubernetes Secret.
 	// +optional
-	Annotations map[string]string `json:"annotations,omitempty"`
+	Annotations map[string]string
 
 	// Labels is a key value map to be copied to the target Kubernetes Secret.
 	// +optional
-	Labels map[string]string `json:"labels,omitempty"`
+	Labels map[string]string
 }

--- a/test/e2e/framework/helper/validation/certificates/certificates.go
+++ b/test/e2e/framework/helper/validation/certificates/certificates.go
@@ -41,7 +41,7 @@ type ValidationFunc func(certificate *cmapi.Certificate, secret *corev1.Secret) 
 
 // ExpectValidKeysInSecret checks that the secret contains valid keys
 func ExpectValidKeysInSecret(_ *cmapi.Certificate, secret *corev1.Secret) error {
-	validKeys := [5]string{corev1.TLSPrivateKeyKey, corev1.TLSCertKey, cmmeta.TLSCAKey, cmapi.CertificateOutputFormatDERKey, cmapi.CertificateOutputFormatCombinedPEMKey}
+	validKeys := []string{corev1.TLSPrivateKeyKey, corev1.TLSCertKey, cmmeta.TLSCAKey, cmapi.CertificateOutputFormatDERKey, cmapi.CertificateOutputFormatCombinedPEMKey}
 	nbValidKeys := 0
 	for k := range secret.Data {
 		for _, k2 := range validKeys {


### PR DESCRIPTION
/assign @munnerz @jahrlin 

See https://github.com/jetstack/cert-manager/pull/4745

Removes the JSON tags from our internal API types.

Also removes the `5` from the e2e helper func to not make it an array.

/kind cleanup
/area api

```release-note
NONE
```
