### PR TITLE
REVERT: API defaults for issuer reference kind and group

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -80,12 +80,14 @@ spec:
                     Challenge will be marked as failed.
                   properties:
                     group:
-                      default: cert-manager.io
-                      description: Group of the issuer being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      default: Issuer
-                      description: Kind of the issuer being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
                       description: Name of the issuer being referred to.

--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_orders.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_orders.yaml
@@ -99,12 +99,14 @@ spec:
                     Order will be marked as failed.
                   properties:
                     group:
-                      default: cert-manager.io
-                      description: Group of the issuer being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      default: Issuer
-                      description: Kind of the issuer being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
                       description: Name of the issuer being referred to.

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificaterequests.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificaterequests.yaml
@@ -127,12 +127,14 @@ spec:
                     The `name` field of the reference must always be specified.
                   properties:
                     group:
-                      default: cert-manager.io
-                      description: Group of the issuer being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      default: Issuer
-                      description: Kind of the issuer being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
                       description: Name of the issuer being referred to.

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_certificates.yaml
@@ -161,12 +161,14 @@ spec:
                     The `name` field of the reference must always be specified.
                   properties:
                     group:
-                      default: cert-manager.io
-                      description: Group of the issuer being referred to.
+                      description: |-
+                        Group of the issuer being referred to.
+                        Defaults to 'cert-manager.io'.
                       type: string
                     kind:
-                      default: Issuer
-                      description: Kind of the issuer being referred to.
+                      description: |-
+                        Kind of the issuer being referred to.
+                        Defaults to 'Issuer'.
                       type: string
                     name:
                       description: Name of the issuer being referred to.

--- a/deploy/crds/acme.cert-manager.io_challenges.yaml
+++ b/deploy/crds/acme.cert-manager.io_challenges.yaml
@@ -80,12 +80,14 @@ spec:
                   Challenge will be marked as failed.
                 properties:
                   group:
-                    default: cert-manager.io
-                    description: Group of the issuer being referred to.
+                    description: |-
+                      Group of the issuer being referred to.
+                      Defaults to 'cert-manager.io'.
                     type: string
                   kind:
-                    default: Issuer
-                    description: Kind of the issuer being referred to.
+                    description: |-
+                      Kind of the issuer being referred to.
+                      Defaults to 'Issuer'.
                     type: string
                   name:
                     description: Name of the issuer being referred to.

--- a/deploy/crds/acme.cert-manager.io_orders.yaml
+++ b/deploy/crds/acme.cert-manager.io_orders.yaml
@@ -98,12 +98,14 @@ spec:
                   Order will be marked as failed.
                 properties:
                   group:
-                    default: cert-manager.io
-                    description: Group of the issuer being referred to.
+                    description: |-
+                      Group of the issuer being referred to.
+                      Defaults to 'cert-manager.io'.
                     type: string
                   kind:
-                    default: Issuer
-                    description: Kind of the issuer being referred to.
+                    description: |-
+                      Kind of the issuer being referred to.
+                      Defaults to 'Issuer'.
                     type: string
                   name:
                     description: Name of the issuer being referred to.

--- a/deploy/crds/cert-manager.io_certificaterequests.yaml
+++ b/deploy/crds/cert-manager.io_certificaterequests.yaml
@@ -126,12 +126,14 @@ spec:
                   The `name` field of the reference must always be specified.
                 properties:
                   group:
-                    default: cert-manager.io
-                    description: Group of the issuer being referred to.
+                    description: |-
+                      Group of the issuer being referred to.
+                      Defaults to 'cert-manager.io'.
                     type: string
                   kind:
-                    default: Issuer
-                    description: Kind of the issuer being referred to.
+                    description: |-
+                      Kind of the issuer being referred to.
+                      Defaults to 'Issuer'.
                     type: string
                   name:
                     description: Name of the issuer being referred to.

--- a/deploy/crds/cert-manager.io_certificates.yaml
+++ b/deploy/crds/cert-manager.io_certificates.yaml
@@ -160,12 +160,14 @@ spec:
                   The `name` field of the reference must always be specified.
                 properties:
                   group:
-                    default: cert-manager.io
-                    description: Group of the issuer being referred to.
+                    description: |-
+                      Group of the issuer being referred to.
+                      Defaults to 'cert-manager.io'.
                     type: string
                   kind:
