### PR TITLE
Make unit test time comparisons even less strict

### DIFF
--- a/internal/test/testutil/compare.go
+++ b/internal/test/testutil/compare.go
@@ -31,14 +31,14 @@ import (
 func Diff(a any, b any, opts ...cmp.Option) error {
 	allOpts := []cmp.Option{
 		cmp.Transformer("metav1.Time", func(in metav1.Time) string {
-			return in.Time.Format(time.RFC3339)
+			return in.Time.UTC().Format(time.RFC3339)
 		}),
 		cmp.Transformer("metav1.TimePtr", func(in *metav1.Time) *string {
 			if in == nil {
 				return nil
 			}
 
-			out := in.Time.Format(time.RFC3339)
+			out := in.Time.UTC().Format(time.RFC3339)
 			return &out
 		}),
 	}


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR is a follow-up after https://github.com/cert-manager/cert-manager/pull/8272, normalizing also the timezone when comparing Time fields in unit tests. This is required to get progress on graduating the ServerSideApply feature gate in https://github.com/cert-manager/cert-manager/pull/7908.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
