### PR TITLE
Misc adjustments to Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,9 @@
 {
   $schema: 'https://docs.renovatebot.com/renovate-schema.json',
   enabled: true,
+  enabledManagers: [
+    'gomod'
+  ],
   separateMajorMinor: false,
   extends: [
     'config:best-practices',
@@ -13,6 +16,8 @@
   timezone: 'Europe/London',
   labels: [
     'dependencies',
+    'kind/cleanup',
+    'release-note-none',
   ],
   postUpgradeTasks: {
     commands: [
@@ -21,16 +26,6 @@
     executionMode: 'branch',
   },
   packageRules: [
-    // Currently, there seems to be issues with permissions which doesn't allow Renovate to update actions.
-    {
-      groupName: 'GitHub Actions',
-      matchManagers: [
-        'github-actions',
-      ],
-      matchPackageNames: [
-        '*',
-      ],
-    },
     {
       groupName: 'Misc Go deps',
       matchManagers: [
@@ -62,7 +57,6 @@
         'github.com/AzureAD**/**',
         'github.com/cloudflare**/**',
         'github.com/digitalocean**/**',
-        'github.com/Venafi**/**',
         'google.golang.org/api',
       ],
     },
@@ -88,15 +82,6 @@
       enabled: false,
     },
   ],
-  ignorePaths: [
-    '**/vendor/**',
-    '**/node_modules/**',
-    '**/__tests__/**',
-    // The following files are managed from makefile-modules, and should be ignored by Renovate in other projects.
-    '.github/workflows/govulncheck.yaml',
-    '.github/workflows/make-self-upgrade.yaml',
-    '.github/dependabot.yaml',
-  ],
   prBodyDefinitions: {
     Package: '{{depName}}',
   },
@@ -106,11 +91,5 @@
     'Update',
     'Change',
     'References',
-  ],
-  prBodyNotes: [
-    '/kind cleanup',
-    '### Release Note\n```release-note\nNONE\n```',
-    '**Note**: This PR was automatically created by Renovate Bot.',
-    '',
   ],
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR includes the following changes to the Renovate config:
- Move the Venafi dependencies out of the cloud group. Mainly to get it merged now, but it seems like the release rate of public cloud APIs is considerably higher.
- Add labels instead of customizing the PR body to set kind and release-note-none.
- Remove GitHub actions from the config, as we now know that the GH workflow token cannot get permissions to upgrade workflows. I've also set the enabled Renovate managers to just gomod to avoid some additional config - like the ignored files.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind clenup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
