### PR TITLE
Always use the kubernetes.io/ingress.class annotation (#4537)

### DIFF
--- a/internal/ingress/BUILD.bazel
+++ b/internal/ingress/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
     deps = [
         "//pkg/controller:go_default_library",
         "//test/unit/discovery:go_default_library",
+        "@com_github_google_gofuzz//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
         "@io_k8s_api//networking/v1:go_default_library",
         "@io_k8s_api//networking/v1beta1:go_default_library",

--- a/internal/ingress/convert.go
+++ b/internal/ingress/convert.go
@@ -225,25 +225,7 @@ func autoConvert_networking_IngressBackend_To_v1beta1_IngressBackend(in *network
 //  out := new(networkingv1.Ingress)
 //  err := Convert_v1beta1_Ingress_To_networking_Ingress(in, out, nil)
 func Convert_v1beta1_Ingress_To_networking_Ingress(in *networkingv1beta1.Ingress, out *networkingv1.Ingress, s conversion.Scope) error {
-	err := autoConvert_v1beta1_Ingress_To_networking_Ingress(in, out, s)
-	if err != nil {
-		return err
-	}
-	// v1beta1 Ingresses should not have IngressClassName set but instead use the deprecated annotation.
-	// Move the ingress class from the annotations to the Spec
-	if in.Annotations == nil {
-		return nil
-	}
-	if ingressClass, found := in.Annotations["kubernetes.io/ingress.class"]; found {
-		out.Spec.IngressClassName = &ingressClass
-		// HERE BE DRAGONS:
-		// in.Annotations and out.Annotations point to the same map.
-		// This mutates in as well as out, so make sure in is not an object in
-		// client-go's cache, for example by only passing DeepCopy()d objects
-		// to Convert_v1beta1_Ingress_To_networking_Ingress
-		delete(out.Annotations, "kubernetes.io/ingress.class")
-	}
-	return nil
+	return autoConvert_v1beta1_Ingress_To_networking_Ingress(in, out, s)
 }
 
 func autoConvert_v1beta1_Ingress_To_networking_Ingress(in *networkingv1beta1.Ingress, out *networkingv1.Ingress, s conversion.Scope) error {

--- a/pkg/issuer/acme/http/ingress_test.go
+++ b/pkg/issuer/acme/http/ingress_test.go
@@ -533,6 +533,7 @@ func TestMergeIngressObjectMetaWithIngressResourceTemplate(t *testing.T) {
 					"nginx.ingress.kubernetes.io/whitelist-source-range":  "0.0.0.0/0,::/0",
 					"nginx.org/mergeable-ingress-type":                    "minion",
 					"traefik.ingress.kubernetes.io/frontend-entry-points": "http",
+					"kubernetes.io/ingress.class":                         "nginx",
 				}
 				s.testResources[createdIngressKey] = expectedIngress
 				s.Builder.Sync()


### PR DESCRIPTION
**What this PR does / why we need it**:

As discussed in https://github.com/jetstack/cert-manager/issues/4537 the `spec.ingressClassName` field is not equivalent to the `kubernetes.io/ingress.class` annotation. This changes the HTTP-01 solver to create ingresses that only have the annotation.

**Which issue this PR fixes** : fixes #4537

**Release note**:
```release-note
The HTTP-01 ACME solver now uses the `kubernetes.io/ingress.class` annotation instead of the `spec.ingressClassName` in created Ingress resources.
```

We are currently testing the full impact of this change for the release notes and upgrade guide