### PR TITLE
bugfix: update secret function adapt ssa feature gate

### DIFF
--- a/test/unit/coreclients/secrets.go
+++ b/test/unit/coreclients/secrets.go
@@ -75,6 +75,14 @@ func SetFakeSecretsGetterGet(s *corev1.Secret, err error) FakeSecretsGetterModif
 	}
 }
 
+// SetFakeSecretsGetterUpdateFn is a function that can be used to inject code
+// when the FakeSecretsGetter is Updated.
+func SetFakeSecretsGetterUpdateFn(fn func() (*corev1.Secret, error)) FakeSecretsGetterModifier {
+	return func(f *FakeSecretsGetter) {
+		f.c.UpdateFn = fn
+	}
+}
+
 // SetFakeSecretsGetterApplyFn is a function that can be used to inject code
 // when the FakeSecretsGetter is Applied.
 func SetFakeSecretsGetterApplyFn(fn ApplyFn) FakeSecretsGetterModifier {


### PR DESCRIPTION
### Pull Request Motivation

When I deployed the cert-manager 1.16 version to the k8s 1.22 cluster, I encountered an error: "re-queuing item due to error processing" err="failed to apply secret tcs-system/tcs-admission-webhook-tls: 415: Unsupported Media Type" logger="cert-manager.controller". I checked the code and found that in the module where the controller updates the secret, there was no control using the ssa feature gate. Because I noticed that the default value of ServerSideApply was false. After I redeployed using the modified code to the cluster, it worked normally.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
