### PR TITLE
fix(helm): roll deployments on config changes (checksum)

### DIFF
--- a/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/cainjector-deployment.yaml
@@ -40,17 +40,19 @@ spec:
         {{- with .Values.cainjector.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cainjector.podAnnotations }}
       annotations:
+        {{- if .Values.cainjector.config -}}
+        checksum/config: {{ include (print $.Template.BasePath "/cainjector-config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.cainjector.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
-      {{- if not .Values.cainjector.podAnnotations }}
-      annotations:
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
+        {{- if not .Values.cainjector.podAnnotations }}
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9402'
+        {{- end }}
       {{- end }}
     spec:
       {{- if not .Values.cainjector.serviceAccount.create }}

--- a/deploy/charts/cert-manager/templates/deployment.yaml
+++ b/deploy/charts/cert-manager/templates/deployment.yaml
@@ -39,17 +39,19 @@ spec:
         {{- with .Values.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- if .Values.config }}
+        checksum/config: {{ include (print $.Template.BasePath "/controller-config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
-      {{- if not .Values.podAnnotations }}
-      annotations:
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
+        {{- if not .Values.podAnnotations }}
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9402'
+        {{- end }}
       {{- end }}
     spec:
       {{- if not .Values.serviceAccount.create }}

--- a/deploy/charts/cert-manager/templates/webhook-deployment.yaml
+++ b/deploy/charts/cert-manager/templates/webhook-deployment.yaml
@@ -39,17 +39,19 @@ spec:
         {{- with .Values.webhook.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.webhook.podAnnotations }}
       annotations:
+        {{- if .Values.webhook.config -}}
+        checksum/config: {{ include (print $.Template.BasePath "/webhook-config.yaml") . | sha256sum }}
+        {{- end }}
+        {{- with .Values.webhook.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
-      {{- if not .Values.webhook.podAnnotations }}
-      annotations:
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.prometheus.enabled (not (or .Values.prometheus.servicemonitor.enabled .Values.prometheus.podmonitor.enabled)) }}
+        {{- if not .Values.webhook.podAnnotations }}
         prometheus.io/path: "/metrics"
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9402'
+        {{- end }}
       {{- end }}
     spec:
       {{- if not .Values.webhook.serviceAccount.create }}


### PR DESCRIPTION
### Pull Request Motivation

Add checksum-based pod template annotations for the controller, webhook, and cainjector configmaps so config updates trigger rollout/reload without changing existing annotation checks.

### Kind

/kind feature

### Release Note

Helm: cert-manager controller, webhook, and cainjector deployments now include configmap checksum pod annotations so config changes trigger automatic pod rollouts.