### PR TITLE
Fix unregulated retries with the DigitalOcean, Azure DNS, and AWS Route53 DNS-01 solver

### DIFF
--- a/pkg/controller/acmechallenges/sync.go
+++ b/pkg/controller/acmechallenges/sync.go
@@ -21,8 +21,13 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/digitalocean/godo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
@@ -118,7 +123,9 @@ func (c *controller) Sync(ctx context.Context, chOriginal *cmacme.Challenge) (er
 			err = solver.CleanUp(ctx, ch)
 			if err != nil {
 				c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonCleanUpError, "Error cleaning up challenge: %v", err)
-				ch.Status.Reason = err.Error()
+				// stabilize the error message to avoid spurious updates which would
+				// cause repeated reconciles
+				ch.Status.Reason = stabilizeSolverErrorMessage(err)
 				log.Error(err, "error cleaning up challenge")
 				return err
 			}
@@ -163,7 +170,9 @@ func (c *controller) Sync(ctx context.Context, chOriginal *cmacme.Challenge) (er
 		err := solver.Present(ctx, genericIssuer, ch)
 		if err != nil {
 			c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonPresentError, "Error presenting challenge: %v", err)
-			ch.Status.Reason = err.Error()
+			// stabilize the error message to avoid spurious updates which would
+			// cause repeated reconciles
+			ch.Status.Reason = stabilizeSolverErrorMessage(err)
 			return err
 		}
 
@@ -190,6 +199,72 @@ func (c *controller) Sync(ctx context.Context, chOriginal *cmacme.Challenge) (er
 	}
 
 	return nil
+}
+
+// stabilizeSolverErrorMessage will attempt to remove any unique IDs from the given
+// error message so that it can be assigned to the Challenge.Status.Reason
+// field without causing spurious updates.
+//
+// For example,
+// - Azure SDK returns the contents of the HTTP requests in its error messages.
+// - AWS SDK adds request UIDs to its error messages.
+// - DigitalOcean SDK adds request UIDs to its error messages.
+//
+// TODO(wallrj): Ideally this would not be necessary. It should be possible to
+// add the unique error message to the status without triggering another
+// reconcile.
+//
+// TODO(wallrj): This won't work if one of the unstable errors is wrapped inside
+// another unstable error, because we only unwrap the first instance and the
+// strings.ReplaceAll calls won't find it. At time of wriging none of the DNS
+// SDKs returns nested unstable errors, so we do not expect this to be a problem
+// in practice.
+func stabilizeSolverErrorMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	fullMessage := err.Error()
+	{
+		var target *awshttp.ResponseError
+		if errors.As(err, &target) {
+			fullMessage = strings.ReplaceAll(
+				fullMessage,
+				target.Error(),
+				"<redacted AWS SDK error: http.ResponseError: see events and logs for details>",
+			)
+		}
+	}
+	{
+		var target *azidentity.AuthenticationFailedError
+		if errors.As(err, &target) {
+			fullMessage = strings.ReplaceAll(
+				fullMessage,
+				target.Error(),
+				"<redacted Azure SDK error: azidentity.AuthenticationFailedError: see events and logs for details>",
+			)
+		}
+	}
+	{
+		var target *azcore.ResponseError
+		if errors.As(err, &target) {
+			fullMessage = strings.ReplaceAll(
+				fullMessage,
+				target.Error(),
+				"<redacted Azure SDK error: azcore.ResponseError: see events and logs for details>",
+			)
+		}
+	}
+	{
+		var target *godo.ErrorResponse
+		if errors.As(err, &target) {
+			fullMessage = strings.ReplaceAll(
+				fullMessage,
+				target.Error(),
+				"<redacted DigitalOcean SDK error: godo.ErrorResponse: see events and logs for details>",
+			)
+		}
+	}
+	return fullMessage
 }
 
 // handleError will handle ACME error types, updating the challenge resource
