### PR TITLE
feat(chart): Set ttlSecondsAfterFinished for statupapicheck

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -1921,6 +1921,13 @@ Container Security Context to be set on the controller component container. For 
 > ```
 
 Timeout for 'kubectl check api' command.
+#### **startupapicheck.ttlSecondsAfterFinished** ~ `unknown`
+> Default value:
+> ```yaml
+> null
+> ```
+
+ttlSecondsAfterFinished for the startupapicheck Job
 #### **startupapicheck.backoffLimit** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  {{- if .Values.startupapicheck.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ .Values.startupapicheck.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1500,6 +1500,9 @@
         "tolerations": {
           "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
         },
+        "ttlSecondsAfterFinished": {
+          "$ref": "#/$defs/helm-values.startupapicheck.ttlSecondsAfterFinished"
+        },
         "volumeMounts": {
           "$ref": "#/$defs/helm-values.startupapicheck.volumeMounts"
         },
@@ -1719,6 +1722,9 @@
       "description": "A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
       "items": {},
       "type": "array"
+    },
+    "helm-values.startupapicheck.ttlSecondsAfterFinished": {
+      "description": "ttlSecondsAfterFinished for the startupapicheck Job"
     },
     "helm-values.startupapicheck.volumeMounts": {
       "default": [],

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1457,6 +1457,9 @@ startupapicheck:
   # Timeout for 'kubectl check api' command.
   timeout: 1m
 
+  # ttlSecondsAfterFinished for the startupapicheck Job
+  ttlSecondsAfterFinished: NULL
+
   # Job backoffLimit
   backoffLimit: 4
 


### PR DESCRIPTION
### Pull Request Motivation

Kube-linter reports a notice that `ttlSecondsAfterFinished` is unset.

I have no idea how to get the schema to detect `int` or `NULL` as the only valid values..

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Set ttlSecondsAfterFinished for statupapicheck via helm
```
