### PR TITLE
helm's readme.md: point to the supported releases page

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -8,7 +8,9 @@ cert-manager can obtain certificates from a [variety of certificate authorities]
 
 ## Prerequisites
 
-- Kubernetes 1.22+
+Make sure you are using a version of Kubernetes that is supported by
+cert-manager. For more information, see the [Supported Releases
+page](https://cert-manager.io/docs/releases/).
 
 ## Installing the Chart
 


### PR DESCRIPTION
instead of hardcoding "Kubernetes 1.22+".

Fixes #8606.

```release-note
NONE
```
