### PR TITLE
feat(dns01): refactoring azure dns to interfaces

### DIFF
--- a/pkg/issuer/acme/dns/azuredns/azure_types.go
+++ b/pkg/issuer/acme/dns/azuredns/azure_types.go
@@ -1,0 +1,168 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package azuredns
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	dns "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/dns/armdns"
+)
+
+type ClientOptions struct {
+	IfMatch     *string
+	IfNoneMatch *string
+}
+
+// RecordSet represents an abstraction over both privatedns.RecordSet and dns.RecordSet.
+type RecordSet interface {
+	GetTXTRecords() [][]*string
+	SetTXTRecords(records [][]*string)
+	GetETag() *string
+}
+
+// RecordsClient is a wrapper interface around the Azure SDK RecordsClient. This interface should satisfy both public and
+// private record clients and also allow us to implement mock testing.
+type RecordsClient interface {
+	CreateOrUpdate(ctx context.Context, resourceGroupName string, zoneName string, relativeRecordSetName string, set RecordSet, options *ClientOptions) (RecordSet, error)
+	Get(ctx context.Context, resourceGroupName string, zoneName string, relativeRecordSetName string, options *ClientOptions) (RecordSet, error)
+	Delete(ctx context.Context, resourceGroupName string, zoneName string, relativeRecordSetName string, options *ClientOptions) error
+}
+
+type ZonesClient interface {
+	Get(ctx context.Context, resourceGroupName string, zoneName string, options *ClientOptions) error
+}
+
+// PublicRecordsClient is a wrapper around the Azure SDK RecordSetsClient for public DNS zones.
+type PublicRecordsClient struct {
+	client *dns.RecordSetsClient
+}
+
+func NewPublicRecordsClient(cl *dns.RecordSetsClient) RecordsClient {
+	return &PublicRecordsClient{
+		client: cl,
+	}
+}
+
+func (ps *PublicRecordsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, zoneName string, relativeRecordSetName string, set RecordSet, options *ClientOptions) (RecordSet, error) {
+	pubSet, ok := set.(*PublicTXTRecordSet)
+	if !ok {
+		return nil, fmt.Errorf("expected *PublicTXTRecordSet, got %T", set)
+	}
+	opt := new(dns.RecordSetsClientCreateOrUpdateOptions)
+	if options != nil {
+		opt.IfMatch = options.IfMatch
+		opt.IfNoneMatch = options.IfNoneMatch
+	}
+
+	resp, err := ps.client.CreateOrUpdate(ctx, resourceGroupName, zoneName, relativeRecordSetName, dns.RecordTypeTXT, *pubSet.RS, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublicTXTRecordSet{RS: &resp.RecordSet}, nil
+}
+
+func (ps *PublicRecordsClient) Get(ctx context.Context, resourceGroupName string, zoneName string, relativeRecordSetName string, options *ClientOptions) (RecordSet, error) {
+	opt := new(dns.RecordSetsClientGetOptions)
+	resp, err := ps.client.Get(ctx, resourceGroupName, zoneName, relativeRecordSetName, dns.RecordTypeTXT, opt)
+	if err != nil {
+		return nil, err
+	}
+
+	return &PublicTXTRecordSet{RS: &resp.RecordSet}, nil
+}
+
+func (ps *PublicRecordsClient) Delete(ctx context.Context, resourceGroupName string, zoneName string, relativeRecordSetName string, options *ClientOptions) error {
+	opt := new(dns.RecordSetsClientDeleteOptions)
+	if options != nil {
+		opt.IfMatch = options.IfMatch
+	}
+
+	_, err := ps.client.Delete(ctx, resourceGroupName, zoneName, relativeRecordSetName, dns.RecordTypeTXT, opt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type PublicZonesClient struct {
+	client *dns.ZonesClient
+}
+
+func NewPublicZonesClient(cl *dns.ZonesClient) ZonesClient {
+	return &PublicZonesClient{
+		client: cl,
+	}
+}
+
+func (pc *PublicZonesClient) Get(ctx context.Context, resourceGroupName string, zoneName string, options *ClientOptions) error {
+	opt := new(dns.ZonesClientGetOptions)
+	_, err := pc.client.Get(ctx, resourceGroupName, zoneName, opt)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+type PublicTXTRecordSet struct {
+	RS *dns.RecordSet
+}
+
+func (ps *PublicTXTRecordSet) GetETag() *string {
+	if ps.RS == nil {
+		return nil
+	}
+	return ps.RS.Etag
+}
+
+func (ps *PublicTXTRecordSet) GetTXTRecords() [][]*string {
+	if ps.RS == nil || ps.RS.Properties == nil {
+		return nil
+	}
+
+	out := make([][]*string, 0, len(ps.RS.Properties.TxtRecords))
+	for _, txtRec := range ps.RS.Properties.TxtRecords {
+		out = append(out, txtRec.Value)
+	}
+
+	return out
+}
+
+func (ps *PublicTXTRecordSet) SetTXTRecords(records [][]*string) {
+	if ps.RS == nil || ps.RS.Properties == nil {
+		ps.RS = &dns.RecordSet{
+			Properties: &dns.RecordSetProperties{
+				TTL:        to.Ptr[int64](60),
+				TxtRecords: []*dns.TxtRecord{},
+			},
+			Etag: to.Ptr(""),
+		}
+	}
+
+	var txtRecords []*dns.TxtRecord
+	for _, r := range records {
+		txtRecords = append(txtRecords, &dns.TxtRecord{
+			Value: r,
+		})
+	}
+
+	ps.RS.Properties.TxtRecords = txtRecords
+}

--- a/pkg/issuer/acme/dns/azuredns/azuredns.go
+++ b/pkg/issuer/acme/dns/azuredns/azuredns.go
@@ -35,8 +35,8 @@ import (
 // DNSProvider implements the util.ChallengeProvider interface
 type DNSProvider struct {
 	dns01Nameservers  []string
-	recordClient      *dns.RecordSetsClient
-	zoneClient        *dns.ZonesClient
+	recordClient      RecordsClient
+	zoneClient        ZonesClient
 	resourceGroupName string
 	zoneName          string
 	log               logr.Logger
@@ -59,15 +59,18 @@ func NewDNSProviderCredentials(environment, clientID, clientSecret, subscription
 	if err != nil {
 		return nil, err
 	}
+	rcl := NewPublicRecordsClient(rc)
+
 	zc, err := dns.NewZonesClient(subscriptionID, cred, &arm.ClientOptions{ClientOptions: clientOpt})
 	if err != nil {
 		return nil, err
 	}
+	zcl := NewPublicZonesClient(zc)
 
 	return &DNSProvider{
 		dns01Nameservers:  dns01Nameservers,
-		recordClient:      rc,
-		zoneClient:        zc,
+		recordClient:      rcl,
+		zoneClient:        zcl,
 		resourceGroupName: resourceGroupName,
 		zoneName:          zoneName,
 		log:               logf.Log.WithName("azure-dns"),
@@ -139,34 +142,37 @@ func getAuthorization(clientOpt policy.ClientOptions, clientID, clientSecret, te
 
 // Present creates a TXT record using the specified parameters
 func (c *DNSProvider) Present(ctx context.Context, domain, fqdn, value string) error {
-	return c.updateTXTRecord(ctx, fqdn, func(set *dns.RecordSet) {
+	return c.updateTXTRecord(ctx, fqdn, func(set RecordSet) {
 		var found bool
-		for _, r := range set.Properties.TxtRecords {
-			if len(r.Value) > 0 && *r.Value[0] == value {
+		txtRecords := set.GetTXTRecords()
+		for _, r := range txtRecords {
+			if len(r) > 0 && *r[0] == value {
 				found = true
 				break
 			}
 		}
 
 		if !found {
-			set.Properties.TxtRecords = append(set.Properties.TxtRecords, &dns.TxtRecord{
-				Value: []*string{to.Ptr(value)},
+			txtRecords = append(txtRecords, []*string{
+				to.Ptr(value),
 			})
+			set.SetTXTRecords(txtRecords)
 		}
 	})
 }
 
 // CleanUp removes the TXT record matching the specified parameters
 func (c *DNSProvider) CleanUp(ctx context.Context, domain, fqdn, value string) error {
-	return c.updateTXTRecord(ctx, fqdn, func(set *dns.RecordSet) {
-		var records []*dns.TxtRecord
-		for _, r := range set.Properties.TxtRecords {
-			if len(r.Value) > 0 && *r.Value[0] != value {
+	return c.updateTXTRecord(ctx, fqdn, func(set RecordSet) {
+		txtRecords := set.GetTXTRecords()
+		records := make([][]*string, 0, len(txtRecords))
+		for _, r := range txtRecords {
+			if len(r) > 0 && *r[0] != value {
 				records = append(records, r)
 			}
 		}
 
-		set.Properties.TxtRecords = records
+		set.SetTXTRecords(records)
 	})
 }
 
@@ -182,7 +188,7 @@ func (c *DNSProvider) getHostedZoneName(ctx context.Context, fqdn string) (strin
 		return "", fmt.Errorf("Zone %s not found for domain %s", z, fqdn)
 	}
 
-	if _, err := c.zoneClient.Get(ctx, c.resourceGroupName, util.UnFqdn(z), nil); err != nil {
+	if err := c.zoneClient.Get(ctx, c.resourceGroupName, util.UnFqdn(z), nil); err != nil {
 		c.log.Error(err, "Error getting Zone for domain", "zone", z, "domain", fqdn, "resource group", c.resourceGroupName)
 		return "", fmt.Errorf("Zone %s not found in AzureDNS for domain %s. Err: %w", z, fqdn, err)
 	}
@@ -200,7 +206,7 @@ func (c *DNSProvider) trimFqdn(fqdn string, zone string) string {
 }
 
 // Updates or removes DNS TXT record while respecting optimistic concurrency control
-func (c *DNSProvider) updateTXTRecord(ctx context.Context, fqdn string, updater func(*dns.RecordSet)) error {
+func (c *DNSProvider) updateTXTRecord(ctx context.Context, fqdn string, updater func(RecordSet)) error {
 	zone, err := c.getHostedZoneName(ctx, fqdn)
 	if err != nil {
 		return err
@@ -208,33 +214,36 @@ func (c *DNSProvider) updateTXTRecord(ctx context.Context, fqdn string, updater 
 
 	name := c.trimFqdn(fqdn, zone)
 
-	var set *dns.RecordSet
+	var set RecordSet
 
-	resp, err := c.recordClient.Get(ctx, c.resourceGroupName, zone, name, dns.RecordTypeTXT, nil)
+	resp, err := c.recordClient.Get(ctx, c.resourceGroupName, zone, name, nil)
 	if err != nil {
 		var respErr *azcore.ResponseError
 		if errors.As(err, &respErr); respErr != nil && respErr.StatusCode == http.StatusNotFound {
-			set = &dns.RecordSet{
-				Properties: &dns.RecordSetProperties{
-					TTL:        to.Ptr(int64(60)),
-					TxtRecords: []*dns.TxtRecord{},
+			// Conditional initialization to avoid nil pointer
+			set = &PublicTXTRecordSet{
+				RS: &dns.RecordSet{
+					Properties: &dns.RecordSetProperties{
+						TTL:        to.Ptr[int64](60),
+						TxtRecords: []*dns.TxtRecord{},
+					},
+					Etag: to.Ptr(""),
 				},
-				Etag: to.Ptr(""),
 			}
 		} else {
 			c.log.Error(err, "Error reading TXT", "zone", zone, "domain", fqdn, "resource group", c.resourceGroupName)
 			return err
 		}
 	} else {
-		set = &resp.RecordSet
+		set = resp
 	}
 
 	updater(set)
 
-	if len(set.Properties.TxtRecords) == 0 {
-		if *set.Etag != "" {
+	if len(set.GetTXTRecords()) == 0 {
+		if etag := set.GetETag(); etag != nil && *etag != "" {
 			// Etag will cause the deletion to fail if any updates happen concurrently
-			_, err = c.recordClient.Delete(ctx, c.resourceGroupName, zone, name, dns.RecordTypeTXT, &dns.RecordSetsClientDeleteOptions{IfMatch: set.Etag})
+			err = c.recordClient.Delete(ctx, c.resourceGroupName, zone, name, &ClientOptions{IfMatch: set.GetETag()})
 			if err != nil {
 				c.log.Error(err, "Error deleting TXT", "zone", zone, "domain", fqdn, "resource group", c.resourceGroupName)
 				return err
@@ -244,13 +253,13 @@ func (c *DNSProvider) updateTXTRecord(ctx context.Context, fqdn string, updater 
 		return nil
 	}
 
-	opts := &dns.RecordSetsClientCreateOrUpdateOptions{}
-	if *set.Etag == "" {
+	opts := &ClientOptions{}
+	if etag := set.GetETag(); etag != nil && *etag == "" {
 		// This is used to indicate that we want the API call to fail if a conflicting record was created concurrently
 		// Only relevant when this is a new record, for updates conflicts are solved with Etag
 		opts.IfNoneMatch = to.Ptr("*")
 	} else {
-		opts.IfMatch = set.Etag
+		opts.IfMatch = set.GetETag()
 	}
 
 	_, err = c.recordClient.CreateOrUpdate(
@@ -258,8 +267,7 @@ func (c *DNSProvider) updateTXTRecord(ctx context.Context, fqdn string, updater 
 		c.resourceGroupName,
 		zone,
 		name,
-		dns.RecordTypeTXT,
-		*set,
+		set,
 		opts)
 	if err != nil {
 		c.log.Error(err, "Error upserting TXT", "zone", zone, "domain", fqdn, "resource group", c.resourceGroupName)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR originated from the work done in this PR https://github.com/cert-manager/cert-manager/pull/8011 to add azure's private dns. However, with the way azure's sdk separate private and public dns clients, we had to do a lot of changes to accommodate the feature. This PR makes it easier to add the private dns client by utilizing a set of common interfaces. Additionally, this also gives us the ability to write up mock tests which were missing from the provider.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
