### PR TITLE
improve error messages when resource creation fails

### DIFF
--- a/internal/apis/certmanager/validation/certificaterequest.go
+++ b/internal/apis/certmanager/validation/certificaterequest.go
@@ -113,11 +113,22 @@ func validateCertificateRequestSpecRequest(crSpec *cmapi.CertificateRequestSpec,
 		pki.CertificateTemplateValidateAndOverrideKeyUsages(keyUsage, extKeyUsage),
 	)
 	if err != nil {
-		el = append(el, field.Invalid(fldPath.Child("request"), crSpec.Request, err.Error()))
+		// truncate the request to avoid creating a ridiculously long error message with the whole CSR in it
+		el = append(el, field.Invalid(fldPath.Child("request"), truncateString(string(crSpec.Request)), err.Error()))
 		return el
 	}
 
 	return el
+}
+
+func truncateString(s string) string {
+	const maxLength = 100
+
+	if len(s) <= maxLength {
+		return s
+	}
+
+	return s[:maxLength-3] + "..."
 }
 
 // ValidateCertificateRequestApprovalCondition will ensure that only a single

--- a/internal/controller/certificates/policies/checks_test.go
+++ b/internal/controller/certificates/policies/checks_test.go
@@ -93,7 +93,7 @@ func Test_NewTriggerPolicyChain(t *testing.T) {
 				},
 			},
 			reason:  InvalidKeyPair,
-			message: "Issuing certificate as Secret contains invalid private key data: error decoding private key PEM block",
+			message: "Issuing certificate as Secret contains invalid private key data: error decoding private key PEM block: no PEM data was found in given input",
 			reissue: true,
 		},
 		"trigger issuance as Secret contains corrupt certificate data": {
@@ -105,7 +105,7 @@ func Test_NewTriggerPolicyChain(t *testing.T) {
 				},
 			},
 			reason:  InvalidCertificate,
-			message: "Issuing certificate as Secret contains an invalid certificate: error decoding certificate PEM block",
+			message: "Issuing certificate as Secret contains an invalid certificate: error decoding certificate PEM block: no valid certificates found",
 			reissue: true,
 		},
 		"trigger issuance as Secret contains corrupt private key data": {
@@ -119,7 +119,7 @@ func Test_NewTriggerPolicyChain(t *testing.T) {
 				},
 			},
 			reason:  InvalidKeyPair,
-			message: "Issuing certificate as Secret contains invalid private key data: error decoding private key PEM block",
+			message: "Issuing certificate as Secret contains invalid private key data: error decoding private key PEM block: no PEM data was found in given input",
 			reissue: true,
 		},
 		"trigger issuance as Secret contains a non-matching key-pair": {
@@ -1459,9 +1459,9 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
-							  "f:tls-combined.pem": {}
+							{"f:data": {
+								".": {},
+								"f:tls-combined.pem": {}
 							}}`),
 							}},
 						},
@@ -1482,9 +1482,9 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
-							  "f:key.der": {}
+							{"f:data": {
+								".": {},
+								"f:key.der": {}
 							}}`),
 							}},
 						},
@@ -1505,10 +1505,10 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
-							  "f:tls-combined.pem": {},
-							  "f:key.der": {}
+							{"f:data": {
+								".": {},
+								"f:tls-combined.pem": {},
+								"f:key.der": {}
 							}}`),
 							}},
 						},
@@ -1529,9 +1529,9 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
-							  "f:tls-combined.pem": {}
+							{"f:data": {
+								".": {},
+								"f:tls-combined.pem": {}
 							}}`),
 							}},
 						},
@@ -1552,9 +1552,9 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
-							  "f:key.der": {}
+							{"f:data": {
+								".": {},
+								"f:key.der": {}
 							}}`),
 							}},
 						},
@@ -1575,10 +1575,10 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:tls-combined.pem": {},
-							  "f:key.der": {}
+								"f:key.der": {}
 							}}`),
 							}},
 						},
@@ -1601,8 +1601,8 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:tls-combined.pem": {}
 							}}`),
 							}},
@@ -1626,8 +1626,8 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:key.der": {}
 							}}`),
 							}},
