### PR TITLE
[release-1.18] Upgrade Go to v1.24.4

### DIFF
--- a/klone.yaml
+++ b/klone.yaml
@@ -10,35 +10,35 @@ targets:
     - folder_name: boilerplate
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/boilerplate
     - folder_name: generate-verify
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/generate-verify
     - folder_name: go
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/go
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/help
     - folder_name: klone
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/klone
     - folder_name: repository-base
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/repository-base
     - folder_name: tools
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 1a768a45cdbaae2b802472e6777eeb9e79d8b3a5
+      repo_hash: b7b26d582f37b3108de74d487ee52dbdd4232b91
       repo_path: modules/tools

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -172,7 +172,7 @@ ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-VENDORED_GO_VERSION := 1.24.3
+VENDORED_GO_VERSION := 1.24.4
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -395,10 +395,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=3333f6ea53afa971e9078895eaa4ac7204a8c6b5c68c10e6bc9a33e8e391bdd8
-go_linux_arm64_SHA256SUM=a463cb59382bd7ae7d8f4c68846e73c4d589f223c589ac76871b66811ded7836
-go_darwin_amd64_SHA256SUM=13e6fe3fcf65689d77d40e633de1e31c6febbdbcb846eb05fc2434ed2213e92b
-go_darwin_arm64_SHA256SUM=64a3fa22142f627e78fac3018ce3d4aeace68b743eff0afda8aae0411df5e4fb
+go_linux_amd64_SHA256SUM=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
+go_linux_arm64_SHA256SUM=d5501ee5aca0f258d5fe9bfaed401958445014495dc115f202d43d5210b45241
+go_darwin_amd64_SHA256SUM=69bef555e114b4a2252452b6e7049afc31fbdf2d39790b669165e89525cd3f5c
+go_darwin_arm64_SHA256SUM=27973684b515eaf461065054e6b572d9390c05e69ba4a423076c160165336470
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
I ran `make upgrade-klone` to pull in the latest version of Go.

> go1.24.4 (released 2025-06-05) includes security fixes to the crypto/x509,
net/http, and os packages, as well as bug fixes to the linker, the go command, and the hash/maphash and os packages

See https://go.dev/doc/devel/release#go1.24.minor

/kind cleanup

xref: 
 * https://github.com/cert-manager/cert-manager/pull/7784
 * https://github.com/cert-manager/makefile-modules/pull/297

```release-note
Upgrade Go to `v1.24.4`
```
