### PR TITLE
venafi: Process custom fields annotations on Issuer

### DIFF
--- a/pkg/controller/certificaterequests/venafi/custom_fields.go
+++ b/pkg/controller/certificaterequests/venafi/custom_fields.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package venafi
+
+import (
+	"encoding/json"
+	"sort"
+
+	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
+)
+
+func parseCustomFieldAnnotation(annotation string) ([]api.CustomField, error) {
+	var fields []api.CustomField
+	err := json.Unmarshal([]byte(annotation), &fields)
+	if err != nil {
+		return nil, err
+	}
+	return fields, nil
+}
+
+func mergeCustomFields(global, override []api.CustomField) []api.CustomField {
+	mergedMap := make(map[string]api.CustomField)
+	for _, g := range global {
+		mergedMap[g.Name] = g
+	}
+
+	for _, o := range override {
+		mergedMap[o.Name] = o
+	}
+
+	merged := make([]api.CustomField, 0, len(mergedMap))
+	for _, v := range mergedMap {
+		merged = append(merged, v)
+	}
+	sort.Slice(merged, func(i, j int) bool {
+		return merged[i].Name < merged[j].Name
+	})
+
+	return merged
+}

--- a/pkg/controller/certificaterequests/venafi/custom_fields_test.go
+++ b/pkg/controller/certificaterequests/venafi/custom_fields_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package venafi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	cmapi "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
+	"github.com/cert-manager/cert-manager/pkg/issuer/venafi/client/api"
+)
+
+func TestParseCustomFields(t *testing.T) {
+	annotation := map[string]string{
+		cmapi.VenafiCustomFieldsAnnotationKey: `[
+                  {"name": "Authoriser Name", "value": "John Doe"},{"name": "Division", "value": "BU1"}
+                ]`,
+	}
+	parsed, err := parseCustomFieldAnnotation(annotation[cmapi.VenafiCustomFieldsAnnotationKey])
+	expected := []api.CustomField{
+		{Name: "Authoriser Name", Value: "John Doe"},
+		{Name: "Division", Value: "BU1"},
+	}
+	assert.NoError(t, err)
+	assert.ElementsMatch(t, parsed, expected)
+
+	brokenAnnotation := map[string]string{
+		cmapi.VenafiCustomFieldsAnnotationKey: `[{"foo", "bar"}]`,
+	}
+	_, err = parseCustomFieldAnnotation(brokenAnnotation[cmapi.VenafiCustomFieldsAnnotationKey])
+	assert.Error(t, err)
+}
+
+func TestMergeFields(t *testing.T) {
+	globalFields := []api.CustomField{
+		{Name: "Authoriser Name", Value: "John Doe"},
+	}
+	overrideFields := []api.CustomField{
+		{Name: "Authoriser Name", Value: "Mary Jane"},
+	}
+
+	merged := mergeCustomFields(globalFields, overrideFields)
+	assert.Equal(t, merged[0].Value, "Mary Jane")
+
+	appendFields := []api.CustomField{
+		{Name: "ServiceNow Application Code", Value: "CIXXXXX"},
+	}
+	appended := mergeCustomFields(globalFields, appendFields)
+	assert.Len(t, appended, 2)
+	assert.Contains(t, appended, appendFields[0])
+}


### PR DESCRIPTION
When processing custom fields on CSR take into consideration annotation on Issuer and use them as base, whith
override/append on CSR level.

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

We have 200+ clusters with more that 4000 applications. With Venafi custom field enforcement, it would be nice to have and ability to define "global" custom fields on Issuer level with override/append on CSR level. 

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
For Venafi provider, read `venafi.cert-manager.io/custom-fields` annotation on Issuer/ClusterIssuer and use it as base with override/append capabilities on Certificate level.
```

CyberArk tracker: [VC-47691](https://venafi.atlassian.net/browse/VC-47691) <!-- do not edit this line, will be re-added automatically -->