### PR TITLE
Fix broken Gateway API E2E tests by loading the deleted Bitnami Envoy image from a different repo

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -33,6 +33,10 @@ IMAGE_vault_amd64 := docker.io/hashicorp/vault:1.14.1@sha256:436d056e8e2a96c7356
 IMAGE_bind_amd64 := europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/bind9:9.18-22.04_beta@sha256:8c45ba363b2921950161451cf3ff58dff1816fa46b16fb8fa601d5500cdc2ffc
 IMAGE_sampleexternalissuer_amd64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:964b378fe0dda7fc38ce3f211c3b24c780e44cef13c39d3206de985bad67f294
 IMAGE_projectcontour_amd64 := ghcr.io/projectcontour/contour:v1.29.1@sha256:bb7af851ac5832c315e0863d12ed583cee54c495d58a206f1d0897647505ed70
+# We use the bitnamilegacy image because Bitnami are deprecating support for
+# non-hardened, Debian-based software images in its free tier. See
+# https://github.com/bitnami/containers/issues/83267
+IMAGE_projectcontourenvoy_amd64 := docker.io/bitnamilegacy/envoy:1.29.5-debian-12-r0@sha256:34be30978b7765699c4548a393374a5fea64613352078ec49581be26c2024dec
 
 IMAGE_ingressnginx_arm64 := registry.k8s.io/ingress-nginx/controller:v1.12.3@sha256:800048a4cdf4ad487a17f56d22ec6be7a34248fc18900d945bc869fee4ccb2f7
 IMAGE_kyverno_arm64 := ghcr.io/kyverno/kyverno:v1.12.3@sha256:c076a1ba9e0fb33d8eca3e7499caddfa3bb4f5e52e9dee589d8476ae1688cd34
@@ -41,6 +45,10 @@ IMAGE_vault_arm64 := docker.io/hashicorp/vault:1.14.1@sha256:27dd264f3813c71a667
 IMAGE_bind_arm64 := europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/bind9:9.18-22.04_beta@sha256:7fcfebdfacf52fa0dee2b1ae37ebe235fe169cbc404974c396937599ca69da6f
 IMAGE_sampleexternalissuer_arm64 := ghcr.io/cert-manager/sample-external-issuer/controller:v0.4.0@sha256:bdff00089ec7581c0d12414ce5ad1c6ccf5b6cacbfb0b0804fefe5043a1cb849
 IMAGE_projectcontour_arm64 := ghcr.io/projectcontour/contour:v1.29.1@sha256:dbfec77951e123bf383a09412a51df218b716aaf3fe7b2778bb2f208ac495dc5
+# We use the bitnamilegacy image because Bitnami are deprecating support for
+# non-hardened, Debian-based software images in its free tier. See
+# https://github.com/bitnami/containers/issues/83267
+IMAGE_projectcontourenvoy_arm64 := docker.io/bitnamilegacy/envoy:1.29.5-debian-12-r0@sha256:0862aad6a034e822ef6cc0e2f2af697ec924d58b8e9acffba48be5b29a9d9776
 
 # We are using @inteon's fork of Pebble, which adds support for signing CSRs with
 # Ed25519 keys:
@@ -166,7 +174,7 @@ preload-kind-image: $(call image-tar,kind) | $(NEEDS_CTR)
 	$(CTR) inspect $(IMAGE_kind_$(CRI_ARCH)) 2>/dev/null >&2 || $(CTR) load -i $<
 endif
 
-LOAD_TARGETS=load-$(call image-tar,ingressnginx) load-$(call image-tar,kyverno) load-$(call image-tar,kyvernopre) load-$(call image-tar,bind) load-$(call image-tar,projectcontour) load-$(call image-tar,sampleexternalissuer) load-$(call local-image-tar,vaultretagged) load-$(call local-image-tar,pebble) load-$(call local-image-tar,samplewebhook) load-$(bin_dir)/containers/cert-manager-controller-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-acmesolver-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-cainjector-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-webhook-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-startupapicheck-linux-$(CRI_ARCH).tar
+LOAD_TARGETS=load-$(call image-tar,ingressnginx) load-$(call image-tar,kyverno) load-$(call image-tar,kyvernopre) load-$(call image-tar,bind) load-$(call image-tar,projectcontour) load-$(call image-tar,projectcontourenvoy) load-$(call image-tar,sampleexternalissuer) load-$(call local-image-tar,vaultretagged) load-$(call local-image-tar,pebble) load-$(call local-image-tar,samplewebhook) load-$(bin_dir)/containers/cert-manager-controller-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-acmesolver-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-cainjector-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-webhook-linux-$(CRI_ARCH).tar load-$(bin_dir)/containers/cert-manager-startupapicheck-linux-$(CRI_ARCH).tar
 .PHONY: $(LOAD_TARGETS)
 $(LOAD_TARGETS): load-%: % $(bin_dir)/scratch/kind-exists | $(NEEDS_KIND)
 	$(KIND) load image-archive --name=$(shell cat $(bin_dir)/scratch/kind-exists) $*
