### PR TITLE
feat: promote CAInjectorMerging to beta and enable by default

### DIFF
--- a/internal/cainjector/feature/features.go
+++ b/internal/cainjector/feature/features.go
@@ -49,6 +49,7 @@ const (
 
 	// Owner: @ThatsMrTalbot
 	// Alpha: v1.17
+	// Beta: v1.19
 	//
 	// CAInjectorMerging changes the ca-injector to merge new certs in instead
 	// of replacing them outright.
@@ -68,5 +69,5 @@ func init() {
 // Where utilfeature is github.com/cert-manager/cert-manager/pkg/util/feature.
 var cainjectorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
 	ServerSideApply:   {Default: false, PreRelease: featuregate.Alpha},
-	CAInjectorMerging: {Default: false, PreRelease: featuregate.Alpha},
+	CAInjectorMerging: {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This pull request updates the `CAInjectorMerging` feature gate in the CA Injector component, promoting it from Alpha to Beta status and enabling it by default. This means the feature, which merges new certs instead of replacing them outright, is now considered more stable and will be active unless explicitly disabled.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The `CAInjectorMerging` feature has been promoted to BETA and is now enabled by default
```
