### PR TITLE
fix(ci): changing renovate config to match webhook-cert-lib

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,168 +1,100 @@
 {
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
+  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
-  extends: ["config:base", ":dependencyDashboard", ":gitSignOff"],
-  timezone: "Europe/London",
-  labels: ["dependencies", "renovate"],
-  prConcurrentLimit: 0,
-  prHourlyLimit: 0,
-  semanticCommits: "enabled",
-  semanticCommitScope: "deps",
-  repositories: ["cert-manager/cert-manager"],
-  automerge: false,
-  useBaseBranchConfig: "merge",
-  pruneStaleBranches: true,
+  extends: [
+    'config:best-practices',
+    ':gitSignOff',
+    ':semanticCommits',
+    ':disableVulnerabilityAlerts',
+    ':prConcurrentLimit10', // Set a limit to avoid too many PRs, at least on the first run
+    ':prHourlyLimitNone',
+  ],
+  timezone: 'Europe/London',
+  labels: [
+    'dependencies',
+  ],
   postUpgradeTasks: {
-    // This is a temporary fix to disable errors on a non interactive shell. Longer term, fix this in the makefiles-module.
-    commands: ["export PS1='> ' && make generate"],
-    executionMode: "branch",
-  },
-  postUpdateOptions: ["gomodTidy", "gomodUpdateImportPaths"],
-  vulnerabilityAlerts: {
-    enabled: false,
+    commands: [
+      'make generate',
+    ],
+    executionMode: 'branch',
   },
   packageRules: [
+    // Currently, there seems to be issues with permissions which doesn't allow Renovate to update actions.
     {
-      description: "Kubernetes dependencies",
-      matchDatasources: ["go"],
-      matchPackageNames: ["k8s.io/**", "sigs.k8s.io/**"],
-      groupSlug: "kubernetes",
-      enabled: true,
-    },
-    {
-      description: "Azure dependencies",
-      matchDatasources: ["go"],
-      groupSlug: "azure-sdk-go",
-      enabled: true,
-      matchPackageNames: ["github.com/Azure{/,}**", "github.com/AzureAD{/,}**"],
-    },
-    {
-      description: "Golang dependencies",
-      groupSlug: "go-deps",
-      matchPackageNames: ["golang.org/x/**", "github.com/golang{/,}**", "github.com/golang-jwt{/,}**"],
-      enabled: true,
-    },
-    {
-      description: "AWS dependencies",
-      matchDatasources: ["go"],
-      enabled: true,
-      groupSlug: "aws-sdk-go",
-      matchPackageNames: ["github.com/aws{/,}**"],
-    },
-    {
-      description: "Google dependencies",
-      groupSlug: "googledeps",
-      enabled: true,
-      matchDatasources: ["go"],
-      matchPackageNames: ["github.com/google{/,}**", "github.com/googleapis{/,}**", "/^google.golang.org/"]
-    },
-    {
-      description: "Hashicorp dependencies",
-      enabled: true,
-      matchDatasources: ["go"],
-      groupSlug: "hashicorp",
-      matchPackageNames: ["github.com/hashicorp{/,}**"],
-    },
-    {
-      description: "Monitoring/metrics dependencies",
-      matchDatasources: ["go"],
-      groupSlug: "monitoring",
-      enabled: true,
-      matchPackageNames: ["/github.com/prometheus.*/", "/^go.opentelemetry.io/"]
-    },
-    {
-      description: "Group GitHub Actions",
-      matchManagers: ["github-actions"]
-    },
-    {
-      description: "Pin Go version more conservatively",
-      matchDatasources: ["golang-version"],
-      rangeStrategy: "pin"
-    },
-    {
-      description: "Group testing tools",
-      matchPackageNames: [
-        "github.com/onsi/ginkgo",
-        "github.com/onsi/gomega",
-        "github.com/stretchr/testify"
+      groupName: 'GitHub Actions',
+      matchManagers: [
+        'github-actions',
       ],
-      groupSlug: "testing",
-      matchDatasources: ["go"]
-    },
-    {
-      description: "Security updates should be raised immediately",
-      matchDatasources: ["go"],
-      matchUpdateTypes: ["patch"],
-      prPriority: 10,
-      labels: ["security", "priority/important"],
-      minimumReleaseAge: "0 days",
       matchPackageNames: [
-        "golang.org/x/crypto",
-        "golang.org/x/net",
-        "github.com/golang-jwt/jwt",
-        "google.golang.org/protobuf"
+        '/.*/',
       ],
     },
     {
-      description: "Be careful with Helm dependencies",
-      matchDatasources: ["helm"],
-      rangeStrategy: "bump",
-      enabled: false,
-      commitMessagePrefix: "chore(helm):",
-    },
-    {
-      description: "Group linting tools",
-      groupSlug: "linters",
+      groupName: 'Misc Go deps',
+      matchManagers: [
+        'gomod',
+      ],
       matchPackageNames: [
-        "golangci/golangci-lint",
-        "mvdan.cc/gofumpt",
-        "github.com/daixiang0/gci"
+        '/.*/',
       ],
     },
     {
-      description: "Update cert-manager images",
-      matchDatasources: ["docker"],
-      matchPackageNames: ["/^quay.io/jetstack/cert-manager/"],
+      groupName: 'Kubernetes Go deps',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        '/^sigs.k8s.io/',
+        '/^k8s.io/',
+      ],
     },
     {
-      description: "Disable cert manager updates",
-      matchDatasources: ["go"],
-      matchPackageNames: ["/^github.com/cert-manager/cert-manager$/"],
+      groupName: 'Cloud Go deps',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        '/^github.com/Azure/',
+        '/^github.com/AzureAD/',
+        '/^github.com/aws/',
+      ],
+    },
+    {
+      description: 'Disable all cert-manager related dependencies',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        '/^github.com/cert-manager/',
+      ],
+      allowedVersions: '!/0.0.0/',
       enabled: false,
     },
