### PR TITLE
Switch to globs instead of regex in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -28,7 +28,7 @@
         'github-actions',
       ],
       matchPackageNames: [
-        '/.*/',
+        '*',
       ],
     },
     {
@@ -37,7 +37,7 @@
         'gomod',
       ],
       matchPackageNames: [
-        '/.*/',
+        '*',
       ],
     },
     {
@@ -46,8 +46,8 @@
         'gomod',
       ],
       matchPackageNames: [
-        '/^sigs.k8s.io/',
-        '/^k8s.io/',
+        'sigs.k8s.io**/**',
+        'k8s.io**/**',
       ],
     },
     {
@@ -56,14 +56,14 @@
         'gomod',
       ],
       matchPackageNames: [
-        '/^github.com/akamai/',
-        '/^github.com/aws/',
-        '/^github.com/Azure/',
-        '/^github.com/AzureAD/',
-        '/^github.com/cloudflare/',
-        '/^github.com/digitalocean/',
-        '/^github.com/Venafi',
-        '/^google.golang.org/api'
+        'github.com/akamai**/**',
+        'github.com/aws**/**',
+        'github.com/Azure**/**',
+        'github.com/AzureAD**/**',
+        'github.com/cloudflare**/**',
+        'github.com/digitalocean**/**',
+        'github.com/Venafi**/**',
+        'google.golang.org/api',
       ],
     },
     {
@@ -72,19 +72,19 @@
         'gomod',
       ],
       matchPackageNames: [
-        '/^golang.org/x/',
+        'golang.org/x**/*',
       ],
       addLabels: ['skip-review'], // Adding label to allow PRs to automerge
     },
     {
-      description: 'Disable all cert-manager related dependencies',
+      description: 'Disable Go pseudo-version updates',
       matchManagers: [
         'gomod',
       ],
       matchPackageNames: [
-        '/^github.com/cert-manager/',
+        '*',
       ],
-      allowedVersions: '!/0.0.0/',
+      "matchCurrentValue": "v0.0.0*",
       enabled: false,
     },
   ],


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I personally find it easier to reason about globs compared to regex, which is also noted in the Renovate docs: https://docs.renovatebot.com/string-pattern-matching/#glob-matching. It seems like we have some matching issues now, and instead of trying to fix the regexes, I suggest migrating to globs, which should work.

The current issue is visible in https://github.com/cert-manager/cert-manager/pull/7982, where Venafi and Google API should be part of the cloud group instead.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
