### PR TITLE
Remove deprecated ObjectReference

### DIFF
--- a/internal/apis/meta/types.go
+++ b/internal/apis/meta/types.go
@@ -57,11 +57,6 @@ type IssuerReference struct {
 	Group string
 }
 
-// ObjectReference is a reference to an object with a given name, kind and group.
-//
-// Deprecated: Use IssuerReference instead.
-type ObjectReference = IssuerReference
-
 // A reference to a specific 'key' within a Secret resource.
 // In some instances, `key` is a required field.
 type SecretKeySelector struct {

--- a/internal/generated/openapi/zz_generated.openapi.go
+++ b/internal/generated/openapi/zz_generated.openapi.go
@@ -4786,7 +4786,7 @@ func schema_pkg_apis_meta_v1_IssuerReference(ref common.ReferenceCallback) commo
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "ObjectReference is a reference to an object with a given name, kind and group.\n\nDeprecated: Use IssuerReference instead.",
+				Description: "IssuerReference is a reference to a certificate issuer object with a given name, kind and group.",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"name": {

--- a/pkg/apis/meta/v1/types.go
+++ b/pkg/apis/meta/v1/types.go
@@ -62,11 +62,6 @@ type IssuerReference struct {
 	Group string `json:"group,omitempty"`
 }
 
-// ObjectReference is a reference to an object with a given name, kind and group.
-//
-// Deprecated: Use IssuerReference instead.
-type ObjectReference = IssuerReference
-
 // A reference to a specific 'key' within a Secret resource.
 // In some instances, `key` is a required field.
 type SecretKeySelector struct {


### PR DESCRIPTION
This type was deprecated in https://github.com/cert-manager/cert-manager/pull/7414.

### Pull Request Motivation

### Kind

/kind cleanup

### Release Note

```release-note
API cleanup: removed deprecated ObjectReference
```

/cc @erikgb 