### PR TITLE
Make unit test time comparisons less strict

### DIFF
--- a/internal/test/testutil/compare.go
+++ b/internal/test/testutil/compare.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Diff is a wrapper around "github.com/google/go-cmp/cmp".Diff to compare two objects,
+// taking into account that metav1.Time fields need special handling. This helps to avoid
+// challenges with serializing/deserializing time fields in tests.
+// The return value is also converted from cmp.Diff's string output to an error type.
+func Diff(a any, b any, opts ...cmp.Option) error {
+	allOpts := []cmp.Option{
+		cmp.Transformer("metav1.Time", func(in metav1.Time) string {
+			return in.Time.Format(time.RFC3339)
+		}),
+		cmp.Transformer("metav1.TimePtr", func(in *metav1.Time) *string {
+			if in == nil {
+				return nil
+			}
+
+			out := in.Time.Format(time.RFC3339)
+			return &out
+		}),
+	}
+
+	allOpts = append(allOpts, opts...)
+
+	diff := cmp.Diff(
+		a,
+		b,
+		allOpts...,
+	)
+
+	if diff != "" {
+		return fmt.Errorf("unexpected difference between compared objects (-want +got):\n%s", diff)
+	}
+
+	return nil
+}

--- a/pkg/controller/certificaterequests/util/reporter_test.go
+++ b/pkg/controller/certificaterequests/util/reporter_test.go
@@ -18,7 +18,6 @@ package util
 
 import (
 	"errors"
-	"fmt"
 	"slices"
 	"testing"
 	"time"
@@ -26,6 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clocktesting "k8s.io/utils/clock/testing"
 
+	"github.com/cert-manager/cert-manager/internal/test/testutil"
 	apiutil "github.com/cert-manager/cert-manager/pkg/api/util"
 	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	controllertest "github.com/cert-manager/cert-manager/pkg/controller/test"
@@ -263,11 +263,8 @@ func (tt *reporterT) runTest(t *testing.T) {
 		reporter.Ready(tt.certificateRequest)
 	}
 
-	expConditions := conditionsToString(tt.expectedConditions)
-	gotConditions := conditionsToString(tt.certificateRequest.Status.Conditions)
-	if expConditions != gotConditions {
-		t.Errorf("got unexpected conditions response exp=%+v got=%+v",
-			expConditions, gotConditions)
+	if diffErr := testutil.Diff(tt.expectedConditions, tt.certificateRequest.Status.Conditions); diffErr != nil {
+		t.Errorf("got unexpected conditions response: %v", diffErr)
 	}
 
 	if !slices.Equal(tt.expectedEvents, recorder.Events) {
@@ -289,8 +286,4 @@ func (tt *reporterT) runTest(t *testing.T) {
 				tt.certificateRequest.Status.FailureTime.String())
 		}
 	}
-}
-
-func conditionsToString(conds []cmapi.CertificateRequestCondition) string {
-	return fmt.Sprintf("%+v", conds)
 }

--- a/pkg/controller/test/actions.go
+++ b/pkg/controller/test/actions.go
@@ -17,10 +17,10 @@ limitations under the License.
 package test
 
 import (
-	"fmt"
-
 	"github.com/google/go-cmp/cmp"
 	coretesting "k8s.io/client-go/testing"
+
+	"github.com/cert-manager/cert-manager/internal/test/testutil"
 )
 
 // ActionMatchFn is a type of custom matcher for two Actions.
