### PR TITLE
Make sure that cmctl x install uses the cert-manager namespace 

### DIFF
--- a/cmd/ctl/pkg/install/install.go
+++ b/cmd/ctl/pkg/install/install.go
@@ -96,6 +96,32 @@ func NewCmdInstall(ctx context.Context, ioStreams genericclioptions.IOStreams) *
 		Short: "Install cert-manager",
 		Long:  installDesc(),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// The Helm client flagset and settings are configured to look up
+			// the default namespace in the following order:
+			// `--namespace` flag value, if the flag is supplied,
+			// `--namespace` flag default value, or
+			// `HELM_NAMESPACE` environment variable (if set).
+			//
+			// The Helm cli.New function does not provide an easy way to
+			// override the namespace lookup mechanism so here
+			// we check whether the user supplied the `--namespace` option,
+			// and if not we force the default value to `cert-manager`.
+			// The original default value is "" which would result in
+			// cert-manager being installed to the "default" namespace.
+			// See https://github.com/helm/helm/issues/9790
+			//
+			// The default value that is shown in the `--help` usage message is
+			// overridden elsewhere; when the flagset is configured (below).
+			namespaceFlag := cmd.Flags().Lookup("namespace")
+			if !namespaceFlag.Changed {
+				if err := namespaceFlag.Value.Set(defaultCertManagerNamespace); err != nil {
+					return fmt.Errorf("unexpected error while setting the default namespace: %v", err)
+				}
+			}
+			if settings.Debug {
+				cmd.DebugFlags()
+			}
+
 			options.client.Namespace = settings.Namespace()
 
 			rel, err := options.runInstall(ctx)
@@ -116,6 +142,8 @@ func NewCmdInstall(ctx context.Context, ioStreams genericclioptions.IOStreams) *
 	}
 
 	settings.AddFlags(cmd.Flags())
+	// Here we set the default value shown in the usage message.
+	// The actual default value is overridden in the RunE function above.
 	cmd.Flag("namespace").DefValue = defaultCertManagerNamespace
 
 	addInstallUninstallFlags(cmd.Flags(), &options.client.Timeout, &options.Wait)


### PR DESCRIPTION
I am sure that `cmctl x install` *used* to install into the `cert-manager` namespace by default, but somehow that behaviour changed.
I hacked in this change which seems to work for me, but I am fairly confused about when the flags get configured and when they get parsed, and why the `DefVal` that we were always setting (and which always appeared as the default value in the --help) is suddenly not being used as the default value.

Fixes: #4739 

```release-note
NONE
```
