### PR TITLE
Update Go documentation badge from godoc.org to pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <!-- prow build badge, godoc, and go report card-->
 <img alt="Build Status" src="https://prow.infra.cert-manager.io/badge.svg?jobs=ci-cert-manager-master-make-test">
 </a>
-<a href="https://godoc.org/github.com/cert-manager/cert-manager"><img src="https://godoc.org/github.com/cert-manager/cert-manager?status.svg"></a>
+<a href="https://pkg.go.dev/github.com/cert-manager/cert-manager"><img src="https://pkg.go.dev/badge/github.com/cert-manager/cert-manager.svg" alt="Go Reference"></a>
 <a href="https://goreportcard.com/report/github.com/cert-manager/cert-manager"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/cert-manager" /></a>
 <br />
 <a href="https://artifacthub.io/packages/search?repo=cert-manager"><img alt="Artifact Hub" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager" /></a>


### PR DESCRIPTION
### Pull Request Motivation

godoc.org has been deprecated and returns a 301 redirect to pkg.go.dev. This updates the README badge to link directly to pkg.go.dev with the current badge format.

/kind cleanup

```release-note
NONE
```