@@ -78,7 +78,7 @@ func (a *action) Action() coretesting.Action {
 
 // Matches compares action.action with another Action.
 func (a *action) Matches(act coretesting.Action) error {
-	diff := cmp.Diff(a.action, act,
+	return testutil.Diff(a.action, act,
 		// We ignore differences in .ManagedFields since the expected object does not have them.
 		// FIXME: don't ignore this field
 		cmp.FilterPath(func(p cmp.Path) bool {
@@ -86,8 +86,4 @@ func (a *action) Matches(act coretesting.Action) error {
 			return p.Last().String() == ".ManagedFields"
 		}, cmp.Ignore()),
 	)
-	if diff != "" {
-		return fmt.Errorf("unexpected difference between actions (-want +got):\n%s", diff)
-	}
-	return nil
 }

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -256,6 +256,7 @@ func (b *Builder) AllActionsExecuted() error {
 		if a.GetVerb() == "list" || a.GetVerb() == "watch" {
 			continue
 		}
+
 		found := false
 		var err error
 		for i, expA := range missingActions {
@@ -277,6 +278,7 @@ func (b *Builder) AllActionsExecuted() error {
 			found = true
 			break
 		}
+
 		if !found {
 			unexpectedActions = append(unexpectedActions, a)
 
@@ -285,12 +287,15 @@ func (b *Builder) AllActionsExecuted() error {
 			}
 		}
 	}
+
 	for _, a := range missingActions {
 		errs = append(errs, fmt.Errorf("missing action: %v", actionToString(a.Action())))
 	}
+
 	for _, a := range unexpectedActions {
 		errs = append(errs, fmt.Errorf("unexpected action: %v", actionToString(a)))
 	}
+
 	return utilerrors.NewAggregate(errs)
 }
 

--- a/pkg/issuer/acme/setup_test.go
+++ b/pkg/issuer/acme/setup_test.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclock "k8s.io/utils/clock/testing"
 
+	"github.com/cert-manager/cert-manager/internal/test/testutil"
 	"github.com/cert-manager/cert-manager/pkg/acme/accounts"
 	fakeregistry "github.com/cert-manager/cert-manager/pkg/acme/accounts/test"
 	acmecl "github.com/cert-manager/cert-manager/pkg/acme/client"
@@ -604,11 +605,9 @@ func TestAcme_Setup(t *testing.T) {
 
 			// Verify issuer's state after Setup was called.
 			gotConditions := test.issuer.GetStatus().Conditions
-			// Issuer can only have a single condition, so no need to sort the
-			// conditions.
-			if !reflect.DeepEqual(gotConditions, test.expectedConditions) {
-				t.Errorf("Expected issuer's conditions: %#+v\ngot: %#+v",
-					test.expectedConditions, gotConditions)
+			diffErr := testutil.Diff(test.expectedConditions, gotConditions)
+			if diffErr != nil {
+				t.Errorf("Issuer conditions differ: %v", diffErr)
 			}
 
 			// Verify that the expected events were recorded.


### PR DESCRIPTION
### Pull Request Motivation

The ultimate goal of this change is to move us forward with enabling SSA by default, as in #7908

This PR will remove one of those barriers, in that it relaxes how we compare time values.

In Kubernetes most timestamps are RFC3339 formatted, precise to a second (aside: it seems unlikely for that to change, see https://github.com/kubernetes/kubernetes/issues/15262)

Our comparisons _without_ SSA seem to be checking the `.String` representation of timestamps, and our comparisons _with_ SSA break because something in the SSA machinery does the RFC3339 conversion. The timestamps are fake anyway, but one way in which the tests fail under SSA-by-default is that the comparisons break.

This PR changes to use a wrapper around cmp.Diff which converts metav1.Time values and pointers into their respective RFC3339 representations. There might be better ways of achieving this goal, but this change has two big positives:

1) It doesn't break our tests _without_ SSA
2) It stops timestamp comparisons from being an issue _with_ SSA.

This PR should have runtime impacts at all, and should only affect a few of our unit tests.

I've checked that this removes the timestamp issues with SSA enabled by default (cherry-picked onto #7908 ).

### Also Considered

I also considered truncating the timestamps we set for `lastTransitionTime` to second-level precision, but I don't want to lose the more precise measurements if I can help it.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```

CyberArk tracker: [VC-47201](https://venafi.atlassian.net/browse/VC-47201) <!-- do not edit this line, will be re-added automatically -->