### PR TITLE
Bug: Fix Certificate's AdditionalOutputFormat in admission within Webhook

### DIFF
--- a/deploy/crds/crd-certificates.yaml
+++ b/deploy/crds/crd-certificates.yaml
@@ -68,7 +68,7 @@ spec:
                 - secretName
               properties:
                 additionalOutputFormats:
-                  description: AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+                  description: AdditionalOutputFormats defines extra output formats of the private key and signed certificate chain to be written to this Certificate's target Secret. This is an Alpha Feature and is only enabled with the `--feature-gates=AdditionalCertificateOutputFormats=true` option on both the controller and webhook components.
                   type: array
                   items:
                     description: CertificateAdditionalOutputFormat defines an additional output format of a Certificate resource. These contain supplementary data formats of the signed certificate chain and paired private key.

--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -169,7 +169,8 @@ type CertificateSpec struct {
 	// AdditionalOutputFormats defines extra output formats of the private key
 	// and signed certificate chain to be written to this Certificate's target
 	// Secret. This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+	// `--feature-gates=AdditionalCertificateOutputFormats=true` option on both
+	// the controller and webhook components.
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat
 }
 

--- a/internal/apis/certmanager/v1alpha2/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha2/types_certificate.go
@@ -213,7 +213,8 @@ type CertificateSpec struct {
 	// AdditionalOutputFormats defines extra output formats of the private key
 	// and signed certificate chain to be written to this Certificate's target
 	// Secret. This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+	// `--feature-gates=AdditionalCertificateOutputFormats=true` option on both
+	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 }

--- a/internal/apis/certmanager/v1alpha3/types_certificate.go
+++ b/internal/apis/certmanager/v1alpha3/types_certificate.go
@@ -211,7 +211,8 @@ type CertificateSpec struct {
 	// AdditionalOutputFormats defines extra output formats of the private key
 	// and signed certificate chain to be written to this Certificate's target
 	// Secret. This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+	// `--feature-gates=AdditionalCertificateOutputFormats=true` option on both
+	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 }

--- a/internal/apis/certmanager/v1beta1/types_certificate.go
+++ b/internal/apis/certmanager/v1beta1/types_certificate.go
@@ -188,7 +188,8 @@ type CertificateSpec struct {
 	// AdditionalOutputFormats defines extra output formats of the private key
 	// and signed certificate chain to be written to this Certificate's target
 	// Secret. This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+	// `--feature-gates=AdditionalCertificateOutputFormats=true` option on both
+	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 }

--- a/internal/apis/certmanager/validation/BUILD.bazel
+++ b/internal/apis/certmanager/validation/BUILD.bazel
@@ -17,7 +17,7 @@ go_library(
         "//internal/apis/certmanager:go_default_library",
         "//internal/apis/certmanager/validation/util:go_default_library",
         "//internal/apis/meta:go_default_library",
-        "//internal/controller/feature:go_default_library",
+        "//internal/webhook/feature:go_default_library",
         "//pkg/api/util:go_default_library",
         "//pkg/apis/acme:go_default_library",
         "//pkg/apis/certmanager:go_default_library",
@@ -31,6 +31,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/validation:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/validation:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
+        "@io_k8s_apimachinery//pkg/util/sets:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
     ],
 )
@@ -49,7 +50,9 @@ go_test(
         "//internal/apis/acme:go_default_library",
         "//internal/apis/certmanager:go_default_library",
         "//internal/apis/meta:go_default_library",
+        "//internal/webhook/feature:go_default_library",
         "//pkg/apis/certmanager/v1:go_default_library",
+        "//pkg/util/feature:go_default_library",
         "//pkg/util/pki:go_default_library",
         "//test/unit/gen:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",
@@ -57,6 +60,7 @@ go_test(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/util/validation/field:go_default_library",
+        "@io_k8s_component_base//featuregate/testing:go_default_library",
     ],
 )
 

