### PR TITLE
feat(dns01): adding azure private dns support

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -44,6 +44,7 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore,MIT
 github.com/Azure/azure-sdk-for-go/sdk/azidentity,MIT
 github.com/Azure/azure-sdk-for-go/sdk/internal,MIT
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns,MIT
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns,MIT
 github.com/Azure/go-ntlmssp,MIT
 github.com/AzureAD/microsoft-authentication-library-for-go/apps,MIT
 github.com/Khan/genqlient/graphql,MIT

--- a/cmd/controller/LICENSES
+++ b/cmd/controller/LICENSES
@@ -43,6 +43,7 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore,MIT
 github.com/Azure/azure-sdk-for-go/sdk/azidentity,MIT
 github.com/Azure/azure-sdk-for-go/sdk/internal,MIT
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns,MIT
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns,MIT
 github.com/Azure/go-ntlmssp,MIT
 github.com/AzureAD/microsoft-authentication-library-for-go/apps,MIT
 github.com/Khan/genqlient/graphql,MIT

--- a/cmd/controller/go.mod
+++ b/cmd/controller/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 // indirect
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 // indirect
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.5.0 // indirect
 	github.com/Khan/genqlient v0.8.1 // indirect

--- a/cmd/controller/go.sum
+++ b/cmd/controller/go.sum
@@ -16,6 +16,12 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDo
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0/go.mod h1:fSvRkb8d26z9dbL40Uf/OO6Vo9iExtZK3D0ulRV+8M0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0/go.mod h1:GE4m0rnnfwLGX0Y9A9A25Zx5N/90jneT5ABevqzhuFQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -253,6 +253,9 @@ spec:
                             hostedZoneName:
                               description: name of the DNS zone that should be used
                               type: string
+                            isPrivateZone:
+                              description: Required if your hosted zone is private.
+                              type: boolean
                             managedIdentity:
                               description: |-
                                 Auth: Azure Workload Identity or Azure Managed Service Identity:

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -366,6 +366,9 @@ spec:
                                   hostedZoneName:
                                     description: name of the DNS zone that should be used
                                     type: string
+                                  isPrivateZone:
+                                    description: Required if your hosted zone is private.
+                                    type: boolean
                                   managedIdentity:
                                     description: |-
                                       Auth: Azure Workload Identity or Azure Managed Service Identity:

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -365,6 +365,9 @@ spec:
                                   hostedZoneName:
                                     description: name of the DNS zone that should be used
                                     type: string
+                                  isPrivateZone:
+                                    description: Required if your hosted zone is private.
+                                    type: boolean
                                   managedIdentity:
                                     description: |-
                                       Auth: Azure Workload Identity or Azure Managed Service Identity:

--- a/deploy/crds/acme.cert-manager.io_challenges.yaml
+++ b/deploy/crds/acme.cert-manager.io_challenges.yaml
@@ -255,6 +255,9 @@ spec:
                           hostedZoneName:
                             description: name of the DNS zone that should be used
                             type: string
+                          isPrivateZone:
+                            description: Required if your hosted zone is private.
+                            type: boolean
                           managedIdentity:
                             description: |-
                               Auth: Azure Workload Identity or Azure Managed Service Identity:

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -370,6 +370,9 @@ spec:
                                   description: name of the DNS zone that should be
                                     used
                                   type: string
+                                isPrivateZone:
+                                  description: Required if your hosted zone is private.
+                                  type: boolean
                                 managedIdentity:
                                   description: |-
                                     Auth: Azure Workload Identity or Azure Managed Service Identity:

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -369,6 +369,9 @@ spec:
                                   description: name of the DNS zone that should be
                                     used
                                   type: string
