### PR TITLE
fix: harden the creation of private key secrets to avoid creating duplicates

### DIFF
--- a/pkg/controller/certificates/keymanager/keymanager_controller.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller.go
@@ -334,11 +334,26 @@ func (c *controller) updateOrApplyStatus(ctx context.Context, crt *cmapi.Certifi
 }
 
 func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.Certificate, pk crypto.Signer) (*corev1.Secret, error) {
+	// Since crt.Status.NextPrivateKeySecretName is set based on the name of the
+	// secret this function returns there is a possibility that this function
+	// reconciles twice before the cache is updated with the latest changes.
+	//
+	// In that case since we would not see the NextPrivateKeySecretName we just
+	// set and we would generate a new secret with a different name, updating
+	// NextPrivateKeySecretName once again.
+	//
+	// Given this code path is only hit in limited circumstances, it is not
+	// unreasonable to get the latest object via a real api call.
+	latestCrt, err := c.client.CertmanagerV1().Certificates(crt.Namespace).Get(ctx, crt.Name, metav1.GetOptions{})
+	if err != nil {
+		return nil, err
+	}
+
 	// if the 'nextPrivateKeySecretName' field is already set, use this as the
 	// name of the Secret resource.
 	name := ""
-	if crt.Status.NextPrivateKeySecretName != nil {
-		name = *crt.Status.NextPrivateKeySecretName
+	if latestCrt.Status.NextPrivateKeySecretName != nil {
+		name = *latestCrt.Status.NextPrivateKeySecretName
 	}
 
 	pkData, err := pki.EncodePrivateKey(pk, cmapi.PKCS8)
@@ -364,10 +379,20 @@ func (c *controller) createNewPrivateKeySecret(ctx context.Context, crt *cmapi.C
 		// TODO: handle certificate resources that have especially long names
 		s.GenerateName = crt.Name + "-"
 	}
+
 	s, err = c.coreClient.CoreV1().Secrets(s.Namespace).Create(ctx, s, metav1.CreateOptions{})
+
+	// We only get to this code path if both NextPrivateKeySecretName is set AND
+	// we counted zero secrets. If we get an IsAlreadyExists error it means our
+	// cache was outdated and there _is_ a secret.
+	if apierrors.IsAlreadyExists(err) && name != "" {
+		return c.coreClient.CoreV1().Secrets(crt.Namespace).Get(ctx, name, metav1.GetOptions{})
+	}
+
 	if err != nil {
 		return nil, err
 	}
+
 	return s, nil
 }
 

--- a/pkg/controller/certificates/keymanager/keymanager_controller_test.go
+++ b/pkg/controller/certificates/keymanager/keymanager_controller_test.go
@@ -162,6 +162,11 @@ func TestProcessItem(t *testing.T) {
 			},
 			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "test-notrandom"`},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewAction(coretesting.NewUpdateSubresourceAction(
 					cmapi.SchemeGroupVersion.WithResource("certificates"),
 					"status",
@@ -209,6 +214,11 @@ func TestProcessItem(t *testing.T) {
 			},
 			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "fixed-name"`},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -239,8 +249,14 @@ func TestProcessItem(t *testing.T) {
 					},
 				},
 			},
-			secrets: []runtime.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "fixed-name"}}},
+			secrets:        []runtime.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: "testns", Name: "fixed-name"}}},
+			expectedEvents: []string{`Normal Generated Stored new private key in temporary Secret resource "fixed-name"`},
 			expectedActions: []testpkg.Action{
+				testpkg.NewAction(coretesting.NewGetAction(
+					cmapi.SchemeGroupVersion.WithResource("certificates"),
+					"testns",
+					"test",
+				)),
 				testpkg.NewCustomMatch(coretesting.NewCreateAction(
 					corev1.SchemeGroupVersion.WithResource("secrets"),
 					"testns",
@@ -254,8 +270,12 @@ func TestProcessItem(t *testing.T) {
 						Data: map[string][]byte{"tls.key": nil},
 					},
 				), relaxedSecretMatcher),
+				testpkg.NewAction(coretesting.NewGetAction(
+					corev1.SchemeGroupVersion.WithResource("secrets"),
+					"testns",
+					"fixed-name",
+				)),
 			},
-			err: `secrets "fixed-name" already exists`,
 		},
 		"if multiple owned secrets exist, delete them all": {
 			certificate: &cmapi.Certificate{


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This pull request improves the reliability of secret creation in the certificate key manager controller by addressing potential cache staleness issues. The main changes ensure that the latest certificate object is fetched directly from the API and that secret creation gracefully handles cases where the cache may be outdated.

Improvements to cache consistency and error handling:

* In `createNewPrivateKeySecret`, the latest `Certificate` object is now fetched via a direct API call before proceeding, reducing the risk of operating on stale data.

  While the extra API call in `createNewPrivateKeySecret` bypasses the informer cache to get a fresh `Certificate` object, this code path is only actually reached when:

  1. The certificate has `Issuing == True` (an active issuance cycle), **and**
  2. Zero "next private key" secrets are visible in the cache — i.e. the very start of that cycle

  This means it fires at most once per renewal (e.g. every 60–90 days), and the single `Get` is far cheaper than the `Create` that immediately follows it on the same path. There is no meaningful performance impact.

* After attempting to create a new secret, if an `IsAlreadyExists` error is encountered (indicating the cache was outdated and the secret already exists), the code now fetches and returns the existing secret instead of failing.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind bug
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```