### PR TITLE
WIP: Improve challenge update logic (SSA)

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -190,7 +190,7 @@ func (c *controller) runScheduler(ctx context.Context) {
 		log := logf.WithResource(log, chOriginal)
 		ch := chOriginal.DeepCopy()
 		ch.Status.Processing = true
-		if err := c.updateObject(ctx, chOriginal, ch); err != nil {
+		if err := c.updateObject(ctx, chOriginal, ChallengeUpdateIntent{Status: &ch.Status}); err != nil {
 			log.Error(err, "error scheduling challenge for processing")
 			return
 		}

--- a/pkg/controller/acmechallenges/sync_test.go
+++ b/pkg/controller/acmechallenges/sync_test.go
@@ -132,7 +132,7 @@ func TestSyncHappyPath(t *testing.T) {
 				},
 			},
 		},
-		"if the challenge is deleted and the cleanup fails, set the reason (and remove the finalizer, which is a bug)": {
+		"if the challenge is deleted and the cleanup fails, set the reason": {
 			challenge: gen.ChallengeFrom(deletedChallenge,
 				gen.SetChallengeProcessing(true),
 				gen.SetChallengeURL("testurl"),
@@ -153,15 +153,6 @@ func TestSyncHappyPath(t *testing.T) {
 					testIssuerHTTP01Enabled,
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewUpdateAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
-						gen.DefaultTestNamespace,
-						gen.ChallengeFrom(deletedChallenge,
-							gen.SetChallengeProcessing(true),
-							gen.SetChallengeURL("testurl"),
-							gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
-							gen.SetChallengeFinalizers([]string{}),
-							gen.SetChallengeReason(simulatedCleanupError.Error()),
-						))),
 					testpkg.NewAction(
 						coretesting.NewUpdateSubresourceAction(cmacme.SchemeGroupVersion.WithResource("challenges"),
 							"status",
@@ -170,7 +161,6 @@ func TestSyncHappyPath(t *testing.T) {
 								gen.SetChallengeProcessing(true),
 								gen.SetChallengeType(cmacme.ACMEChallengeTypeHTTP01),
 								gen.SetChallengeURL("testurl"),
-								gen.SetChallengeFinalizers([]string{}),
 								gen.SetChallengeReason(simulatedCleanupError.Error()),
 							))),
 				},


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

The main motivation for this PR is to make progress on the stalled PR to graduate the ServerSideApply feature gate, https://github.com/cert-manager/cert-manager/pull/7908.

Instead of providing a generic challenge "updater", I propose a new ChallengeUpdateIntent struct containing only the specific fields we currently support in the updater. This allows us to start using challenge apply configurations and avoid the error-prone marshalling apply utility functions. This will also allow us to remove some now obsolete tests of these helper functions.

One test was failing after this primary change, and after digging in, it seems like the test is documenting an existing bug, which should now be fixed: The challenge finalizer should not be deleted if the cleanup fails.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Only remove the challenge finalizer if cleanup is successful
```
