### PR TITLE
[release-1.19] Bump go to latest 1.25.x

### DIFF
--- a/make/_shared/tools/00_mod.mk
+++ b/make/_shared/tools/00_mod.mk
@@ -217,7 +217,7 @@ tools += $(ADDITIONAL_TOOLS)
 
 # https://go.dev/dl/
 # renovate: datasource=golang-version packageName=go
-VENDORED_GO_VERSION := 1.25.7
+VENDORED_GO_VERSION := 1.25.8
 
 # Print the go version which can be used in GH actions
 .PHONY: print-go-version
@@ -440,10 +440,10 @@ $(call for_each_kv,go_dependency,$(go_dependencies))
 # File downloads #
 ##################
 
-go_linux_amd64_SHA256SUM=12e6d6a191091ae27dc31f6efc630e3a3b8ba409baf3573d955b196fdf086005
-go_linux_arm64_SHA256SUM=ba611a53534135a81067240eff9508cd7e256c560edd5d8c2fef54f083c07129
-go_darwin_amd64_SHA256SUM=bf5050a2152f4053837b886e8d9640c829dbacbc3370f913351eb0904cb706f5
-go_darwin_arm64_SHA256SUM=ff18369ffad05c57d5bed888b660b31385f3c913670a83ef557cdfd98ea9ae1b
+go_linux_amd64_SHA256SUM=ceb5e041bbc3893846bd1614d76cb4681c91dadee579426cf21a63f2d7e03be6
+go_linux_arm64_SHA256SUM=7d137f59f66bb93f40a6b2b11e713adc2a9d0c8d9ae581718e3fad19e5295dc7
+go_darwin_amd64_SHA256SUM=a0b8136598baf192af400051cee2481ffb407f4c113a81ff400896e26cbce9e4
+go_darwin_arm64_SHA256SUM=c6547959f5dbe8440bf3da972bd65ba900168de5e7ab01464fbdc7ac8375c21c
 
 .PRECIOUS: $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz
 $(DOWNLOAD_DIR)/tools/go@$(VENDORED_GO_VERSION)_$(HOST_OS)_$(HOST_ARCH).tar.gz: | $(DOWNLOAD_DIR)/tools


### PR DESCRIPTION
### Pull Request Motivation

I had to do this elsewhere so thought I'd raise this to save us a job. Not currently planning on doing a cert-manager release but this is good prep.

### Kind

/kind cleanup

### Release Note

```release-note
Bump go to 1.25.8 to address several reported vulnerabilities
```
