### PR TITLE
Fix manual invocation of versionchecker testdata fetch

### DIFF
--- a/test/integration/versionchecker/testdata/fetch.sh
+++ b/test/integration/versionchecker/testdata/fetch.sh
@@ -28,8 +28,8 @@ elif ! command -v bazel &>/dev/null; then
 else
   (
     set -o xtrace
-    bazel build //pkg/util/versionchecker/testdata:test_manifests.tar
-    cp -f "$(bazel info bazel-bin)/pkg/util/versionchecker/testdata/test_manifests.tar" "$SCRIPT_ROOT"
+    bazel build //test/integration/versionchecker/testdata:test_manifests.tar
+    cp -f "$(bazel info bazel-bin)/test/integration/versionchecker/testdata/test_manifests.tar" "$SCRIPT_ROOT"
   )
   exit 0
 fi


### PR DESCRIPTION
I doubt anyone used this path directly, but I didn't spot that fetch.sh hardcoded the path to the bazel target which was moved.

This wouldn't have affected any tests, since they'll all still use bazel directly and won't invoke this script directly. Might as well fix it though.

/kind bug

```release-note
NONE
```
