### PR TITLE
Deprecate GenericIssuer.GetObjectMeta

### DIFF
--- a/internal/apis/certmanager/generic_issuer.go
+++ b/internal/apis/certmanager/generic_issuer.go
@@ -27,7 +27,6 @@ type GenericIssuer interface {
 	runtime.Object
 	metav1.Object
 
-	GetObjectMeta() *metav1.ObjectMeta
 	GetSpec() *IssuerSpec
 	GetStatus() *IssuerStatus
 }
@@ -35,9 +34,6 @@ type GenericIssuer interface {
 var _ GenericIssuer = &Issuer{}
 var _ GenericIssuer = &ClusterIssuer{}
 
-func (c *ClusterIssuer) GetObjectMeta() *metav1.ObjectMeta {
-	return &c.ObjectMeta
-}
 func (c *ClusterIssuer) GetSpec() *IssuerSpec {
 	return &c.Spec
 }
@@ -53,9 +49,7 @@ func (c *ClusterIssuer) SetStatus(status IssuerStatus) {
 func (c *ClusterIssuer) Copy() GenericIssuer {
 	return c.DeepCopy()
 }
-func (c *Issuer) GetObjectMeta() *metav1.ObjectMeta {
-	return &c.ObjectMeta
-}
+
 func (c *Issuer) GetSpec() *IssuerSpec {
 	return &c.Spec
 }

--- a/pkg/api/util/issuers.go
+++ b/pkg/api/util/issuers.go
@@ -51,7 +51,7 @@ func NameForIssuer(i cmapi.GenericIssuer) (string, error) {
 	case i.GetSpec().Venafi != nil:
 		return IssuerVenafi, nil
 	}
-	return "", fmt.Errorf("no issuer specified for Issuer '%s/%s'", i.GetObjectMeta().Namespace, i.GetObjectMeta().Name)
+	return "", fmt.Errorf("no issuer specified for Issuer '%s/%s'", i.GetNamespace(), i.GetName())
 }
 
 // IssuerKind returns the kind of issuer for a certificate.

--- a/pkg/apis/certmanager/v1/generic_issuer.go
+++ b/pkg/apis/certmanager/v1/generic_issuer.go
@@ -27,6 +27,7 @@ type GenericIssuer interface {
 	runtime.Object
 	metav1.Object
 
+	// Deprecated: Use the metav1.Object functions directly instead.
 	GetObjectMeta() *metav1.ObjectMeta
 	GetSpec() *IssuerSpec
 	GetStatus() *IssuerStatus
@@ -35,6 +36,7 @@ type GenericIssuer interface {
 var _ GenericIssuer = &Issuer{}
 var _ GenericIssuer = &ClusterIssuer{}
 
+// Deprecated: Use the metav1.Object functions directly instead.
 func (c *ClusterIssuer) GetObjectMeta() *metav1.ObjectMeta {
 	return &c.ObjectMeta
 }
@@ -53,6 +55,8 @@ func (c *ClusterIssuer) SetStatus(status IssuerStatus) {
 func (c *ClusterIssuer) Copy() GenericIssuer {
 	return c.DeepCopy()
 }
+
+// Deprecated: Use the metav1.Object functions directly instead.
 func (c *Issuer) GetObjectMeta() *metav1.ObjectMeta {
 	return &c.ObjectMeta
 }

--- a/pkg/controller/acmeorders/checks.go
+++ b/pkg/controller/acmeorders/checks.go
@@ -42,7 +42,7 @@ func handleGenericIssuerFunc(
 
 		certs, err := ordersForGenericIssuer(iss, orderLister)
 		if err != nil {
-			runtime.HandleError(fmt.Errorf("error looking up Orders observing Issuer/ClusterIssuer: %s/%s", iss.GetObjectMeta().Namespace, iss.GetObjectMeta().Name))
+			runtime.HandleError(fmt.Errorf("error looking up Orders observing Issuer/ClusterIssuer: %s/%s", iss.GetNamespace(), iss.GetName()))
 			return
 		}
 		for _, crt := range certs {
@@ -69,11 +69,11 @@ func ordersForGenericIssuer(iss cmapi.GenericIssuer, orderLister cmacmelisters.O
 			continue
 		}
 		if !isClusterIssuer {
-			if o.Namespace != iss.GetObjectMeta().Namespace {
+			if o.Namespace != iss.GetNamespace() {
 				continue
 			}
 		}
-		if o.Spec.IssuerRef.Name != iss.GetObjectMeta().Name {
+		if o.Spec.IssuerRef.Name != iss.GetName() {
 			continue
 		}
 		affected = append(affected, o)

--- a/pkg/controller/certificaterequests/checks.go
+++ b/pkg/controller/certificaterequests/checks.go
@@ -64,11 +64,11 @@ func (c *Controller) certificatesRequestsForGenericIssuer(iss cmapi.GenericIssue
 			continue
 		}
 		if !isClusterIssuer {
-			if crt.Namespace != iss.GetObjectMeta().Namespace {
+			if crt.Namespace != iss.GetNamespace() {
 				continue
 			}
 		}
-		if crt.Spec.IssuerRef.Name != iss.GetObjectMeta().Name {
+		if crt.Spec.IssuerRef.Name != iss.GetName() {
 			continue
 		}
 		affected = append(affected, crt)

--- a/pkg/controller/helper.go
+++ b/pkg/controller/helper.go
@@ -24,7 +24,7 @@ import (
 // ResourceNamespace returns the Kubernetes namespace where resources
 // created or read by `iss` are located.
 func (o IssuerOptions) ResourceNamespace(iss cmapi.GenericIssuer) string {
-	ns := iss.GetObjectMeta().Namespace
+	ns := iss.GetNamespace()
 	if ns == "" {
 		ns = o.ClusterResourceNamespace
 	}

--- a/test/unit/gen/issuer.go
+++ b/test/unit/gen/issuer.go
@@ -458,6 +458,6 @@ func AddIssuerCondition(c v1.IssuerCondition) IssuerModifier {
 
 func SetIssuerNamespace(namespace string) IssuerModifier {
 	return func(iss v1.GenericIssuer) {
-		iss.GetObjectMeta().Namespace = namespace
+		iss.SetNamespace(namespace)
 	}
 }


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

By coincidence, I notice the comment

> TODO: refactor these functions away

in generic_issuer.go. We could clean a lot more, but I suspect this will be slight breaking changes in the Go API. So let's start easy with a non-breaking change.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
