### PR TITLE
Fix new noctx linter violations

### DIFF
--- a/cmd/cainjector/app/controller.go
+++ b/cmd/cainjector/app/controller.go
@@ -159,7 +159,8 @@ func Run(opts *config.CAInjectorConfiguration, ctx context.Context) error {
 
 	// if a PprofAddr is provided, start the pprof listener
 	if opts.EnablePprof {
-		pprofListener, err := net.Listen("tcp", opts.PprofAddress)
+		lc := net.ListenConfig{}
+		pprofListener, err := lc.Listen(ctx, "tcp", opts.PprofAddress)
 		if err != nil {
 			return err
 		}

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -99,7 +99,7 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 	}
 
 	// Start metrics server
-	metricsLn, err := server.Listen("tcp", opts.MetricsListenAddress,
+	metricsLn, err := server.Listen(rootCtx, "tcp", opts.MetricsListenAddress,
 		server.WithCertificateSource(certificateSource),
 		server.WithTLSCipherSuites(opts.MetricsTLSConfig.CipherSuites),
 		server.WithTLSMinVersion(opts.MetricsTLSConfig.MinTLSVersion),
@@ -131,7 +131,8 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 
 	// Start profiler if it is enabled
 	if opts.EnablePprof {
-		profilerLn, err := net.Listen("tcp", opts.PprofAddress)
+		lc := net.ListenConfig{}
+		profilerLn, err := lc.Listen(rootCtx, "tcp", opts.PprofAddress)
 		if err != nil {
 			return fmt.Errorf("failed to listen on profiler address %s: %v", opts.PprofAddress, err)
 		}
@@ -160,7 +161,8 @@ func Run(rootCtx context.Context, opts *config.ControllerConfiguration) error {
 			return nil
 		})
 	}
-	healthzListener, err := net.Listen("tcp", opts.HealthzListenAddress)
+	lc := net.ListenConfig{}
+	healthzListener, err := lc.Listen(rootCtx, "tcp", opts.HealthzListenAddress)
 	if err != nil {
 		return fmt.Errorf("failed to listen on healthz address %s: %v", opts.HealthzListenAddress, err)
 	}

--- a/internal/cmd/util/signal_test.go
+++ b/internal/cmd/util/signal_test.go
@@ -37,7 +37,7 @@ func testExitCode(
 		os.Exit(0)
 	}
 
-	cmd := exec.Command(os.Args[0], "-test.run="+t.Name())
+	cmd := exec.CommandContext(t.Context(), os.Args[0], "-test.run="+t.Name())
 	cmd.Env = append(os.Environ(), "BE_CRASHER=1")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/pkg/healthz/healthz_test.go
+++ b/pkg/healthz/healthz_test.go
@@ -196,7 +196,8 @@ func TestHealthzLivezLeaderElection(t *testing.T) {
 			ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 			defer cancel()
 
-			l, err := net.Listen("tcp", "127.0.0.1:0")
+			lc := net.ListenConfig{}
+			l, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
 			require.NoError(t, err)
 
 			livezURL := "http://" + l.Addr().String() + "/livez/leaderElection"

--- a/pkg/issuer/acme/http/http_test.go
+++ b/pkg/issuer/acme/http/http_test.go
@@ -102,7 +102,7 @@ func TestReachabilityCustomDnsServers(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to parse url %s: %v", site, err)
 	}
-	ips, err := net.LookupIP(u.Host)
+	ips, err := net.LookupIP(u.Host) // nolint: noctx // We intentionally use LookupIP here for test compatibility
 	if err != nil {
 		t.Fatalf("Failed to resolve %s: %v", u.Host, err)
 	}

--- a/pkg/server/listener.go
+++ b/pkg/server/listener.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"context"
 	"crypto/tls"
 	"net"
 
@@ -38,9 +39,10 @@ type ListenerOption func(*ListenerConfig) error
 
 // Listen will listen on a given network and port, with additional options available
 // for enabling TLS and obtaining certificates.
-func Listen(network, addr string, options ...ListenerOption) (net.Listener, error) {
+func Listen(ctx context.Context, network, addr string, options ...ListenerOption) (net.Listener, error) {
 	// Create the base listener on the configured network and address
-	listener, err := net.Listen(network, addr)
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(ctx, network, addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/webhook/server/server.go
+++ b/pkg/webhook/server/server.go
@@ -181,7 +181,8 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// if a HealthzAddr is provided, start the healthz listener
 	if s.HealthzAddr != nil {
-		healthzListener, err := net.Listen("tcp", fmt.Sprintf(":%d", *s.HealthzAddr))
+		lc := net.ListenConfig{}
+		healthzListener, err := lc.Listen(ctx, "tcp", fmt.Sprintf(":%d", *s.HealthzAddr))
 		if err != nil {
 			return err
 		}
@@ -223,7 +224,8 @@ func (s *Server) Run(ctx context.Context) error {
 
 	// if a PprofAddr is provided, start the pprof listener
 	if s.EnablePprof {
-		pprofListener, err := net.Listen("tcp", s.PprofAddress)
+		lc := net.ListenConfig{}
+		pprofListener, err := lc.Listen(ctx, "tcp", s.PprofAddress)
 		if err != nil {
 			return err
 		}

--- a/test/acme/server/server.go
+++ b/test/acme/server/server.go
@@ -71,8 +71,9 @@ func (b *BasicServer) RunWithAddress(ctx context.Context, listenAddr, network st
 		return fmt.Errorf("listen address must be provided")
 	}
 
+	lc := net.ListenConfig{}
 	if network == "tcp" {
-		listener, err := net.Listen("tcp", listenAddr)
+		listener, err := lc.Listen(ctx, "tcp", listenAddr)
 		if err != nil {
 			return err
 		}
@@ -80,7 +81,7 @@ func (b *BasicServer) RunWithAddress(ctx context.Context, listenAddr, network st
 		b.server = &dns.Server{Listener: listener, ReadTimeout: time.Hour, WriteTimeout: time.Hour, MsgAcceptFunc: msgAcceptFunc}
 		b.listenAddr = listener.Addr().String()
 	} else {
-		pc, err := net.ListenPacket("udp", listenAddr)
+		pc, err := lc.ListenPacket(ctx, "udp", listenAddr)
 		if err != nil {
 			return err
 		}

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -46,7 +46,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 	// We first setup the global addons, but do not provision them yet.
 	// This is because we need to transfer the data from ginkgo process #1
 	// to the other ginkgo processes.
-	toBeTransferred, err := addon.SetupGlobalsPrimary(cfg)
+	toBeTransferred, err := addon.SetupGlobalsPrimary(ctx, cfg)
 	if err != nil {
 		framework.Failf("Error provisioning global addons: %v", err)
 	}
@@ -76,7 +76,7 @@ var _ = ginkgo.SynchronizedBeforeSuite(func(ctx context.Context) []byte {
 		// the Setup data returned by ginkgo process #1.
 		addon.InitGlobals(cfg)
 
-		err := addon.SetupGlobalsNonPrimary(cfg, transferredData)
+		err := addon.SetupGlobalsNonPrimary(ctx, cfg, transferredData)
 		if err != nil {
 			framework.Failf("Error provisioning global addons: %v", err)
 		}

--- a/test/e2e/framework/addon/base/base.go
+++ b/test/e2e/framework/addon/base/base.go
@@ -58,8 +58,8 @@ func (d *Details) Helper() *helper.Helper {
 	}
 }
 
-func (b *Base) Setup(c *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
-	kubeConfig, err := util.LoadConfig(c.KubeConfig, c.KubeContext)
+func (b *Base) Setup(_ context.Context, cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
+	kubeConfig, err := util.LoadConfig(cfg.KubeConfig, cfg.KubeContext)
 	if err != nil {
 		return nil, err
 	}
@@ -73,7 +73,7 @@ func (b *Base) Setup(c *config.Config, _ ...internal.AddonTransferableData) (int
 	}
 
 	b.details = &Details{
-		Config: c,
+		Config: cfg,
 
 		KubeConfig: kubeConfig,
 		KubeClient: kubeClientset,

--- a/test/e2e/framework/addon/chart/addon.go
+++ b/test/e2e/framework/addon/chart/addon.go
@@ -100,7 +100,7 @@ type Details struct {
 	Namespace string
 }
 
-func (c *Chart) Setup(cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
+func (c *Chart) Setup(_ context.Context, cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
 	var err error
 
 	c.config = cfg

--- a/test/e2e/framework/addon/globals.go
+++ b/test/e2e/framework/addon/globals.go
@@ -87,10 +87,10 @@ func InitGlobals(cfg *config.Config) {
 // block to ensure it is run only on ginkgo process #1. It has to be run before
 // any other ginkgo processes are started, because the return value of this function
 // has to be transferred to the other ginkgo processes.
-func SetupGlobalsPrimary(cfg *config.Config) ([]AddonTransferableData, error) {
+func SetupGlobalsPrimary(ctx context.Context, cfg *config.Config) ([]AddonTransferableData, error) {
 	toBeTransferred := make([]AddonTransferableData, len(allAddons))
 	for addonIdx, g := range allAddons {
-		data, err := g.Setup(cfg)
+		data, err := g.Setup(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -110,9 +110,9 @@ func SetupGlobalsPrimary(cfg *config.Config) ([]AddonTransferableData, error) {
 // can be passed into this function. This function calls Setup on all of the non-primary
 // processes (processes #2 and above) and passes in the AddonTransferableData data returned
 // by the primary process.
-func SetupGlobalsNonPrimary(cfg *config.Config, transferred []AddonTransferableData) error {
+func SetupGlobalsNonPrimary(ctx context.Context, cfg *config.Config, transferred []AddonTransferableData) error {
 	for addonIdx, g := range allAddons {
-		_, err := g.Setup(cfg, transferred[addonIdx])
+		_, err := g.Setup(ctx, cfg, transferred[addonIdx])
 		if err != nil {
 			return err
 		}

--- a/test/e2e/framework/addon/internal/globals.go
+++ b/test/e2e/framework/addon/internal/globals.go
@@ -28,7 +28,7 @@ type Addon interface {
 	// any arguments. For global addons, this function is called on ginkgo process #1
 	// without any arguments, but the returned data is passed to the Setup function
 	// on all other ginkgo processes.
-	Setup(*config.Config, ...AddonTransferableData) (AddonTransferableData, error)
+	Setup(ctx context.Context, cfg *config.Config, leaderData ...AddonTransferableData) (AddonTransferableData, error)
 
 	// For non-global addons, this function is called on all ginkgo processes. For global
 	// addons, this function is called only on ginkgo process #1.

--- a/test/e2e/framework/addon/vault/proxy.go
+++ b/test/e2e/framework/addon/vault/proxy.go
@@ -44,11 +44,12 @@ type proxy struct {
 }
 
 func newProxy(
+	ctx context.Context,
 	clientset kubernetes.Interface,
 	kubeConfig *rest.Config,
 	podNamespace, podName string,
 ) *proxy {
-	freePort, err := freePort()
+	freePort, err := freePort(ctx)
 	if err != nil {
 		panic(err)
 	}
@@ -65,9 +66,10 @@ func newProxy(
 	}
 }
 
-func freePort() (int, error) {
+func freePort(ctx context.Context) (int, error) {
 	// Reserve a port for the proxy.
-	listener, err := net.Listen("tcp", "localhost:0")
+	lc := net.ListenConfig{}
+	listener, err := lc.Listen(ctx, "tcp", "localhost:0")
 	if err != nil {
 		return -1, err
 	}

--- a/test/e2e/framework/addon/vault/vault.go
+++ b/test/e2e/framework/addon/vault/vault.go
@@ -116,7 +116,7 @@ func convertInterfaceToDetails(unmarshalled interface{}) (Details, error) {
 	return details, nil
 }
 
-func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
+func (v *Vault) Setup(ctx context.Context, cfg *config.Config, leaderData ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
 	if v.Name == "" {
 		return nil, fmt.Errorf("'Name' field must be set on Vault addon")
 	}
@@ -266,7 +266,7 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 		)
 	}
 
-	_, err := v.chart.Setup(cfg)
+	_, err := v.chart.Setup(ctx, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -298,6 +298,7 @@ func (v *Vault) Setup(cfg *config.Config, leaderData ...internal.AddonTransferab
 			return nil, fmt.Errorf("path to kubectl must be specified")
 		}
 		v.proxy = newProxy(
+			ctx,
 			v.Base.Details().KubeClient,
 			v.Base.Details().KubeConfig,
 			v.Namespace,

--- a/test/e2e/framework/addon/venafi/cloud.go
+++ b/test/e2e/framework/addon/venafi/cloud.go
@@ -49,12 +49,12 @@ type CloudDetails struct {
 	issuerTemplate cmapi.VenafiIssuer
 }
 
-func (v *VenafiCloud) Setup(cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
+func (v *VenafiCloud) Setup(ctx context.Context, cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
 	v.config = cfg
 
 	if v.Base == nil {
 		v.Base = &base.Base{}
-		_, err := v.Base.Setup(cfg)
+		_, err := v.Base.Setup(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/framework/addon/venafi/tpp.go
+++ b/test/e2e/framework/addon/venafi/tpp.go
@@ -49,12 +49,12 @@ type TPPDetails struct {
 	issuerTemplate cmapi.VenafiIssuer
 }
 
-func (v *VenafiTPP) Setup(cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
+func (v *VenafiTPP) Setup(ctx context.Context, cfg *config.Config, _ ...internal.AddonTransferableData) (internal.AddonTransferableData, error) {
 	v.config = cfg
 
 	if v.Base == nil {
 		v.Base = &base.Base{}
-		_, err := v.Base.Setup(cfg)
+		_, err := v.Base.Setup(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -200,9 +200,9 @@ func (f *Framework) printAddonLogs(ctx context.Context) {
 // are present in the 'globals' variable, as they will not be Provisioned properly
 // otherwise.
 func (f *Framework) RequireGlobalAddon(a addon.Addon) {
-	BeforeEach(func() {
+	BeforeEach(func(ctx context.Context) {
 		By("Setting up access for global shared addon")
-		_, err := a.Setup(f.Config)
+		_, err := a.Setup(ctx, f.Config)
 		Expect(err).NotTo(HaveOccurred())
 	})
 }
@@ -218,7 +218,7 @@ func (f *Framework) RequireAddon(a addon.Addon) {
 
 	BeforeEach(func(ctx context.Context) {
 		By("Provisioning test-scoped addon")
-		_, err := a.Setup(f.Config)
+		_, err := a.Setup(ctx, f.Config)
 		if errors.IsSkip(err) {
 			Skipf("Skipping test as addon could not be setup: %v", err)
 		}

--- a/test/e2e/framework/helper/certificaterequests.go
+++ b/test/e2e/framework/helper/certificaterequests.go
@@ -201,8 +201,8 @@ func (h *Helper) WaitCertificateRequestIssuedValid(ctx context.Context, ns, name
 		log.Logf("Error waiting for CertificateRequest to become Ready: %v", err)
 		return kerrors.NewAggregate([]error{
 			err,
-			h.Kubectl(ns).DescribeResource("certificaterequest", name),
-			h.Kubectl(ns).Describe("order", "challenge"),
+			h.Kubectl(ns).DescribeResource(ctx, "certificaterequest", name),
+			h.Kubectl(ns).Describe(ctx, "order", "challenge"),
 		})
 	}
 
@@ -211,8 +211,8 @@ func (h *Helper) WaitCertificateRequestIssuedValid(ctx context.Context, ns, name
 		log.Logf("Error validating issued certificate: %v", err)
 		return kerrors.NewAggregate([]error{
 			err,
-			h.Kubectl(ns).DescribeResource("certificaterequest", name),
-			h.Kubectl(ns).Describe("order", "challenge"),
+			h.Kubectl(ns).DescribeResource(ctx, "certificaterequest", name),
+			h.Kubectl(ns).Describe(ctx, "order", "challenge"),
 		})
 	}
 

--- a/test/e2e/framework/helper/certificates.go
+++ b/test/e2e/framework/helper/certificates.go
@@ -80,14 +80,14 @@ func (h *Helper) waitForCertificateCondition(ctx context.Context, client clients
 		errs = append(errs, h.describeCMObject(certificate))
 
 		log.Logf("Order and challenge descriptions:\n")
-		errs = append(errs, h.Kubectl(certificate.Namespace).Describe("order", "challenge"))
+		errs = append(errs, h.Kubectl(certificate.Namespace).Describe(ctx, "order", "challenge"))
 
 		log.Logf("CertificateRequest description:\n")
 		crName, err := apiutil.ComputeName(certificate.Name, certificate.Spec)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to compute CertificateRequest name from certificate: %w", err))
 		} else {
-			errs = append(errs, h.Kubectl(certificate.Namespace).DescribeResource("certificaterequest", crName))
+			errs = append(errs, h.Kubectl(certificate.Namespace).DescribeResource(ctx, "certificaterequest", crName))
 		}
 
 		pollErr = kerrors.NewAggregate(errs)

--- a/test/e2e/framework/helper/kubectl.go
+++ b/test/e2e/framework/helper/kubectl.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helper
 
 import (
+	"context"
 	"os/exec"
 	"strings"
 
@@ -30,13 +31,13 @@ type Kubectl struct {
 	kubecontext string
 }
 
-func (k *Kubectl) Describe(resources ...string) error {
+func (k *Kubectl) Describe(ctx context.Context, resources ...string) error {
 	resourceNames := strings.Join(resources, ",")
-	return k.Run("describe", resourceNames)
+	return k.Run(ctx, "describe", resourceNames)
 }
 
-func (k *Kubectl) DescribeResource(resource, name string) error {
-	return k.Run("describe", resource, name)
+func (k *Kubectl) DescribeResource(ctx context.Context, resource, name string) error {
+	return k.Run(ctx, "describe", resource, name)
 }
 
 func (h *Helper) Kubectl(ns string) *Kubectl {
@@ -48,7 +49,7 @@ func (h *Helper) Kubectl(ns string) *Kubectl {
 	}
 }
 
-func (k *Kubectl) Run(args ...string) error {
+func (k *Kubectl) Run(ctx context.Context, args ...string) error {
 	baseArgs := []string{"--kubeconfig", k.kubeconfig, "--context", k.kubecontext}
 	if k.namespace == "" {
 		baseArgs = append(baseArgs, "--all-namespaces")
@@ -56,7 +57,7 @@ func (k *Kubectl) Run(args ...string) error {
 		baseArgs = []string{"--namespace", k.namespace}
 	}
 	args = append(baseArgs, args...)
-	cmd := exec.Command(k.kubectl, args...)
+	cmd := exec.CommandContext(ctx, k.kubectl, args...)
 	cmd.Stdout = log.Writer
 	cmd.Stderr = log.Writer
 	return cmd.Run()

--- a/test/e2e/suite/conformance/certificates/venafi/venafi.go
+++ b/test/e2e/suite/conformance/certificates/venafi/venafi.go
@@ -93,7 +93,7 @@ func (v *venafiProvisioner) createIssuer(ctx context.Context, f *framework.Frame
 		Namespace: f.Namespace.Name,
 	}
 
-	_, err := v.tpp.Setup(f.Config)
+	_, err := v.tpp.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}
@@ -124,7 +124,7 @@ func (v *venafiProvisioner) createClusterIssuer(ctx context.Context, f *framewor
 		Namespace: f.Config.Addons.CertManager.ClusterResourceNamespace,
 	}
 
-	_, err := v.tpp.Setup(f.Config)
+	_, err := v.tpp.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}

--- a/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
+++ b/test/e2e/suite/conformance/certificates/venaficloud/cloud.go
@@ -93,7 +93,7 @@ func (v *venafiProvisioner) createIssuer(ctx context.Context, f *framework.Frame
 		Namespace: f.Namespace.Name,
 	}
 
-	_, err := v.cloud.Setup(f.Config)
+	_, err := v.cloud.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}
@@ -124,7 +124,7 @@ func (v *venafiProvisioner) createClusterIssuer(ctx context.Context, f *framewor
 		Namespace: f.Config.Addons.CertManager.ClusterResourceNamespace,
 	}
 
-	_, err := v.cloud.Setup(f.Config)
+	_, err := v.cloud.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}

--- a/test/e2e/suite/conformance/certificatesigningrequests/venafi/cloud.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/venafi/cloud.go
@@ -94,7 +94,7 @@ func (c *cloud) createIssuer(ctx context.Context, f *framework.Framework) string
 		Namespace: f.Namespace.Name,
 	}
 
-	_, err := c.Setup(f.Config)
+	_, err := c.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}
@@ -124,7 +124,7 @@ func (c *cloud) createClusterIssuer(ctx context.Context, f *framework.Framework)
 		Namespace: f.Config.Addons.CertManager.ClusterResourceNamespace,
 	}
 
-	_, err := c.Setup(f.Config)
+	_, err := c.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}

--- a/test/e2e/suite/conformance/certificatesigningrequests/venafi/tpp.go
+++ b/test/e2e/suite/conformance/certificatesigningrequests/venafi/tpp.go
@@ -96,7 +96,7 @@ func (t *tpp) createIssuer(ctx context.Context, f *framework.Framework) string {
 		Namespace: f.Namespace.Name,
 	}
 
-	_, err := t.Setup(f.Config)
+	_, err := t.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}
@@ -118,7 +118,7 @@ func (t *tpp) createClusterIssuer(ctx context.Context, f *framework.Framework) s
 		Namespace: f.Config.Addons.CertManager.ClusterResourceNamespace,
 	}
 
-	_, err := t.Setup(f.Config)
+	_, err := t.Setup(ctx, f.Config)
 	if errors.IsSkip(err) {
 		framework.Skipf("Skipping test as addon could not be setup: %v", err)
 	}

--- a/test/e2e/suite/issuers/acme/dnsproviders/cloudflare.go
+++ b/test/e2e/suite/issuers/acme/dnsproviders/cloudflare.go
@@ -45,22 +45,22 @@ type Cloudflare struct {
 	createdSecret *corev1.Secret
 }
 
-func (b *Cloudflare) Setup(c *config.Config, _ ...addon.AddonTransferableData) (addon.AddonTransferableData, error) {
-	if c.Suite.ACME.Cloudflare.APIKey == "" ||
-		c.Suite.ACME.Cloudflare.Domain == "" ||
-		c.Suite.ACME.Cloudflare.Email == "" {
+func (b *Cloudflare) Setup(ctx context.Context, cfg *config.Config, _ ...addon.AddonTransferableData) (addon.AddonTransferableData, error) {
+	if cfg.Suite.ACME.Cloudflare.APIKey == "" ||
+		cfg.Suite.ACME.Cloudflare.Domain == "" ||
+		cfg.Suite.ACME.Cloudflare.Email == "" {
 		return nil, errors.NewSkip(ErrNoCredentials)
 	}
 
 	if b.Base == nil {
 		b.Base = &base.Base{}
-		_, err := b.Base.Setup(c)
+		_, err := b.Base.Setup(ctx, cfg)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	b.cf = c.Suite.ACME.Cloudflare
+	b.cf = cfg.Suite.ACME.Cloudflare
 
 	return nil, nil
 }

--- a/test/e2e/suite/issuers/acme/dnsproviders/rfc2136.go
+++ b/test/e2e/suite/issuers/acme/dnsproviders/rfc2136.go
@@ -29,8 +29,8 @@ type RFC2136 struct {
 	nameserver string
 }
 
-func (b *RFC2136) Setup(c *config.Config, _ ...addon.AddonTransferableData) (addon.AddonTransferableData, error) {
-	b.nameserver = c.Addons.ACMEServer.DNSServer
+func (b *RFC2136) Setup(_ context.Context, cfg *config.Config, _ ...addon.AddonTransferableData) (addon.AddonTransferableData, error) {
+	b.nameserver = cfg.Addons.ACMEServer.DNSServer
 	return nil, nil
 }
 

--- a/test/integration/certificates/metrics_controller_test.go
+++ b/test/integration/certificates/metrics_controller_test.go
@@ -66,7 +66,8 @@ func TestMetricsController(t *testing.T) {
 
 	metricsHandler := metrics.New(logf.Log, fixedClock)
 
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	lc := net.ListenConfig{}
+	ln, err := lc.Listen(t.Context(), "tcp", "127.0.0.1:0")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

As https://github.com/cert-manager/cert-manager/pull/7910 is upgrading golangci-lint, we need to fix quite a few new linter violations. It didn't feeel right to just do these changes on the self-upgrade branch, so here is a pre-PR to ensure https://github.com/cert-manager/cert-manager/pull/7910 succeeds in CI.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
