### PR TITLE
make e2e-setup-gateway-api: bump from v1.5.0-rc.1 to v1.5.0-rc.3

### DIFF
--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -19,7 +19,7 @@ GOTEST := CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) $(GO) test
 GOTESTSUM := CGO_ENABLED=$(CGO_ENABLED) GOEXPERIMENT=$(GOEXPERIMENT) $(GOTESTSUM)
 
 # Version of Gateway API install bundle https://gateway-api.sigs.k8s.io/v1alpha2/guides/#installing-gateway-api
-GATEWAY_API_VERSION=v1.5.0-rc.1
+GATEWAY_API_VERSION=v1.5.0-rc.3
 
 $(bin_dir)/scratch/gateway-api-$(GATEWAY_API_VERSION).yaml: | $(bin_dir)/scratch
 	$(CURL) https://github.com/kubernetes-sigs/gateway-api/releases/download/$(GATEWAY_API_VERSION)/experimental-install.yaml -o $@


### PR DESCRIPTION
In https://github.com/cert-manager/cert-manager/pull/8542, Gateway API was bumped to v1.5.0-rc.3, but Renovate isn't able to also update the CRD version pulled from GitHub releases in our e2es.

/kind cleanup

```release-note
NONE
```
