### PR TITLE
fix: Ensure SignatureAlgorithm is copied to the certificate

### DIFF
--- a/pkg/util/pki/certificatetemplate.go
+++ b/pkg/util/pki/certificatetemplate.go
@@ -146,6 +146,7 @@ func CertificateTemplateFromCSR(csr *x509.CertificateRequest, validatorMutators 
 	cert := &x509.Certificate{
 		PublicKeyAlgorithm: csr.PublicKeyAlgorithm,
 		PublicKey:          csr.PublicKey,
+		SignatureAlgorithm: csr.SignatureAlgorithm,
 		Subject:            csr.Subject,
 		RawSubject:         csr.RawSubject,
 

--- a/pkg/util/pki/certificatetemplate_test.go
+++ b/pkg/util/pki/certificatetemplate_test.go
@@ -143,6 +143,15 @@ func TestCertificateTemplateFromCSR(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "should copy signature algorithm",
+			csr: &x509.CertificateRequest{
+				SignatureAlgorithm: x509.ECDSAWithSHA512,
+			},
+			expected: &x509.Certificate{
+				SignatureAlgorithm: x509.ECDSAWithSHA512,
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

My CA issuer is generating ECDSAWithSHA512 certs even though I've specified ECDSAWithSHA384 as the signatureAlgorithm. I believe it's the same issue as #6325 (which was closed stale), and hopefully this is the fix.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
The specified `signatureAlgorithm` for self-signed / CA issuer certificates should now flow through to the x.509 certificate stored in secret data.
```
