### PR TITLE
Fix ServiceMonitor and PodMonitor

### DIFF
--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -29,23 +29,8 @@ metadata:
 spec:
   jobLabel: app.kubernetes.io/name
   selector:
-    matchExpressions:
-      - key: app.kubernetes.io/name
-        operator: In
-        values:
-        - {{ include "cainjector.name" . }}
-        - {{ template "cert-manager.name" . }}
-        - {{ include "webhook.name" . }}
-      - key: app.kubernetes.io/instance
-        operator: In
-        values:
-        - {{ .Release.Name }}
-      - key: app.kubernetes.io/component
-        operator: In
-        values:
-        - cainjector
-        - controller
-        - webhook
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.prometheus.podmonitor.namespace }}
   namespaceSelector:
     matchNames:

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -31,23 +31,8 @@ metadata:
 spec:
   jobLabel: app.kubernetes.io/name
   selector:
-    matchExpressions:
-      - key: app.kubernetes.io/name
-        operator: In
-        values:
-        - {{ include "cainjector.name" . }}
-        - {{ template "cert-manager.name" . }}
-        - {{ include "webhook.name" . }}
-      - key: app.kubernetes.io/instance
-        operator: In
-        values:
-        - {{ .Release.Name }}
-      - key: app.kubernetes.io/component
-        operator: In
-        values:
-        - cainjector
-        - controller
-        - webhook
+    matchLabels:
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{- if .Values.prometheus.servicemonitor.namespace }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->
cert-manager helm-chart currently deploys either a ServiceMonitor or PodMonitor with the following matchExpressions
```yaml
  selector:
    matchExpressions:
    - key: app.kubernetes.io/name
      operator: In
      values:
      - cainjector
      - cert-manager
      - webhook
    - key: app.kubernetes.io/instance
      operator: In
      values:
      - cert-manager
    - key: app.kubernetes.io/component
      operator: In
      values:
      - cainjector
      - controller
      - webhook
 ```

This was introduced in https://github.com/cert-manager/cert-manager/pull/7182 and the motivation there was to selectively enable scraping for each cert-manager component.

Now that all cert-manager components can be scraped, the matchExpressions can be reduced down to a simple matchLabels
```yaml
  selector:
    matchLabels:
      app.kubernetes.io/instance: cert-manager
```

In my older Prometheus v2.53.4 (old I know, will need to upgrade) there [seems to be a bug](https://github.com/prometheus/prometheus/issues/17939) where the matchExpressions only scrapes the webhook. This change to matchLabels solves that issue.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