@@ -262,7 +337,9 @@ func (c *controller) handleFinalizer(ctx context.Context, ch *cmacme.Challenge) 
 	err = solver.CleanUp(ctx, ch)
 	if err != nil {
 		c.recorder.Eventf(ch, corev1.EventTypeWarning, reasonCleanUpError, "Error cleaning up challenge: %v", err)
-		ch.Status.Reason = err.Error()
+		// stabilize the error message to avoid spurious updates which would
+		// cause repeated reconciles
+		ch.Status.Reason = stabilizeSolverErrorMessage(err)
 		log.Error(err, "error cleaning up challenge")
 		return nil
 	}

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -20,8 +20,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
+	"github.com/aws/smithy-go"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
+	"github.com/digitalocean/godo"
+	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	coretesting "k8s.io/client-go/testing"
@@ -619,4 +627,59 @@ func runTest(t *testing.T, test testT) {
 	}
 
 	test.builder.CheckAndFinish(err)
+}
+
+func Test_StabilizeSolverErrorMessage(t *testing.T) {
+	newResponseError := func() *smithyhttp.ResponseError {
+		return &smithyhttp.ResponseError{
+			Err: errors.New("foo"),
+			Response: &smithyhttp.Response{
+				Response: &http.Response{},
+			},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		err             error
+		expectedMessage string
+	}{
+		{
+			name:            "aws response error",
+			err:             &smithy.OperationError{OperationName: "test", Err: &awshttp.ResponseError{RequestID: "SOMEREQUESTID", ResponseError: newResponseError()}},
+			expectedMessage: "operation error : test, <redacted AWS SDK error: http.ResponseError: see events and logs for details>",
+		},
+		{
+			name: "azure sdk azidentity.AuthenticationFailed error",
+			err: &azidentity.AuthenticationFailedError{
+				RawResponse: &http.Response{},
+			},
+			expectedMessage: "<redacted Azure SDK error: azidentity.AuthenticationFailedError: see events and logs for details>",
+		},
+		{
+			name: "azure sdk azcore.ResponseError other error",
+			err: fmt.Errorf("wrapper message: %w", &azcore.ResponseError{
+				StatusCode: 500,
+				ErrorCode:  "SomeOtherError",
+			}),
+			expectedMessage: "wrapper message: <redacted Azure SDK error: azcore.ResponseError: see events and logs for details>",
+		},
+		{
+			name: "DigitalOcean SDK error",
+			err: fmt.Errorf("wrapper message: %w", &godo.ErrorResponse{
+				Response: &http.Response{
+					Request: &http.Request{},
+				},
+				Message:   "some detailed error message",
+				RequestID: "SOMEREQUESTID",
+			}),
+
+			expectedMessage: "wrapper message: <redacted DigitalOcean SDK error: godo.ErrorResponse: see events and logs for details>",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expectedMessage, stabilizeSolverErrorMessage(tt.err))
+		})
+	}
 }

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -379,7 +379,7 @@ func (s *Solver) solverForChallenge(ctx context.Context, ch *cmacme.Challenge) (
 			s.RESTConfig.UserAgent,
 		)
 		if err != nil {
-			return nil, nil, fmt.Errorf("error instantiating route53 challenge solver: %s", err)
+			return nil, nil, fmt.Errorf("error instantiating route53 challenge solver: %w", err)
 		}
 	case providerConfig.AzureDNS != nil:
 		dbg.Info("preparing to create AzureDNS provider")

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	awsmiddleware "github.com/aws/aws-sdk-go-v2/aws/middleware"
-	awshttp "github.com/aws/aws-sdk-go-v2/aws/transport/http"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/credentials"
 	"github.com/aws/aws-sdk-go-v2/service/route53"
@@ -143,7 +142,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 
 	cfg, err := config.LoadDefaultConfig(ctx, optFns...)
 	if err != nil {
-		return aws.Config{}, fmt.Errorf("unable to create aws config: %s", err)
+		return aws.Config{}, fmt.Errorf("unable to create aws config: %w", err)
 	}
 
 	if d.Role != "" && d.WebIdentityToken == "" {
@@ -154,7 +153,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			RoleSessionName: aws.String("cert-manager"),
 		})
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role: %s", removeReqID(err))
+			return aws.Config{}, fmt.Errorf("unable to assume role: %w", err)
 		}
 
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(
@@ -174,7 +173,7 @@ func (d *sessionProvider) GetSession(ctx context.Context) (aws.Config, error) {
 			WebIdentityToken: aws.String(d.WebIdentityToken),
 		})
 		if err != nil {
-			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %s", removeReqID(err))
+			return aws.Config{}, fmt.Errorf("unable to assume role with web identity: %w", err)
 		}
 
 		cfg.Credentials = credentials.NewStaticCredentialsProvider(
@@ -263,7 +262,7 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 	log := logf.FromContext(ctx)
 	hostedZoneID, err := r.getHostedZoneID(ctx, fqdn)
 	if err != nil {
-		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %v", err)
+		return fmt.Errorf("failed to determine Route 53 hosted zone ID: %w", err)
 	}
 
 	recordSet := newTXTRecordSet(fqdn, value, ttl)
@@ -293,7 +292,7 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 			)
 			return nil
 		}
