### PR TITLE
[release-1.18] Bump go to 1.24.6

### DIFF
--- a/make/_shared/klone/01_mod.mk
+++ b/make/_shared/klone/01_mod.mk
@@ -18,7 +18,10 @@
 generate-klone: | $(NEEDS_KLONE)
 	$(KLONE) sync
 
-shared_generate_targets += generate-klone
+# MANUAL CHANGE!
+# generate-klone is removed so we can manually update versions
+# and diverge from upstream klone
+# shared_generate_targets += generate-klone
 
 .PHONY: upgrade-klone
 ## Upgrade klone Makefile modules to latest version

--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -172,7 +172,7 @@ ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-VENDORED_GO_VERSION := 1.24.4
+VENDORED_GO_VERSION := 1.24.6
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -395,10 +395,13 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
-go_linux_arm64_SHA256SUM=d5501ee5aca0f258d5fe9bfaed401958445014495dc115f202d43d5210b45241
-go_darwin_amd64_SHA256SUM=69bef555e114b4a2252452b6e7049afc31fbdf2d39790b669165e89525cd3f5c
-go_darwin_arm64_SHA256SUM=27973684b515eaf461065054e6b572d9390c05e69ba4a423076c160165336470
+# NB: Manually copied from upstream makefile-modules and backported
+# Upstream commit: 6717aee1a6639d3ac352a92321ac8ab4c12783f8
+
+go_linux_amd64_SHA256SUM=bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712
+go_linux_arm64_SHA256SUM=124ea6033a8bf98aa9fbab53e58d134905262d45a022af3a90b73320f3c3afd5
+go_darwin_amd64_SHA256SUM=4a8d7a32052f223e71faab424a69430455b27b3fff5f4e651f9d97c3e51a8746
+go_darwin_arm64_SHA256SUM=4e29202c49573b953be7cc3500e1f8d9e66ddd12faa8cf0939a4951411e09a2a
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
### Pull Request Motivation

Fixes CVE-2025-47907 (which is likely not something cert-manager is actually vulnerable to).

### Kind

/kind cleanup

### Release Note

```release-note
Upgrades Go to v1.24.6
```
