### PR TITLE
fix(chart): set valid job label on pod/service monitors

### DIFF
--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -27,7 +27,7 @@ metadata:
     {{- end }}
 {{- end }}
 spec:
-  jobLabel: {{ template "cert-manager.fullname" . }}
+  jobLabel: app.kubernetes.io/name
   selector:
     matchExpressions:
       - key: app.kubernetes.io/name

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -29,7 +29,7 @@ metadata:
     {{- end }}
 {{- end }}
 spec:
-  jobLabel: {{ template "cert-manager.fullname" . }}
+  jobLabel: app.kubernetes.io/name
   selector:
     matchExpressions:
       - key: app.kubernetes.io/name


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

Fixes #7088.

As per the Prometheus Operator documentation, the `jobLabel` field on both [service](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.ServiceMonitorSpec) and [pod](https://prometheus-operator.dev/docs/api-reference/api/#monitoring.coreos.com/v1.PodMonitorSpec) monitors refers to a label on the monitored resource, which is set as the label of metrics pulled into Prometheus.

If that field is set to a label which doesn't exist on the respective resource, the metrics label will default to some other value (`<namespace>/<resource name>` for pod monitors, `<resource name>` for service monitors). This can break things - for instance `cert-manager-mixin` [expects](https://github.com/imusmanmalik/cert-manager-mixin/blob/main/config.libsonnet#L5) the label to be set to `cert-manager`, whereas while using a pod monitor the label is set to `cert-manager/cert-manager`, causing the absence alerts to fire when cert-manager is running perfectly fine.

This PR will set the field's value to `app.kubernetes.io/name`, which will set the metric job label to the previously intended `cert-manager`, as well as make the value configurable via Helm values. 
### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
When Prometheus monitoring is enabled, the metrics label is now set to the intended value of `cert-manager`. Previously, it was set depending on various factors (namespace cert-manager is installed in and/or Helm release name).
```