-		return fmt.Errorf("failed to change Route 53 record set: %v", removeReqID(err))
+		return fmt.Errorf("failed to change Route 53 record set: %w", err)
 
 	}
 
@@ -305,7 +304,7 @@ func (r *DNSProvider) changeRecord(ctx context.Context, action route53types.Chan
 		}
 		resp, err := r.client.GetChange(ctx, reqParams)
 		if err != nil {
-			return false, fmt.Errorf("failed to query Route 53 change status: %v", removeReqID(err))
+			return false, fmt.Errorf("failed to query Route 53 change status: %w", err)
 		}
 		if resp.ChangeInfo.Status == route53types.ChangeStatusInsync {
 			return true, nil
@@ -321,7 +320,7 @@ func (r *DNSProvider) getHostedZoneID(ctx context.Context, fqdn string) (string,
 
 	authZone, err := util.FindZoneByFqdn(ctx, fqdn, r.dns01Nameservers)
 	if err != nil {
-		return "", fmt.Errorf("error finding zone from fqdn: %v", err)
+		return "", fmt.Errorf("error finding zone from fqdn: %w", err)
 	}
 
 	// .DNSName should not have a trailing dot
@@ -330,7 +329,7 @@ func (r *DNSProvider) getHostedZoneID(ctx context.Context, fqdn string) (string,
 	}
 	resp, err := r.client.ListHostedZonesByName(ctx, reqParams)
 	if err != nil {
-		return "", removeReqID(err)
+		return "", err
 	}
 
 	zoneToID := make(map[string]string)
@@ -369,22 +368,4 @@ func newTXTRecordSet(fqdn, value string, ttl int) *route53types.ResourceRecordSe
 			{Value: aws.String(value)},
 		},
 	}
-}
-
-// The aws-sdk-go library appends a request id to its error messages. We
-// want our error messages to be the same when the cause is the same to
-// avoid spurious challenge updates.
-//
-// This function must be called everywhere we have an error coming from
-// an aws-sdk-go func. The passed error is modified in place.
-func removeReqID(err error) error {
-	var responseError *awshttp.ResponseError
-	if errors.As(err, &responseError) {
-		before := responseError.Error()
-		// remove the request id from the error message
-		responseError.RequestID = "<REDACTED>"
-		after := responseError.Error()
-		return errors.New(strings.Replace(err.Error(), before, after, 1))
-	}
-	return err
 }


### PR DESCRIPTION
Fixes: #8166
Fixes: #6230

I've moved the error-message "stabilization" closer to the place where it is needed; so that it is clearer that redaction is only necessary for certain error messages and only where they are used in the `Challenge.Status.Reason` value. 
This has the added benefit that the unredacted errors can be added to events, where previously, the user would have to examine the logs to see the trace IDs and response details for debugging.