+                                isPrivateZone:
+                                  description: Required if your hosted zone is private.
+                                  type: boolean
                                 managedIdentity:
                                   description: |-
                                     Auth: Azure Workload Identity or Azure Managed Service Identity:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.19.1
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.0
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0
+	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0
 	github.com/Venafi/vcert/v5 v5.12.2
 	github.com/akamai/AkamaiOPEN-edgegrid-golang/v12 v12.1.0
 	github.com/aws/aws-sdk-go-v2 v1.39.2

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,12 @@ github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2 h1:9iefClla7iYpfYWdzPCRDo
 github.com/Azure/azure-sdk-for-go/sdk/internal v1.11.2/go.mod h1:XtLgD3ZD34DAaVIIAyG3objl5DynM3CQ/vMcbBNJZGI=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0 h1:lpOxwrQ919lCZoNCd69rVt8u1eLZuMORrGXqy8sNf3c=
 github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns v1.2.0/go.mod h1:fSvRkb8d26z9dbL40Uf/OO6Vo9iExtZK3D0ulRV+8M0=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0 h1:2qsIIvxVT+uE6yrNldntJKlLRgxGbZ85kgtz5SNBhMw=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/v3 v3.1.0/go.mod h1:AW8VEadnhw9xox+VaVd9sP7NjzOAnaZBLRH6Tq3cJ38=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0 h1:yzrctSl9GMIQ5lHu7jc8olOsGjWDCsBpJhWqfGa/YIM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns v1.3.0/go.mod h1:GE4m0rnnfwLGX0Y9A9A25Zx5N/90jneT5ABevqzhuFQ=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0 h1:Dd+RhdJn0OTtVGaeDLZpcumkIVCtA/3/Fo42+eoYvVM=
+github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/resources/armresources v1.2.0/go.mod h1:5kakwfW5CjC9KK+Q4wjXAg+ShuIm2mBMua0ZFj2C8PE=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358 h1:mFRzDkZVAjdal+s7s0MwaRv9igoPqLRdzOLzw/8Xvq8=
 github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/AzureAD/microsoft-authentication-extensions-for-go/cache v0.1.1 h1:WJTmL004Abzc5wDB5VtZG2PJk5ndYDgVacGqfirKxjM=

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -617,6 +617,8 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	Environment AzureDNSEnvironment
 
 	ManagedIdentity *AzureManagedIdentity
+
+	IsPrivateZone bool `json:"isPrivateZone,omitempty"`
 }
 
 type AzureManagedIdentity struct {

--- a/internal/apis/acme/v1/zz_generated.conversion.go
+++ b/internal/apis/acme/v1/zz_generated.conversion.go
@@ -1142,6 +1142,7 @@ func autoConvert_v1_ACMEIssuerDNS01ProviderAzureDNS_To_acme_ACMEIssuerDNS01Provi
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = acme.AzureDNSEnvironment(in.Environment)
 	out.ManagedIdentity = (*acme.AzureManagedIdentity)(unsafe.Pointer(in.ManagedIdentity))
+	out.IsPrivateZone = in.IsPrivateZone
 	return nil
 }
 
@@ -1167,6 +1168,7 @@ func autoConvert_acme_ACMEIssuerDNS01ProviderAzureDNS_To_v1_ACMEIssuerDNS01Provi
 	out.HostedZoneName = in.HostedZoneName
 	out.Environment = acmev1.AzureDNSEnvironment(in.Environment)
 	out.ManagedIdentity = (*acmev1.AzureManagedIdentity)(unsafe.Pointer(in.ManagedIdentity))
+	out.IsPrivateZone = in.IsPrivateZone
 	return nil
 }
 

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1538,6 +1538,13 @@ func schema_pkg_apis_acme_v1_ACMEIssuerDNS01ProviderAzureDNS(ref common.Referenc
 							Ref:         ref("github.com/cert-manager/cert-manager/pkg/apis/acme/v1.AzureManagedIdentity"),
 						},
 					},
+					"isPrivateZone": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Required if your hosted zone is private.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 				},
 				Required: []string{"subscriptionID", "resourceGroupName"},
 			},

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -738,6 +738,10 @@ type ACMEIssuerDNS01ProviderAzureDNS struct {
 	// If set, ClientID, ClientSecret and TenantID must not be set.
 	// +optional
 	ManagedIdentity *AzureManagedIdentity `json:"managedIdentity,omitempty"`
+
+	// Required if your hosted zone is private.
+	// +optional
+	IsPrivateZone bool `json:"isPrivateZone,omitempty"`
 }
 
 // AzureManagedIdentity contains the configuration for Azure Workload Identity or Azure Managed Service Identity

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01providerazuredns.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01providerazuredns.go
@@ -34,6 +34,7 @@ type ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration struct {
 	HostedZoneName    *string                                     `json:"hostedZoneName,omitempty"`
 	Environment       *acmev1.AzureDNSEnvironment                 `json:"environment,omitempty"`
 	ManagedIdentity   *AzureManagedIdentityApplyConfiguration     `json:"managedIdentity,omitempty"`
+	IsPrivateZone     *bool                                       `json:"isPrivateZone,omitempty"`
 }
 
 // ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration constructs a declarative configuration of the ACMEIssuerDNS01ProviderAzureDNS type for use with
