### PR TITLE
Use API defaults for issuerRef fields

### DIFF
--- a/pkg/api/util/issuers.go
+++ b/pkg/api/util/issuers.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
-	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
 const (
@@ -52,12 +51,4 @@ func NameForIssuer(i cmapi.GenericIssuer) (string, error) {
 		return IssuerVenafi, nil
 	}
 	return "", fmt.Errorf("no issuer specified for Issuer '%s/%s'", i.GetObjectMeta().Namespace, i.GetObjectMeta().Name)
-}
-
-// IssuerKind returns the kind of issuer for a certificate.
-func IssuerKind(ref cmmeta.IssuerReference) string {
-	if ref.Kind == "" {
-		return cmapi.IssuerKind
-	}
-	return ref.Kind
 }

--- a/pkg/controller/acmeorders/sync_test.go
+++ b/pkg/controller/acmeorders/sync_test.go
@@ -491,7 +491,7 @@ Dfvp7OOGAN6dEOM4+qR9sdjoSYKEBpsr6GtPAQw4dy753ec5
 				},
 				ExpectedEvents: []string{
 					//nolint: dupword
-					`Normal Created Created Challenge resource "testorder-756011405" for domain "test.com"`,
+					`Normal Created Created Challenge resource "testorder-2580184217" for domain "test.com"`,
 				},
 			},
 			acmeClient: &acmecl.FakeACME{

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -43,7 +43,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
 
-	if !(cr.Spec.IssuerRef.Group == "" || cr.Spec.IssuerRef.Group == certmanager.GroupName) {
+	if cr.Spec.IssuerRef.Group != certmanager.GroupName {
 		dbg.Info("certificate request issuerRef group does not match certmanager group so skipping processing")
 		return nil
 	}
@@ -91,7 +91,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	issuerObj, err := c.helper.GetGenericIssuer(crCopy.Spec.IssuerRef, crCopy.Namespace)
 	if k8sErrors.IsNotFound(err) {
 		c.reporter.Pending(crCopy, err, "IssuerNotFound",
-			fmt.Sprintf("Referenced %q not found", apiutil.IssuerKind(crCopy.Spec.IssuerRef)))
+			fmt.Sprintf("Referenced %q not found", crCopy.Spec.IssuerRef.Kind))
 		return nil
 	}
 

--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -33,14 +33,14 @@ func (o IssuerOptions) ResourceNamespace(iss cmapi.GenericIssuer) string {
 
 // ResourceNamespaceRef returns the Kubernetes namespace where resources
 // created or read by the referenced issuer are located.
-// This function is identical to CanUseAmbientCredentials, but takes a reference to
+// This function is identical to ResourceNamespace, but takes a reference to
 // the issuer instead of the issuer itself (which means we don't need to fetch the
 // issuer from the API server).
 func (o IssuerOptions) ResourceNamespaceRef(ref cmmeta.IssuerReference, challengeNamespace string) string {
 	switch ref.Kind {
 	case cmapi.ClusterIssuerKind:
 		return o.ClusterResourceNamespace
-	case "", cmapi.IssuerKind:
+	case cmapi.IssuerKind:
 		return challengeNamespace
 	}
 	return challengeNamespace // Should not be reached
@@ -67,7 +67,7 @@ func (o IssuerOptions) CanUseAmbientCredentialsFromRef(ref cmmeta.IssuerReferenc
 	switch ref.Kind {
 	case cmapi.ClusterIssuerKind:
 		return o.ClusterIssuerAmbientCredentials
-	case "", cmapi.IssuerKind:
+	case cmapi.IssuerKind:
 		return o.IssuerAmbientCredentials
 	}
 	return false

--- a/pkg/issuer/acme/dns/dns_test.go
+++ b/pkg/issuer/acme/dns/dns_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/acmedns"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/cloudflare"
 	"github.com/cert-manager/cert-manager/pkg/issuer/acme/dns/util"
+	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
 const (
@@ -583,23 +584,14 @@ func TestRoute53AmbientCreds(t *testing.T) {
 					},
 				},
 				dnsProviders: newFakeDNSProviders(),
-				Challenge: &cmacme.Challenge{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: fakeIssuerNamespace,
-					},
-					Spec: cmacme.ChallengeSpec{
-						Solver: cmacme.ACMEChallengeSolver{
-							DNS01: &cmacme.ACMEChallengeSolverDNS01{
-								Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-									Region: "us-west-2",
-								},
-							},
-						},
-						IssuerRef: cmmeta.IssuerReference{
-							Name: "test-issuer",
-						},
-					},
-				},
+				Challenge: gen.Challenge("",
+					gen.SetChallengeNamespace(fakeIssuerNamespace),
+					gen.SetChallengeIssuer(cmmeta.IssuerReference{Name: "test-issuer"}),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+							Region: "us-west-2",
+						}}),
+				),
 			},
 			result{
 				expectedCall: &fakeDNSProviderCall{
@@ -689,24 +681,15 @@ func TestRoute53AssumeRole(t *testing.T) {
 					},
 				},
 				dnsProviders: newFakeDNSProviders(),
-				Challenge: &cmacme.Challenge{
-					ObjectMeta: metav1.ObjectMeta{
-						Namespace: fakeIssuerNamespace,
-					},
-					Spec: cmacme.ChallengeSpec{
-						Solver: cmacme.ACMEChallengeSolver{
-							DNS01: &cmacme.ACMEChallengeSolverDNS01{
-								Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
-									Region: "us-west-2",
-									Role:   "my-role",
-								},
-							},
-						},
-						IssuerRef: cmmeta.IssuerReference{
-							Name: "test-issuer",
-						},
-					},
-				},
+				Challenge: gen.Challenge("",
+					gen.SetChallengeNamespace(fakeIssuerNamespace),
+					gen.SetChallengeIssuer(cmmeta.IssuerReference{Name: "test-issuer"}),
+					gen.SetChallengeSolverDNS01(cmacme.ACMEChallengeSolverDNS01{
+						Route53: &cmacme.ACMEIssuerDNS01ProviderRoute53{
+							Region: "us-west-2",
+							Role:   "my-role",
+						}}),
+				),
 			},
 			result{
 				expectedCall: &fakeDNSProviderCall{

--- a/pkg/issuer/helper.go
+++ b/pkg/issuer/helper.go
@@ -56,7 +56,7 @@ func NewHelper(issuerLister cmlisters.IssuerLister, clusterIssuerLister cmlister
 // that defines the IssuerRef (i.e. the namespace of the Certificate resource).
 func (h *helperImpl) GetGenericIssuer(ref cmmeta.IssuerReference, ns string) (cmapi.GenericIssuer, error) {
 	switch ref.Kind {
-	case "", cmapi.IssuerKind:
+	case cmapi.IssuerKind:
 		return h.issuerLister.Issuers(ns).Get(ref.Name)
 	case cmapi.ClusterIssuerKind:
 		// handle edge case where the ClusterIssuerLister is not set.
@@ -69,6 +69,6 @@ func (h *helperImpl) GetGenericIssuer(ref cmmeta.IssuerReference, ns string) (cm
 		}
 		return h.clusterIssuerLister.Get(ref.Name)
 	default:
-		return nil, fmt.Errorf(`invalid value %q for issuerRef.kind. Must be empty, %q or %q`, ref.Kind, cmapi.IssuerKind, cmapi.ClusterIssuerKind)
+		return nil, fmt.Errorf(`invalid value %q for issuerRef.kind. Must be %q or %q`, ref.Kind, cmapi.IssuerKind, cmapi.ClusterIssuerKind)
 	}
 }

--- a/pkg/issuer/helper_test.go
+++ b/pkg/issuer/helper_test.go
@@ -68,8 +68,9 @@ func TestGetGenericIssuer(t *testing.T) {
 		},
 		{
 			Name:     "name",
+			Kind:     "",
 			Err:      true,
-			Expected: nilIssuer,
+			Expected: nil,
 		},
 		{
 			Name:                   "name",

--- a/test/unit/gen/certificate.go
+++ b/test/unit/gen/certificate.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	internalv1 "github.com/cert-manager/cert-manager/internal/apis/certmanager/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
@@ -36,15 +37,17 @@ func Certificate(name string, mods ...CertificateModifier) *v1.Certificate {
 	for _, mod := range mods {
 		mod(c)
 	}
+	internalv1.SetObjectDefaults_Certificate(c)
 	return c
 }
 
-func CertificateFrom(crt *v1.Certificate, mods ...CertificateModifier) *v1.Certificate {
-	crt = crt.DeepCopy()
+func CertificateFrom(c *v1.Certificate, mods ...CertificateModifier) *v1.Certificate {
+	c = c.DeepCopy()
 	for _, mod := range mods {
-		mod(crt)
+		mod(c)
 	}
-	return crt
+	internalv1.SetObjectDefaults_Certificate(c)
+	return c
 }
 
 // SetCertificateIssuer sets the Certificate.spec.issuerRef field

--- a/test/unit/gen/certificaterequest.go
+++ b/test/unit/gen/certificaterequest.go
@@ -19,6 +19,7 @@ package gen
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	internalv1 "github.com/cert-manager/cert-manager/internal/apis/certmanager/v1"
 	v1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
@@ -26,13 +27,14 @@ import (
 type CertificateRequestModifier func(*v1.CertificateRequest)
 
 func CertificateRequest(name string, mods ...CertificateRequestModifier) *v1.CertificateRequest {
-	c := &v1.CertificateRequest{
+	cr := &v1.CertificateRequest{
 		ObjectMeta: ObjectMeta(name),
 	}
 	for _, mod := range mods {
-		mod(c)
+		mod(cr)
 	}
-	return c
+	internalv1.SetObjectDefaults_CertificateRequest(cr)
+	return cr
 }
 
 func CertificateRequestFrom(cr *v1.CertificateRequest, mods ...CertificateRequestModifier) *v1.CertificateRequest {
@@ -40,6 +42,7 @@ func CertificateRequestFrom(cr *v1.CertificateRequest, mods ...CertificateReques
 	for _, mod := range mods {
 		mod(cr)
 	}
+	internalv1.SetObjectDefaults_CertificateRequest(cr)
 	return cr
 }
 

--- a/test/unit/gen/challenge.go
+++ b/test/unit/gen/challenge.go
@@ -19,6 +19,7 @@ package gen
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	internalv1 "github.com/cert-manager/cert-manager/internal/apis/acme/v1"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
@@ -26,13 +27,14 @@ import (
 type ChallengeModifier func(*cmacme.Challenge)
 
 func Challenge(name string, mods ...ChallengeModifier) *cmacme.Challenge {
-	c := &cmacme.Challenge{
+	ch := &cmacme.Challenge{
 		ObjectMeta: ObjectMeta(name),
 	}
 	for _, mod := range mods {
-		mod(c)
+		mod(ch)
 	}
-	return c
+	internalv1.SetObjectDefaults_Challenge(ch)
+	return ch
 }
 
 func ChallengeFrom(ch *cmacme.Challenge, mods ...ChallengeModifier) *cmacme.Challenge {
@@ -40,6 +42,7 @@ func ChallengeFrom(ch *cmacme.Challenge, mods ...ChallengeModifier) *cmacme.Chal
 	for _, mod := range mods {
 		mod(ch)
 	}
+	internalv1.SetObjectDefaults_Challenge(ch)
 	return ch
 }
 
@@ -131,5 +134,11 @@ func SetChallengeDeletionTimestamp(ts metav1.Time) ChallengeModifier {
 func ResetChallengeStatus() ChallengeModifier {
 	return func(ch *cmacme.Challenge) {
 		ch.Status = cmacme.ChallengeStatus{}
+	}
+}
+
+func SetChallengeSolverDNS01(solver cmacme.ACMEChallengeSolverDNS01) ChallengeModifier {
+	return func(ch *cmacme.Challenge) {
+		ch.Spec.Solver.DNS01 = &solver
 	}
 }

--- a/test/unit/gen/order.go
+++ b/test/unit/gen/order.go
@@ -21,6 +21,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	internalv1 "github.com/cert-manager/cert-manager/internal/apis/acme/v1"
 	cmacme "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
@@ -34,6 +35,7 @@ func Order(name string, mods ...OrderModifier) *cmacme.Order {
 	for _, mod := range mods {
 		mod(order)
 	}
+	internalv1.SetObjectDefaults_Order(order)
 	return order
 }
 
@@ -42,6 +44,7 @@ func OrderFrom(order *cmacme.Order, mods ...OrderModifier) *cmacme.Order {
 	for _, mod := range mods {
 		mod(order)
 	}
+	internalv1.SetObjectDefaults_Order(order)
 	return order
 }
 
@@ -127,5 +130,11 @@ func SetOrderAnnotations(annotations map[string]string) OrderModifier {
 func SetOrderOwnerReference(ref metav1.OwnerReference) OrderModifier {
 	return func(order *cmacme.Order) {
 		order.OwnerReferences = []metav1.OwnerReference{ref}
+	}
+}
+
+func SetOrderProfile(profile string) OrderModifier {
+	return func(order *cmacme.Order) {
+		order.Spec.Profile = profile
 	}
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This is follow-up PR to https://github.com/cert-manager/cert-manager/pull/7900 and https://github.com/cert-manager/cert-manager/pull/7892, which leverage the new API defaults from issuerRef fields (group and kind) **in our user-facing APIs**.. The `defaulter-gen` setup seems a bit awkward to me, as the defaulting functions for our public APIs are generated inside the internal API package, but that's how it is. There is probably a reason for it, and I have no plans to change this. But if we had defaults for the equivalent fields in our internal APIs, this could be simplified more.

I chose to invoke the defaulting function from our unit-test constructors, as this appears to be the newer way of writing tests.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
