### PR TITLE
fix(acme/http01): solver mishandles host headers containing an IPv6 address without a port number

### DIFF
--- a/pkg/issuer/acme/http/solver/solver.go
+++ b/pkg/issuer/acme/http/solver/solver.go
@@ -18,8 +18,8 @@ package solver
 
 import (
 	"fmt"
+	"net"
 	"net/http"
-	"net/netip"
 	"path"
 	"strings"
 	"time"
@@ -117,18 +117,15 @@ func (h *HTTP01Solver) challengeHandler(log logr.Logger) http.HandlerFunc {
 }
 
 func parseHost(s string) string {
-	// ip v4/v6 with port
-	addrPort, err := netip.ParseAddrPort(s)
-	if err == nil {
-		return addrPort.Addr().String()
+	// According to RFC 3986 Section 3.2.2, IPv6 address literals must be enclosed in square brackets.
+	// In addition, per RFC 9110, the HTTP Host header follows URI host syntax.
+	// Therefore, square brackets are required for IPv6 addresses.
+
+	// with port
+	if host, _, err := net.SplitHostPort(s); err == nil {
+		return host
 	}
 
-	// ip v4/v6 without port
-	addr, err := netip.ParseAddr(s)
-	if err == nil {
-		return addr.String()
-	}
-
-	host := strings.Split(s, ":")
-	return host[0]
+	// without port
+	return strings.Trim(s, "[]")
 }

--- a/pkg/issuer/acme/http/solver/solver_test.go
+++ b/pkg/issuer/acme/http/solver/solver_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSolver(t *testing.T) {
@@ -135,7 +136,55 @@ func TestSolver(t *testing.T) {
 			if tc.solverKey != "" && response != tc.solverKey {
 				t.Errorf("Expected response body %q, got %q", tc.solverKey, response)
 			}
+		})
+	}
+}
 
+func Test_parseHost(t *testing.T) {
+	t.Parallel()
+
+	cases := map[string]struct {
+		input    string
+		expected string
+	}{
+		"FQDN with port": {
+			input:    "example.com:8080",
+			expected: "example.com",
+		},
+		"FQDN without port": {
+			input:    "example.com",
+			expected: "example.com",
+		},
+		"IPv4 address with port": {
+			input:    "192.168.1.1:8080",
+			expected: "192.168.1.1",
+		},
+		"IPv4 address without port": {
+			input:    "192.168.1.1",
+			expected: "192.168.1.1",
+		},
+		"IPv6 address with port": {
+			input:    "[2001:db8:3333:4444:5555:6666:7777:8888]:1234",
+			expected: "2001:db8:3333:4444:5555:6666:7777:8888",
+		},
+		"IPv6 address with port - 2": {
+			input:    "[2a00:8a00:4000:435::13a]:1234",
+			expected: "2a00:8a00:4000:435::13a",
+		},
+		"IPv6 address without port": {
+			input:    "[2001:db8:3333:4444:5555:6666:7777:8888]",
+			expected: "2001:db8:3333:4444:5555:6666:7777:8888",
+		},
+		"IPv6 address without bracket": {
+			input:    "2001:db8:3333:4444:5555:6666:7777:8888",
+			expected: "2001:db8:3333:4444:5555:6666:7777:8888",
+		},
+	}
+
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			actual := parseHost(tc.input)
+			assert.Equal(t, tc.expected, actual)
 		})
 	}
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes https://github.com/cert-manager/cert-manager/issues/8423.

The `netip.ParseAddr` functions do not support IPv6 address literals (notation enclosed in square brackets). Therefore, if the host header is an IPv6 address literal without a port number, it always falls back to a simple string split implementation, which caused the verification of IPv6 address hosts to fail.

According to RFC 3986 Section 3.2.2, IPv6 address literals must be enclosed in square brackets. In addition, per RFC 9110, the HTTP Host header follows URI host syntax.
Therefore, square brackets are required for IPv6 addresses.

### Kind

/kind bug

### Release Note

```release-note
Fixed an issue where HTTP-01 challenges failed when the Host header contains an IPv6 address. This means that users can now issue IP address certificates for IPv6 address subjects.
```
