### PR TITLE
feat: emit event when passwordSecretRef not found

### DIFF
--- a/pkg/controller/certificates/issuing/internal/secret.go
+++ b/pkg/controller/certificates/issuing/internal/secret.go
@@ -28,6 +28,7 @@ import (
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	coreclient "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/tools/record"
 
 	"github.com/cert-manager/cert-manager/internal/controller/certificates"
 	internalinformers "github.com/cert-manager/cert-manager/internal/informers"
@@ -48,6 +49,7 @@ var (
 type SecretsManager struct {
 	secretClient coreclient.SecretsGetter
 	secretLister internalinformers.SecretLister
+	recorder     record.EventRecorder
 
 	// fieldManager is the manager name used for the Apply operations on Secrets.
 	fieldManager string
@@ -72,12 +74,14 @@ type SecretData struct {
 func NewSecretsManager(
 	secretClient coreclient.SecretsGetter,
 	secretLister internalinformers.SecretLister,
+	recorder record.EventRecorder,
 	fieldManager string,
 	enableSecretOwnerReferences bool,
 ) *SecretsManager {
 	return &SecretsManager{
 		secretClient:                secretClient,
 		secretLister:                secretLister,
+		recorder:                    recorder,
 		fieldManager:                fieldManager,
 		enableSecretOwnerReferences: enableSecretOwnerReferences,
 	}
@@ -254,6 +258,11 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 		switch {
 		case ref.Name != "":
 			pwSecret, err := s.secretLister.Secrets(crt.Namespace).Get(ref.Name)
+
+			if apierrors.IsNotFound(err) {
+				s.recorder.Eventf(crt, corev1.EventTypeWarning, "KeystorePasswordSecretNotFound", "PKCS12 keystore password Secret %q not found", ref.Name)
+			}
+
 			if err != nil {
 				return fmt.Errorf("fetching PKCS12 keystore password from Secret: %v", err)
 			}
@@ -304,6 +313,11 @@ func (s *SecretsManager) setKeystores(crt *cmapi.Certificate, secret *corev1.Sec
 		switch {
 		case ref.Name != "":
 			pwSecret, err := s.secretLister.Secrets(crt.Namespace).Get(ref.Name)
+
+			if apierrors.IsNotFound(err) {
+				s.recorder.Eventf(crt, corev1.EventTypeWarning, "KeystorePasswordSecretNotFound", "JKS keystore password Secret %q not found", ref.Name)
+			}
+
 			if err != nil {
 				return fmt.Errorf("fetching JKS keystore password from Secret: %v", err)
 			}

--- a/pkg/controller/certificates/issuing/internal/secret_test.go
+++ b/pkg/controller/certificates/issuing/internal/secret_test.go
@@ -30,6 +30,7 @@ import (
 	apitypes "k8s.io/apimachinery/pkg/types"
 	applycorev1 "k8s.io/client-go/applyconfigurations/core/v1"
 	applymetav1 "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/client-go/tools/record"
 	fakeclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 
@@ -817,6 +818,7 @@ func Test_SecretsManager(t *testing.T) {
 
 			testManager := NewSecretsManager(
 				secretClient, secretLister,
+				record.NewFakeRecorder(10),
 				testpkg.FieldManager,
 				test.certificateOptions.EnableOwnerRef,
 			)

--- a/pkg/controller/certificates/issuing/issuing_controller.go
+++ b/pkg/controller/certificates/issuing/issuing_controller.go
@@ -140,7 +140,7 @@ func NewController(
 
 	secretsManager := internal.NewSecretsManager(
 		ctx.Client.CoreV1(), secretsInformer.Lister(),
-		ctx.FieldManager, ctx.CertificateOptions.EnableOwnerRef,
+		ctx.Recorder, ctx.FieldManager, ctx.CertificateOptions.EnableOwnerRef,
 	)
 
 	return &controller{


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

This pull request introduces event recording functionality to the `SecretsManager` in the certificate issuing controller. The main change is to allow the manager to emit Kubernetes events when keystore password secrets are missing, improving visibility and debugging for users. T

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```