### PR TITLE
feat: Support Ingress annotation override for HTTP-01 ingressClassName

### DIFF
--- a/internal/apis/certmanager/types.go
+++ b/internal/apis/certmanager/types.go
@@ -85,6 +85,9 @@ const (
 	// acmeIssuerHTTP01IngressClassAnnotation can be used to override the http01 ingressClass
 	// if the challenge type is set to http01
 	IngressACMEIssuerHTTP01IngressClassAnnotationKey = "acme.cert-manager.io/http01-ingress-class"
+	// acmeIssuerHTTP01IngressClassNameAnnotation can be used to override the http01 ingressClassName
+	// if the challenge type is set to http01
+	IngressACMEIssuerHTTP01IngressClassNameAnnotationKey = "acme.cert-manager.io/http01-ingress-ingressclassname"
 
 	// IngressClassAnnotationKey picks a specific "class" for the Ingress. The
 	// controller only processes Ingresses with this annotation either unset, or

--- a/pkg/apis/acme/v1/types.go
+++ b/pkg/apis/acme/v1/types.go
@@ -34,6 +34,15 @@ const (
 	// solver for each ingress class.
 	ACMECertificateHTTP01IngressClassOverride = "acme.cert-manager.io/http01-override-ingress-class"
 
+	// ACMECertificateHTTP01IngressClassNameOverride is annotation to override ingressClassName.
+	// If this annotation is specified on a Certificate or Order resource when
+	// using the HTTP01 solver type, the ingress.ingressClassName field of the HTTP01
+	// solver's configuration will be set to the value given here.
+	// This is especially useful for users deploying many different ingress
+	// classes into a single cluster that want to be able to re-use a single
+	// solver for each ingress class.
+	ACMECertificateHTTP01IngressClassNameOverride = "acme.cert-manager.io/http01-override-ingress-ingressclassname"
+
 	// IngressEditInPlaceAnnotationKey is used to toggle the use of ingressClass instead
 	// of ingress on the created Certificate resource
 	IngressEditInPlaceAnnotationKey = "acme.cert-manager.io/http01-edit-in-place"

--- a/pkg/apis/certmanager/v1/types.go
+++ b/pkg/apis/certmanager/v1/types.go
@@ -143,6 +143,9 @@ const (
 	// IngressACMEIssuerHTTP01IngressClassAnnotationKey holds the acmeIssuerHTTP01IngressClassAnnotation value
 	// which can be used to override the http01 ingressClass if the challenge type is set to http01
 	IngressACMEIssuerHTTP01IngressClassAnnotationKey = "acme.cert-manager.io/http01-ingress-class"
+	// IngressACMEIssuerHTTP01IngressClassNameAnnotationKey holds the annotation value
+	// which can be used to override the http01 ingressClassName if the challenge type is set to http01
+	IngressACMEIssuerHTTP01IngressClassNameAnnotationKey = "acme.cert-manager.io/http01-ingress-ingressclassname"
 
 	// IngressClassAnnotationKey picks a specific "class" for the Ingress. The
 	// controller only processes Ingresses with this annotation either unset, or

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -152,7 +152,45 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 				},
 			},
 		},
