### PR TITLE
Removes duplicated service annotations from Helm chart

### DIFF
--- a/deploy/charts/cert-manager/templates/service.yaml
+++ b/deploy/charts/cert-manager/templates/service.yaml
@@ -17,10 +17,6 @@ metadata:
     {{- with .Values.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.serviceAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/deploy/charts/cert-manager/templates/webhook-service.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-service.yaml
@@ -16,10 +16,6 @@ metadata:
     {{- with .Values.webhook.serviceLabels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.webhook.serviceAnnotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
 spec:
   type: {{ .Values.webhook.serviceType }}
   {{- with .Values.webhook.loadBalancerIP }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -144,9 +144,6 @@ podLabels: {}
 # Optional additional labels to add to the controller Service
 # serviceLabels: {}
 
-# Optional additional annotations to add to the controller service
-# serviceAnnotations: {}
-
 # Optional DNS settings, useful if you have a public and private DNS zone for
 # the same domain on Route 53. What follows is an example of ensuring
 # cert-manager can access an ingress or DNS TXT records at all times.
@@ -259,9 +256,6 @@ webhook:
 
   # Optional additional annotations to add to the webhook ValidatingWebhookConfiguration
   # validatingWebhookConfigurationAnnotations: {}
-
-  # Optional additional annotations to add to the webhook service
-  # serviceAnnotations: {}
 
   # Additional command line flags to pass to cert-manager webhook binary.
   # To see all available flags run docker run quay.io/jetstack/cert-manager-webhook:<version> --help


### PR DESCRIPTION
This PR removes duplicated service annotations fields from Helm values files and Helm templates.

These were added by merging #4329 on top of changes added by #3639 and #4556 .

I have verified that this change actually works (also with multiple service annotations, see https://github.com/jetstack/cert-manager/pull/4329#issuecomment-1021023685) by building the chart (`bazel build //deploy/charts/cert-manager`) and deploying with a values file with multiple service annotations:
```
irbe@yamls$ cat helm-values.yaml 
installCRDs: true
serviceAnnotations:
  foo: bar
  bar: baz
  baz: foo
webhook:
  serviceAnnotations:
    foo: bar
    bar: baz
    baz: foo
```

and verified that the installation succeeds and the annotations get added.



```release-note
NONE
```

Signed-off-by: irbekrm <irbekrm@gmail.com>
