### PR TITLE
Fix typo in Order Duration field comment

### DIFF
--- a/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_orders.yaml
+++ b/deploy/charts/cert-manager/templates/crd-acme.cert-manager.io_orders.yaml
@@ -79,7 +79,7 @@ spec:
                 duration:
                   description: |-
                     Duration is the duration for the not after date for the requested certificate.
-                    this is set on order creation as pe the ACME spec.
+                    This is set on order creation as per the ACME spec.
                   type: string
                 ipAddresses:
                   description: |-

--- a/deploy/crds/acme.cert-manager.io_orders.yaml
+++ b/deploy/crds/acme.cert-manager.io_orders.yaml
@@ -78,7 +78,7 @@ spec:
               duration:
                 description: |-
                   Duration is the duration for the not after date for the requested certificate.
-                  this is set on order creation as pe the ACME spec.
+                  This is set on order creation as per the ACME spec.
                 type: string
               ipAddresses:
                 description: |-

--- a/internal/apis/acme/types_order.go
+++ b/internal/apis/acme/types_order.go
@@ -72,7 +72,7 @@ type OrderSpec struct {
 	IPAddresses []string
 
 	// Duration is the duration for the not after date for the requested certificate.
-	// this is set on order creation as pe the ACME spec.
+	// This is set on order creation as per the ACME spec.
 	Duration *metav1.Duration
 
 	// Profile allows requesting a certificate profile from the ACME server.

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -2346,7 +2346,7 @@ func schema_pkg_apis_acme_v1_OrderSpec(ref common.ReferenceCallback) common.Open
 					},
 					"duration": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Duration is the duration for the not after date for the requested certificate. this is set on order creation as pe the ACME spec.",
+							Description: "Duration is the duration for the not after date for the requested certificate. This is set on order creation as per the ACME spec.",
 							Ref:         ref(metav1.Duration{}.OpenAPIModelName()),
 						},
 					},

--- a/pkg/apis/acme/v1/types_order.go
+++ b/pkg/apis/acme/v1/types_order.go
@@ -89,7 +89,7 @@ type OrderSpec struct {
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 
 	// Duration is the duration for the not after date for the requested certificate.
-	// this is set on order creation as pe the ACME spec.
+	// This is set on order creation as per the ACME spec.
 	// +optional
 	Duration *metav1.Duration `json:"duration,omitempty"`
 

--- a/pkg/client/applyconfigurations/acme/v1/orderspec.go
+++ b/pkg/client/applyconfigurations/acme/v1/orderspec.go
@@ -49,7 +49,7 @@ type OrderSpecApplyConfiguration struct {
 	// This field must match the corresponding field on the DER encoded CSR.
 	IPAddresses []string `json:"ipAddresses,omitempty"`
 	// Duration is the duration for the not after date for the requested certificate.
-	// this is set on order creation as pe the ACME spec.
+	// This is set on order creation as per the ACME spec.
 	Duration *apismetav1.Duration `json:"duration,omitempty"`
 	// Profile allows requesting a certificate profile from the ACME server.
 	// Supported profiles are listed by the server's ACME directory URL.


### PR DESCRIPTION
### Pull Request Motivation

Fix a typo in the `Duration` field comment on `OrderSpec`: "as pe the ACME spec" → "as per the ACME spec". Also capitalizes the sentence start.

The fix is applied to the source API types and all generated files (CRDs, OpenAPI, apply configurations).

/kind cleanup

```release-note
NONE
```