### PR TITLE
Don't run AdditionalOutputFormats e2e test if the feature gate is not enabled

### DIFF
--- a/test/e2e/suite/issuers/ca/BUILD.bazel
+++ b/test/e2e/suite/issuers/ca/BUILD.bazel
@@ -13,9 +13,11 @@ go_library(
     tags = ["manual"],
     visibility = ["//visibility:public"],
     deps = [
+        "//internal/controller/feature:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
         "//pkg/apis/meta/v1:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//test/e2e/framework:go_default_library",
         "//test/e2e/util:go_default_library",
         "//test/unit/gen:go_default_library",

--- a/test/e2e/suite/issuers/ca/certificate.go
+++ b/test/e2e/suite/issuers/ca/certificate.go
@@ -22,14 +22,15 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/jetstack/cert-manager/internal/controller/feature"
 	v1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/jetstack/cert-manager/pkg/apis/meta/v1"
-
+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
 	"github.com/jetstack/cert-manager/test/e2e/framework"
 	"github.com/jetstack/cert-manager/test/e2e/util"
 	"github.com/jetstack/cert-manager/test/unit/gen"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 var _ = framework.CertManagerDescribe("CA Certificate", func() {
@@ -126,6 +127,12 @@ var _ = framework.CertManagerDescribe("CA Certificate", func() {
 		})
 
 		It("should be able to create a certificate with additional output formats", func() {
+			// Output formats is only enabled via this feature gate being enabled.
+			// Don't run test if the gate isn't enabled.
+			if !utilfeature.DefaultFeatureGate.Enabled(feature.AdditionalCertificateOutputFormats) {
+				framework.Skipf("feature gate %s is not enabled, skipping test", feature.AdditionalCertificateOutputFormats)
+			}
+
 			certClient := f.CertManagerClientSet.CertmanagerV1().Certificates(f.Namespace.Name)
 
 			cert := util.NewCertManagerBasicCertificate(certificateName, certificateSecretName, issuerName, v1.IssuerKind, nil, nil)


### PR DESCRIPTION
/assign @irbekrm 
/kind cleanup
/area e2e

The AdditionalOutputFormats feature is gated behind a feature flag. Being Alpha, the feature is not enabled on e2e tests targeting Kubernetes v1.18. This PR adds a feature gate check to ensure it is skipped on those test runners.

```release-note
NONE
```