> ⚠️ **Note on Design Intent**
>
> This PR stabilizes error messages from certain DNS providers to prevent the ACME challenge controller from re-reconciling challenges too frequently. The root issue is that the controller reacts to any change in `status.Reason`, including unique error content like UIDs, triggering rapid reprocessing.
>
> While this workaround builds on a pattern we maintainers introduced years ago (e.g., AWS Route53) and later endorsed (e.g., Azure DNS), it’s not an architectural decision. Internally, we’ve long questioned this approach and discussed alternatives—like ignoring status-only updates in the informer/workqueue—but haven’t had bandwidth to pursue them.
>
> A proper fix is planned in a [follow-up PR](https://github.com/cert-manager/cert-manager/pull/8220): challenges should only be immediately reconciled when `Challenge.Spec` changes, and errors should trigger backoff-based retries. This can be achieved by checking `metadata.generation`.
>
> I’ve avoided introducing inversion-of-control here to keep this workaround lightweight and clearly temporary. Once the proper fix lands, this logic can be removed.

-   Replaced provider-level custom normalization with centralized handling in `pkg/controller/acmechallenges/sync.go`.
-   Switched some `fmt.Errorf("%s", err)` calls to `%w` so errors can be inspected with `errors.As`.
-   Removed duplicated logic from Azure/Route53 provider code.

/kind cleanup

```release-note
Fix unregulated retries with the DigitalOcean DNS-01 solver
Add full detailed DNS-01 errors to the events attached to the Challenge, for easier debugging
```

## xrefs
- This PR supplants https://github.com/cert-manager/cert-manager/pull/8167. I have come to agree with @Peac36  that all the errors should be wrapped with `%w`. I originally considered it a leak abstraction, but this PR is an example of a case where it is useful to be able to reach the wrapped errors from a higher function. Afterall, redacting the errors in the lower functions so as not to cause problems for the parent reconciler is also a leaky abstraction.
- The stabilization of DigitalOcean ErrorResponse should prevent the rapid API requests and stabilize the unique error responses reported by @maaft in https://github.com/cert-manager/cert-manager/issues/6230
- The error message stabilization in this PR is an alternative to the retry-with-backoff mechanism proposed by @dunglas in: https://github.com/cert-manager/cert-manager/pull/8205
- The stabilization should address the rapid API requests and error responses reported by @sdudley in https://github.com/cert-manager/cert-manager/issues/3848#issuecomment-965760406

## Testing

I've built Docker images from this branch and published them to my GitHub packages:

```sh
make ko-images-push KO_REGISTRY=ghcr.io/wallrj-cyberark
```

```sh
crane ls ghcr.io/wallrj-cyberark/cert-manager-controller
```

Install cert-manager:
```sh
helm upgrade test cert-manager \
  --repo https://charts.jetstack.io \
  --version 1.19.1 \
  --install \
  --create-namespace \
  --namespace cert-manager \
  --set global.logLevel=4 \
  --set crds.enabled=true \
  --set image.repository=ghcr.io/wallrj-cyberark/cert-manager-controller \
  --set image.tag=v1.19.0-51-g52737d18b2f780
```

Create an AWS Route 53 Issuer with a bad credential:

```yaml
# resources.yaml
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: letsencrypt-staging
spec:
  acme:
    server: https://acme-staging-v02.api.letsencrypt.org/directory
    email: ${EMAIL_ADDRESS}
    profile: tlsserver
    privateKeySecretRef:
      name: letsencrypt-staging
    solvers:
    - dns01:
        route53:
          region: us-east-2
          accessKeyIDSecretRef:
            name: aws-credentials
            key: AWS_ACCESS_KEY_ID
          secretAccessKeySecretRef:
            name: aws-credentials
            key: AWS_SECRET_ACCESS_KEY
---
apiVersion: cert-manager.io/v1
kind: Certificate
metadata:
  name: www
spec:
  secretName: www-tls
  privateKey:
    rotationPolicy: Always
  commonName: www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net
  dnsNames:
    - www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net
  usages:
    - digital signature
    - key encipherment
    - server auth
  issuerRef:
    name: letsencrypt-staging
    kind: ClusterIssuer
    group: cert-manager.io

```


```sh
export EMAIL_ADDRESS=test@my-domain.com
envsubst < resources.yaml | kubectl apply -f -
```

Observe the redacted error in the Reason field and the actual errors in the events and notice the backoff interval between the events.

```sh
$ kubectl describe challenges.acme.cert-manager.io
Name:         www-1-3309209053-3014772441
Namespace:    default
...
Status:
  Presented:   false
  Processing:  true
  Reason:      failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, <redacted AWS SDK error: http.ResponseError: see events and logs for details>
  State:       pending
Events:
  Type     Reason        Age   From                     Message
  ----     ------        ----  ----                     -------
  Normal   Started       38s   cert-manager-challenges  Challenge scheduled for processing
  Warning  PresentError  37s   cert-manager-challenges  Error presenting challenge: failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 403, RequestID: 7c31c507-4343-4b75-bb99-d60450e3d212, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
  Warning  PresentError  36s   cert-manager-challenges  Error presenting challenge: failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 403, RequestID: 430c4ecc-b425-45f8-84a8-683656c6ad76, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
  Warning  PresentError  31s   cert-manager-challenges  Error presenting challenge: failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 403, RequestID: 0ea176f9-e187-4ba0-a094-d269012ad7e6, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
  Warning  PresentError  10s   cert-manager-challenges  Error presenting challenge: failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 403, RequestID: 0bc17599-ebf1-4d0c-8e58-446c57bd3c22, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
```

And observe the detailed errors in the logs:

```sh
$ kubectl -n cert-manager logs deployments/test-cert-manager --follow
...
I1031 17:37:08.984077       1 controller.go:144] "syncing item" logger="cert-manager.controller"
I1031 17:37:08.984183       1 dns.go:296] "preparing to create Route53 provider" logger="cert-manager.controller.Present.solverForChallenge" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net"
I1031 17:37:08.991507       1 route53.go:139] "not using ambient credentials" logger="cert-manager.controller.Present" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net"
I1031 17:37:08.991709       1 route53.go:195] "loaded-config" logger="cert-manager.controller.Present" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" defaults-mode="legacy" region="us-east-2" runtime-environment={"EnvironmentIdentifier":"","Region":"","EC2InstanceMetadataRegion":""}
I1031 17:37:08.991771       1 dns.go:104] "presenting DNS01 challenge for domain" logger="cert-manager.controller.Present" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net"
I1031 17:37:09.107720       1 wait.go:376] "Caching DNS response" logger="cert-manager.controller.Present" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" fqdn="_acme-challenge.www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net." ttl=5
I1031 17:37:09.108863       1 route53.go:85] "Request\nGET /2013-04-01/hostedzonesbyname?dnsname=richard-gcp.jetstacker.net HTTP/1.1\r\nHost: route53.amazonaws.com\r\nUser-Agent: aws-sdk-go-v2/1.39.2 ua/2.1 os/linux lang/go#1.25.1 md/GOOS#linux md/GOARCH#amd64 api/route53#1.58.4 cert-manager/cert-manager-challenges-canary--linux-amd64--cert-manager- m/E,e\r\nAmz-Sdk-Invocation-Id: 265785f0-e326-4b35-a118-851f8884fa48\r\nAmz-Sdk-Request: attempt=1; max=3\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIAU3SWGEVCHUA6BE45/20251031/us-east-1/route53/aws4_request, SignedHeaders=amz-sdk-invocation-id;amz-sdk-request;host;x-amz-date, Signature=ce210bd13d5a5eccc5c6e10f415b9c222443064ba68d30f3a2be85800ddc5b38\r\nX-Amz-Date: 20251031T173709Z\r\nAccept-Encoding: gzip\r\n\r\n" logger="cert-manager.controller.Present" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" dnsName="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" type="DNS-01" resource_name="www-1-3309209053-3014772441" resource_namespace="default" resource_kind="Challenge" resource_version="v1" domain="www.cert-manager-aws-tutorial.richard-gcp.jetstacker.net" aws-classification="DEBUG"
E1031 17:37:09.747142       1 controller.go:157] "re-queuing item due to error processing" err="failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 403, RequestID: 3c80746d-a458-44fc-8f24-917e3a7f4f01, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details." logger="cert-manager.controller"
I1031 17:37:09.747270       1 logs.go:185] "Event(v1.ObjectReference{Kind:\"Challenge\", Namespace:\"default\", Name:\"www-1-3309209053-3014772441\", UID:\"6045ec60-43b1-43cb-94a2-026cab843b0e\", APIVersion:\"acme.cert-manager.io/v1\", ResourceVersion:\"7027\", FieldPath:\"\"}): type: 'Warning' reason: 'PresentError' Error presenting challenge: failed to determine Route 53 hosted zone ID: operation error Route 53: ListHostedZonesByName, https response error StatusCode: 403, RequestID: 3c80746d-a458-44fc-8f24-917e3a7f4f01, api error SignatureDoesNotMatch: The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details." logger="cert-manager.controller"
```

