### PR TITLE
Temporarily ungroup sigs.k8s.io/gateway-api in Renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -39,6 +39,13 @@
   ],
   packageRules: [
     {
+      // FIXME: Ungroup sigs.k8s.io/gateway-api temporarily waiting for a new release.
+      groupName: null,
+      matchPackageNames: [
+        'sigs.k8s.io/gateway-api',
+      ],
+    },
+    {
       groupName: 'Base Images',
       matchManagers: [
         'custom.regex',


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

While we are waiting for gateway-api 1.5, I propose ungrouping the gateway-api dependency from the Renovate Kubernetes group. This will allow us to upgrade other dependencies in the same group, unblocking https://github.com/cert-manager/cert-manager/pull/8488.

There should soon be an RC release of gateway-api available, ref. https://kubernetes.slack.com/archives/CR0H13KGA/p1770408844131569

Similar to https://github.com/cert-manager/istio-csr/pull/644.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
