### PR TITLE
[release-1.18] Bump Go to 1.24.9

### DIFF
--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -172,7 +172,7 @@ ADDITIONAL_TOOLS ?=
 tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
-VENDORED_GO_VERSION := 1.24.6
+VENDORED_GO_VERSION := 1.24.9
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -398,10 +398,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # NB: Manually copied from upstream makefile-modules and backported
 # Upstream commit: 6717aee1a6639d3ac352a92321ac8ab4c12783f8
 
-go_linux_amd64_SHA256SUM=bbca37cc395c974ffa4893ee35819ad23ebb27426df87af92e93a9ec66ef8712
-go_linux_arm64_SHA256SUM=124ea6033a8bf98aa9fbab53e58d134905262d45a022af3a90b73320f3c3afd5
-go_darwin_amd64_SHA256SUM=4a8d7a32052f223e71faab424a69430455b27b3fff5f4e651f9d97c3e51a8746
-go_darwin_arm64_SHA256SUM=4e29202c49573b953be7cc3500e1f8d9e66ddd12faa8cf0939a4951411e09a2a
+go_linux_amd64_SHA256SUM=5b7899591c2dd6e9da1809fde4a2fad842c45d3f6b9deb235ba82216e31e34a6
+go_linux_arm64_SHA256SUM=9aa1243d51d41e2f93e895c89c0a2daf7166768c4a4c3ac79db81029d295a540
+go_darwin_amd64_SHA256SUM=961aa2ae2b97e428d6d8991367e7c98cb403bac54276b8259aead42a0081591c
+go_darwin_arm64_SHA256SUM=af451b40651d7fb36db1bbbd9c66ddbed28b96d7da48abea50a19f82c6e9d1d6
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
- Bump vendored Go from 1.24.6 to 1.24.9
- Update make/_shared/tools/00_mod.mk used by build tooling and CI

Release notes:
> go1.24.7 (released 2025-09-03) includes fixes to the go command, and the net and os/exec packages. See the Go 1.24.7 milestone on our issue tracker for details.
>
> go1.24.8 (released 2025-10-07) includes security fixes to the archive/tar, crypto/tls, crypto/x509, encoding/asn1, encoding/pem, net/http, net/mail,
net/textproto, and net/url packages, as well as bug fixes to the compiler, the linker, and the debug/pe, net/http, os, and sync/atomic packages. See the Go 1.24.8 milestone on our issue tracker for details.
>
> go1.24.9 (released 2025-10-13) includes fixes to the crypto/x509 package. See
the Go 1.24.9 milestone on our issue tracker for details.
>
> --  https://go.dev/doc/devel/release#go1.24.minor

Fixes the following vulnerabilities:

- CVE-2025-61724
- CVE-2025-58187
- CVE-2025-47912
- CVE-2025-58183
- CVE-2025-61723
- CVE-2025-58186
- CVE-2025-58185
- CVE-2025-58188
- CVE-2025-61725



/kind bug

```release-note
Bump Go to 1.24.9. Fixes the following vulnerabilities: CVE-2025-61724, CVE-2025-58187, CVE-2025-47912, CVE-2025-58183, CVE-2025-61723, CVE-2025-58186, CVE-2025-58185, CVE-2025-58188, CVE-2025-61725
```

CyberArk tracker: [VC-46120](https://venafi.atlassian.net/browse/VC-46120) <!-- do not edit this line, will be re-added automatically -->