### PR TITLE
Add default field manager to test context builder

### DIFF
--- a/pkg/controller/certificate-shim/sync_test.go
+++ b/pkg/controller/certificate-shim/sync_test.go
@@ -3855,7 +3855,7 @@ func TestSync(t *testing.T) {
 						cr.Namespace,
 						cr,
 						metav1.CreateOptions{
-							FieldManager: "cert-manager-test",
+							FieldManager: testpkg.FieldManager,
 						},
 					)),
 				)
@@ -3897,7 +3897,7 @@ func TestSync(t *testing.T) {
 				DefaultIssuerGroup:                test.DefaultIssuerGroup,
 				DefaultAutoCertificateAnnotations: []string{"kubernetes.io/tls-acme"},
 				ExtraCertificateAnnotations:       []string{"venafi.cert-manager.io/custom-fields"},
-			}, "cert-manager-test")
+			}, testpkg.FieldManager)
 			b.Start()
 
 			err := sync(t.Context(), test.IngressLike)

--- a/pkg/controller/certificaterequests/acme/acme_test.go
+++ b/pkg/controller/certificaterequests/acme/acme_test.go
@@ -332,10 +332,11 @@ func TestSign(t *testing.T) {
 					"Normal OrderCreated Created Order resource default-unit-test-ns/test-cr-3104426127",
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
+					testpkg.NewAction(coretesting.NewCreateActionWithOptions(
 						cmacme.SchemeGroupVersion.WithResource("orders"),
 						gen.DefaultTestNamespace,
 						ipBaseOrder,
+						metav1.CreateOptions{FieldManager: testpkg.FieldManager},
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapiv1.SchemeGroupVersion.WithResource("certificaterequests"),
@@ -366,10 +367,11 @@ func TestSign(t *testing.T) {
 					"Normal OrderCreated Created Order resource default-unit-test-ns/test-cr-1733622556",
 				},
 				ExpectedActions: []testpkg.Action{
-					testpkg.NewAction(coretesting.NewCreateAction(
+					testpkg.NewAction(coretesting.NewCreateActionWithOptions(
 						cmacme.SchemeGroupVersion.WithResource("orders"),
 						gen.DefaultTestNamespace,
 						baseOrder,
+						metav1.CreateOptions{FieldManager: testpkg.FieldManager},
 					)),
 					testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 						cmapiv1.SchemeGroupVersion.WithResource("certificaterequests"),

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -157,7 +157,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -196,7 +196,7 @@ func Test_SecretsManager(t *testing.T) {
 						})
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -244,7 +244,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -297,7 +297,7 @@ func Test_SecretsManager(t *testing.T) {
 						})
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -347,7 +347,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -397,7 +397,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -444,7 +444,7 @@ func Test_SecretsManager(t *testing.T) {
 						})
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -484,7 +484,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -524,7 +524,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -565,7 +565,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeTLS)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -624,7 +624,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeOpaque)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -684,7 +684,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeOpaque)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -744,7 +744,7 @@ func Test_SecretsManager(t *testing.T) {
 						WithType(corev1.SecretTypeOpaque)
 					assert.Equal(t, expCnf, gotCnf)
 
-					expOpts := metav1.ApplyOptions{FieldManager: "cert-manager-test", Force: true}
+					expOpts := metav1.ApplyOptions{FieldManager: testpkg.FieldManager, Force: true}
 					assert.Equal(t, expOpts, gotOpts)
 
 					return nil, nil
@@ -817,7 +817,7 @@ func Test_SecretsManager(t *testing.T) {
 
 			testManager := NewSecretsManager(
 				secretClient, secretLister,
-				"cert-manager-test",
+				testpkg.FieldManager,
 				test.certificateOptions.EnableOwnerRef,
 			)
 
@@ -902,7 +902,7 @@ func Test_getCertificateSecret(t *testing.T) {
 			s := SecretsManager{
 				secretClient: builder.Client.CoreV1(),
 				secretLister: builder.KubeSharedInformerFactory.Secrets().Lister(),
-				fieldManager: "cert-manager-test",
+				fieldManager: testpkg.FieldManager,
 			}
 
 			builder.Start()

--- a/pkg/controller/certificatesigningrequests/acme/acme_test.go
+++ b/pkg/controller/certificatesigningrequests/acme/acme_test.go
@@ -503,10 +503,11 @@ func Test_ProcessItem(t *testing.T) {
 							},
 						},
 					)),
-					testpkg.NewAction(coretesting.NewCreateAction(
+					testpkg.NewAction(coretesting.NewCreateActionWithOptions(
 						cmacme.SchemeGroupVersion.WithResource("orders"),
 						gen.DefaultTestNamespace,
 						baseOrder,
+						metav1.CreateOptions{FieldManager: testpkg.FieldManager},
 					)),
 				},
 			},

--- a/pkg/controller/test/context_builder.go
+++ b/pkg/controller/test/context_builder.go
@@ -56,6 +56,8 @@ func init() {
 	ctrl.SetLogger(logs.Log)
 }
 
+const FieldManager = "cert-manager-test"
+
 type StringGenerator func(n int) string
 
 // Builder is a structure used to construct new Contexts for use during tests.
@@ -115,6 +117,9 @@ func (b *Builder) Init() {
 	}
 	if b.Context.RootContext == nil {
 		b.Context.RootContext = context.Background()
+	}
+	if b.Context.FieldManager == "" {
+		b.Context.FieldManager = FieldManager
 	}
 	if b.StringGenerator == nil {
 		b.StringGenerator = rand.String


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This proposed change is extracted from https://github.com/cert-manager/cert-manager/pull/8470. When migrating to SSA, it is required to set a field manager for SSA requests. This PR sets a default field manager for tests using the test-context framework.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
