### PR TITLE
Use kubernetes 1.33 for local clusters by default

### DIFF
--- a/make/cluster.sh
+++ b/make/cluster.sh
@@ -25,7 +25,7 @@ set -e
 source ./make/kind_images.sh
 
 mode=kind
-k8s_version=1.31
+k8s_version=1.33
 name=kind
 
 help() {

--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -24,7 +24,7 @@ CRI_ARCH := $(HOST_ARCH)
 
 # TODO: this version is also defaulted in ./make/cluster.sh. Make it so that it
 # is set in one place only.
-K8S_VERSION := 1.30
+K8S_VERSION := 1.33
 
 IMAGE_ingressnginx_amd64 := registry.k8s.io/ingress-nginx/controller:v1.12.3@sha256:aadad8e26329d345dea3a69b8deb9f3c52899a97cbaf7e702b8dfbeae3082c15
 IMAGE_kyverno_amd64 := ghcr.io/kyverno/kyverno:v1.12.3@sha256:127def0e41f49fea6e260abf7b1662fe7bdfb9f33e8f9047fb74d0162a5697bb


### PR DESCRIPTION
This doesn't affect CI, where our jobs manually set a Kubernetes version.

I see no reason not to test with the latest version of k8s locally

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
