### PR TITLE
[release-1.20] disable generate-klone so that we can manually update versions

### DIFF
--- a/make/_shared/klone/01_mod.mk
+++ b/make/_shared/klone/01_mod.mk
@@ -18,7 +18,10 @@
 generate-klone: | $(NEEDS_KLONE)
 	$(KLONE) sync
 
-shared_generate_targets += generate-klone
+# MANUAL CHANGE!
+# generate-klone is removed so we can manually update versions
+# and diverge from upstream klone
+# shared_generate_targets += generate-klone
 
 .PHONY: upgrade-klone
 ## Upgrade klone Makefile modules to latest version


### PR DESCRIPTION
Part of the release process. This is required to prevent future Go version bumps on the release branch from being reverted by `make generate`.

This instruction was added to the release process in [website#1993](https://github.com/cert-manager/website/pull/1993/changes#r2891576066).

/kind cleanup

```release-note
NONE
```
