### PR TITLE
Design: Image config Helm Chart (Introduction of 2 additional Helm Values)

### DIFF
--- a/design/20260120.images-in-the-helm-chart.md
+++ b/design/20260120.images-in-the-helm-chart.md
@@ -100,6 +100,16 @@ imageRegistry: quay.io
 imageNamespace: jetstack
 ```
 
+This design relies on per-component `image.name` values which can be overridden by users. The chart uses these names when constructing the image repository from `imageRegistry` and `imageNamespace`.
+
+Examples of where these fields would live:
+
+- `image.name` (controller)
+- `webhook.image.name`
+- `cainjector.image.name`
+- `startupapicheck.image.name`
+- `acmesolver.image.name`
+
 Image repository construction for a given component becomes:
 
 ```pseudocode
@@ -184,6 +194,21 @@ If FIPS images are selected by using `-fips` in the image name, users still only
 ```yaml
 imageRegistry: private-registry.venafi.cloud
 imageNamespace: cert-manager
+
+image:
+  name: cert-manager-controller-fips
+acmesolver:
+  image:
+    name: cert-manager-acmesolver-fips
+webhook:
+  image:
+    name: cert-manager-webhook-fips
+cainjector:
+  image:
+    name: cert-manager-cainjector-fips
+startupapicheck:
+  image:
+    name: cert-manager-startupapicheck-fips
 ```
 
 ```


### PR DESCRIPTION
Building on the Design proposed here: https://github.com/cert-manager/cert-manager/pull/7748

Preview: [20260120.images-in-the-helm-chart.md](https://github.com/FelixPhipps/helm-chart-images-design/blob/master/design/20260120.images-in-the-helm-chart.md)

```release-note
NONE
```