### PR TITLE
fix: deduplicate HTTPRoute parentRefs for multi-listener Gateways

### DIFF
--- a/pkg/controller/acmeorders/util.go
+++ b/pkg/controller/acmeorders/util.go
@@ -231,7 +231,7 @@ func applyGatewayAPIAnnotationParentRefOverride(o *cmacme.Order, s *cmacme.ACMEC
 		}
 
 		parentRefNs := o.GetNamespace()
-		s.HTTP01.GatewayHTTPRoute.ParentRefs = append(s.HTTP01.GatewayHTTPRoute.ParentRefs, gwapi.ParentReference{
+		annotationRef := gwapi.ParentReference{
 			Kind: func() *gwapi.Kind {
 				g := gwapi.Kind(parentRefKind)
 				return &g
@@ -241,7 +241,18 @@ func applyGatewayAPIAnnotationParentRefOverride(o *cmacme.Order, s *cmacme.ACMEC
 				ns := gwapi.Namespace(parentRefNs)
 				return &ns
 			}(),
-		})
+		}
+
+		// Only append the annotation-based parentRef if the same parent
+		// (kind+name+namespace) is not already referenced. The issuer's
+		// solver config may already contain a parentRef for this Gateway
+		// (possibly with a sectionName set). Appending a second reference
+		// to the same parent without sectionName violates Gateway API
+		// v1.5.0+ which requires sectionName when multiple parentRefs
+		// target the same parent.
+		if !parentRefAlreadyExists(s.HTTP01.GatewayHTTPRoute.ParentRefs, annotationRef) {
+			s.HTTP01.GatewayHTTPRoute.ParentRefs = append(s.HTTP01.GatewayHTTPRoute.ParentRefs, annotationRef)
+		}
 	}
 
 	// If after processing annotations we don't find any parentRefs this means the HTTPRoute
@@ -252,6 +263,64 @@ func applyGatewayAPIAnnotationParentRefOverride(o *cmacme.Order, s *cmacme.ACMEC
 	}
 
 	return nil
