### PR TITLE
fix incorrect error handling in route53 dns provider

### DIFF
--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -378,7 +378,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			s.RESTConfig.UserAgent,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating route53 challenge solver: %s", err)
+			return nil, nil, fmt.Errorf("error instantiating route53 challenge solver: %w", err)
 		}
 	case providerConfig.AzureDNS != nil:
 		dbg.Info("preparing to create AzureDNS provider")

--- a/pkg/issuer/acme/dns/route53/route53_test.go
+++ b/pkg/issuer/acme/dns/route53/route53_test.go
@@ -588,7 +588,7 @@ func makeMockSessionProvider(
 	}
 }
 
-func Test_removeReqID(t *testing.T) {
+func Test_RedactedError(t *testing.T) {
 	newResponseError := func() *smithyhttp.ResponseError {
 		return &smithyhttp.ResponseError{
 			Err: errors.New("foo"),
@@ -628,15 +628,10 @@ func Test_removeReqID(t *testing.T) {
 			err:     errors.New("foo"),
 			wantErr: errors.New("foo"),
 		},
-		{
-			name:    "should ignore nil errors",
-			err:     nil,
-			wantErr: nil,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := removeReqID(tt.err)
+			err := &RedactedError{tt.err}
 			if tt.wantErr != nil {
 				require.Error(t, err)
 				assert.Equal(t, tt.wantErr.Error(), err.Error())


### PR DESCRIPTION
### Pull Request Motivation
Fixes: https://github.com/cert-manager/cert-manager/issues/8166

/bug

```release-note
NONE
```

CyberArk tracker: [VC-46126](https://venafi.atlassian.net/browse/VC-46126) <!-- do not edit this line, will be re-added automatically -->