### PR TITLE
feat(chart): add ttlSecondsAfterFinished field in startupapicheck Job

### DIFF
--- a/deploy/charts/cert-manager/README.template.md
+++ b/deploy/charts/cert-manager/README.template.md
@@ -2009,6 +2009,13 @@ Timeout for 'kubectl check api' command.
 > 4
 > ```
 
+Job 'ttlSecondsAfterFinished'
+#### **startupapicheck.ttlSecondsAfterFinished** ~ `number`
+> Default value:
+> ```yaml
+> 30
+> ```
+
 Job backoffLimit
 #### **startupapicheck.jobAnnotations** ~ `object`
 > Default value:

--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -16,6 +16,7 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  ttlSecondsAfterFinished: {{ .Values.startupapicheck.ttlSecondsAfterFinished }}
   template:
     metadata:
       labels:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1492,6 +1492,9 @@
         "backoffLimit": {
           "$ref": "#/$defs/helm-values.startupapicheck.backoffLimit"
         },
+        "ttlSecondsAfterFinished": {
+          "$ref": "#/$defs/helm-values.startupapicheck.ttlSecondsAfterFinished"
+        },
         "containerSecurityContext": {
           "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext"
         },
@@ -1561,6 +1564,11 @@
     "helm-values.startupapicheck.backoffLimit": {
       "default": 4,
       "description": "Job backoffLimit",
+      "type": "number"
+    },
+    "helm-values.startupapicheck.ttlSecondsAfterFinished": {
+      "default": 30,
+      "description": "Job ttlSecondsAfterFinished",
       "type": "number"
     },
     "helm-values.startupapicheck.containerSecurityContext": {

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1529,6 +1529,9 @@ startupapicheck:
   # Job backoffLimit
   backoffLimit: 4
 
+  # Job ttlSecondsAfterFinished
+  ttlSecondsAfterFinished: 30
+
   # Optional additional annotations to add to the startupapicheck Job.
   # +docs:property
   jobAnnotations:


### PR DESCRIPTION
### Pull Request Motivation

Fixes: https://github.com/cert-manager/cert-manager/issues/8363

### Kind

/kind feature


### Release Note

```release-note
Set add ttlSecondsAfterFinished fiels in startupapicheck Job ; default value is 30.
```