-                    default: Issuer
-                    description: Kind of the issuer being referred to.
+                    description: |-
+                      Kind of the issuer being referred to.
+                      Defaults to 'Issuer'.
                     type: string
                   name:
                     description: Name of the issuer being referred to.

--- a/internal/apis/acme/v1/defaults.go
+++ b/internal/apis/acme/v1/defaults.go
@@ -18,8 +18,46 @@ package v1
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+
+	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&acmev1.Challenge{}, func(obj interface{}) { SetObjectDefaults_Challenge(obj.(*acmev1.Challenge)) })
+	scheme.AddTypeDefaultingFunc(&acmev1.ChallengeList{}, func(obj interface{}) { SetObjectDefaults_ChallengeList(obj.(*acmev1.ChallengeList)) })
+	scheme.AddTypeDefaultingFunc(&acmev1.Order{}, func(obj interface{}) { SetObjectDefaults_Order(obj.(*acmev1.Order)) })
+	scheme.AddTypeDefaultingFunc(&acmev1.OrderList{}, func(obj interface{}) { SetObjectDefaults_OrderList(obj.(*acmev1.OrderList)) })
 	return RegisterDefaults(scheme)
+}
+
+func SetObjectDefaults_Challenge(in *acmev1.Challenge) {
+	if in.Spec.IssuerRef.Kind == "" {
+		in.Spec.IssuerRef.Kind = "Issuer"
+	}
+	if in.Spec.IssuerRef.Group == "" {
+		in.Spec.IssuerRef.Group = "cert-manager.io"
+	}
+}
+
+func SetObjectDefaults_ChallengeList(in *acmev1.ChallengeList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Challenge(a)
+	}
+}
+
+func SetObjectDefaults_Order(in *acmev1.Order) {
+	if in.Spec.IssuerRef.Kind == "" {
+		in.Spec.IssuerRef.Kind = "Issuer"
+	}
+	if in.Spec.IssuerRef.Group == "" {
+		in.Spec.IssuerRef.Group = "cert-manager.io"
+	}
+}
+
+func SetObjectDefaults_OrderList(in *acmev1.OrderList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Order(a)
+	}
 }

--- a/internal/apis/acme/v1/zz_generated.defaults.go
+++ b/internal/apis/acme/v1/zz_generated.defaults.go
@@ -22,7 +22,6 @@ limitations under the License.
 package v1
 
 import (
-	acmev1 "github.com/cert-manager/cert-manager/pkg/apis/acme/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -30,41 +29,5 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&acmev1.Challenge{}, func(obj interface{}) { SetObjectDefaults_Challenge(obj.(*acmev1.Challenge)) })
-	scheme.AddTypeDefaultingFunc(&acmev1.ChallengeList{}, func(obj interface{}) { SetObjectDefaults_ChallengeList(obj.(*acmev1.ChallengeList)) })
-	scheme.AddTypeDefaultingFunc(&acmev1.Order{}, func(obj interface{}) { SetObjectDefaults_Order(obj.(*acmev1.Order)) })
-	scheme.AddTypeDefaultingFunc(&acmev1.OrderList{}, func(obj interface{}) { SetObjectDefaults_OrderList(obj.(*acmev1.OrderList)) })
 	return nil
-}
-
-func SetObjectDefaults_Challenge(in *acmev1.Challenge) {
-	if in.Spec.IssuerRef.Kind == "" {
-		in.Spec.IssuerRef.Kind = "Issuer"
-	}
-	if in.Spec.IssuerRef.Group == "" {
-		in.Spec.IssuerRef.Group = "cert-manager.io"
-	}
-}
-
-func SetObjectDefaults_ChallengeList(in *acmev1.ChallengeList) {
-	for i := range in.Items {
-		a := &in.Items[i]
-		SetObjectDefaults_Challenge(a)
-	}
-}
-
-func SetObjectDefaults_Order(in *acmev1.Order) {
-	if in.Spec.IssuerRef.Kind == "" {
-		in.Spec.IssuerRef.Kind = "Issuer"
-	}
-	if in.Spec.IssuerRef.Group == "" {
-		in.Spec.IssuerRef.Group = "cert-manager.io"
-	}
-}
-
-func SetObjectDefaults_OrderList(in *acmev1.OrderList) {
-	for i := range in.Items {
-		a := &in.Items[i]
-		SetObjectDefaults_Order(a)
-	}
 }

