### PR TITLE
cleanup: remove unused RenewCertificate method from Connector interface

### DIFF
--- a/pkg/issuer/venafi/client/fake/connector.go
+++ b/pkg/issuer/venafi/client/fake/connector.go
@@ -29,7 +29,6 @@ type Connector struct {
 	ReadZoneConfigurationFunc func() (*endpoint.ZoneConfiguration, error)
 	RetrieveCertificateFunc   func(*certificate.Request) (*certificate.PEMCollection, error)
 	RequestCertificateFunc    func(*certificate.Request) (string, error)
-	RenewCertificateFunc      func(*certificate.RenewalRequest) (string, error)
 }
 
 func (f Connector) Default() *Connector {
@@ -65,11 +64,4 @@ func (f *Connector) RequestCertificate(req *certificate.Request) (requestID stri
 		return f.RequestCertificateFunc(req)
 	}
 	return f.Connector.RequestCertificate(req)
-}
-
-func (f *Connector) RenewCertificate(req *certificate.RenewalRequest) (requestID string, err error) {
-	if f.RenewCertificateFunc != nil {
-		return f.RenewCertificateFunc(req)
-	}
-	return f.Connector.RenewCertificate(req)
 }

--- a/pkg/issuer/venafi/client/instrumentedvenaficlient.go
+++ b/pkg/issuer/venafi/client/instrumentedvenaficlient.go
@@ -78,12 +78,3 @@ func (ic instrumentedConnector) Ping() error {
 	ic.metrics.ObserveVenafiRequestDuration(time.Since(start), labels...)
 	return err
 }
-
-func (ic instrumentedConnector) RenewCertificate(req *certificate.RenewalRequest) (string, error) {
-	start := time.Now()
-	ic.logger.V(logf.TraceLevel).Info("calling RenewCertificate")
-	reqID, err := ic.conn.RenewCertificate(req)
-	labels := []string{"renew_certificate"}
-	ic.metrics.ObserveVenafiRequestDuration(time.Since(start), labels...)
-	return reqID, err
-}

--- a/pkg/issuer/venafi/client/venaficlient.go
+++ b/pkg/issuer/venafi/client/venaficlient.go
@@ -86,8 +86,6 @@ type connector interface {
 	ReadZoneConfiguration() (config *endpoint.ZoneConfiguration, err error)
 	RequestCertificate(req *certificate.Request) (requestID string, err error)
 	RetrieveCertificate(req *certificate.Request) (certificates *certificate.PEMCollection, err error)
-	// TODO: (irbekrm) this method is never used - can it be removed?
-	RenewCertificate(req *certificate.RenewalRequest) (requestID string, err error)
 }
 
 // New constructs a Venafi client Interface. Errors may be network errors and


### PR DESCRIPTION
<!--
Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Fixes #8645 

### Kind 

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
