### PR TITLE
docs: update ingress and gateway documentation references to use Gate…

### DIFF
--- a/deploy/charts/cert-manager/templates/NOTES.txt
+++ b/deploy/charts/cert-manager/templates/NOTES.txt
@@ -17,13 +17,7 @@ can be found in our documentation:
 https://cert-manager.io/docs/configuration/
 
 For information on how to configure cert-manager to automatically provision
-Certificates for Gateway API resources, take a look ats at the `gateway` resource
-documentation:
-
-https://cert-manager.io/docs/usage/gateway/
-
-For information on how to configure cert-manager to automatically provision
-Certificates for Gateway API resources, take a look at the `gateway resource`
+Certificates for Gateway API resources, take a look at the `gateway` resource
 documentation:
 
 https://cert-manager.io/docs/usage/gateway/


### PR DESCRIPTION
- Update Helm installation NOTES to reference Gateway API documentation instead of ingress-shim documentation, as ingress-nginx is being deprecated in favor of Gateway API.

## Changes
- Updated line 23 to reference `gateway` resource documentation instead of `ingress-shim`
- Updated line 26 to reference Gateway API docs with correct phrasing
- Fixed formatting issues (duplicate "take a look ats ats")

## Related
Closes #8257

```release-note
NONE
```