--- a/internal/apis/certmanager/v1/defaults.go
+++ b/internal/apis/certmanager/v1/defaults.go
@@ -25,6 +25,12 @@ import (
 )
 
 func addDefaultingFuncs(scheme *runtime.Scheme) error {
+	scheme.AddTypeDefaultingFunc(&cmapi.Certificate{}, func(obj interface{}) { SetObjectDefaults_Certificate(obj.(*cmapi.Certificate)) })
+	scheme.AddTypeDefaultingFunc(&cmapi.CertificateList{}, func(obj interface{}) { SetObjectDefaults_CertificateList(obj.(*cmapi.CertificateList)) })
+	scheme.AddTypeDefaultingFunc(&cmapi.CertificateRequest{}, func(obj interface{}) { SetObjectDefaults_CertificateRequest(obj.(*cmapi.CertificateRequest)) })
+	scheme.AddTypeDefaultingFunc(&cmapi.CertificateRequestList{}, func(obj interface{}) {
+		SetObjectDefaults_CertificateRequestList(obj.(*cmapi.CertificateRequestList))
+	})
 	return RegisterDefaults(scheme)
 }
 
@@ -59,5 +65,37 @@ func SetRuntimeDefaults_Certificate(in *cmapi.Certificate) {
 			defaultRotationPolicy = cmapi.RotationPolicyAlways
 		}
 		in.Spec.PrivateKey.RotationPolicy = defaultRotationPolicy
+	}
+}
+
+func SetObjectDefaults_Certificate(in *cmapi.Certificate) {
+	if in.Spec.IssuerRef.Kind == "" {
+		in.Spec.IssuerRef.Kind = "Issuer"
+	}
+	if in.Spec.IssuerRef.Group == "" {
+		in.Spec.IssuerRef.Group = "cert-manager.io"
+	}
+}
+
+func SetObjectDefaults_CertificateList(in *cmapi.CertificateList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_Certificate(a)
+	}
+}
+
+func SetObjectDefaults_CertificateRequest(in *cmapi.CertificateRequest) {
+	if in.Spec.IssuerRef.Kind == "" {
+		in.Spec.IssuerRef.Kind = "Issuer"
+	}
+	if in.Spec.IssuerRef.Group == "" {
+		in.Spec.IssuerRef.Group = "cert-manager.io"
+	}
+}
+
+func SetObjectDefaults_CertificateRequestList(in *cmapi.CertificateRequestList) {
+	for i := range in.Items {
+		a := &in.Items[i]
+		SetObjectDefaults_CertificateRequest(a)
 	}
 }

