### PR TITLE
Remove G601 linter exceptions

### DIFF
--- a/internal/apis/certmanager/validation/issuer.go
+++ b/internal/apis/certmanager/validation/issuer.go
@@ -143,7 +143,7 @@ func ValidateACMEIssuerConfig(iss *cmacme.ACMEIssuer, fldPath *field.Path) (fiel
 	}
 
 	for i, sol := range iss.Solvers {
-		el = append(el, ValidateACMEIssuerChallengeSolverConfig(&sol, fldPath.Child("solvers").Index(i))...) // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
+		el = append(el, ValidateACMEIssuerChallengeSolverConfig(&sol, fldPath.Child("solvers").Index(i))...)
 	}
 
 	return el, warnings

--- a/pkg/util/solverpicker/solverpicker.go
+++ b/pkg/util/solverpicker/solverpicker.go
@@ -49,7 +49,7 @@ func Pick(ctx context.Context, domainToFind string, challenges []cmacme.ACMEChal
 
 	// 2. filter solvers to only those that matchLabels
 	for _, cfg := range solvers {
-		acmech := challengeForSolver(&cfg) // #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010
+		acmech := challengeForSolver(&cfg)
 		if acmech == nil {
 			dbg.Info("cannot use solver as the ACME authorization does not allow solvers of this type")
 			continue

--- a/test/e2e/suite/certificates/duplicatesecretname.go
+++ b/test/e2e/suite/certificates/duplicatesecretname.go
@@ -129,7 +129,7 @@ var _ = framework.CertManagerDescribe("Certificate Duplicate Secret Name", func(
 				Expect(err).NotTo(HaveOccurred())
 				var ownedReqs int
 				for _, req := range reqs.Items {
-					if predicate.ResourceOwnedBy(crt)(&req) /* #nosec G601 -- False positive. See https://github.com/golang/go/discussions/56010 */ {
+					if predicate.ResourceOwnedBy(crt)(&req) {
 						ownedReqs++
 					}
 				}


### PR DESCRIPTION
These exceptions are no longer required since newer versions of Go don't have the loop var issue anymore.

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
