### PR TITLE
Add new Renovate group for golang.org/x dependencies

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -62,6 +62,16 @@
       ],
     },
     {
+      groupName: 'golang.org/x deps',
+      matchManagers: [
+        'gomod',
+      ],
+      matchPackageNames: [
+        '/^golang.org/x/',
+      ],
+      addLabels: ['skip-review'], // Adding label to allow PRs to automerge
+    },
+    {
       description: 'Disable all cert-manager related dependencies',
       matchManagers: [
         'gomod',


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR adds a new Renovate group for [golang.org/x](https://pkg.go.dev/golang.org/x) dependencies. Since these dependencies could be considered as extensions to the Go stdlib, I am also proposing to allow auto-merge if CI passes.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
