### PR TITLE
Configure test logger for controller-runtime webhook correctly

### DIFF
--- a/internal/webhook/webhook.go
+++ b/internal/webhook/webhook.go
@@ -27,7 +27,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/utils/ptr"
-	crlog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	acmeinstall "github.com/cert-manager/cert-manager/internal/apis/acme/install"
 	cminstall "github.com/cert-manager/cert-manager/internal/apis/certmanager/install"
@@ -48,7 +47,6 @@ import (
 // NewCertManagerWebhookServer creates a new webhook server configured with all cert-manager
 // resource types, validation, defaulting and conversion functions.
 func NewCertManagerWebhookServer(log logr.Logger, opts config.WebhookConfiguration, optionFunctions ...func(*server.Server)) (*server.Server, error) {
-	crlog.SetLogger(log)
 	// nolint:staticcheck // For backwards compatibility.
 	restcfg, err := kube.BuildClientConfig(opts.APIServerHost, opts.KubeConfig)
 	if err != nil {

--- a/test/webhook/testwebhook.go
+++ b/test/webhook/testwebhook.go
@@ -31,9 +31,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/testr"
 	"github.com/spf13/pflag"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/cert-manager/cert-manager/internal/webhook"
 	"github.com/cert-manager/cert-manager/pkg/util/pki"
@@ -58,11 +61,21 @@ type ServerOptions struct {
 }
 
 func StartWebhookServer(t *testing.T, args []string, argumentsForNewServerWithOptions ...func(*server.Server)) (ServerOptions, StopFunc) {
+	// We have to use a global stdout logger, because otherwise -count=2 tests will
+	// fail with "panic: Log in goroutine after Test... has completed: ..." since the
+	// first call to ctrl.SetLogger() will set the logger to the logger linked to the
+	// first test, controller-runtime will ignore the second call to ctrl.SetLogger()
+	// and the second test will end up using the logger linked to the first test, which
+	// will cause the panic.
+	globalLogger := klog.Background()
+	ctrl.SetLogger(globalLogger)
+
 	// Making sure the rootCtx is canceled when StopFunc is called
 	// even when t.Context() has not been canceled yet.
 	stoppableCtx, stopCtxFn := context.WithCancel(t.Context())
 
 	log := testr.New(t)
+	stoppableCtx = logr.NewContext(stoppableCtx, log)
 
 	fs := pflag.NewFlagSet("testset", pflag.ExitOnError)
 	webhookFlags := options.NewWebhookFlags()


### PR DESCRIPTION
Controller runtime accepts a logger both globally and through the context.

As explained in code, the global logger has to be an stdout logger.

This makes it possible to run the approver-policy tests with `-count 5`:
Before:
```
$ go test -test.fullpath=true -timeout 30s -run ^Test_RBACBound$ github.com/cert-manager/approver-policy/pkg/internal/approver/manager/predicate -count 5
panic: Log in goroutine after Test_RBACBound has completed: controller-runtime/webhook: "level"=0 "msg"="Registering webhook" "path"="/mutate"
```

After:
```
$ go test -test.fullpath=true -timeout 160s -run ^Test_RBACBound$ github.com/cert-manager/approver-policy/pkg/internal/approver/manager/predicate -count 5 -v
=== RUN   Test_RBACBound
    /home/tramlot/projects/approver-policy/test/env/env.go:78: starting API server...
    /home/tramlot/projects/approver-policy/test/env/env.go:82: running API server at "https://127.0.0.1:35459/"
    /home/tramlot/projects/approver-policy/test/env/env.go:92: writing cert-manager webhook kubeconfig
    /home/tramlot/projects/approver-policy/test/env/env.go:94: cert-manager webhook kubeconfig written to "/tmp/Test_RBACBound2668605602/001/cert-manager-webhook-kubeconfig.yaml"
I0309 13:04:37.071010  508690 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/mutate"
I0309 13:04:37.071098  508690 server.go:183] "Registering webhook" logger="controller-runtime.webhook" path="/validate"
I0309 13:04:37.071133  508690 server.go:208] "Starting metrics server" logger="controller-runtime.metrics"
I0309 13:04:37.071174  508690 server.go:247] "Serving metrics server" logger="controller-runtime.metrics" bindAddress="0.0.0.0:9402" secure=false
I0309 13:04:37.071234  508690 server.go:191] "Starting webhook server" logger="controller-runtime.webhook"
I0309 13:04:37.071319  508690 server.go:242] "Serving webhook server" logger="controller-runtime.webhook" host="" port=37399
    /home/tramlot/projects/approver-policy/test/env/env.go:97: running cert-manager webhook on "https://127.0.0.1:37399"
=== RUN   Test_RBACBound/if_two_CertificateRequestPolicies_bound_at_namespace_level,_return_policies
=== RUN   Test_RBACBound/if_two_CertificateRequestPolicies_bound_at_namespace_and_cluster_and_other_policies_exist,_return_only_bound_policies
=== RUN   Test_RBACBound/if_no_CertificateRequestPolicies_are_bound_to_the_user,_return_ResultUnprocessed
...
PASS
ok      github.com/cert-manager/approver-policy/pkg/internal/approver/manager/predicate 31.311s
```

### Kind

/kind cleanup

### Release Note

```release-note
NONE
```