@@ -192,7 +200,7 @@ $(LOAD_TARGETS): load-%: % $(bin_dir)/scratch/kind-exists | $(NEEDS_KIND)
 #    tag. The rule will fail and the new digest will be printed out.
 # 3. It prevents us accidentally using the wrong digest when we pin the images
 #    in the variables above.
-$(call image-tar,vault) $(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(call image-tar,projectcontour) $(call image-tar,sampleexternalissuer) $(call image-tar,ingressnginx): $(bin_dir)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
+$(call image-tar,vault) $(call image-tar,kyverno) $(call image-tar,kyvernopre) $(call image-tar,bind) $(call image-tar,projectcontour) $(call image-tar,projectcontourenvoy) $(call image-tar,sampleexternalissuer) $(call image-tar,ingressnginx): $(bin_dir)/downloaded/containers/$(CRI_ARCH)/%.tar: | $(NEEDS_CRANE)
 	@$(eval IMAGE=$(subst +,:,$*))
 	@$(eval IMAGE_WITHOUT_DIGEST=$(shell cut -d@ -f1 <<<"$(IMAGE)"))
 	@$(eval DIGEST=$(subst $(IMAGE_WITHOUT_DIGEST)@,,$(IMAGE)))
@@ -475,12 +483,18 @@ e2e-setup-samplewebhook: load-$(call local-image-tar,samplewebhook) e2e-setup-ce
 		samplewebhook make/config/samplewebhook/chart >/dev/null
 
 .PHONY: e2e-setup-projectcontour
-e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar,projectcontour) make/config/projectcontour/gateway.yaml make/config/projectcontour/contour.yaml $(bin_dir)/scratch/kind-exists | $(NEEDS_HELM) $(NEEDS_KUBECTL)
-	@$(eval TAG=$(shell tar xfO $< manifest.json | jq '.[0].RepoTags[0]' -r | cut -d: -f2))
+e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar,projectcontour) $(call image-tar,projectcontourenvoy) load-$(call image-tar,projectcontourenvoy) make/config/projectcontour/gateway.yaml make/config/projectcontour/contour.yaml $(bin_dir)/scratch/kind-exists | $(NEEDS_HELM) $(NEEDS_KUBECTL)
+	@$(eval CONTOUR_TAG=$(shell tar xfO $< manifest.json | jq '.[0].RepoTags[0]' -r | cut -d: -f2))
+	@$(eval ENVOY_TAG=$(shell tar xfO $(call image-tar,projectcontourenvoy) manifest.json | jq '.[0].RepoTags[0]' -r | cut -d: -f2))
 	$(HELM) repo add bitnami --force-update https://charts.bitnami.com/bitnami >/dev/null
 	# Warning: When upgrading the version of this helm chart, bear in mind that the IMAGE_projectcontour_* images above might need to be updated, too.
 	# Each helm chart version in the bitnami repo corresponds to an underlying application version. Check application versions and chart versions with:
 	# $$ helm search repo bitnami -l | grep -E "contour[^-]"
+	#
+	# TODO(wallrj): The free version of the Bitnami contour chart and the
+	# associated images are deprecated. We are using the docker.io/bitnamilegacy
+	# registry as a stop gap measure until we can move to a different chart. See:
+	# https://github.com/bitnami/charts/blob/main/bitnami/contour/README.md#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog
 	$(HELM) upgrade \
 		--install \
 		--wait \