@@ -103,5 +104,13 @@ func (b *ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration) WithEnvironment(valu
 // If called multiple times, the ManagedIdentity field is set to the value of the last call.
 func (b *ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration) WithManagedIdentity(value *AzureManagedIdentityApplyConfiguration) *ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration {
 	b.ManagedIdentity = value
+	return b
+}
+
+// WithIsPrivateZone sets the IsPrivateZone field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the IsPrivateZone field is set to the value of the last call.
+func (b *ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration) WithIsPrivateZone(value bool) *ACMEIssuerDNS01ProviderAzureDNSApplyConfiguration {
+	b.IsPrivateZone = &value
 	return b
 }

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -401,6 +401,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: hostedZoneName
       type:
         scalar: string
+    - name: isPrivateZone
+      type:
+        scalar: boolean
     - name: managedIdentity
       type:
         namedType: com.github.cert-manager.cert-manager.pkg.apis.acme.v1.AzureManagedIdentity

--- a/pkg/issuer/acme/dns/azuredns/azuredns_types.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns_types.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azuredns
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	dns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+	privatedns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/privatedns/armprivatedns"
+)
+
+// PrivateRecordsClient is an interface shim to make sure we can mock the clients since RecordSetsClient are structs and not interfaces.
+type PrivateRecordsClient interface {
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, privateZoneName string, recordType privatedns.RecordType, relativeRecordSetName string, parameters privatedns.RecordSet, options *privatedns.RecordSetsClientCreateOrUpdateOptions) (privatedns.RecordSetsClientCreateOrUpdateResponse, error)
+	Get(ctx context.Context, resourceGroupName string, privateZoneName string, recordType privatedns.RecordType, relativeRecordSetName string, options *privatedns.RecordSetsClientGetOptions) (privatedns.RecordSetsClientGetResponse, error)
+	Delete(ctx context.Context, resourceGroupName string, privateZoneName string, recordType privatedns.RecordType, relativeRecordSetName string, options *privatedns.RecordSetsClientDeleteOptions) (privatedns.RecordSetsClientDeleteResponse, error)
+}
+
+// PrivateZonesClient is an interface shim for mocking the PrivateZonesClient since they are structs and not interfaces.
+type PrivateZonesClient interface {
+	Get(ctx context.Context, resourceGroupName string, privateZoneName string, options *privatedns.PrivateZonesClientGetOptions) (privatedns.PrivateZonesClientGetResponse, error)
+}
+
+type TXTRecordSet interface {
+	GetTXTRecords() [][]*string
+	AppendTXTRecord(val string)
+}
+
+type PrivateTXTRecordSet struct {
+	RS *privatedns.RecordSet
+}
+
+func (ps *PrivateTXTRecordSet) GetTXTRecords() [][]*string {
+	if ps.RS == nil || ps.RS.Properties == nil {
+		return nil
+	}
+
+	out := make([][]*string, 0, len(ps.RS.Properties.TxtRecords))
+	for _, txtRec := range ps.RS.Properties.TxtRecords {
+		out = append(out, txtRec.Value)
+	}
+
+	return out
+}
+
+func (ps *PrivateTXTRecordSet) AppendTXTRecord(value string) {
+	if ps.RS == nil || ps.RS.Properties == nil {
+		return
+	}
+
+	var found bool
+	var records []*privatedns.TxtRecord
+	for _, r := range ps.RS.Properties.TxtRecords {
+		if len(r.Value) > 0 && *r.Value[0] == value {
+			found = true
+		} else {
+			records = append(records, r)
+		}
+	}
+
+	if !found {
+		ps.RS.Properties.TxtRecords = append(ps.RS.Properties.TxtRecords, &privatedns.TxtRecord{
+			Value: []*string{to.Ptr(value)},
+		})
+	} else {
+		ps.RS.Properties.TxtRecords = records
+	}
+}
+
+type PublicTXTRecordSet struct {
+	RS *dns.RecordSet
+}
+
+func (ps *PublicTXTRecordSet) GetTXTRecords() [][]*string {
+	if ps.RS == nil || ps.RS.Properties == nil {
+		return nil
+	}
+
+	out := make([][]*string, 0, len(ps.RS.Properties.TxtRecords))
+	for _, txtRec := range ps.RS.Properties.TxtRecords {
+		out = append(out, txtRec.Value)
+	}
+
+	return out
+}
+
+func (ps *PublicTXTRecordSet) AppendTXTRecord(value string) {
+	if ps.RS == nil || ps.RS.Properties == nil {
+		return
+	}
+
+	var found bool
+	var records []*dns.TxtRecord
+	for _, r := range ps.RS.Properties.TxtRecords {
+		if len(r.Value) > 0 && *r.Value[0] == value {
+			found = true
+		} else {
+			records = append(records, r)
+		}
+	}
+
+	if !found {
+		ps.RS.Properties.TxtRecords = append(ps.RS.Properties.TxtRecords, &dns.TxtRecord{
+			Value: []*string{to.Ptr(value)},
+		})
+	} else {
+		ps.RS.Properties.TxtRecords = records
+	}
+}

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -62,7 +62,7 @@ type dnsProviderConstructors struct {
 	cloudDNS     func(ctx context.Context, project string, serviceAccount []byte, dns01Nameservers []string, ambient bool, hostedZoneName string) (*clouddns.DNSProvider, error)
 	cloudFlare   func(email, apikey, apiToken string, dns01Nameservers []string, userAgent string) (*cloudflare.DNSProvider, error)
 	route53      func(ctx context.Context, accessKey, secretKey, hostedZoneID, region, role, webIdentityToken string, ambient bool, dns01Nameservers []string, userAgent string) (*route53.DNSProvider, error)
-	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity) (*azuredns.DNSProvider, error)
+	azureDNS     func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity, opts ...azuredns.ProviderOption) (*azuredns.DNSProvider, error)
 	acmeDNS      func(host string, accountJson []byte, dns01Nameservers []string) (*acmedns.DNSProvider, error)
 	digitalOcean func(token string, dns01Nameservers []string, userAgent string) (*digitalocean.DNSProvider, error)
 }
