### PR TITLE
Improve Challenge finalizer handling

### DIFF
--- a/pkg/controller/acmechallenges/controller.go
+++ b/pkg/controller/acmechallenges/controller.go
@@ -190,7 +190,7 @@ func (c *controller) runScheduler(ctx context.Context) {
 		log := logf.WithResource(log, chOriginal)
 		ch := chOriginal.DeepCopy()
 		ch.Status.Processing = true
-		if err := c.updateObject(ctx, chOriginal, ch); err != nil {
+		if _, err := c.updateStatus(ctx, ch); err != nil {
 			log.Error(err, "error scheduling challenge for processing")
 			return
 		}

--- a/pkg/controller/acmechallenges/finalizer.go
+++ b/pkg/controller/acmechallenges/finalizer.go
@@ -29,8 +29,11 @@ import (
 // deployed ("presented") resources and if successful, removes this finalizer
 // allowing the garbage collector to remove the challenge.
 
-// finalizerRequired returns true if the finalizer is not found on the challenge.
-func finalizerRequired(ch *cmacme.Challenge) bool {
-	finalizers := sets.New(ch.Finalizers...)
-	return !finalizers.Has(cmacme.ACMELegacyFinalizer) && !finalizers.Has(cmacme.ACMEDomainQualifiedFinalizer)
+// applyFinalizersRequired returns true when the domain-qualified finalizer is missing
+// or when the legacy finalizer is present on the challenge, indicating finalizers
+// need to be (re)applied.
+func applyFinalizersRequired(ch *cmacme.Challenge) bool {
+	finalizers := sets.NewString(ch.Finalizers...)
+	return !finalizers.Has(cmacme.ACMEDomainQualifiedFinalizer) ||
+		finalizers.Has(cmacme.ACMELegacyFinalizer)
 }

--- a/pkg/controller/acmechallenges/finalizer_test.go
+++ b/pkg/controller/acmechallenges/finalizer_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func Test_finalizerRequired(t *testing.T) {
+func Test_applyFinalizersRequired(t *testing.T) {
 	tests := []struct {
 		name       string
 		finalizers []string
@@ -39,7 +39,7 @@ func Test_finalizerRequired(t *testing.T) {
 		{
 			name:       "only-native-legacy-finalizer",
 			finalizers: []string{cmacme.ACMELegacyFinalizer},
-			want:       false,
+			want:       true,
 		},
 		{
 			name:       "only-native-domain-qualified-finalizer",
@@ -49,12 +49,12 @@ func Test_finalizerRequired(t *testing.T) {
 		{
 			name:       "both-native-finalizers",
 			finalizers: []string{cmacme.ACMELegacyFinalizer, cmacme.ACMEDomainQualifiedFinalizer},
-			want:       false,
+			want:       true,
 		},
 		{
 			name:       "some-foreign-and-legacy-finalizer",
 			finalizers: []string{"f1", "f2", cmacme.ACMELegacyFinalizer, "f3"},
-			want:       false,
+			want:       true,
 		},
 		{
 			name:       "some-foreign-and-domain-qualified-finalizer",
@@ -64,7 +64,7 @@ func Test_finalizerRequired(t *testing.T) {
 		{
 			name:       "some-foreign-and-legacy-finalizer-and-domain-qualified-finalizer",
 			finalizers: []string{"f1", "f2", cmacme.ACMELegacyFinalizer, cmacme.ACMEDomainQualifiedFinalizer, "f3"},
-			want:       false,
+			want:       true,
 		},
 		{
 			name:       "only-foreign-finalizers",
@@ -77,7 +77,7 @@ func Test_finalizerRequired(t *testing.T) {
 			assert.Equal(
 				t,
 				tt.want,
-				finalizerRequired(
+				applyFinalizersRequired(
 					gen.Challenge("example", gen.SetChallengeFinalizers(tt.finalizers)),
 				),
 			)

--- a/pkg/controller/acmechallenges/update_test.go
+++ b/pkg/controller/acmechallenges/update_test.go
@@ -18,12 +18,11 @@ package acmechallenges
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -36,45 +35,29 @@ import (
 	"github.com/cert-manager/cert-manager/test/unit/gen"
 )
 
-func TestUpdateObjectStandard(t *testing.T) {
-	runUpdateObjectTests(t, "update")
+func TestUpdateStatusStandard(t *testing.T) {
+	runUpdateStatusTests(t, "update")
 }
 
-func TestUpdateObjectSSA(t *testing.T) {
+func TestUpdateStatusApply(t *testing.T) {
 	featuretesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, feature.ServerSideApply, true)
-	runUpdateObjectTests(t, "patch")
+	runUpdateStatusTests(t, "patch")
 }
 
-func runUpdateObjectTests(t *testing.T, verb string) {
-	simulatedUpdateError := errors.New("simulated-update-error")
+func runUpdateStatusTests(t *testing.T, verb string) {
 	simulatedUpdateStatusError := errors.New("simulated-update-status-error")
 
-	// NOTE: We cannot test updates to both the main resource and status
-	// subresource in the same test using APPLY as the fake.NewClientset used
-	// in these tests uses a very simple object tracker that does not track main and
-	// subresource fields separately, which is required for SSA to function.
-	// For reference see these comments in upstream K8s code:
-	// - https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/staging/src/k8s.io/client-go/testing/fixture.go#L97-L99
-	// - https://github.com/kubernetes/kubernetes/blob/790393ae92e97262827d4f1fba24e8ae65bbada0/staging/src/k8s.io/client-go/testing/fixture.go#L167-L169
-	// The fake client works for UPDATE, but since the K8s ecosystem is moving towards SSA,
-	// we should try to improve our code (and/or test strategy) long-term.
 	tests := []struct {
 		name              string
-		skip              bool
 		mods              []gen.ChallengeModifier
 		notFound          bool
-		updateError       error
 		updateStatusError error
 		errorMessage      string
 	}{
-		// Modifying the finalizers and any status fields results in both
-		// finalizers and status being updated.
+		// Modifying any status fields results in both status being updated.
 		{
 			name: "success",
-			// FIXME: Skip test case when using SSA. See description above.
-			skip: verb == "patch",
 			mods: []gen.ChallengeModifier{
-				gen.SetChallengeFinalizers([]string{"example.com/another-finalizer"}),
 				gen.SetChallengePresented(true),
 			},
 		},
@@ -88,74 +71,27 @@ func runUpdateObjectTests(t *testing.T, verb string) {
 			},
 			notFound: true,
 		},
-		// Only the Finalizers and Status fields can be updated. Updates to any
-		// other fields suggests a programming error an argument error.
-		{
-			name: "error-on-non-finalizer-non-status-modifications",
-			mods: []gen.ChallengeModifier{
-				gen.SetChallengeDNSName("new-dns-name"),
-			},
-			errorMessage: fmt.Sprintf(
-				"%s: in updateObject: unexpected differences between old and new: only the finalizers and status fields may be modified",
-				errArgument,
-			),
-		},
-		// If the Update API call fails, that error is returned.
-		{
-			name: "update-error-only",
-			mods: []gen.ChallengeModifier{
-				gen.SetChallengeFinalizers([]string{"example.com/another-finalizer"}),
-			},
-			updateError:  simulatedUpdateError,
-			errorMessage: fmt.Sprintf("when updating the finalizers: %s", simulatedUpdateError),
-		},
 		// If the UpdateStatus API call fails, that error is returned.
 		{
-			name: "update-status-error-only",
+			name: "update-status-error",
 			mods: []gen.ChallengeModifier{
 				gen.SetChallengePresented(true),
 			},
 			updateStatusError: simulatedUpdateStatusError,
-			errorMessage:      fmt.Sprintf("when updating the status: %s", simulatedUpdateStatusError),
-		},
-		// If both Update and UpdateStatus API calls fail, both errors are returned.
-		{
-			name: "all-updates-fail",
-			mods: []gen.ChallengeModifier{
-				gen.SetChallengeFinalizers([]string{"example.com/another-finalizer"}),
-				gen.SetChallengePresented(true),
-			},
-			updateError:       simulatedUpdateError,
-			updateStatusError: simulatedUpdateStatusError,
-			errorMessage: fmt.Sprintf(
-				"[when updating the status: %s, when updating the finalizers: %s]",
-				simulatedUpdateStatusError,
-				simulatedUpdateError,
-			),
+			errorMessage:      simulatedUpdateStatusError.Error(),
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.skip {
-				t.Skip("The fake client doesn't support K8s subresources like status when using SSA.")
-			}
-
 			oldChallenge := gen.Challenge("c1")
 			newChallenge := gen.ChallengeFrom(oldChallenge, tt.mods...)
 			cl := fake.NewClientset(oldChallenge)
 			if tt.notFound {
-				cl.PrependReactor(verb, "challenges", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-					t.Log("Simulating a challenge that has been deleted")
-					return true, nil, k8sErrors.NewNotFound(schema.GroupResource{}, "")
+				cl.PrependReactor(verb, "challenges/status", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					t.Log("Simulating a situation where the target object has been deleted")
+					return true, nil, apierrors.NewNotFound(schema.GroupResource{}, "")
 				})
-			}
-			if tt.updateError != nil {
-				cl.PrependReactor(verb, "challenges", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
-					t.Log("Simulating a challenge update error")
-					return true, nil, tt.updateError
-				})
-			}
-			if tt.updateStatusError != nil {
+			} else if tt.updateStatusError != nil {
 				cl.PrependReactor(verb, "challenges/status", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
 					t.Log("Simulating a challenge/status update error")
 					return true, nil, tt.updateStatusError
@@ -163,12 +99,12 @@ func runUpdateObjectTests(t *testing.T, verb string) {
 			}
 
 			updater := newObjectUpdater(cl, "test-fieldmanager")
-			t.Log("Calling updateObject")
-			updateObjectErr := updater.updateObject(t.Context(), oldChallenge, newChallenge)
+			t.Log("Calling updateStatus")
+			_, updateStatusErr := updater.updateStatus(t.Context(), newChallenge)
 			if tt.errorMessage == "" {
-				assert.NoError(t, updateObjectErr)
+				assert.NoError(t, updateStatusErr)
 			} else {
-				assert.EqualError(t, updateObjectErr, tt.errorMessage)
+				assert.EqualError(t, updateStatusErr, tt.errorMessage)
 			}
 
 			if len(tt.mods) == 0 {
@@ -179,21 +115,105 @@ func runUpdateObjectTests(t *testing.T, verb string) {
 				t.Log("Checking whether the object was updated")
 				actual, err := cl.AcmeV1().Challenges(oldChallenge.Namespace).Get(t.Context(), oldChallenge.Name, metav1.GetOptions{})
 				require.NoError(t, err)
-				if updateObjectErr == nil {
+				if updateStatusErr == nil {
 					expected := newChallenge
 					expected.APIVersion = actual.APIVersion
 					expected.Kind = actual.Kind
 					// We ignore differences in .ManagedFields since the expected object does not have them.
 					// FIXME: don't ignore this field
 					expected.ManagedFields = actual.ManagedFields
-					assert.Equal(t, expected, actual, "updateObject did not return an error so the object in the API should have been updated")
-				} else {
-					if !errors.Is(updateObjectErr, simulatedUpdateError) {
-						assert.Equal(t, newChallenge.Finalizers, actual.Finalizers, "The Update did not fail so the Finalizers of the API object should have been updated")
-					}
-					if !errors.Is(updateObjectErr, simulatedUpdateStatusError) {
-						assert.Equal(t, newChallenge.Status, actual.Status, "The UpdateStatus did not fail so the Status of the API object should have been updated")
-					}
+					assert.Equal(t, expected, actual, "updateStatus did not return an error so the object in the API should have been updated")
+				} else if !errors.Is(updateStatusErr, simulatedUpdateStatusError) {
+					assert.Equal(t, newChallenge.Status, actual.Status, "The updateStatus did not fail so the Status of the API object should have been updated")
+				}
+			}
+		})
+	}
+}
+
+func TestApplyFinalizers(t *testing.T) {
+	simulatedApplyError := errors.New("simulated-apply-error")
+
+	tests := []struct {
+		name         string
+		mods         []gen.ChallengeModifier
+		finalizers   []string
+		notFound     bool
+		applyError   error
+		errorMessage string
+	}{
+		// Modifying the finalizers results in finalizers being updated.
+		{
+			name:       "success",
+			finalizers: []string{"example.com/another-finalizer"},
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{"example.com/another-finalizer"}),
+			},
+		},
+		// If the API server responds with a NOT FOUND error, the error is
+		// ignored. Presumably the object has been deleted since the Sync
+		// function began executing.
+		{
+			name:       "not-found",
+			finalizers: []string{"example.com/another-finalizer"},
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{"example.com/another-finalizer"}),
+			},
+			notFound: true,
+		},
+		// If the Apply API call fails, that error is returned.
+		{
+			name:       "apply-error",
+			finalizers: []string{"example.com/another-finalizer"},
+			mods: []gen.ChallengeModifier{
+				gen.SetChallengeFinalizers([]string{"example.com/another-finalizer"}),
+			},
+			applyError:   simulatedApplyError,
+			errorMessage: simulatedApplyError.Error(),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			challenge := gen.Challenge("c1")
+			cl := fake.NewClientset(challenge)
+			if tt.notFound {
+				cl.PrependReactor("patch", "challenges", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					t.Log("Simulating a situation where the target object has been deleted")
+					return true, nil, apierrors.NewNotFound(schema.GroupResource{}, "")
+				})
+			} else if tt.applyError != nil {
+				cl.PrependReactor("patch", "challenges", func(action clienttesting.Action) (handled bool, ret runtime.Object, err error) {
+					t.Log("Simulating a challenge update error")
+					return true, nil, tt.applyError
+				})
+			}
+			updater := newObjectUpdater(cl, "test-fieldmanager")
+			t.Log("Calling applyFinalizers")
+			_, applyFinalizersErr := updater.applyFinalizers(t.Context(), challenge, tt.finalizers)
+			if tt.errorMessage == "" {
+				assert.NoError(t, applyFinalizersErr)
+			} else {
+				assert.EqualError(t, applyFinalizersErr, tt.errorMessage)
+			}
+
+			if len(tt.mods) == 0 {
+				assert.Empty(t, cl.Actions(), "There should not be any API interactions unless the object was modified")
+			}
+
+			if !tt.notFound {
+				t.Log("Checking whether the object was updated")
+				actual, err := cl.AcmeV1().Challenges(challenge.Namespace).Get(t.Context(), challenge.Name, metav1.GetOptions{})
+				require.NoError(t, err)
+				if applyFinalizersErr == nil {
+					expected := gen.ChallengeFrom(challenge, tt.mods...)
+					expected.APIVersion = actual.APIVersion
+					expected.Kind = actual.Kind
+					// We ignore differences in .ManagedFields since the expected object does not have them.
+					// FIXME: don't ignore this field
+					expected.ManagedFields = actual.ManagedFields
+					assert.Equal(t, expected, actual, "applyFinalizers did not return an error so the object in the API should have been updated")
+				} else if !errors.Is(applyFinalizersErr, simulatedApplyError) {
+					assert.Equal(t, tt.finalizers, actual.Finalizers, "The applyFinalizers failed with a different error so the Finalizers of the API object should have been updated")
 				}
 			}
 		})


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

I started looking into `updateObject` for challenges when facing issues working on eventually graduating our `ServerSideApply` feature gate in https://github.com/cert-manager/cert-manager/pull/7908. Because of serious limitations in the fake client, in particular, https://github.com/kubernetes/kubernetes/issues/136672, I wanted to refactor code in this area.

In this PR, I try to separate the challenge status subresource updates from `finalizers` modifications on the challenge main resource. This reduces the pain when migrating to SSA in tests using the fake ("unreal") client.

To set/unset `finalizers`, I propose using server-side apply unconditionally, so we ignore the `ServerSideApply` feature gate here. This was done because I was unable to construct an API supporting both CSA and SSA well. The alternative would be to bring the feature gate reasoning into the functional code, but I'm personally not a huge fan of this.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
Use server-side-apply to maintain challenge finalizers
```
