### PR TITLE
Fixes ./devel/cluster/create.sh script

### DIFF
--- a/devel/cluster/create-kind.sh
+++ b/devel/cluster/create-kind.sh
@@ -80,4 +80,4 @@ fixed_coredns_config=$(
 )
 echo "Patched CoreDNS config:"
 echo "${fixed_coredns_config}"
-kubectl create configmap -oyaml coredns --dry-run --from-literal=Corefile="${fixed_coredns_config}" | kubectl apply --namespace kube-system -f -
+kubectl create configmap -oyaml coredns --dry-run=client --from-literal=Corefile="${fixed_coredns_config}" | kubectl apply --namespace kube-system -f -


### PR DESCRIPTION
**What this PR does / why we need it**:

Explicitly passes `client` option to `--dry-run` argument when applying coredns config to test kind cluster.

Since `kubectl` v1.23 it is required to explicitly pass one of  `client|server|none` options to `--dry-run` (although [the docs](https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#:~:text=formats%20are%20accepted.-,Usage,-%24%20kubectl%20create%20%2Df) aren't explicit about that) so this script was failing with
```
error: --dry-run flag without a value was specified. A value must be set: "none", "server", or "client".
error: no objects passed to apply
```



**Special notes for your reviewer**:

- `client` option is also what they use for the same in test-infra see https://github.com/kubernetes/test-infra/pull/24593/commits/9ab8781f8177fac5450de590ac0f263cf31237ca
- I tried running the updated script with `kubectl` v1.18 and it worked
- this script is only run locally, CI uses `./devel/ci-cluster.sh`

```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
