### PR TITLE
Don't verify chart in ci-presubmit

### DIFF
--- a/make/ci.mk
+++ b/make/ci.mk
@@ -5,7 +5,7 @@ __PYTHON := python3
 ## request or change is merged.
 ##
 ## @category CI
-ci-presubmit: verify-imports verify-chart verify-errexit verify-boilerplate
+ci-presubmit: verify-imports verify-errexit verify-boilerplate
 
 .PHONY: verify-imports
 verify-imports: bin/tools/goimports


### PR DESCRIPTION
This test requires docker/podman, unlike other tests, and so requires other setup

### Kind

/kind bug

### Release Note

```release-note
NONE
```