--- a/internal/apis/certmanager/v1/zz_generated.defaults.go
+++ b/internal/apis/certmanager/v1/zz_generated.defaults.go
@@ -22,7 +22,6 @@ limitations under the License.
 package v1
 
 import (
-	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -30,43 +29,5 @@ import (
 // Public to allow building arbitrary schemes.
 // All generated defaulters are covering - they call all nested defaulters.
 func RegisterDefaults(scheme *runtime.Scheme) error {
-	scheme.AddTypeDefaultingFunc(&certmanagerv1.Certificate{}, func(obj interface{}) { SetObjectDefaults_Certificate(obj.(*certmanagerv1.Certificate)) })
-	scheme.AddTypeDefaultingFunc(&certmanagerv1.CertificateList{}, func(obj interface{}) { SetObjectDefaults_CertificateList(obj.(*certmanagerv1.CertificateList)) })
-	scheme.AddTypeDefaultingFunc(&certmanagerv1.CertificateRequest{}, func(obj interface{}) { SetObjectDefaults_CertificateRequest(obj.(*certmanagerv1.CertificateRequest)) })
-	scheme.AddTypeDefaultingFunc(&certmanagerv1.CertificateRequestList{}, func(obj interface{}) {
-		SetObjectDefaults_CertificateRequestList(obj.(*certmanagerv1.CertificateRequestList))
-	})
 	return nil
-}
-
-func SetObjectDefaults_Certificate(in *certmanagerv1.Certificate) {
-	if in.Spec.IssuerRef.Kind == "" {
-		in.Spec.IssuerRef.Kind = "Issuer"
-	}
-	if in.Spec.IssuerRef.Group == "" {
-		in.Spec.IssuerRef.Group = "cert-manager.io"
-	}
-}
-
-func SetObjectDefaults_CertificateList(in *certmanagerv1.CertificateList) {
-	for i := range in.Items {
-		a := &in.Items[i]
-		SetObjectDefaults_Certificate(a)
-	}
-}
-
-func SetObjectDefaults_CertificateRequest(in *certmanagerv1.CertificateRequest) {
-	if in.Spec.IssuerRef.Kind == "" {
-		in.Spec.IssuerRef.Kind = "Issuer"
-	}
-	if in.Spec.IssuerRef.Group == "" {
-		in.Spec.IssuerRef.Group = "cert-manager.io"
-	}
-}
-
-func SetObjectDefaults_CertificateRequestList(in *certmanagerv1.CertificateRequestList) {
-	for i := range in.Items {
-		a := &in.Items[i]
-		SetObjectDefaults_CertificateRequest(a)
-	}
 }

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -4772,16 +4772,14 @@ func schema_pkg_apis_meta_v1_IssuerReference(ref common.ReferenceCallback) commo
 					},
 					"kind": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Kind of the issuer being referred to.",
-							Default:     "Issuer",
+							Description: "Kind of the issuer being referred to. Defaults to 'Issuer'.",
 							Type:        []string{"string"},
 							Format:      "",
 						},
 					},
 					"group": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Group of the issuer being referred to.",
-							Default:     "cert-manager.io",
+							Description: "Group of the issuer being referred to. Defaults to 'cert-manager.io'.",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/api/util/issuers.go
+++ b/pkg/api/util/issuers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	cmmeta "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 )
 
 const (
@@ -51,4 +52,12 @@ func NameForIssuer(i cmapi.GenericIssuer) (string, error) {
 		return IssuerVenafi, nil
 	}
 	return "", fmt.Errorf("no issuer specified for Issuer '%s/%s'", i.GetObjectMeta().Namespace, i.GetObjectMeta().Name)
+}
+
+// IssuerKind returns the kind of issuer for a certificate.
+func IssuerKind(ref cmmeta.IssuerReference) string {
+	if ref.Kind == "" {
+		return cmapi.IssuerKind
+	}
+	return ref.Kind
 }

--- a/pkg/apis/meta/v1/types.go
+++ b/pkg/apis/meta/v1/types.go
@@ -53,12 +53,12 @@ type IssuerReference struct {
 	// Name of the issuer being referred to.
 	Name string `json:"name"`
 	// Kind of the issuer being referred to.
+	// Defaults to 'Issuer'.
 	// +optional
-	// +default="Issuer"
 	Kind string `json:"kind,omitempty"`
 	// Group of the issuer being referred to.
+	// Defaults to 'cert-manager.io'.
 	// +optional
-	// +default="cert-manager.io"
 	Group string `json:"group,omitempty"`
 }
 