-    {
-      description: "Limit major updates",
-      matchUpdateTypes: ["major"],
-      dependencyDashboardApproval: true,
-      labels: ["breaking-change", "approval-needed"],
-    }
   ],
   ignorePaths: [
-    "**/vendor/**",
-    "**/node_modules/**",
-    "**/__tests__/**",
-    "**/test/**"
+    '**/vendor/**',
+    '**/node_modules/**',
+    '**/__tests__/**',
+    // The following files are managed from makefile-modules, and should be ignored by Renovate in other projects.
+    '.github/workflows/govulncheck.yaml',
+    '.github/workflows/make-self-upgrade.yaml',
+    '.github/dependabot.yaml',
   ],
   prBodyDefinitions: {
-    Package: "{{depName}}",
-    Type: "{{depType}}",
-    Update: "{{updateType}}",
-    "Current value": "{{currentValue}}",
-    "New value": "{{newValue}}",
-    Change: "`{{displayFrom}}` -> `{{displayTo}}`",
-    References: "{{references}}",
-    "Package file": "{{packageFile}}"
+    Package: '{{depName}}',
   },
-  prBodyColumns: ["Package", "Type", "Update", "Change", "References"],
-  prBodyNotes: [
-    "/kind cleanup",
-    "### Release Note\n```release-note\nNONE\n```",
-    "**Note**: This PR was automatically created by Renovate Bot.",
-    "",
+  prBodyColumns: [
+    'Package',
+    'Type',
+    'Update',
+    'Change',
+    'References',
   ],
-  ignoreDeps: ["launchpad.net/gocheck"],
-  constraints: {
-    go: ">=1.21"
-  }
-
+  prBodyNotes: [
+    '/kind cleanup',
+    '### Release Note\n```release-note\nNONE\n```',
+    '**Note**: This PR was automatically created by Renovate Bot.',
+    '',
+  ],
 }

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,6 +1,8 @@
 name: Renovate
 on:
   workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
 jobs:
   renovate:
     runs-on: ubuntu-latest
@@ -10,21 +12,20 @@ jobs:
       statuses: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
         # the tags so `git describe` returns a valid version.
         # see https://github.com/actions/checkout/issues/701 for extra info about this option
         with: { fetch-depth: 0 }
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@85b17ebd5abf43d1c34c01bd4c8dbb8d45bbc2c7 # v43.0.7
+        uses: renovatebot/github-action@b11417b9eaac3145fe9a8544cee66503724e32b6 # v43.0.8
         with:
           configurationFile: .github/renovate.json5
           token: ${{ secrets.GITHUB_TOKEN }}
         env:
           RENOVATE_REPOSITORIES: '["${{ github.repository }}"]'
-          RENOVATE_PLATFORM_COMMIT: "true"
           RENOVATE_ONBOARDING: "false"
           RENOVATE_PLATFORM: "github"
           LOG_LEVEL: "debug"
-          RENOVATE_ALLOWED_COMMANDS: '["^make"]'
+          RENOVATE_ALLOWED_COMMANDS: '[".*make.*"]'


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Bringing back renovate config after testing in webhook cert lib repo.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
