### PR TITLE
Fix misleading gateway-api import alias

### DIFF
--- a/test/e2e/util/util.go
+++ b/test/e2e/util/util.go
@@ -40,7 +40,7 @@ import (
 	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	gwapiv1beta1 "sigs.k8s.io/gateway-api/apis/v1"
+	gwapi "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/cert-manager/cert-manager/e2e-tests/framework/log"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
@@ -312,19 +312,19 @@ func pathTypePrefix() *networkingv1.PathType {
 // watching the 'foo' gateway class, so this Gateway will not be used to
 // actually route traffic, but can be used to test cert-manager controllers that
 // sync Gateways, such as gateway-shim.
-func NewGateway(gatewayName, ns, secretName string, annotations map[string]string, dnsNames ...string) *gwapiv1beta1.Gateway {
+func NewGateway(gatewayName, ns, secretName string, annotations map[string]string, dnsNames ...string) *gwapi.Gateway {
 
-	return &gwapiv1beta1.Gateway{
+	return &gwapi.Gateway{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        gatewayName,
 			Annotations: annotations,
 		},
-		Spec: gwapiv1beta1.GatewaySpec{
+		Spec: gwapi.GatewaySpec{
 			GatewayClassName: "foo",
-			Listeners: []gwapiv1beta1.Listener{{
-				AllowedRoutes: &gwapiv1beta1.AllowedRoutes{
-					Namespaces: &gwapiv1beta1.RouteNamespaces{
-						From: func() *gwapiv1beta1.FromNamespaces { f := gwapiv1beta1.NamespacesFromSame; return &f }(),
+			Listeners: []gwapi.Listener{{
+				AllowedRoutes: &gwapi.AllowedRoutes{
+					Namespaces: &gwapi.RouteNamespaces{
+						From: func() *gwapi.FromNamespaces { f := gwapi.NamespacesFromSame; return &f }(),
 						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{
 							"gw": gatewayName,
 						}},
@@ -332,16 +332,16 @@ func NewGateway(gatewayName, ns, secretName string, annotations map[string]strin
 					Kinds: nil,
 				},
 				Name:     "acme-solver",
-				Protocol: gwapiv1beta1.TLSProtocolType,
-				Port:     gwapiv1beta1.PortNumber(443),
-				Hostname: (*gwapiv1beta1.Hostname)(&dnsNames[0]),
-				TLS: &gwapiv1beta1.GatewayTLSConfig{
-					CertificateRefs: []gwapiv1beta1.SecretObjectReference{
+				Protocol: gwapi.TLSProtocolType,
+				Port:     gwapi.PortNumber(443),
+				Hostname: (*gwapi.Hostname)(&dnsNames[0]),
+				TLS: &gwapi.GatewayTLSConfig{
+					CertificateRefs: []gwapi.SecretObjectReference{
 						{
-							Kind:      func() *gwapiv1beta1.Kind { k := gwapiv1beta1.Kind("Secret"); return &k }(),
-							Name:      gwapiv1beta1.ObjectName(secretName),
-							Group:     func() *gwapiv1beta1.Group { g := gwapiv1beta1.Group(corev1.GroupName); return &g }(),
-							Namespace: (*gwapiv1beta1.Namespace)(&ns),
+							Kind:      func() *gwapi.Kind { k := gwapi.Kind("Secret"); return &k }(),
+							Name:      gwapi.ObjectName(secretName),
+							Group:     func() *gwapi.Group { g := gwapi.Group(corev1.GroupName); return &g }(),
+							Namespace: (*gwapi.Namespace)(&ns),
 						},
 					},
 				},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

While working on https://github.com/cert-manager/cert-manager/pull/8018, the misleading import alias caused me a lot of confusion. This aligns this import alias with the same import in other files.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