--- a/pkg/client/applyconfigurations/internal/internal.go
+++ b/pkg/client/applyconfigurations/internal/internal.go
@@ -1461,11 +1461,9 @@ var schemaYAML = typed.YAMLObject(`types:
     - name: group
       type:
         scalar: string
-      default: cert-manager.io
     - name: kind
       type:
         scalar: string
-      default: Issuer
     - name: name
       type:
         scalar: string

--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -43,7 +43,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	log := logf.FromContext(ctx)
 	dbg := log.V(logf.DebugLevel)
 
-	if cr.Spec.IssuerRef.Group != certmanager.GroupName {
+	if !(cr.Spec.IssuerRef.Group == "" || cr.Spec.IssuerRef.Group == certmanager.GroupName) {
 		dbg.Info("certificate request issuerRef group does not match certmanager group so skipping processing")
 		return nil
 	}
@@ -91,7 +91,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	issuerObj, err := c.helper.GetGenericIssuer(crCopy.Spec.IssuerRef, crCopy.Namespace)
 	if k8sErrors.IsNotFound(err) {
 		c.reporter.Pending(crCopy, err, "IssuerNotFound",
-			fmt.Sprintf("Referenced %q not found", crCopy.Spec.IssuerRef.Kind))
+			fmt.Sprintf("Referenced %q not found", apiutil.IssuerKind(crCopy.Spec.IssuerRef)))
 		return nil
 	}
 

--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -40,7 +40,7 @@ func (o IssuerOptions) ResourceNamespaceRef(ref cmmeta.IssuerReference, challeng
 	switch ref.Kind {
 	case cmapi.ClusterIssuerKind:
 		return o.ClusterResourceNamespace
-	case cmapi.IssuerKind:
+	case "", cmapi.IssuerKind:
 		return challengeNamespace
 	}
 	return challengeNamespace // Should not be reached
@@ -67,7 +67,7 @@ func (o IssuerOptions) CanUseAmbientCredentialsFromRef(ref cmmeta.IssuerReferenc
 	switch ref.Kind {
 	case cmapi.ClusterIssuerKind:
 		return o.ClusterIssuerAmbientCredentials
-	case cmapi.IssuerKind:
+	case "", cmapi.IssuerKind:
 		return o.IssuerAmbientCredentials
 	}
 	return false

--- a/pkg/issuer/helper.go
+++ b/pkg/issuer/helper.go
@@ -56,7 +56,7 @@ func NewHelper(issuerLister cmlisters.IssuerLister, clusterIssuerLister cmlister
 // that defines the IssuerRef (i.e. the namespace of the Certificate resource).
 func (h *helperImpl) GetGenericIssuer(ref cmmeta.IssuerReference, ns string) (cmapi.GenericIssuer, error) {
 	switch ref.Kind {
-	case cmapi.IssuerKind:
+	case "", cmapi.IssuerKind:
 		return h.issuerLister.Issuers(ns).Get(ref.Name)
 	case cmapi.ClusterIssuerKind:
 		// handle edge case where the ClusterIssuerLister is not set.
@@ -69,6 +69,6 @@ func (h *helperImpl) GetGenericIssuer(ref cmmeta.IssuerReference, ns string) (cm
 		}
 		return h.clusterIssuerLister.Get(ref.Name)
 	default:
-		return nil, fmt.Errorf(`invalid value %q for issuerRef.kind. Must be %q or %q`, ref.Kind, cmapi.IssuerKind, cmapi.ClusterIssuerKind)
+		return nil, fmt.Errorf(`invalid value %q for issuerRef.kind. Must be empty, %q or %q`, ref.Kind, cmapi.IssuerKind, cmapi.ClusterIssuerKind)
 	}
 }

--- a/pkg/issuer/helper_test.go
+++ b/pkg/issuer/helper_test.go
@@ -68,9 +68,8 @@ func TestGetGenericIssuer(t *testing.T) {
 		},
 		{
 			Name:     "name",
-			Kind:     "",
 			Err:      true,
-			Expected: nil,
+			Expected: nilIssuer,
 		},
 		{
 			Name:                   "name",


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

With the release of 0.19.0 we got reports of unexpected certificate renewals on upgrade, ref. https://github.com/cert-manager/cert-manager/issues/8158. This is probably happening because the comparison logic is not taking the issuer reference kind and group (since forever) runtime defaults into account. We have an open PR to fix this, https://github.com/cert-manager/cert-manager/pull/8160, but it is required to upgrade to a version containing this fix **BEFORE** upgrading to a version that includes API defaults for these fields.

This has been discussed among the maintainers multiple times, and we agree that the best thing to do right now is to revert the new API defaults introduced in 0.19.0. And eventually return to this matter in a future release.

> 📖 Slack discussion: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1760423137409219

Reverts https://github.com/cert-manager/cert-manager/pull/7414 and https://github.com/cert-manager/cert-manager/pull/7907 (partially; functional revert; not an exact revert of the commits, as things have changed since they were merged)
Fixes https://github.com/cert-manager/cert-manager/issues/8158
Closes https://github.com/cert-manager/cert-manager/pull/8157 (as this PR goes further in reverting the problematic change)

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Revert API defaults for issuer reference kind and group introduced in 0.19.0
```

CyberArk tracker: [VC-46119](https://venafi.atlassian.net/browse/VC-46119) <!-- do not edit this line, will be re-added automatically -->