### PR TITLE
helm: Add optional ttlSecondsAfterFinished to startupapicheck Job

### DIFF
--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  {{- if hasKey .Values.startupapicheck "ttlSecondsAfterFinished" }}
+  ttlSecondsAfterFinished: {{ .Values.startupapicheck.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -835,7 +835,7 @@
       "type": "object"
     },
     "helm-values.global.hostUsers": {
-      "description": "Set all pods to run in a user namespace without host access. Experimental: may be removed once the Kubernetes User Namespaces feature is GA.\n\nRequirements:\n  - Kubernetes ≥ 1.33, or\n  - Kubernetes 1.27–1.32 with UserNamespacesSupport feature gate enabled.\n\nSet to false to run pods in a user namespace without host access.\n\nSee [limitations](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#limitations) for details.",
+      "description": "Set all pods to run in a user namespace without host access. Experimental: may be removed once the Kubernetes User Namespaces feature is GA.\n\nRequirements:\n  - Kubernetes \u2265 1.33, or\n  - Kubernetes 1.27\u20131.32 with UserNamespacesSupport feature gate enabled.\n\nSet to false to run pods in a user namespace without host access.\n\nSee [limitations](https://kubernetes.io/docs/concepts/workloads/pods/user-namespaces/#limitations) for details.",
       "type": "boolean"
     },
     "helm-values.global.imagePullSecrets": {
@@ -1540,6 +1540,9 @@
         "tolerations": {
           "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
         },
+        "ttlSecondsAfterFinished": {
+          "$ref": "#/$defs/helm-values.startupapicheck.ttlSecondsAfterFinished"
+        },
         "volumeMounts": {
           "$ref": "#/$defs/helm-values.startupapicheck.volumeMounts"
         },
@@ -1767,6 +1770,10 @@
       "description": "A list of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\n\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
       "items": {},
       "type": "array"
+    },
+    "helm-values.startupapicheck.ttlSecondsAfterFinished": {
+      "description": "Setting ttlSecondsAfterFinished will allow the Job to be cleaned up automatically after it has finished. If unset, the Job will not be automatically deleted.\nFor more information, see [TTL Controller for Finished Resources](https://kubernetes.io/docs/concepts/workloads/controllers/ttl-after-finished/).",
+      "type": "number"
     },
     "helm-values.startupapicheck.volumeMounts": {
       "default": [],

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1529,6 +1529,13 @@ startupapicheck:
   # Job backoffLimit
   backoffLimit: 4
 
+  # Setting ttlSecondsAfterFinished will allow the Job to be cleaned up
+  # automatically after it has finished. If unset, the Job will not be
+  # automatically deleted.
+  # For more information, see [TTL Controller for Finished Resources](https://kubernetes.io/docs/concepts/workloads/controllers/ttl-after-finished/).
+  # +docs:property
+  # ttlSecondsAfterFinished: 60
+
   # Optional additional annotations to add to the startupapicheck Job.
   # +docs:property
   jobAnnotations:


### PR DESCRIPTION
Fixes #8363

The startupapicheck Job currently has no `ttlSecondsAfterFinished` set, meaning completed Job resources linger in the cluster indefinitely. This triggers linting warnings (e.g. kube-linter) and leaves unnecessary resources behind.

This adds an optional `startupapicheck.ttlSecondsAfterFinished` value that, when set, configures the Job's TTL controller to automatically clean up after completion. Uses `hasKey` for the conditional to correctly handle a value of `0`. Also adds the corresponding schema definition.

Default behavior is unchanged — the field is commented out by default.

```release-note
Add optional `startupapicheck.ttlSecondsAfterFinished` Helm value to configure automatic cleanup of completed startupapicheck Jobs.
```