### PR TITLE
add name to the exposed metrics port

### DIFF
--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -115,6 +115,7 @@ spec:
           {{- end }}
           ports:
           - containerPort: 9402
+            name: http-metrics
             protocol: TCP
           {{- with .Values.containerSecurityContext }}
           securityContext:


### PR DESCRIPTION
### Pull Request Motivation

I'm filtering the ports I need to scrape with Prometheus by names, to avoid scraping non-metrics ports and, at the same time, allow scraping multiple containers per pod. I know I can patch with Kustomize, but..

### Kind

flake

### Release Note

```release-note
NONE
```
