### PR TITLE
[release-1.13] bump go to 1.21.8

### DIFF
--- a/make/tools.mk
+++ b/make/tools.mk
@@ -75,7 +75,7 @@ KUBEBUILDER_ASSETS_VERSION=1.28.0
 TOOLS += etcd=$(KUBEBUILDER_ASSETS_VERSION)
 TOOLS += kube-apiserver=$(KUBEBUILDER_ASSETS_VERSION)
 
-VENDORED_GO_VERSION := 1.20.14
+VENDORED_GO_VERSION := 1.21.8
 
 # When switching branches which use different versions of the tools, we
 # need a way to re-trigger the symlinking from $(BINDIR)/downloaded to $(BINDIR)/tools.


### PR DESCRIPTION
fixes https://github.com/advisories/GHSA-3q2c-pvp5-3cqp (https://go.dev/doc/devel/release#go1.21.0)

Had to go from 1.20 to 1.21 because of EOL of 1.20.

### Kind

/kind cleanup

### Release Note

```release-note
Upgrade go to 1.21.8: fixes CVE-2024-24783
```
