### PR TITLE
gatewayapi-listenerset.md: fix second diagram

### DIFF
--- a/design/20250703.gatewayapi-listenerset.md
+++ b/design/20250703.gatewayapi-listenerset.md
@@ -92,7 +92,7 @@ Two workarounds have been found by cluster operators who don't want to wait for 
 
 ListenerSet provides a mechanism allowing developers to manage TLS configurations, restoring self-service capabilities akin to Ingress. The following diagram illustrates the fact that developers can now configure TLS by creating ListenerSet objects themselves (provided that the correct RBAC permissions are in place):
 
-![Thanks to the new ListenerSet resource, migrating from Ingress to Gateway and HTTPRoute no longer means loss of self-service for application developers](./images/20250703.gatewayapi-listenerset/migrating-without-listenerset.svg)
+![Thanks to the new ListenerSet resource, migrating from Ingress to Gateway and HTTPRoute no longer means loss of self-service for application developers](./images/20250703.gatewayapi-listenerset/migrating-using-listenerset.svg)
 
 ### Locking down Gateway resources
 


### PR DESCRIPTION
The second diagram is a copy of the first. I think I got mixed up.

```release-note
NONE
```