--- a/internal/apis/certmanager/validation/certificate.go
+++ b/internal/apis/certmanager/validation/certificate.go
@@ -26,11 +26,12 @@ import (
 	apivalidation "k8s.io/apimachinery/pkg/api/validation"
 	metavalidation "k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 
 	internalcmapi "github.com/jetstack/cert-manager/internal/apis/certmanager"
 	cmmeta "github.com/jetstack/cert-manager/internal/apis/meta"
-	"github.com/jetstack/cert-manager/internal/controller/feature"
+	"github.com/jetstack/cert-manager/internal/webhook/feature"
 	"github.com/jetstack/cert-manager/pkg/api/util"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
 	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
@@ -78,19 +79,6 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 		default:
 			el = append(el, field.Invalid(fldPath.Child("privateKey", "algorithm"), crt.PrivateKey.Algorithm, "must be either empty or one of rsa or ecdsa"))
 		}
-		if crt.AdditionalOutputFormats != nil {
-			if !utilfeature.DefaultFeatureGate.Enabled(feature.AdditionalCertificateOutputFormats) {
-				el = append(el, field.Forbidden(fldPath.Child("AdditionalOutputFormat"), "Feature gate AdditionalCertificateOutputFormats must be enabled"))
-			}
-			check := make(map[string]bool)
-			for _, val := range crt.AdditionalOutputFormats {
-				if _, exists := check[string(val.Type)]; !exists {
-					check[string(val.Type)] = true
-				} else {
-					el = append(el, field.Invalid(fldPath.Child("AdditionalOutputFormats"), crt.AdditionalOutputFormats, "Duplicate Type in additionalOutputFormats"))
-				}
-			}
-		}
 	}
 
 	if crt.Duration != nil || crt.RenewBefore != nil {
@@ -111,6 +99,8 @@ func ValidateCertificateSpec(crt *internalcmapi.CertificateSpec, fldPath *field.
 			el = append(el, validateSecretTemplateAnnotations(crt, fldPath)...)
 		}
 	}
+
+	el = append(el, validateAdditionalOutputFormats(crt, fldPath)...)
 
 	return el
 }
@@ -222,5 +212,28 @@ func ValidateDuration(crt *internalcmapi.CertificateSpec, fldPath *field.Path) f
 	if crt.RenewBefore != nil && crt.RenewBefore.Duration >= duration {
 		el = append(el, field.Invalid(fldPath.Child("renewBefore"), crt.RenewBefore.Duration, fmt.Sprintf("certificate duration %s must be greater than renewBefore %s", duration, crt.RenewBefore.Duration)))
 	}
+	return el
+}
+
+func validateAdditionalOutputFormats(crt *internalcmapi.CertificateSpec, fldPath *field.Path) field.ErrorList {
+	var el field.ErrorList
+
+	if !utilfeature.DefaultFeatureGate.Enabled(feature.AdditionalCertificateOutputFormats) {
+		if len(crt.AdditionalOutputFormats) > 0 {
+			el = append(el, field.Forbidden(fldPath.Child("additionalOutputFormats"), "feature gate AdditionalCertificateOutputFormats must be enabled"))
+		}
+		return el
+	}
+
+	// Ensure the set of output formats is unique, keyed on "Type".
+	aofSet := sets.NewString()
+	for _, val := range crt.AdditionalOutputFormats {
+		if aofSet.Has(string(val.Type)) {
+			el = append(el, field.Duplicate(fldPath.Child("additionalOutputFormats").Key("type"), string(val.Type)))
+			continue
+		}
+		aofSet.Insert(string(val.Type))
+	}
+
 	return el
 }

--- a/internal/apis/certmanager/validation/certificate_test.go
+++ b/internal/apis/certmanager/validation/certificate_test.go
@@ -25,10 +25,13 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	featuregatetesting "k8s.io/component-base/featuregate/testing"
 
 	internalcmapi "github.com/jetstack/cert-manager/internal/apis/certmanager"
 	cmmeta "github.com/jetstack/cert-manager/internal/apis/meta"
+	"github.com/jetstack/cert-manager/internal/webhook/feature"
 	cmapi "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1"
