### PR TITLE
feat: Add support for specifying `imagePullSecrets` in the `startupapicheck-job` Helm template

### DIFF
--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -48,6 +48,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}-startupapicheck
           image: "{{ template "image" (tuple .Values.startupapicheck.image $.Chart.AppVersion) }}"


### PR DESCRIPTION
### Pull Request Motivation

This PR fixes https://github.com/cert-manager/cert-manager/issues/8185.

When specifying a private registry for the `startupapicheck-job`, the image pull fails because the registry does not allow anonymous access.  
To resolve this, this PR adds support for the `spec.imagePullSecrets` field in `deploy/charts/cert-manager/templates/startupapicheck-job.yaml`, enabling users to specify the image pull secret required for authentication to private registries.

### Kind

/kind feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Add support for specifying `imagePullSecrets` in the `startupapicheck-job` Helm template to enable pulling images from private registries.
```
