### PR TITLE
feat(deploy/charts): adding validate for prometheus crds

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -842,6 +842,13 @@ Otherwise, 'prometheus.io' annotations are added to the cert-manager and cert-ma
 > ```
 
 Create a ServiceMonitor to add cert-manager to Prometheus.
+#### **prometheus.servicemonitor.skipCRDsCheck** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying. Default is set to `true` to not break existing behavior.
 #### **prometheus.servicemonitor.namespace** ~ `string`
 
 The namespace that the service monitor should live in, defaults to the cert-manager namespace.
@@ -931,6 +938,13 @@ endpointAdditionalProperties:
 > ```
 
 Create a PodMonitor to add cert-manager to Prometheus.
+#### **prometheus.podmonitor.skipCRDsCheck** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying. Default is set to `true` to not break existing behavior.
 #### **prometheus.podmonitor.namespace** ~ `string`
 
 The namespace that the pod monitor should live in, defaults to the cert-manager namespace.

--- a/deploy/charts/cert-manager/templates/_helpers.tpl
+++ b/deploy/charts/cert-manager/templates/_helpers.tpl
@@ -265,3 +265,30 @@ set .installCRDs and disabled .crds.keep.
     {{- fail "ERROR: .crds.keep is not compatible with .installCRDs, please use .crds.enabled and .crds.keep instead" }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Check if the service monitor CRDs are installed before rendering the custom resource so that the
+helm chart deployment fails gracefully. Disable the check by setting skipCRDsCheck to `true`. 
+ */}}
+{{- define "cert-manager.shouldRenderServiceMonitor" -}}
+  {{- if not .Values.prometheus.servicemonitor.skipCRDsCheck -}}
+    {{- if not (has "monitoring.coreos.com/v1/ServiceMonitor" .Capabilities.APIVersions) -}}
+      {{- fail "Service Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml or set .Values.prometheus.servicemonitor.skipCRDsCheck=true" -}}
+    {{- end -}}
+    true
+  {{- end -}}
+  true
+{{- end -}}
+
+{{/*
+Check if the pod monitor CRDs are installed before rendering the custom resource so that the
+helm chart deployment fails gracefully. Disable the check by setting skipCRDsCheck to `true`. 
+ */}}
+{{- define "cert-manager.shouldRenderPodMonitor" -}}
+  {{- if not .Values.prometheus.podmonitor.skipCRDsCheck -}}
+    {{- if not (has "monitoring.coreos.com/v1/PodMonitor" .Capabilities.APIVersions) -}}
+      {{- fail "Pod Monitor requires monitoring.coreos.com/v1 CRDs. Please refer to https://github.com/prometheus-operator/prometheus-operator/blob/main/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml or set .Values.prometheus.podmonitor.skipCRDsCheck=true" -}}
+    {{- end -}}
+    true
+  {{- end -}}
+{{- end -}}

--- a/deploy/charts/cert-manager/templates/podmonitor.yaml
+++ b/deploy/charts/cert-manager/templates/podmonitor.yaml
@@ -1,6 +1,7 @@
+{{- $shouldRenderStr := include "cert-manager.shouldRenderPodMonitor" . | trim }}
 {{- if and .Values.prometheus.enabled (and .Values.prometheus.podmonitor.enabled .Values.prometheus.servicemonitor.enabled) }}
 {{- fail "Either .Values.prometheus.podmonitor.enabled or .Values.prometheus.servicemonitor.enabled can be enabled at a time, but not both." }}
-{{- else if and .Values.prometheus.enabled .Values.prometheus.podmonitor.enabled }}
+{{- else if and .Values.prometheus.enabled .Values.prometheus.podmonitor.enabled (eq $shouldRenderStr "true") }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/deploy/charts/cert-manager/templates/servicemonitor.yaml
+++ b/deploy/charts/cert-manager/templates/servicemonitor.yaml
@@ -1,6 +1,7 @@
+{{- $shouldRenderStr := include "cert-manager.shouldRenderServiceMonitor" . | trim }}
 {{- if and .Values.prometheus.enabled (and .Values.prometheus.podmonitor.enabled .Values.prometheus.servicemonitor.enabled) }}
 {{- fail "Either .Values.prometheus.podmonitor.enabled or .Values.prometheus.servicemonitor.enabled can be enabled at a time, but not both." }}
-{{- else if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled }}
+{{- else if and .Values.prometheus.enabled .Values.prometheus.servicemonitor.enabled (eq $shouldRenderStr "true") }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1255,6 +1255,9 @@
         },
         "scrapeTimeout": {
           "$ref": "#/$defs/helm-values.prometheus.podmonitor.scrapeTimeout"
+        },
+        "skipCRDsCheck": {
+          "$ref": "#/$defs/helm-values.prometheus.podmonitor.skipCRDsCheck"
         }
       },
       "type": "object"
@@ -1308,6 +1311,11 @@
       "description": "The timeout before a metrics scrape fails.",
       "type": "string"
     },
+    "helm-values.prometheus.podmonitor.skipCRDsCheck": {
+      "default": true,
+      "description": "Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying. Default is set to `true` to not break existing behavior.",
+      "type": "boolean"
+    },
     "helm-values.prometheus.servicemonitor": {
       "additionalProperties": false,
       "properties": {
@@ -1340,6 +1348,9 @@
         },
         "scrapeTimeout": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.scrapeTimeout"
+        },
+        "skipCRDsCheck": {
+          "$ref": "#/$defs/helm-values.prometheus.servicemonitor.skipCRDsCheck"
         },
         "targetPort": {
           "$ref": "#/$defs/helm-values.prometheus.servicemonitor.targetPort"
@@ -1395,6 +1406,11 @@
       "default": "30s",
       "description": "The timeout before a metrics scrape fails.",
       "type": "string"
+    },
+    "helm-values.prometheus.servicemonitor.skipCRDsCheck": {
+      "default": true,
+      "description": "Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying. Default is set to `true` to not break existing behavior.",
+      "type": "boolean"
     },
     "helm-values.prometheus.servicemonitor.targetPort": {
       "default": "http-metrics",

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -641,6 +641,10 @@ prometheus:
     # Create a ServiceMonitor to add cert-manager to Prometheus.
     enabled: false
 
+    # Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying.
+    # Default is set to `true` to not break existing behavior.
+    skipCRDsCheck: true
+
     # The namespace that the service monitor should live in, defaults
     # to the cert-manager namespace.
     # +docs:property
@@ -692,6 +696,10 @@ prometheus:
   podmonitor:
     # Create a PodMonitor to add cert-manager to Prometheus.
     enabled: false
+
+    # Set to `true` and helm will not check for monitoring.coreos.com/v1 CRDs before deploying.
+    # Default is set to `true` to not break existing behavior.
+    skipCRDsCheck: true
 
     # The namespace that the pod monitor should live in, defaults
     # to the cert-manager namespace.


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

This PR introduces validation for CRDs like `ServiceMonitor` and `PodMonitor`. By default, `trustCRDsExist` is `true` since we have been traditionally not validating it and setting it to false could have an impact on our existing users. Potentially, in the future release we could flip this value to `false`. 
This PR also would assist https://github.com/cert-manager/cert-manager/pull/7689 in having a similar pattern since VPA is a custom resource defn that needs to be present before configuring the resource.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
added `skipCRDsCheck` to prometheus crds.
```