+	utilfeature "github.com/jetstack/cert-manager/pkg/util/feature"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -781,6 +784,117 @@ func TestValidateDuration(t *testing.T) {
 		t.Run(n, func(t *testing.T) {
 			errs := ValidateDuration(&s.cfg.Spec, fldPath)
 			assert.ElementsMatch(t, errs, s.errs)
+		})
+	}
+}
+
+func Test_validateAdditionalOutputFormats(t *testing.T) {
+	tests := map[string]struct {
+		featureEnabled bool
+		spec           *internalcmapi.CertificateSpec
+		expErr         field.ErrorList
+	}{
+		"if feature disabled and no formats defined, expect no error": {
+			featureEnabled: false,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{},
+			},
+			expErr: nil,
+		},
+		"if feature disabled and 1 format defined, expect error": {
+			featureEnabled: false,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+				},
+			},
+			expErr: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "additionalOutputFormats"), "feature gate AdditionalCertificateOutputFormats must be enabled"),
+			},
+		},
+		"if feature disabled and multiple formats defined, expect error": {
+			featureEnabled: false,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+					{Type: internalcmapi.CertificateOutputFormatType("bar")},
+					{Type: internalcmapi.CertificateOutputFormatType("random")},
+				},
+			},
+			expErr: field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "additionalOutputFormats"), "feature gate AdditionalCertificateOutputFormats must be enabled"),
+			},
+		},
+		"if feature enabled and no formats defined, expect no error": {
+			featureEnabled: true,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{},
+			},
+			expErr: nil,
+		},
+		"if feature enabled and single format defined, expect no error": {
+			featureEnabled: true,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+				},
+			},
+			expErr: nil,
+		},
+		"if feature enabled and multiple unique formats defined, expect no error": {
+			featureEnabled: true,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+					{Type: internalcmapi.CertificateOutputFormatType("bar")},
+					{Type: internalcmapi.CertificateOutputFormatType("random")},
+				},
+			},
+			expErr: nil,
+		},
+		"if feature enabled and multiple formats defined but 2 non-unique, expect error": {
+			featureEnabled: true,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+					{Type: internalcmapi.CertificateOutputFormatType("bar")},
+					{Type: internalcmapi.CertificateOutputFormatType("random")},
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+				},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "additionalOutputFormats").Key("type"), "foo"),
+			},
+		},
+		"if feature enabled and multiple formats defined but multiple non-unique, expect error": {
+			featureEnabled: true,
+			spec: &internalcmapi.CertificateSpec{
+				AdditionalOutputFormats: []internalcmapi.CertificateAdditionalOutputFormat{
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+					{Type: internalcmapi.CertificateOutputFormatType("bar")},
+					{Type: internalcmapi.CertificateOutputFormatType("random")},
+					{Type: internalcmapi.CertificateOutputFormatType("random")},
+					{Type: internalcmapi.CertificateOutputFormatType("foo")},
+					{Type: internalcmapi.CertificateOutputFormatType("bar")},
+					{Type: internalcmapi.CertificateOutputFormatType("bar")},
+					{Type: internalcmapi.CertificateOutputFormatType("123")},
+					{Type: internalcmapi.CertificateOutputFormatType("456")},
+				},
+			},
+			expErr: field.ErrorList{
+				field.Duplicate(field.NewPath("spec", "additionalOutputFormats").Key("type"), "random"),
+				field.Duplicate(field.NewPath("spec", "additionalOutputFormats").Key("type"), "foo"),
+				field.Duplicate(field.NewPath("spec", "additionalOutputFormats").Key("type"), "bar"),
+				field.Duplicate(field.NewPath("spec", "additionalOutputFormats").Key("type"), "bar"),
+			},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultMutableFeatureGate, feature.AdditionalCertificateOutputFormats, test.featureEnabled)()
+			gotErr := validateAdditionalOutputFormats(test.spec, field.NewPath("spec"))
+			assert.Equal(t, test.expErr, gotErr)
 		})
 	}
 }