@@ -1652,8 +1652,8 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:tls-combined.pem": {},
 								"f:key.der": {}
 							}}`),
@@ -1678,8 +1678,8 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:tls-combined.pem": {}
 							}}`),
 							}},
@@ -1703,8 +1703,8 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:key.der": {}
 							}}`),
 							}},
@@ -1729,8 +1729,8 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:key.der": {},
 								"f:tls-combined.pem": {}
 							}}`),
@@ -1756,15 +1756,15 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:key.der": {}
 							}}`),
 							}},
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:tls-combined.pem": {}
 							}}`),
 							}},
@@ -1789,16 +1789,16 @@ func Test_SecretAdditionalOutputFormatsManagedFieldsMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: fieldManager, FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:tls-combined.pem": {},
 								"f:key.der": {}
 							}}`),
 							}},
 							{Manager: "not-cert-manager", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-              {"f:data": {
-							  ".": {},
+							{"f:data": {
+								".": {},
 								"f:key.der": {},
 								"f:tls-combined.pem": {}
 							}}`),
@@ -1856,9 +1856,9 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-                {"f:metadata": {
+							{"f:metadata": {
 								"f:ownerReferences": {
-                "k:{\"uid\":\"4c71e68f-5271-4b8d-9df5-5eb71d130d7d\"}": {}
+								"k:{\"uid\":\"4c71e68f-5271-4b8d-9df5-5eb71d130d7d\"}": {}
 							}}}`),
 							}},
 						},
@@ -1878,9 +1878,9 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-                {"f:metadata": {
+								{"f:metadata": {
 								"f:ownerReferences": {
-                "k:{\"uid\":\"uid-123\"}": {}
+								"k:{\"uid\":\"uid-123\"}": {}
 							}}}`),
 							}},
 						},
@@ -1900,9 +1900,9 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager-test", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-                {"f:metadata": {
+								{"f:metadata": {
 								"f:ownerReferences": {
-                "k:{\"uid\":\"uid-123\"}": {}
+								"k:{\"uid\":\"uid-123\"}": {}
 							}}}`),
 							}},
 						},
@@ -1933,9 +1933,9 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-                {"f:metadata": {
+								{"f:metadata": {
 								"f:ownerReferences": {
-                "k:{\"uid\":\"4c71e68f-5271-4b8d-9df5-5eb71d130d7d\"}": {}
+								"k:{\"uid\":\"4c71e68f-5271-4b8d-9df5-5eb71d130d7d\"}": {}
 							}}}`),
 							}},
 						},
