### PR TITLE
Make ServiceMonitor support TLS config

### DIFF
--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -36,4 +36,9 @@ spec:
     interval: {{ .Values.prometheus.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.prometheus.servicemonitor.scrapeTimeout }}
     honorLabels: {{ .Values.prometheus.servicemonitor.honorLabels }}
+    scheme: {{ .Values.prometheus.servicemonitor.scheme }}
+{{- if .Values.prometheus.servicemonitor.tlsConfig }}
+    tlsConfig:
+    {{- .Values.prometheus.servicemonitor.tlsConfig | toYaml | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -171,6 +171,8 @@ prometheus:
     scrapeTimeout: 30s
     labels: {}
     honorLabels: false
+    scheme: http
+    tlsConfig: {}
 
 # Use these variables to configure the HTTP_PROXY environment variables
 # http_proxy: "http://proxy:8080"


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

In some cases we need to customise the ServiceMonitor's TLS config - a common case is in a cluster running Istio Service Mesh, where Prometheus (which doesn't support mTLS) makes requests to a CertManager instance which is inside the mesh. Prometheus must be configured to use Istio workload certs for communication to work. 

### Kind

feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added an optional tlsConfig stanza to the ServiceMonitor.
```