--- a/internal/controller/feature/features.go
+++ b/internal/controller/feature/features.go
@@ -41,6 +41,7 @@ const (
 	// the Gateway API to the HTTP-01 challenge solver.
 	ExperimentalGatewayAPISupport featuregate.Feature = "ExperimentalGatewayAPISupport"
 
+	// Owner: @joshvanl
 	// alpha: v1.7.0
 	//
 	// AdditionalCertificateOutputFormats enable output additional format

--- a/internal/webhook/feature/features.go
+++ b/internal/webhook/feature/features.go
@@ -23,15 +23,19 @@ import (
 )
 
 const (
-// FeatureName will enable XYZ feature.
-// Fill this section out with additional details about the feature.
-//
-// Owner (responsible for graduating feature through to GA): @username
-// Alpha: vX.Y
-// Beta: ...
-//FeatureName featuregate.Feature = "FeatureName"
+	// FeatureName will enable XYZ feature.
+	// Fill this section out with additional details about the feature.
+	//
+	// Owner (responsible for graduating feature through to GA): @username
+	// Alpha: vX.Y
+	// Beta: ...
+	//FeatureName featuregate.Feature = "FeatureName"
 
-// Insert features below this line to maintain the template above.
+	// Owner: @joshvanl
+	// alpha: v1.7.1
+	//
+	// AdditionalCertificateOutputFormats enable output additional format
+	AdditionalCertificateOutputFormats featuregate.Feature = "AdditionalCertificateOutputFormats"
 )
 
 func init() {
@@ -44,5 +48,5 @@ func init() {
 //   utilfeature.DefaultFeatureGate.Enabled(feature.FeatureName)
 // Where utilfeature is github.com/jetstack/cert-manager/pkg/util/feature.
 var webhookFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	//FeatureName: {Default: false, PreRelease: featuregate.Alpha},
+	AdditionalCertificateOutputFormats: {Default: false, PreRelease: featuregate.Alpha},
 }

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -192,7 +192,8 @@ type CertificateSpec struct {
 	// AdditionalOutputFormats defines extra output formats of the private key
 	// and signed certificate chain to be written to this Certificate's target
 	// Secret. This is an Alpha Feature and is only enabled with the
-	// `--feature-gates=AdditionalCertificateOutputFormats=true` option.
+	// `--feature-gates=AdditionalCertificateOutputFormats=true` option on both
+	// the controller and webhook components.
 	// +optional
 	AdditionalOutputFormats []CertificateAdditionalOutputFormat `json:"additionalOutputFormats,omitempty"`
 }


### PR DESCRIPTION
This PR fixes a bug where the Certificate's `additionalOutputFormats' field was only ever being validated by the webhook at admission time if the `privateKey` on the Certificate field was also set. The webhook was also incorrectly using the _controllers_ feature set.

```console
Webhook component providing API validation, mutation and conversion functionality for cert-manager (canary) ()
...
      --feature-gates mapStringBool                  A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                AdditionalCertificateOutputFormats=true|false (ALPHA - default=false)
                AllAlpha=true|false (ALPHA - default=false)
                AllBeta=true|false (BETA - default=false)
                ExperimentalCertificateSigningRequestControllers=true|false (ALPHA - default=false)
                ExperimentalGatewayAPISupport=true|false (ALPHA - default=false)
                ValidateCAA=true|false (ALPHA - default=false)
```

->

```console
$ ./webhook --help
Webhook component providing API validation, mutation and conversion functionality for cert-manager (canary) ()
...
      --feature-gates mapStringBool                  A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                AdditionalCertificateOutputFormats=true|false (ALPHA - default=false)
                AllAlpha=true|false (ALPHA - default=false)
                AllBeta=true|false (BETA - default=false)
...
```

This PR should be backported, and a patch released published.

---

I'll leave the cherry-pick command for another maintainer.

/kind bug
/priority critical-urgent
/milestone v1.8


```release-note
Fix: The alpha feature Certificate's `additionalOutputFormats` is now correctly validated at admission time, and no longer _only_ validated if the `privateKey` field of the Certificate is set. The Webhook component now contains a seperate feature set. 
`AdditionalCertificateOutputFormats` feature gate (disabled by default) has been added to the webhook. This gate is required to be enabled on both the controller and webhook components in order to make use of the Certificate's `additionalOutputFormat` feature. 
```
