### PR TITLE
feat(design): adding initial design for certificate renewal

### DIFF
--- a/design/20250920.certificate-renewal-control.md
+++ b/design/20250920.certificate-renewal-control.md
@@ -13,6 +13,7 @@
 - [Proposed API](#proposed-api)
   - [CRD Snippet](#crd-snippet)
   - [Field Definitions](#field-definitions)
+  - [High Level Diagram](#high-level-diagram)
   - [Timezones](#timezones)
 - [Controller logic](#controller-logic)
   - [Current behavior](#current-behavior)
@@ -132,6 +133,18 @@ spec:
 
 Notes: - `renewal.policy=RenewBefore` and `renewal.policy=EarliestWindow` without `windows` would behave the same way as today
 where they would try to get a `renewalTime` before `renewBefore`.
+
+### High level diagram
+
+| **renewal.policy** | **Windows defined?** | **RenewalTime Decision** | **Statuses Added to Certificate** |
+|--------------------|----------------------|---------------------------|-----------------------------------|
+| **RenewBefore** | **No** | Same as existing behavior — choose `renewBefore` (i.e. `NotAfter - X`). | *None (normal behavior).* |
+| **RenewBefore** | **Yes** | 1. Try to find the **latest** time within the allowed windows that is `≤ renewBefore`.<br>2. If **no** such time exists in any prior window, **pick the next** allowed window (the next forward slot). | *Add appropriate conditions to the cert status.* |
+| **EarliestWindow** | **No** | Same as existing behavior — behaves like `RenewBefore` (i.e., respect `renewBefore` as today). | *None (normal behavior).* |
+| **EarliestWindow** | **Yes** | **Ignore** `renewBefore` for window selection. Find the **earliest** allowed time **within** the configured windows (the earliest window slot). | *Add appropriate conditions to the cert status.* |
+| **Disabled** | — | Certificate renewal is **disabled** (no renewal scheduling). | *None — renewal not performed.* |
+
+*Tip:* When `renewal.windows` are omitted, both `RenewBefore` and `EarliestWindow` fall back to the existing renew-before behavior, so the table's "No windows" rows reflect current behavior.
 
 ### Timezones
 


### PR DESCRIPTION
Rendered proposal: [20250920.certificate-renewal-control.md](https://github.com/hjoshi123/cert-manager/blob/feat/cert-renewal-drafts/design/20250920.certificate-renewal-control.md)

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Design of a new feature that would allow users to define a Certificate renewal policy. This PR was motivated by https://github.com/cert-manager/cert-manager/pull/8091 and https://github.com/cert-manager/cert-manager/issues/6754.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind design
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```

CyberArk tracker: [VC-46166](https://venafi.atlassian.net/browse/VC-46166) <!-- do not edit this line, will be re-added automatically -->