### PR TITLE
[VC-48226] Enable default NetworkPolicies in best-practice installation e2e tests

### DIFF
--- a/make/e2e-setup.mk
+++ b/make/e2e-setup.mk
@@ -249,8 +249,13 @@ E2E_SETUP_OPTION_BESTPRACTICE ?=
 ## which will allow cert-manager to be installed and used in a cluster where
 ## Kyverno and the policies in make/config/kyverno have been applied.
 ##
+## We use the "release-next" branch of the website, because that branch will
+## contain the latest recommendations, including those that rely on features in
+## the next-release of cert-manager.
+## https://github.com/cert-manager/website/blob/release-next/public/docs/installation/best-practice/values.best-practice.yaml
+##
 ## @category Development
-E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL ?= https://raw.githubusercontent.com/cert-manager/website/ea5db62772e6b9d1430b9d63f581e74d5c18b627/public/docs/installation/best-practice/values.best-practice.yaml
+E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL ?= https://raw.githubusercontent.com/cert-manager/website/8336efc6466349e51d28dbb9f8c1c7bd2b654c33/public/docs/installation/best-practice/values.best-practice.yaml
 E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL_SUM := $(shell sha256sum <<<$(E2E_SETUP_OPTION_BESTPRACTICE_HELM_VALUES_URL) | cut -d ' ' -f 1)
 
 ## A local Helm values file containing best-practice configuration values.


### PR DESCRIPTION
I've updated the NetworkPolicy recommendations on cert-manager.io "release-next" branch, to use the new NetworkPolicy Helm chart values. 
This PR ensures that those new recommended values are used in our daily "best-practice" E2E tests.
Building upon these previous PRs:
 * https://github.com/cert-manager/cert-manager/pull/8370
 * https://github.com/cert-manager/website/pull/1911

/kind cleanup

```release-note
NONE
```

CyberArk tracker: [VC-48411](https://venafi.atlassian.net/browse/VC-48411) <!-- do not edit this line, will be re-added automatically -->


## Testing

I triggered the best-practice E2E tests on this branch and they passed. See test results below.