### PR TITLE
docs: clarify PKCS1 encoding behavior for EC keys

### DIFF
--- a/internal/apis/certmanager/types_certificate.go
+++ b/internal/apis/certmanager/types_certificate.go
@@ -75,11 +75,9 @@ type PrivateKeyEncoding string
 
 const (
 	// PKCS1 private key encoding.
-	// PKCS1 produces a PEM block that contains the private key algorithm
-	// in the header and the private key in the body. A key that uses this
-	// can be recognised by its `BEGIN RSA PRIVATE KEY` or `BEGIN EC PRIVATE KEY` header.
-	// NOTE: This encoding is not supported for Ed25519 keys. Attempting to use
-	// this encoding with an Ed25519 key will be ignored and default to PKCS8.
+	// For RSA keys: produces PEM block with `BEGIN RSA PRIVATE KEY` header and private key in PKCS#1 format.
+	// For EC keys: produces PEM block with `BEGIN EC PRIVATE KEY` header and private key in SEC 1 format.
+	// For Ed25519 keys: option will be ignored and PKCS8 encoding will be used instead.
 	PKCS1 PrivateKeyEncoding = "PKCS1"
 
 	// PKCS8 private key encoding.

--- a/pkg/apis/certmanager/v1/types_certificate.go
+++ b/pkg/apis/certmanager/v1/types_certificate.go
@@ -95,11 +95,9 @@ type PrivateKeyEncoding string
 
 const (
 	// PKCS1 private key encoding.
-	// PKCS1 produces a PEM block that contains the private key algorithm
-	// in the header and the private key in the body. A key that uses this
-	// can be recognised by its `BEGIN RSA PRIVATE KEY` or `BEGIN EC PRIVATE KEY` header.
-	// NOTE: This encoding is not supported for Ed25519 keys. Attempting to use
-	// this encoding with an Ed25519 key will be ignored and default to PKCS8.
+	// For RSA keys: produces PEM block with `BEGIN RSA PRIVATE KEY` header and private key in PKCS#1 format.
+	// For EC keys: produces PEM block with `BEGIN EC PRIVATE KEY` header and private key in SEC 1 format.
+	// For Ed25519 keys: option will be ignored and PKCS8 encoding will be used instead.
 	PKCS1 PrivateKeyEncoding = "PKCS1"
 
 	// PKCS8 private key encoding.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR updates the documentation comments for the `PKCS1` constant in `PrivateKeyEncoding`.

The `PKCS#1` standard is exclusively for RSA algorithm, but cert-manager accepts `privateKey.encoding = "PKCS1"`
   for EC keys. The implementation actually produces SEC 1 format (not PKCS#1) when calling
  `x509.MarshalECPrivateKey`, but the documentation incorrectly describes this as PKCS1.

This change explicitly clarifies that distinction to avoid confusion for users.

Fixes #8241

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind documentation
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
