### PR TITLE
Prevent ACME challenge TXT records from being left behind in CloudDNS

### DIFF
--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -279,6 +279,8 @@ func (c *DNSProvider) getHostedZone(ctx context.Context, domain string) (string,
 func (c *DNSProvider) findTxtRecords(ctx context.Context, zone, fqdn, value string) ([]*dns.ResourceRecordSet, error) {
 	recs, err := c.client.ResourceRecordSets.
 		List(c.project, zone).
+		Name(fqdn).
+		Type("TXT").
 		Context(ctx).
 		Do()
 	if err != nil {
@@ -288,12 +290,10 @@ func (c *DNSProvider) findTxtRecords(ctx context.Context, zone, fqdn, value stri
 	found := []*dns.ResourceRecordSet{}
 RecLoop:
 	for _, r := range recs.Rrsets {
-		if r.Type == "TXT" && r.Name == fqdn {
-			for _, s := range r.Rrdatas {
-				if strings.Trim(s, "\"") == value {
-					found = append(found, r)
-					continue RecLoop
-				}
+		for _, s := range r.Rrdatas {
+			if strings.Trim(s, "\"") == value {
+				found = append(found, r)
+				continue RecLoop
 			}
 		}
 	}


### PR DESCRIPTION
### Pull Request Motivation

Relates to https://github.com/cert-manager/cert-manager/issues/3640

Cloud DNS’s `resourceRecordSets.list` API returns only a fixed number of records per request (1000 at the time I checked).
https://cloud.google.com/dns/docs/reference/rest/v1/resourceRecordSets/list

`func (r *ResourceRecordSetsService) List()`, which uses this API, therefore returns only the first 1000 records. As a result, ACME TXT records are not always cleaned up when the total number of resource records exceeds 1000.

This PR fixes the issue by querying only the target record instead of listing all records, avoiding pagination.

### Kind

/kind bug

### Release Note

```release-note
Fix an issue where ACME challenge TXT records are not cleaned up when there are many resource records in CloudDNS.
```