@@ -408,6 +408,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			s.DNS01Nameservers,
 			canUseAmbientCredentials,
 			providerConfig.AzureDNS.ManagedIdentity,
+			azuredns.WithPrivateZone(providerConfig.AzureDNS.IsPrivateZone),
 		)
 		if err != nil {
 			return nil, nil, fmt.Errorf("error instantiating azuredns challenge solver: %s", err)

--- a/pkg/issuer/acme/dns/util_test.go
+++ b/pkg/issuer/acme/dns/util_test.go
@@ -133,7 +133,7 @@ func newFakeDNSProviders() *fakeDNSProviders {
 			f.call("route53", accessKey, secretKey, hostedZoneID, region, role, webIdentityToken, ambient, util.RecursiveNameservers)
 			return nil, nil
 		},
-		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity) (*azuredns.DNSProvider, error) {
+		azureDNS: func(environment, clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName string, dns01Nameservers []string, ambient bool, managedIdentity *cmacme.AzureManagedIdentity, opts ...azuredns.ProviderOption) (*azuredns.DNSProvider, error) {
 			f.call("azuredns", clientID, clientSecret, subscriptionID, tenantID, resourceGroupName, hostedZoneName, util.RecursiveNameservers, ambient, managedIdentity)
 			return nil, nil
 		},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Adding azure private dns support to bring it to parity with route53 which also supports private zones.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
updated azuredns provider to support private zones
```

CyberArk tracker: [VC-45095](https://venafi.atlassian.net/browse/VC-45095) <!-- do not edit this line, will be re-added automatically -->