### PR TITLE
Add global.tolerations to helm chart

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -105,6 +105,18 @@ The nodeSelector on Pods tells Kubernetes to schedule Pods on the nodes with mat
   
 If a component-specific nodeSelector is also set, it will be merged and take precedence.
 
+#### **global.tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Global tolerations  
+  
+A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).  
+  
+If component-specific tolerations are also set, they will be merged.
+
 #### **global.commonLabels** ~ `object`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -151,7 +151,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cainjector.tolerations }}
+      {{- $tolerations := .Values.global.tolerations | default list }}
+      {{- $tolerations = concat $tolerations (.Values.cainjector.tolerations | default list) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -224,7 +224,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.tolerations }}
+      {{- $tolerations := .Values.global.tolerations | default list }}
+      {{- $tolerations = concat $tolerations (.Values.tolerations | default list) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -95,7 +95,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.startupapicheck.tolerations }}
+      {{- $tolerations := .Values.global.tolerations | default list }}
+      {{- $tolerations = concat $tolerations (.Values.startupapicheck.tolerations | default list) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -204,7 +204,9 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.webhook.tolerations }}
+      {{- $tolerations := .Values.global.tolerations | default list }}
+      {{- $tolerations = concat $tolerations (.Values.webhook.tolerations | default list) }}
+      {{- with $tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -22,6 +22,14 @@ global:
   # +docs:property
   nodeSelector: {}
   
+  # Global tolerations
+  #
+  # A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
+  #
+  # If component-specific tolerations are also set, they will be merged.
+  # +docs:property
+  tolerations: []
+  
   # Labels to apply to all resources.
   # Please note that this does not add labels to the resources created dynamically by the controllers.
   # For these resources, you have to add the labels in the template in the cert-manager custom resource:


### PR DESCRIPTION
Adds a global.tolerations option to be able to set tolerations for all services in a single location. Component-specific tolerations are merged with the global ones. This is similar to the existing global.nodeSelector

<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

I have a nodeSelector for control-plane and I want all components to have control-plane tolerations without copy pasting it.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Adds a global.tolerations option to be able to set tolerations for all services.
```