+}
+
+// parentRefAlreadyExists returns true if the given parentRef matches any
+// existing ref by kind, name, and namespace (ignoring sectionName and port).
+// This is used to avoid adding duplicate parentRefs to the same parent, which
+// is rejected by Gateway API v1.5.0+ when sectionName is not specified.
+func parentRefAlreadyExists(existing []gwapi.ParentReference, candidate gwapi.ParentReference) bool {
+	for _, ref := range existing {
+		if parentRefSameTarget(ref, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// parentRefSameTarget returns true if two ParentReferences refer to the same
+// parent resource (same group, kind, namespace, and name), regardless of
+// sectionName or port.
+func parentRefSameTarget(a, b gwapi.ParentReference) bool {
+	aGroup := gwapi.Group("gateway.networking.k8s.io")
+	if a.Group != nil {
+		aGroup = *a.Group
+	}
+	bGroup := gwapi.Group("gateway.networking.k8s.io")
+	if b.Group != nil {
+		bGroup = *b.Group
+	}
+	if aGroup != bGroup {
+		return false
+	}
+
+	aKind := gwapi.Kind("Gateway")
+	if a.Kind != nil {
+		aKind = *a.Kind
+	}
+	bKind := gwapi.Kind("Gateway")
+	if b.Kind != nil {
+		bKind = *b.Kind
+	}
+	if aKind != bKind {
+		return false
+	}
+
+	if a.Name != b.Name {
+		return false
+	}
+
+	// Compare namespaces. Nil namespace is treated as empty string for
+	// comparison since the annotation-based ref always sets namespace.
+	aNs := gwapi.Namespace("")
+	if a.Namespace != nil {
+		aNs = *a.Namespace
+	}
+	bNs := gwapi.Namespace("")
+	if b.Namespace != nil {
+		bNs = *b.Namespace
+	}
+	return aNs == bNs
 }
 
 func ensureKeysForChallenges(cl acmecl.Interface, challenges []*cmacme.Challenge) ([]*cmacme.Challenge, error) {

--- a/pkg/controller/acmeorders/util_test.go
+++ b/pkg/controller/acmeorders/util_test.go
@@ -593,6 +593,40 @@ func TestBuildChallengeSpecFromOrder_ParentRefAnnotations(t *testing.T) {
 			orderNS: "custom-namespace",
 			want:    parentRefs("Gateway", "test-gateway", "custom-namespace"),
 		},
+		{
+			name:   "skip duplicate when annotation ref matches existing parentRef",
+			issuer: gatewayIssuer(parentRefs("Gateway", "my-gateway", "test-namespace")),
+			orderAnnotations: map[string]string{
+				"acme.cert-manager.io/http01-parentrefname": "my-gateway",
+				"acme.cert-manager.io/http01-parentrefkind": "Gateway",
+			},
+			orderNS: "test-namespace",
+			want:    parentRefs("Gateway", "my-gateway", "test-namespace"),
+		},
+		{
+			name: "skip duplicate when annotation ref matches existing parentRef with sectionName",
+			issuer: gatewayIssuer([]gwapi.ParentReference{
+				{
+					Kind:        ptr.To(gwapi.Kind("Gateway")),
+					Name:        gwapi.ObjectName("my-gateway"),
+					Namespace:   ptr.To(gwapi.Namespace("test-namespace")),
+					SectionName: ptr.To(gwapi.SectionName("http")),
+				},
+			}),
+			orderAnnotations: map[string]string{
+				"acme.cert-manager.io/http01-parentrefname": "my-gateway",
+				"acme.cert-manager.io/http01-parentrefkind": "Gateway",
+			},
+			orderNS: "test-namespace",
+			want: []gwapi.ParentReference{
+				{
+					Kind:        ptr.To(gwapi.Kind("Gateway")),
+					Name:        gwapi.ObjectName("my-gateway"),
+					Namespace:   ptr.To(gwapi.Namespace("test-namespace")),
+					SectionName: ptr.To(gwapi.SectionName("http")),
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/issuer/acme/http/httproute.go
+++ b/pkg/issuer/acme/http/httproute.go
@@ -151,7 +151,7 @@ func generateHTTPRouteSpec(ch *cmacme.Challenge, svcName string) gwapi.HTTPRoute
 
 	return gwapi.HTTPRouteSpec{
 		CommonRouteSpec: gwapi.CommonRouteSpec{
-			ParentRefs: ch.Spec.Solver.HTTP01.GatewayHTTPRoute.ParentRefs,
+			ParentRefs: deduplicateParentRefs(ch.Spec.Solver.HTTP01.GatewayHTTPRoute.ParentRefs),
 		},
 		Hostnames: hostnames,
 		Rules: []gwapi.HTTPRouteRule{
@@ -181,4 +181,86 @@ func generateHTTPRouteSpec(ch *cmacme.Challenge, svcName string) gwapi.HTTPRoute
 			},
 		},
 	}
+}
+
+// deduplicateParentRefs removes duplicate parentRefs that target the same
+// parent Gateway (same group, kind, namespace, and name) when none of the
+// duplicates have sectionName set. Gateway API v1.5.0+ rejects HTTPRoutes
+// with multiple parentRefs to the same parent unless sectionName is specified
+// on each one. When duplicates targeting the same parent all lack sectionName,
+// only the first is kept. When sectionName is set on any of them, all are
+// preserved since they are valid per the Gateway API spec.
+func deduplicateParentRefs(refs []gwapi.ParentReference) []gwapi.ParentReference {
+	if len(refs) <= 1 {
+		return refs
+	}
+
+	type parentKey struct {
+		group     gwapi.Group
+		kind      gwapi.Kind
+		namespace gwapi.Namespace
+		name      gwapi.ObjectName
+	}
+
+	keyFor := func(ref gwapi.ParentReference) parentKey {
+		group := gwapi.Group("gateway.networking.k8s.io")
+		if ref.Group != nil {
+			group = *ref.Group
+		}
+		kind := gwapi.Kind("Gateway")
+		if ref.Kind != nil {
+			kind = *ref.Kind
+		}
+		ns := gwapi.Namespace("")
+		if ref.Namespace != nil {
+			ns = *ref.Namespace
+		}
+		return parentKey{
+			group:     group,
+			kind:      kind,
+			namespace: ns,
+			name:      ref.Name,
+		}
+	}
+
+	// First pass: group indices by parent key.
+	seen := make(map[parentKey][]int)
+	for i, ref := range refs {
+		key := keyFor(ref)
+		seen[key] = append(seen[key], i)
+	}
+
+	// Build a set of indices to skip.
+	skip := make(map[int]bool)
+	for _, indices := range seen {
+		if len(indices) <= 1 {
+			continue
+		}
+		// Check if any ref in this group has sectionName set.
+		anySectionName := false
+		for _, idx := range indices {
+			if refs[idx].SectionName != nil {
+				anySectionName = true
+				break
+			}
+		}
+		// If none have sectionName, keep only the first and skip the rest.
+		if !anySectionName {
+			for _, idx := range indices[1:] {
+				skip[idx] = true
+			}
+		}
+	}
+
+	if len(skip) == 0 {
+		return refs
+	}
+
+	deduped := make([]gwapi.ParentReference, 0, len(refs)-len(skip))
+	for i, ref := range refs {
+		if !skip[i] {
+			deduped = append(deduped, ref)
+		}
+	}
+	return deduped
 }

--- a/pkg/issuer/acme/http/httproute_test.go
+++ b/pkg/issuer/acme/http/httproute_test.go
@@ -261,6 +261,98 @@ func TestEnsureGatewayHTTPRoute(t *testing.T) {
 	}
 }
 
+func TestDeduplicateParentRefs(t *testing.T) {
+	gatewayGroup := gwapi.Group("gateway.networking.k8s.io")
+	gatewayKind := gwapi.Kind("Gateway")
+	ns := gwapi.Namespace("default")
+	sectionHTTP := gwapi.SectionName("http")
+	sectionHTTPS := gwapi.SectionName("https")
+
+	tests := []struct {
+		name     string
+		input    []gwapi.ParentReference
+		expected []gwapi.ParentReference
+	}{
+		{
+			name:     "nil input",
+			input:    nil,
+			expected: nil,
+		},
+		{
+			name: "single ref unchanged",
+			input: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+			expected: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+		},
+		{
+			name: "duplicate refs without sectionName are deduplicated",
+			input: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+			expected: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+		},
+		{
+			name: "duplicate refs with sectionName are preserved",
+			input: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw", SectionName: &sectionHTTP},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw", SectionName: &sectionHTTPS},
+			},
+			expected: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw", SectionName: &sectionHTTP},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw", SectionName: &sectionHTTPS},
+			},
+		},
+		{
+			name: "different parents are not deduplicated",
+			input: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "gw-1"},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "gw-2"},
+			},
+			expected: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "gw-1"},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "gw-2"},
+			},
+		},
+		{
+			name: "three duplicate refs without sectionName deduplicated to one",
+			input: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+			expected: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+		},
+		{
+			name: "mixed: one ref with sectionName and one without for same parent are preserved",
+			input: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw", SectionName: &sectionHTTP},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+			expected: []gwapi.ParentReference{
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw", SectionName: &sectionHTTP},
+				{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := deduplicateParentRefs(tt.input)
+			if !reflect.DeepEqual(got, tt.expected) {
+				t.Errorf("deduplicateParentRefs() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
 func TestGenerateHTTPRouteSpec(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -309,5 +401,37 @@ func TestGenerateHTTPRouteSpec(t *testing.T) {
 				t.Errorf("Expected hostnames %v, but got %v", tt.expectedHostnames, spec.Hostnames)
 			}
 		})
+	}
+}
+
+func TestGenerateHTTPRouteSpec_DeduplicatesParentRefs(t *testing.T) {
+	gatewayGroup := gwapi.Group("gateway.networking.k8s.io")
+	gatewayKind := gwapi.Kind("Gateway")
+	ns := gwapi.Namespace("default")
+
+	ch := &cmacme.Challenge{
+		Spec: cmacme.ChallengeSpec{
+			DNSName: "example.com",
+			Token:   "test-token",
+			Solver: cmacme.ACMEChallengeSolver{
+				HTTP01: &cmacme.ACMEChallengeSolverHTTP01{
+					GatewayHTTPRoute: &cmacme.ACMEChallengeSolverHTTP01GatewayHTTPRoute{
+						ParentRefs: []gwapi.ParentReference{
+							{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+							{Group: &gatewayGroup, Kind: &gatewayKind, Namespace: &ns, Name: "my-gw"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	spec := generateHTTPRouteSpec(ch, "fakeservice")
+
+	if len(spec.ParentRefs) != 1 {
+		t.Errorf("Expected 1 parentRef after deduplication, got %d", len(spec.ParentRefs))
+	}
+	if spec.ParentRefs[0].Name != "my-gw" {
+		t.Errorf("Expected parentRef name 'my-gw', got %q", spec.ParentRefs[0].Name)
 	}
 }


### PR DESCRIPTION
### Pull Request Motivation

Fixes a regression in cert-manager 1.20.0 where the ACME HTTP-01 solver
fails to create an HTTPRoute when a Gateway has multiple listeners
(e.g., HTTP on port 80 + HTTPS on port 443) pointing to the same Gateway.

Gateway API v1.5.0 (adopted in cert-manager 1.20.0) now enforces that
`sectionName` must be specified when an HTTPRoute has 2+ `parentRefs`
targeting the same parent. The solver was creating duplicate `parentRefs`
because `applyGatewayAPIAnnotationParentRefOverride` unconditionally
appended an annotation-derived parentRef even when the issuer's solver
config already referenced the same Gateway (possibly with a `sectionName`).

This caused an infinite error loop:
```
Error presenting challenge: HTTPRoute.gateway.networking.k8s.io "cm-acme-http-solver-xxxxx"
is invalid: spec.parentRefs: Invalid value: "array": sectionName must be specified when
parentRefs includes 2 or more references to the same parent
```

The fix has two layers:
1. **Root cause fix** (`util.go`): Check whether the parent is already
   referenced before appending the annotation-based parentRef.
2. **Defense-in-depth** (`httproute.go`): Deduplicate parentRefs in
   `generateHTTPRouteSpec` — if multiple refs target the same parent and
   none have `sectionName` set, keep only the first.

Downgrading to 1.19.3 was the only known workaround; this fix restores
correct behavior on 1.20.0+.

Fixes #8611

### Kind

/kind bug

### Release Note

```release-note
Fixed a regression where the ACME HTTP-01 solver failed to create an
HTTPRoute when a Gateway had multiple listeners targeting the same
parent without sectionName, due to Gateway API v1.5.0 validation
rejecting duplicate parentRefs.
```