### PR TITLE
chore: don't create a useless context for the DigitalOcean HTTP client

### DIFF
--- a/pkg/issuer/acme/dns/digitalocean/digitalocean.go
+++ b/pkg/issuer/acme/dns/digitalocean/digitalocean.go
@@ -50,8 +50,7 @@ func NewDNSProviderCredentials(token string, dns01Nameservers []string, userAgen
 		return nil, fmt.Errorf("DigitalOcean token missing")
 	}
 
-	unusedCtx := context.Background() // context is not actually used
-	c := oauth2.NewClient(unusedCtx, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))
+	c := oauth2.NewClient(nil, oauth2.StaticTokenSource(&oauth2.Token{AccessToken: token}))
 
 	clientOpts := []godo.ClientOpt{godo.SetUserAgent(userAgent)}
 	client, err := godo.New(c, clientOpts...)


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

The context is unused and can be nil.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
