### PR TITLE
fix(util): report province mismatch correctly

### DIFF
--- a/pkg/util/pki/match.go
+++ b/pkg/util/pki/match.go
@@ -189,7 +189,7 @@ func RequestMatchesSpec(req *cmapi.CertificateRequest, spec cmapi.CertificateSpe
 			violations = append(violations, "spec.subject.postCodes")
 		}
 		if !util.EqualUnsorted(x509req.Subject.Province, spec.Subject.Provinces) {
-			violations = append(violations, "spec.subject.postCodes")
+			violations = append(violations, "spec.subject.provinces")
 		}
 		if !util.EqualUnsorted(x509req.Subject.StreetAddress, spec.Subject.StreetAddresses) {
 			violations = append(violations, "spec.subject.streetAddresses")


### PR DESCRIPTION
### Pull Request Motivation

RequestMatchesSpec now appends spec.subject.provinces when the CSR province list differs, avoiding duplicate post code violation messages.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
