### PR TITLE
fix: Confusing messaging when certificate secret name already exist

### DIFF
--- a/pkg/controller/certificaterequests/sync.go
+++ b/pkg/controller/certificaterequests/sync.go
@@ -160,7 +160,7 @@ func (c *Controller) Sync(ctx context.Context, cr *cmapi.CertificateRequest) (er
 	if err != nil {
 		message := "Failed to decode returned certificate"
 		if issuerType == apiutil.IssuerCA {
-			message = "Failed to decode returned certificate: if using a CA issuer, ensure the Certificate's secretName is different from the CA issuer's secretName to avoid overwriting the CA secret"
+			message = "Failed to decode returned certificate: with CA issuers, ensure the Certificate's secretName is different from the CA issuer's secretName to avoid overwriting the CA secret"
 		}
 		c.reporter.Failed(crCopy, err, "DecodeError", message)
 		return nil


### PR DESCRIPTION
Fixes #7002

## Changes
- Improve error message when decoding certificate fails for CA issuers
- Add hint about ensuring Certificate's secretName is different from the CA issuer's secretName to avoid overwriting the CA secret

```release-note
Improve error message when CA issuers are misconfigured to use a clashing secret name
```