### PR TITLE
Add a build tag for the e2e test only

### DIFF
--- a/test/e2e/BUILD.bazel
+++ b/test/e2e/BUILD.bazel
@@ -29,6 +29,9 @@ go_test(
     name = "go_default_test",
     srcs = ["e2e_test.go"],
     embed = [":go_default_library"],
+    gotags = [
+        "e2e_test",
+    ],
     tags = ["manual"],  # 'bazel test //...' should not run e2e tests
     deps = [
         "//pkg/logs:go_default_library",

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -1,3 +1,5 @@
+//go:build e2e_test
+
 /*
 Copyright 2020 The cert-manager Authors.
 


### PR DESCRIPTION
This was initially part of #4565 which was closed in favour of moving integration tests, but the consensus was that the e2e test is a special case.

The e2e test requires so much more ahead-of-time setup that our bazel build flow special cases it by marking it manual. This is a `go test` equivalent to that, which enables the e2e test to remain under the `test/` directory while still allowing `go test ./test/...` to work generally for all other tests.

We'll add make targets for the e2e tests down the road. For now, we add the build tag and define it in bazel so this commit should be a no-op in effect.

/kind cleanup

```release-note
NONE
```
