### PR TITLE
Remove non-breaking space characters from comments

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_challenges.yaml
@@ -406,7 +406,7 @@ spec:
                               description: |-
                                 The IP address or hostname of an authoritative DNS server supporting
                                 RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                 This field is required.
                               type: string
                             protocol:

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_clusterissuers.yaml
@@ -519,7 +519,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:

--- a/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
+++ b/deploy/charts/cert-manager/templates/crd-cert-manager.io_issuers.yaml
@@ -518,7 +518,7 @@ spec:
                                     description: |-
                                       The IP address or hostname of an authoritative DNS server supporting
                                       RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                      enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                      enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                       This field is required.
                                     type: string
                                   protocol:

--- a/deploy/crds/acme.cert-manager.io_challenges.yaml
+++ b/deploy/crds/acme.cert-manager.io_challenges.yaml
@@ -414,7 +414,7 @@ spec:
                             description: |-
                               The IP address or hostname of an authoritative DNS server supporting
                               RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                              enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                              enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                               This field is required.
                             type: string
                           protocol:

--- a/deploy/crds/cert-manager.io_clusterissuers.yaml
+++ b/deploy/crds/cert-manager.io_clusterissuers.yaml
@@ -531,7 +531,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:

--- a/deploy/crds/cert-manager.io_issuers.yaml
+++ b/deploy/crds/cert-manager.io_issuers.yaml
@@ -530,7 +530,7 @@ spec:
                                   description: |-
                                     The IP address or hostname of an authoritative DNS server supporting
                                     RFC2136 in the form host:port. If the host is an IPv6 address it must be
-                                    enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+                                    enclosed in square brackets (e.g [2001:db8::1]); port is optional.
                                     This field is required.
                                   type: string
                                 protocol:

--- a/internal/apis/acme/types_issuer.go
+++ b/internal/apis/acme/types_issuer.go
@@ -649,7 +649,7 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The IP address or hostname of an authoritative DNS server supporting
 	// RFC2136 in the form host:port. If the host is an IPv6 address it must be
-	// enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+	// enclosed in square brackets (e.g [2001:db8::1]) port is optional.
 	// This field is required.
 	Nameserver string
 

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -1667,7 +1667,7 @@ func schema_pkg_apis_acme_v1_ACMEIssuerDNS01ProviderRFC2136(ref common.Reference
 				Properties: map[string]spec.Schema{
 					"nameserver": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1])\u00a0; port is optional. This field is required.",
+							Description: "The IP address or hostname of an authoritative DNS server supporting RFC2136 in the form host:port. If the host is an IPv6 address it must be enclosed in square brackets (e.g [2001:db8::1]); port is optional. This field is required.",
 							Default:     "",
 							Type:        []string{"string"},
 							Format:      "",

--- a/pkg/apis/acme/v1/types_issuer.go
+++ b/pkg/apis/acme/v1/types_issuer.go
@@ -781,7 +781,7 @@ type ACMEIssuerDNS01ProviderAcmeDNS struct {
 type ACMEIssuerDNS01ProviderRFC2136 struct {
 	// The IP address or hostname of an authoritative DNS server supporting
 	// RFC2136 in the form host:port. If the host is an IPv6 address it must be
-	// enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+	// enclosed in square brackets (e.g [2001:db8::1]); port is optional.
 	// This field is required.
 	Nameserver string `json:"nameserver"`
 

--- a/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01providerrfc2136.go
+++ b/pkg/client/applyconfigurations/acme/v1/acmeissuerdns01providerrfc2136.go
@@ -31,7 +31,7 @@ import (
 type ACMEIssuerDNS01ProviderRFC2136ApplyConfiguration struct {
 	// The IP address or hostname of an authoritative DNS server supporting
 	// RFC2136 in the form host:port. If the host is an IPv6 address it must be
-	// enclosed in square brackets (e.g [2001:db8::1]) ; port is optional.
+	// enclosed in square brackets (e.g [2001:db8::1]); port is optional.
 	// This field is required.
 	Nameserver *string `json:"nameserver,omitempty"`
 	// The name of the secret containing the TSIG value.


### PR DESCRIPTION
Identified via a website error while raising https://github.com/cert-manager/website/pull/1981

There's no reason for these to be in the source code. I confirmed them via a hexdump.

```text
00006fe0: 3a31 5d29 c2a0 3b20 706f 7274 2069 7320  :1])..; port is
```

`c2a0` is a unicode nbsp.

This was added in https://github.com/cert-manager/cert-manager/pull/2682 originally.

### Kind

/kind bug

### Release Note

```release-note
NONE
```