@@ -491,13 +505,17 @@ e2e-setup-projectcontour: $(call image-tar,projectcontour) load-$(call image-tar
 		--set contour.ingressClass.default=false \
 		--set contour.image.registry=ghcr.io \
 		--set contour.image.repository=projectcontour/contour \
-		--set contour.image.tag=$(TAG) \
+		--set contour.image.tag=$(CONTOUR_TAG) \
 		--set contour.image.pullPolicy=Never \
 		--set contour.service.type=ClusterIP \
 		--set contour.service.externalTrafficPolicy="" \
 		--set envoy.service.type=ClusterIP \
 		--set envoy.service.externalTrafficPolicy="" \
 		--set envoy.service.clusterIP=${SERVICE_IP_PREFIX}.14 \
+		--set envoy.image.registry=docker.io/bitnamilegacy \
+		--set envoy.image.repository=envoy \
+		--set envoy.image.tag=$(ENVOY_TAG) \
+		--set envoy.image.pullPolicy=Never \
 		--set-file configInline=make/config/projectcontour/contour.yaml \
 		projectcontour bitnami/contour >/dev/null
 	$(KUBECTL) apply --server-side -f make/config/projectcontour/gateway.yaml


### PR DESCRIPTION
This PR fixes broken Gateway API E2E tests by addressing the [deprecation of Bitnami's non-hardened Debian images in their free tier](https://github.com/bitnami/charts/blob/main/bitnami/contour/README.md#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog). The solution involves switching to the bitnamilegacy registry for the Envoy image while maintaining the same functionality.

Bitnami wrote:
> Starting August 28th, over two weeks, all existing container images, including older or versioned tags (e.g., 2.50.0, 10.6), will be migrated from the public catalog (docker.io/bitnami) to the “Bitnami Legacy” repository (docker.io/bitnamilegacy), where they will no longer receive updates.
> https://github.com/bitnami/charts/blob/main/bitnami/contour/README.md#%EF%B8%8F-important-notice-upcoming-changes-to-the-bitnami-catalog

Why did the E2E tests suddenly started failing on 30 September 2025?  
<img width="1920" height="1092" alt="image" src="https://github.com/user-attachments/assets/95a3c69d-308f-4daf-99e5-cad862933615" />
-- https://testgrid.k8s.io/cert-manager-periodics-master#ci-cert-manager-master-e2e-v1-34

Because Bitnami finally deleted the Docker images:
> After evaluating the impact and community feedback, the Bitnami team has postponed the deletion of the Bitnami public catalog (docker.io/bitnami) until September 29th to give users more time to adapt to the upcoming changes.

You can see this in the kubelet logs among the [Prow artifacts](https://storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/8122/pull-cert-manager-master-e2e-v1-34/1972990600860930048/artifacts/cert-manager-e2e-logs/kind-control-plane/kubelet.log)https://[storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/8122/pull-cert-manager-master-e2e-v1-34/1972990600860930048/artifacts/cert-manager-e2e-logs/kind-control-plane/kubelet.log](https://storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/8122/pull-cert-manager-master-e2e-v1-34/1972990600860930048/artifacts/cert-manager-e2e-logs/kind-control-plane/kubelet.log):

> Sep 30 12:17:24 kind-control-plane kubelet[781]: E0930 12:17:24.559315     781 pod_workers.go:1324] "Error syncing pod, skipping" err="failed to \"StartContainer\" for \"envoy\" with ImagePullBackOff: \"Back-off pulling image \\\"docker.io/bitnami/envoy:1.29.5-debian-12-r0\\\": ErrImagePull: rpc error: code = NotFound desc = failed to pull and unpack image \\\"docker.io/bitnami/envoy:1.29.5-debian-12-r0\\\": failed to resolve reference \\\"docker.io/bitnami/envoy:1.29.5-debian-12-r0\\\": docker.io/bitnami/envoy:1.29.5-debian-12-r0: not found\"" pod="projectcontour/projectcontour-envoy-x8m2f" podUID="bb95f79a-f25d-4535-9558-685edec99412"

Changes:
- Add IMAGE_projectcontourenvoy_amd64 and IMAGE_projectcontourenvoy_arm64
- Include projectcontourenvoy in LOAD_TARGETS and image-tar downloads
- Update e2e-setup-projectcontour to load envoy image and extract tag
- Set Helm envoy image to bitnamilegacy/envoy and pullPolicy Never
- Rationale: Bitnami deprecated non-hardened Debian images in free tier


```release-note
NONE
```

## Testing

The E2E tests now pass:
 * https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/8124/pull-cert-manager-master-e2e-v1-34/1973073333259866112

You can see the envoy image in the images.log among the test artifacts: 
 * https://storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_cert-manager/8124/pull-cert-manager-master-e2e-v1-34/1973073333259866112/artifacts/cert-manager-e2e-logs/kind-control-plane/images.log

```
IMAGE                                                                                    TAG                                  IMAGE ID            SIZE
registry.k8s.io/ingress-nginx/kube-webhook-certgen                                       <none>                               0ea86a0862033       28.3MB
docker.io/bitnamilegacy/envoy                                                            1.29.5-debian-12-r0                  5f6c4df452e61       71.2MB
docker.io/kindest/kindnetd                                                               v20250512-df8de77b                   409467f978b4a       44.4MB
docker.io/kindest/local-path-helper                                                      v20241212-8ac705d0                   baa0d31514ee5       3.08MB
docker.io/kindest/local-path-provisioner                                                 v20250214-acbabc1a                   bbb6209cc873b       22.5MB
docker.io/library/cert-manager-acmesolver-amd64                                          v1.18.0-beta.0-369-gd13fa856bee178   695565076b39b       18.6MB
docker.io/library/cert-manager-cainjector-amd64                                          v1.18.0-beta.0-369-gd13fa856bee178   b868cdc4b4cd6       39.1MB
docker.io/library/cert-manager-controller-amd64                                          v1.18.0-beta.0-369-gd13fa856bee178   a584f2208b359       82.8MB
docker.io/library/cert-manager-startupapicheck-amd64                                     v1.18.0-beta.0-369-gd13fa856bee178   113812e1be666       35.5MB
docker.io/library/cert-manager-webhook-amd64                                             v1.18.0-beta.0-369-gd13fa856bee178   b9abe3eb7d756       69.1MB
docker.io/local/pebble                                                                   local                                49c5a18cb7d3f       14.8MB
docker.io/local/samplewebhook                                                            local                                c0600e03450be       110MB
docker.io/local/vault                                                                    local                                21ecef7f5c367       103MB
europe-west1-docker.pkg.dev/cert-manager-tests-trusted/cert-manager-infra-images/bind9   9.18-22.04_beta                      6793f3018cc8f       61.2MB
gcr.io/kubebuilder/kube-rbac-proxy                                                       v0.13.1                              eb5a02daef2fe       24.5MB
ghcr.io/cert-manager/sample-external-issuer/controller                                   v0.4.0                               7198bfd8baff6       25.1MB
ghcr.io/projectcontour/contour                                                           v1.29.1                              1d3f8aed4aeed       16.2MB
registry.k8s.io/coredns/coredns                                                          v1.12.1                              52546a367cc9e       22.4MB
registry.k8s.io/etcd                                                                     3.6.4-0                              5f1f5298c888d       74.3MB
registry.k8s.io/ingress-nginx/controller                                                 v1.12.3                              158e2f2d90f21       106MB
registry.k8s.io/kube-apiserver-amd64                                                     v1.34.0                              90550c43ad2bc       89MB
registry.k8s.io/kube-apiserver                                                           v1.34.0                              90550c43ad2bc       89MB
registry.k8s.io/kube-controller-manager-amd64                                            v1.34.0                              a0af72f2ec6d6       76MB
registry.k8s.io/kube-controller-manager                                                  v1.34.0                              a0af72f2ec6d6       76MB
registry.k8s.io/kube-proxy-amd64                                                         v1.34.0                              df0860106674d       73.1MB
registry.k8s.io/kube-proxy                                                               v1.34.0                              df0860106674d       73.1MB
registry.k8s.io/kube-scheduler-amd64                                                     v1.34.0                              46169d968e920       53.8MB
registry.k8s.io/kube-scheduler                                                           v1.34.0                              46169d968e920       53.8MB
registry.k8s.io/pause     
```

CyberArk tracker: [VC-45763](https://venafi.atlassian.net/browse/VC-45763) <!-- do not edit this line, will be re-added automatically -->