@@ -1955,9 +1955,9 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "cert-manager-test", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-                {"f:metadata": {
+								{"f:metadata": {
 								"f:ownerReferences": {
-                "k:{\"uid\":\"uid-123\"}": {}
+								"k:{\"uid\":\"uid-123\"}": {}
 							}}}`),
 							}},
 						},
@@ -1977,9 +1977,9 @@ func Test_SecretOwnerReferenceManagedFieldMismatch(t *testing.T) {
 						ManagedFields: []metav1.ManagedFieldsEntry{
 							{Manager: "not-cert-manager-test", FieldsV1: &metav1.FieldsV1{
 								Raw: []byte(`
-                {"f:metadata": {
+								{"f:metadata": {
 								"f:ownerReferences": {
-                "k:{\"uid\":\"uid-123\"}": {}
+								"k:{\"uid\":\"uid-123\"}": {}
 							}}}`),
 							}},
 						},

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -240,7 +240,7 @@ func TestSign(t *testing.T) {
 				KubeObjects:        []runtime.Object{},
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer.DeepCopy()},
 				ExpectedEvents: []string{
-					"Warning RequestParsingError Failed to decode CSR in spec.request: error decoding certificate request PEM block",
+					"Warning RequestParsingError Failed to decode CSR in spec.request: error decoding certificate request PEM block: no PEM data was found in given input",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -253,7 +253,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapiv1.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapiv1.CertificateRequestReasonFailed,
-								Message:            "Failed to decode CSR in spec.request: error decoding certificate request PEM block",
+								Message:            "Failed to decode CSR in spec.request: error decoding certificate request PEM block: no PEM data was found in given input",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 							gen.SetCertificateRequestFailureTime(metaFixedClockStart),

--- a/pkg/controller/certificaterequests/ca/ca_test.go
+++ b/pkg/controller/certificaterequests/ca/ca_test.go
@@ -240,7 +240,7 @@ func TestSign(t *testing.T) {
 					),
 				},
 				ExpectedEvents: []string{
-					"Normal SecretInvalidData Failed to parse signing CA keypair from secret default-unit-test-ns/root-ca-secret: error decoding private key PEM block",
+					"Normal SecretInvalidData Failed to parse signing CA keypair from secret default-unit-test-ns/root-ca-secret: error decoding private key PEM block: no PEM data was found in given input",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -252,7 +252,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonPending,
-								Message:            "Failed to parse signing CA keypair from secret default-unit-test-ns/root-ca-secret: error decoding private key PEM block",
+								Message:            "Failed to parse signing CA keypair from secret default-unit-test-ns/root-ca-secret: error decoding private key PEM block: no PEM data was found in given input",
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 						),

--- a/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificaterequests/selfsigned/selfsigned_test.go
@@ -327,7 +327,7 @@ func TestSign(t *testing.T) {
 				KubeObjects:        []runtime.Object{invalidKeySecret},
 				CertManagerObjects: []runtime.Object{baseCR.DeepCopy(), baseIssuer},
 				ExpectedEvents: []string{
-					`Normal ErrorParsingKey Failed to get key "test-rsa-key" referenced in annotation "cert-manager.io/private-key-secret-name": error decoding private key PEM block`,
+					`Normal ErrorParsingKey Failed to get key "test-rsa-key" referenced in annotation "cert-manager.io/private-key-secret-name": error decoding private key PEM block: no PEM data was found in given input`,
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -339,7 +339,7 @@ func TestSign(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             cmapi.CertificateRequestReasonPending,
-								Message:            `Failed to get key "test-rsa-key" referenced in annotation "cert-manager.io/private-key-secret-name": error decoding private key PEM block`,
+								Message:            `Failed to get key "test-rsa-key" referenced in annotation "cert-manager.io/private-key-secret-name": error decoding private key PEM block: no PEM data was found in given input`,
 								LastTransitionTime: &metaFixedClockStart,
 							}),
 						),

--- a/pkg/controller/certificaterequests/sync_test.go
+++ b/pkg/controller/certificaterequests/sync_test.go
@@ -585,7 +585,7 @@ func TestSync(t *testing.T) {
 						gen.SetCertificateRequestCertificate([]byte("a bad certificate")),
 					)},
 				ExpectedEvents: []string{
-					"Warning DecodeError Failed to decode returned certificate: error decoding certificate PEM block",
+					"Warning DecodeError Failed to decode returned certificate: error decoding certificate PEM block: no valid certificates found",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
@@ -598,7 +598,7 @@ func TestSync(t *testing.T) {
 								Type:               cmapi.CertificateRequestConditionReady,
 								Status:             cmmeta.ConditionFalse,
 								Reason:             "Failed",
-								Message:            "Failed to decode returned certificate: error decoding certificate PEM block",
+								Message:            "Failed to decode returned certificate: error decoding certificate PEM block: no valid certificates found",
 								LastTransitionTime: &nowMetaTime,
 							}),
 							gen.SetCertificateRequestFailureTime(nowMetaTime),

--- a/pkg/controller/certificates/readiness/readiness_controller_test.go
+++ b/pkg/controller/certificates/readiness/readiness_controller_test.go
@@ -377,7 +377,7 @@ func TestNewReadinessPolicyChain(t *testing.T) {
 					corev1.TLSCertKey:       []byte("test"),
 				})),
 			reason:         policies.InvalidKeyPair,
-			message:        "Issuing certificate as Secret contains invalid private key data: error decoding private key PEM block",
+			message:        "Issuing certificate as Secret contains invalid private key data: error decoding private key PEM block: no PEM data was found in given input",
 			violationFound: true,
 		},
 		"Certificate not Ready as Secret contains corrupt certificate data": {
@@ -388,7 +388,7 @@ func TestNewReadinessPolicyChain(t *testing.T) {
 					corev1.TLSCertKey:       []byte("test"),
 				})),
 			reason:         policies.InvalidCertificate,
-			message:        "Issuing certificate as Secret contains an invalid certificate: error decoding certificate PEM block",
+			message:        "Issuing certificate as Secret contains an invalid certificate: error decoding certificate PEM block: no valid certificates found",
 			violationFound: true,
 		},
 		"Certificate not Ready as Secret contains a non-matching key-pair": {

--- a/pkg/controller/certificatesigningrequests/acme/acme_test.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme_test.go
@@ -292,7 +292,7 @@ func Test_ProcessItem(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
 				ExpectedEvents: []string{
-					"Warning RequestParsingError Failed to decode CSR in spec.request: error decoding certificate request PEM block",
+					"Warning RequestParsingError Failed to decode CSR in spec.request: error decoding certificate request PEM block: no PEM data was found in given input",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewCreateAction(
@@ -332,7 +332,7 @@ func Test_ProcessItem(t *testing.T) {
 								Type:               certificatesv1.CertificateFailed,
 								Status:             corev1.ConditionTrue,
 								Reason:             "RequestParsingError",
-								Message:            "Failed to decode CSR in spec.request: error decoding certificate request PEM block",
+								Message:            "Failed to decode CSR in spec.request: error decoding certificate request PEM block: no PEM data was found in given input",
 								LastTransitionTime: metaFixedClockStart,
 								LastUpdateTime:     metaFixedClockStart,
 							}),
@@ -742,7 +742,7 @@ func Test_ProcessItem(t *testing.T) {
 					),
 				},
 				ExpectedEvents: []string{
-					"Warning OrderBadCertificate Deleting Order with bad certificate: error decoding certificate PEM block",
+					"Warning OrderBadCertificate Deleting Order with bad certificate: error decoding certificate PEM block: no valid certificates found",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewCreateAction(

--- a/pkg/controller/certificatesigningrequests/ca/ca_test.go
+++ b/pkg/controller/certificatesigningrequests/ca/ca_test.go
@@ -239,7 +239,7 @@ func TestSign(t *testing.T) {
 				),
 				},
 				ExpectedEvents: []string{
-					"Warning SecretInvalidData Failed to parse signing CA keypair from secret default-unit-test-ns/root-ca-secret: error decoding private key PEM block",
+					"Warning SecretInvalidData Failed to parse signing CA keypair from secret default-unit-test-ns/root-ca-secret: error decoding private key PEM block: no PEM data was found in given input",
 				},
 
 				ExpectedActions: []testpkg.Action{

--- a/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
+++ b/pkg/controller/certificatesigningrequests/selfsigned/selfsigned_test.go
@@ -275,7 +275,7 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 				ExpectedEvents: []string{
-					`Warning ErrorParsingKey Failed to parse signing key from secret default-unit-test-ns/test-secret: error decoding private key PEM block`,
+					`Warning ErrorParsingKey Failed to parse signing key from secret default-unit-test-ns/test-secret: error decoding private key PEM block: no PEM data was found in given input`,
 				},
 
 				ExpectedActions: []testpkg.Action{
@@ -320,7 +320,7 @@ func TestProcessItem(t *testing.T) {
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
 				KubeObjects:        []runtime.Object{csrBundle.secret},
 				ExpectedEvents: []string{
-					"Warning ErrorGenerating Error generating certificate template: error decoding certificate request PEM block",
+					"Warning ErrorGenerating Error generating certificate template: error decoding certificate request PEM block: no PEM data was found in given input",
 				},
 
 				ExpectedActions: []testpkg.Action{
@@ -364,7 +364,7 @@ func TestProcessItem(t *testing.T) {
 								Type:               certificatesv1.CertificateFailed,
 								Status:             corev1.ConditionTrue,
 								Reason:             "ErrorGenerating",
-								Message:            "Error generating certificate template: error decoding certificate request PEM block",
+								Message:            "Error generating certificate template: error decoding certificate request PEM block: no PEM data was found in given input",
 								LastTransitionTime: metaFixedClockStart,
 								LastUpdateTime:     metaFixedClockStart,
 							}),

--- a/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
+++ b/pkg/controller/certificatesigningrequests/venafi/venafi_test.go
@@ -755,7 +755,7 @@ func TestProcessItem(t *testing.T) {
 			builder: &testpkg.Builder{
 				CertManagerObjects: []runtime.Object{baseIssuer.DeepCopy()},
 				ExpectedEvents: []string{
-					"Warning ErrorParse Failed to parse returned certificate bundle: error decoding certificate PEM block",
+					"Warning ErrorParse Failed to parse returned certificate bundle: error decoding certificate PEM block: no valid certificates found",
 				},
 				ExpectedActions: []testpkg.Action{
 					testpkg.NewAction(coretesting.NewCreateAction(
@@ -798,7 +798,7 @@ func TestProcessItem(t *testing.T) {
 								Type:               certificatesv1.CertificateFailed,
 								Status:             corev1.ConditionTrue,
 								Reason:             "ErrorParse",
-								Message:            "Failed to parse returned certificate bundle: error decoding certificate PEM block",
+								Message:            "Failed to parse returned certificate bundle: error decoding certificate PEM block: no valid certificates found",
 								LastTransitionTime: metaFixedClockStart,
 								LastUpdateTime:     metaFixedClockStart,
 							}),

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -31,7 +31,7 @@ func DecodePrivateKeyBytes(keyBytes []byte) (crypto.Signer, error) {
 	// decode the private key pem
 	block, _, err := pem.SafeDecodePrivateKey(keyBytes)
 	if err != nil {
-		return nil, errors.NewInvalidData("error decoding private key PEM block")
+		return nil, errors.NewInvalidData("error decoding private key PEM block: %s", err.Error())
 	}
 
 	switch block.Type {
@@ -90,13 +90,14 @@ func decodeMultipleCerts(certBytes []byte, decodeFn func([]byte) (*stdpem.Block,
 		// parse the tls certificate
 		cert, err := x509.ParseCertificate(block.Bytes)
 		if err != nil {
-			return nil, errors.NewInvalidData("error parsing TLS certificate: %s", err.Error())
+			return nil, errors.NewInvalidData("error parsing X.509 certificate: %s", err.Error())
 		}
+
 		certs = append(certs, cert)
 	}
 
 	if len(certs) == 0 {
-		return nil, errors.NewInvalidData("error decoding certificate PEM block")
+		return nil, errors.NewInvalidData("error decoding certificate PEM block: no valid certificates found")
 	}
 
 	return certs, nil
@@ -130,7 +131,7 @@ func DecodeX509CertificateBytes(certBytes []byte) (*x509.Certificate, error) {
 func DecodeX509CertificateRequestBytes(csrBytes []byte) (*x509.CertificateRequest, error) {
 	block, _, err := pem.SafeDecodeCSR(csrBytes)
 	if err != nil {
-		return nil, errors.NewInvalidData("error decoding certificate request PEM block")
+		return nil, errors.NewInvalidData("error decoding certificate request PEM block: %s", err)
 	}
 
 	csr, err := x509.ParseCertificateRequest(block.Bytes)


### PR DESCRIPTION
### Pull Request Motivation

I was creating some test certs for #7642 and observed that the error messages absolutely sucked if I tried to create a CertificateRequest which was far too large:

```text
Warning  RequestFailed  22m (x6 over 22m)  cert-manager-certificates-request-manager  Failed to create CertificateRequest: admission webhook "webhook.cert-manager.io" denied the request: spec.request: Invalid value: []byte{...}: error decoding certificate request PEM block
```

This has two issues:

1. The `[]byte{...}` contained tens of thousands of hex-encoded characters (e.g. `0x30`) from the literal certificate request, making the actual error _huge_
2. The actual error (that the CR is too large) is removed.

This PR should add the actual error message in a few places, and will also truncate the stringified CR specifically when the CR is too large.

### Kind

/kind cleanup

### Release Note

```release-note
Improve error messages when certificates, CRLs or private keys fail admission due to malformed or missing PEM data
```
