### PR TITLE
feat: Allow extra containers in deployment

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -472,6 +472,43 @@ For example:
 extraArgs:
   - --controllers=*,-certificaterequests-approver
 ```
+#### **extraContainers** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Extra containers to add to the pod spec in the deployment of the cert-manager controller. For example, to deploy the [aws_signing_helper](https://github.com/aws/rolesanywhere-credential-helper) (replacing the ARNs as relevant):
+
+```yaml
+extraEnv:
+  - name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+  - value: http://127.0.0.1:9911
+extraContainers:
+  - name: rolesanywhere-credential-helper
+    image: public.ecr.aws/rolesanywhere/credential-helper:latest
+    command: [aws_signing_helper]
+    args:
+      - serve
+      - --private-key
+      - /etc/cert/tls.key
+      - --certificate
+      - /etc/cert/tls.crt
+      - --role-arn
+      - $ROLE_ARN
+      - --profile-arn
+      - $PROFILE_ARN
+      - --trust-anchor-arn
+      - $TRUST_ANCHOR_ARN
+    volumeMounts:
+      - name: cert
+        mountPath: /etc/cert/
+        readOnly: true
+volumes:
+  - name: cert
+    secret:
+      secretName: cert
+```
 #### **extraEnv** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       priorityClassName: {{ . | quote }}
       {{- end }}
       {{- if (hasKey .Values.global "hostUsers") }}
-      hostUsers: {{ .Values.global.hostUsers }}       
+      hostUsers: {{ .Values.global.hostUsers }}
       {{- end }}
       {{- with .Values.securityContext }}
       securityContext:
@@ -76,8 +76,8 @@ spec:
       {{- if or .Values.volumes .Values.config}}
       volumes:
         {{- if .Values.config }}
-        - name: config 
-          configMap: 
+        - name: config
+          configMap:
             name: {{ include "cert-manager.fullname" . }}
         {{- end }}
         {{ with .Values.volumes }}
@@ -163,7 +163,7 @@ spec:
           {{- if or .Values.config .Values.volumeMounts }}
           volumeMounts:
             {{- if .Values.config }}
-            - name: config 
+            - name: config
               mountPath: /var/cert-manager/config
             {{- end }}
             {{- with .Values.volumeMounts }}
@@ -212,6 +212,9 @@ spec:
             failureThreshold: {{ .failureThreshold }}
           {{- end }}
           {{- end }}
+      {{- if .Values.extraContainers }}
+        {{- toYaml .Values.extraContainers | nindent 8 }}
+      {{- end }}
       {{- $nodeSelector := .Values.global.nodeSelector | default dict }}
       {{- $nodeSelector = merge $nodeSelector (.Values.nodeSelector | default dict) }}
       {{- with $nodeSelector }}

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -57,6 +57,9 @@
         "extraArgs": {
           "$ref": "#/$defs/helm-values.extraArgs"
         },
+        "extraContainers": {
+          "$ref": "#/$defs/helm-values.extraContainers"
+        },
         "extraEnv": {
           "$ref": "#/$defs/helm-values.extraEnv"
         },
@@ -659,6 +662,12 @@
     "helm-values.extraArgs": {
       "default": [],
       "description": "Additional command line flags to pass to cert-manager controller binary. To see all available flags run `docker run quay.io/jetstack/cert-manager-controller:<version> --help`.\n\nUse this flag to enable or disable arbitrary controllers. For example, to disable the CertificateRequests approver.\n\nFor example:\nextraArgs:\n  - --controllers=*,-certificaterequests-approver",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.extraContainers": {
+      "default": [],
+      "description": "Extra containers to add to the pod spec in the deployment of the cert-manager controller. For example, to deploy the [aws_signing_helper](https://github.com/aws/rolesanywhere-credential-helper) (replacing the ARNs as relevant):\nextraEnv:\n  - name: AWS_EC2_METADATA_SERVICE_ENDPOINT\n  - value: http://127.0.0.1:9911\nextraContainers:\n  - name: rolesanywhere-credential-helper\n    image: public.ecr.aws/rolesanywhere/credential-helper:latest\n    command: [aws_signing_helper]\n    args:\n      - serve\n      - --private-key\n      - /etc/cert/tls.key\n      - --certificate\n      - /etc/cert/tls.crt\n      - --role-arn\n      - $ROLE_ARN\n      - --profile-arn\n      - $PROFILE_ARN\n      - --trust-anchor-arn\n      - $TRUST_ANCHOR_ARN\n    volumeMounts:\n      - name: cert\n        mountPath: /etc/cert/\n        readOnly: true\nvolumes:\n  - name: cert\n    secret:\n      secretName: cert",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -21,7 +21,7 @@ global:
   # If a component-specific nodeSelector is also set, it will be merged and take precedence.
   # +docs:property
   nodeSelector: {}
-  
+
   # Labels to apply to all resources.
   # Please note that this does not add labels to the resources created dynamically by the controllers.
   # For these resources, you have to add the labels in the template in the cert-manager custom resource:
@@ -315,6 +315,38 @@ approveSignerNames:
 #  extraArgs:
 #    - --controllers=*,-certificaterequests-approver
 extraArgs: []
+
+# Extra containers to add to the pod spec in the deployment of the cert-manager controller.
+# For example, to deploy the [aws_signing_helper](https://github.com/aws/rolesanywhere-credential-helper) (replacing the ARNs as relevant):
+#
+# extraEnv:
+#   - name: AWS_EC2_METADATA_SERVICE_ENDPOINT
+#   - value: http://127.0.0.1:9911
+# extraContainers:
+#   - name: rolesanywhere-credential-helper
+#     image: public.ecr.aws/rolesanywhere/credential-helper:latest
+#     command: [aws_signing_helper]
+#     args:
+#       - serve
+#       - --private-key
+#       - /etc/cert/tls.key
+#       - --certificate
+#       - /etc/cert/tls.crt
+#       - --role-arn
+#       - $ROLE_ARN
+#       - --profile-arn
+#       - $PROFILE_ARN
+#       - --trust-anchor-arn
+#       - $TRUST_ANCHOR_ARN
+#     volumeMounts:
+#       - name: cert
+#         mountPath: /etc/cert/
+#         readOnly: true
+# volumes:
+#   - name: cert
+#     secret:
+#       secretName: cert
+extraContainers: []
 
 # Additional environment variables to pass to cert-manager controller binary.
 # For example:


### PR DESCRIPTION
### Pull Request Motivation

resolves: #8354 

This PR copies the patterns of the [cert-manager/aws-privateca-issuer](https://github.com/cert-manager/aws-privateca-issuer) to allow deploying arbitrary sidecar containers within the main cert-manager operator pod.

This allows use of the [aws_signing_helper](https://github.com/aws/rolesanywhere-credential-helper) to use AWS IAM Roles Anywhere for DNS validation of domain ownership even if the certificates themselves are not coming from AWS.

### Kind

/kind feature

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Added 'extraContainers' helm chart value, allowing the deployment of arbitrary sidecar containers within the cert-manager operator pod. This can be used to support, for e.g., AWS IAM Roles Anywhere for Route53 DNS01 verification. 
```