-		"should return an error if both ingress class and name override annotations are set": {
+		"should override the ingressClassName to edit if override annotation is specified": {
+			acmeClient: basicACMEClient,
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
+						ACME: &cmacme.ACMEIssuer{
+							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
+						},
+					},
+				},
+			},
+			order: &cmacme.Order{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						cmacme.ACMECertificateHTTP01IngressClassNameOverride: "test-ingressclassname-to-override",
+					},
+				},
+				Spec: cmacme.OrderSpec{
+					DNSNames: []string{"example.com"},
+				},
+			},
+			authz: &cmacme.ACMEAuthorization{
+				Identifier: "example.com",
+				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
+			},
+			expectedChallengeSpec: &cmacme.ChallengeSpec{
+				Type:    cmacme.ACMEChallengeTypeHTTP01,
+				DNSName: "example.com",
+				Token:   acmeChallengeHTTP01.Token,
+				Solver: cmacme.ACMEChallengeSolver{
+					HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+						Ingress: &cmacme.ACMEChallengeSolverHTTP01Ingress{
+							IngressClassName: ptr.To("test-ingressclassname-to-override"),
+						},
+					},
+				},
+			},
+		},
+		"should return an error if both ingress name and ingress class override annotations are set": {
 			acmeClient: basicACMEClient,
 			issuer: &cmapi.Issuer{
 				Spec: cmapi.IssuerSpec{
@@ -168,6 +206,91 @@ func TestChallengeSpecForAuthorization(t *testing.T) {
 					Annotations: map[string]string{
 						cmacme.ACMECertificateHTTP01IngressNameOverride:  "test-name-to-override",
 						cmacme.ACMECertificateHTTP01IngressClassOverride: "test-class-to-override",
+					},
+				},
+				Spec: cmacme.OrderSpec{
+					DNSNames: []string{"example.com"},
+				},
+			},
+			authz: &cmacme.ACMEAuthorization{
+				Identifier: "example.com",
+				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
+			},
+			expectedError: true,
+		},
+		"should return an error if both ingress class and ingressClassName override annotations are set": {
+			acmeClient: basicACMEClient,
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
+						ACME: &cmacme.ACMEIssuer{
+							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
+						},
+					},
+				},
+			},
+			order: &cmacme.Order{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						cmacme.ACMECertificateHTTP01IngressClassOverride:     "test-class-to-override",
+						cmacme.ACMECertificateHTTP01IngressClassNameOverride: "test-ingressclassname-to-override",
+					},
+				},
+				Spec: cmacme.OrderSpec{
+					DNSNames: []string{"example.com"},
+				},
+			},
+			authz: &cmacme.ACMEAuthorization{
+				Identifier: "example.com",
+				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
+			},
+			expectedError: true,
+		},
+		"should return an error if both ingress name and ingressClassName override annotations are set": {
+			acmeClient: basicACMEClient,
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
+						ACME: &cmacme.ACMEIssuer{
+							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
+						},
+					},
+				},
+			},
+			order: &cmacme.Order{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						cmacme.ACMECertificateHTTP01IngressNameOverride:      "test-name-to-override",
+						cmacme.ACMECertificateHTTP01IngressClassNameOverride: "test-ingressclassname-to-override",
+					},
+				},
+				Spec: cmacme.OrderSpec{
+					DNSNames: []string{"example.com"},
+				},
+			},
+			authz: &cmacme.ACMEAuthorization{
+				Identifier: "example.com",
+				Challenges: []cmacme.ACMEChallenge{*acmeChallengeHTTP01},
+			},
+			expectedError: true,
+		},
+		"should return an error if all ingress name, ingress class and ingressClassName override annotations are set": {
+			acmeClient: basicACMEClient,
+			issuer: &cmapi.Issuer{
+				Spec: cmapi.IssuerSpec{
+					IssuerConfig: cmapi.IssuerConfig{
+						ACME: &cmacme.ACMEIssuer{
+							Solvers: []cmacme.ACMEChallengeSolver{emptySelectorSolverHTTP01},
+						},
+					},
+				},
+			},
+			order: &cmacme.Order{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						cmacme.ACMECertificateHTTP01IngressNameOverride:      "test-name-to-override",
+						cmacme.ACMECertificateHTTP01IngressClassOverride:     "test-class-to-override",
+						cmacme.ACMECertificateHTTP01IngressClassNameOverride: "test-ingressclassname-to-override",
 					},
 				},
 				Spec: cmacme.OrderSpec{


### PR DESCRIPTION
This PR implements a new `acme.cert-manager.io/http01-ingress-ingressclassname` Ingress annotation, to enable users to configure annotation-based override for HTTP01 solver's `ingressClassName` field in ACME Issuer.

This reduces operational complexity and the likelihood of user misconfiguration. Notably it also maintains strict backward compatibility with the existing `acme.cert-manager.io/http01-ingress-class` annotation - users who want to override the value of the `kubernetes.io/ingress.class` Ingress annotation can still make use of it.


```mermaid
sequenceDiagram
    participant User
    participant Ingress
    participant CertShim as Certificate-Shim
    participant Cert as Certificate
    participant Orders as ACME Orders
    participant Challenge as HTTP01 Challenge

    User->>Ingress: Create Ingress with new annotation
    Note over User,Ingress: acme.cert-manager.io/http01-ingress-ingressclassname
    CertShim->>Ingress: Watch and reconcile
    CertShim->>Cert: Create Certificate with override annotation
    Note over CertShim,Cert: acme.cert-manager.io/http01-override-ingress-ingressclassname
    Orders->>Cert: Process Certificate request
    Orders->>Orders: Validate mutual exclusivity
    Orders->>Challenge: Create HTTP01 challenge with custom ingressClassName
    Challenge->>Challenge: Apply ingressClassName override
```

_Please refer to this [design proposal](https://docs.google.com/document/d/1iSKx2B17wBl0W1sernt-HYcOXnjsLo4U-wPwoBp2O54/edit?usp=sharing) for the full context._

### Pull Request Motivation

Closes https://github.com/cert-manager/cert-manager/issues/6184

Currently cert-manager supports annotation-based overrides for `http01.ingress.class` via annotation `acme.cert-manager.io/http01-ingress-class`. But the same capability is missing for `http01.ingress.ingressClassName` spec field. This inconsistency could easily break the user experience and would likely cause misconfigurations, resulting in a "[conflict](https://github.com/cert-manager/cert-manager/issues/6184)".

It would also eliminate the requirement to set up a dedicated Issuer for every Ingress controller/class, as [#6184 (comment)](https://github.com/cert-manager/cert-manager/issues/6184#issuecomment-1720976571) and [#6651 (comment)](https://github.com/cert-manager/cert-manager/issues/6651#issuecomment-2273138674) reported.

### E2E Verification

Issuer with `ingressClassName`

<details>
<summary>with new Ingress annotation to override `ingressClassName`</summary>

```
# create Issuer with ingressClassName
k apply -f - << EOF
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: letsencrypt-universal
spec:
  acme:
    server: https://acme-staging-v02.api.letsencrypt.org/directory
    privateKeySecretRef:
      name: letsencrypt-http01-resources
    solvers:
    - http01:
        ingress:
          ingressClassName: fake
EOF

# create Ingress with new annotation
k apply -f - << EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-universal
    acme.cert-manager.io/http01-ingress-ingressclassname: nginx
  name: pebble
  namespace: pebble
spec:
  ingressClassName: nginx
  rules:
  - host: pebble.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: pebble
            port:
              number: 443
  tls:
  - hosts:
    - pebble.com
    secretName: pebble-cert
EOF

# check Ingress, Challenge, Certificate objects value should be override properly
k get ingress -n pebble -o yaml
...
metadata:
  annotations:
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::
  name: cm-acme-http-solver-k8nh8
  namespace: pebble
spec:
  ingressClassName: nginx
...

k get challenge -n pebble -o yaml
...
  spec:
    solver:
      http01:
        ingress:
          ingressClassName: nginx
...

k get certificate -n pebble -o yaml
...
  metadata:
    annotations:
      acme.cert-manager.io/http01-override-ingress-ingressclassname: nginx
    name: pebble-cert
    namespace: pebble
...
```

</details>

<details>
<summary>with old Ingress annotation to override `Class`</summary>

```
# create Ingress with old annotation
k apply -f - << EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-universal
    acme.cert-manager.io/http01-ingress-class: nginx
  name: pebble
  namespace: pebble
spec:
  ingressClassName: nginx
  rules:
  - host: pebble.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: pebble
            port:
              number: 443
  tls:
  - hosts:
    - pebble.com
    secretName: pebble-cert
EOF

# check Ingress, Challenge, Certificate objects value should be override properly
k get ingress -n pebble -o yaml
...
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::/0
  name: cm-acme-http-solver-q2fs6
  namespace: pebble
...

k get challenge -n pebble -o yaml
...
  spec:
    solver:
      http01:
        ingress:
          class: nginx
...

k get certificate -n pebble -o yaml
...
  metadata:
    annotations:
      acme.cert-manager.io/http01-override-ingress-class: nginx
    name: pebble-cert
    namespace: pebble
...
```

</details>

<details>
<summary>with both Ingress annotations</summary>

covered by UT - ACME Order creation fails with validation error

</details>

Issuer with `class`

<details>
<summary>with new Ingress annotation to override `ingressClassName`</summary>

```
# create Issuer with class
k apply -f - << EOF
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: letsencrypt-universal
spec:
  acme:
    server: https://acme-staging-v02.api.letsencrypt.org/directory
    privateKeySecretRef:
      name: letsencrypt-http01-resources
    solvers:
    - http01:
        ingress:
          class: fake
EOF

# create Ingress with new annotation

# check Ingress, Challenge, Certificate objects value should be override properly
k get ingress -n pebble -o yaml
...
metadata:
  annotations:
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::/0
  name: cm-acme-http-solver-k8nh8
  namespace: pebble
spec:
  ingressClassName: nginx
...

k get challenge -n pebble -o yaml
...
  spec:
    solver:
      http01:
        ingress:
          ingressClassName: nginx
...

k get certificate -n pebble -o yaml
...
  metadata:
    annotations:
      acme.cert-manager.io/http01-override-ingress-ingressclassname: nginx
    name: pebble-cert
    namespace: pebble
...
```

</details>

<details>
<summary>with old Ingress annotation to override `Class`</summary>

```
# create Ingress with legacy annotation

# check Ingress, Challenge, Certificate objects value should be override properly
k get ingress -n pebble -o yaml
...
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::/0
  name: cm-acme-http-solver-tcr9t
  namespace: pebble
...

k get challenge -n pebble -o yaml
...
  spec:
    solver:
      http01:
        ingress:
          class: nginx
...

k get certificate -n pebble -o yaml
...
  metadata:
    annotations:
      acme.cert-manager.io/http01-override-ingress-class: nginx
    name: pebble-cert
    namespace: pebble
...
```

</details>

<details>
<summary>with no Ingress annotation for override</summary>

```
# create Ingress with neither annotation
k apply -f - << EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-universal
  name: pebble
  namespace: pebble
spec:
  ingressClassName: fake
  rules:
  - host: pebble.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: pebble
            port:
              number: 443
  tls:
  - hosts:
    - pebble.com
    secretName: pebble-cert
EOF

# check Ingress, Challenge, Certificate objects value should not be overridden (uses solver's configs)
k get ingress -n pebble -o yaml
...
metadata:
  annotations:
    kubernetes.io/ingress.class: fake
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::/0
  name: cm-acme-http-solver-x4h6c
  namespace: pebble
...

k get challenge -n pebble -o yaml
...
  spec:
    solver:
      http01:
        ingress:
          class: fake
...

k get certificate -n pebble -o yaml
...
  metadata:
    name: pebble-cert
    namespace: pebble
...
```

</details>

<details>
<summary>with both Ingress annotations</summary>

covered by UT - ACME Order creation fails with validation error

</details>

[Multiple solvers] Issuer with `ingressClassName` and `class`

<details>
<summary>with new Ingress annotation to override `ingressClassName`</summary>

```
# create Issuer with ingressClassName + class
k apply -f - << EOF
apiVersion: cert-manager.io/v1
kind: ClusterIssuer
metadata:
  name: letsencrypt-universal
spec:
  acme:
    server: https://acme-staging-v02.api.letsencrypt.org/directory
    privateKeySecretRef:
      name: letsencrypt-http01-resources
    solvers:
    - http01:
        ingress:
          ingressClassName: fake
      selector:
        dnsZones:
          - pebble-new.com
    - http01:
        ingress:
          class: fake
      selector:
        dnsZones:
          - pebble-legacy.com
EOF

# create Ingress with new annotation
k apply -f - << EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-universal
    acme.cert-manager.io/http01-ingress-ingressclassname: nginx
  name: pebble
  namespace: pebble
spec:
  ingressClassName: nginx
  rules:
  - host: a.pebble-new.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: pebble
            port:
              number: 443
  tls:
  - hosts:
    - a.pebble-new.com
    secretName: pebble-cert
EOF

# check Ingress, Challenge, Certificate objects value should be override properly
k get ingress -n pebble -l acme.cert-manager.io/http01-solver="true" -o yaml
...
metadata:
  annotations:
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::/0
  name: cm-acme-http-solver-tcr9t
  namespace: pebble
spec:
  ingressClassName: nginx
  rules:
  - host: a.pebble-new.com
...

k get challenge -n pebble -o yaml
...
  spec:
    solver:
      http01:
        ingress:
          ingressClassName: nginx
      selector:
        dnsZones:
        - pebble-new.com
...

k get certificate -n pebble -o yaml
...
  metadata:
    annotations:
      acme.cert-manager.io/http01-override-ingress-ingressclassname: nginx
    name: pebble-cert
    namespace: pebble
...
```

</details>

<details>
<summary>with old Ingress annotation to override `Class`</summary>

```
# create ingress with legacy annotation
k apply -f - << EOF
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt-universal
    acme.cert-manager.io/http01-ingress-class: nginx
  name: pebble
  namespace: pebble
spec:
  ingressClassName: nginx
  rules:
  - host: b.pebble-legacy.com
    http:
      paths:
      - pathType: Prefix
        path: /
        backend:
          service:
            name: pebble
            port:
              number: 443
  tls:
  - hosts:
    - b.pebble-legacy.com
    secretName: pebble-cert
EOF

# check Ingress, Challenge, Certificate objects value should be override properly
k get ingress -n pebble -l acme.cert-manager.io/http01-solver="true" -o yaml
...
metadata:
  annotations:
    kubernetes.io/ingress.class: nginx
    nginx.ingress.kubernetes.io/whitelist-source-range: 0.0.0.0/0,::/0
  name: cm-acme-http-solver-tcr9t
  namespace: pebble
spec:
  rules:
  - host: b.pebble-legacy.com
...

k get challenge -n pebble -o yaml
...
    solver:
      http01:
        ingress:
          class: nginx
      selector:
        dnsZones:
        - pebble-legacy.com
...

k get certificate -n pebble -o yaml
...
  metadata:
    annotations:
      acme.cert-manager.io/http01-override-ingress-class: nginx
    name: pebble-cert
    namespace: pebble
...
```

</details>

### Kind

/kind feature

### Release Note

```release-note
Introduce a new Ingress annotation `acme.cert-manager.io/http01-ingress-ingressclassname` to override `http01.ingress.ingressClassName` field in HTTP-01 challenge solvers.
```
