### PR TITLE
certificate request webhook: add caching for negative results

### DIFF
--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"sync"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -51,7 +52,10 @@ type certificateRequestApproval struct {
 	// resourceInfo stores the associated resource info for a given GroupKind
 	// to prevent making multiple queries to the API server for every approval.
 	resourceInfo map[schema.GroupKind]resourceInfo
-	mutex        sync.RWMutex
+
+	// missingAPIs stores the last time a missing API was not found
+	missingAPIs map[schema.GroupKind]time.Time
+	mutex       sync.RWMutex
 }
 
 type resourceInfo struct {
@@ -65,6 +69,7 @@ func NewPlugin(authz authorizer.Authorizer, discoveryClient discovery.DiscoveryI
 	return &certificateRequestApproval{
 		Handler:      admission.NewHandler(admissionv1.Update),
 		resourceInfo: map[schema.GroupKind]resourceInfo{},
+		missingAPIs:  map[schema.GroupKind]time.Time{},
 
 		authorizer: authz,
 		discovery:  discoveryClient,
@@ -134,10 +139,12 @@ func (c *certificateRequestApproval) apiResourceForGroupKind(groupKind schema.Gr
 		return resource, nil
 	}
 
+	// do a quick check for whether we did not find the resource before
+	if c.checkAPIResourceNotFound(groupKind) {
+		return nil, errNoResourceExists
+	}
+
 	// otherwise, query the apiserver
-	// TODO: we should enhance caching here to avoid performing discovery queries
-	//       many times if many CertificateRequest resources exist that reference
-	//       a resource that doesn't exist
 	groups, err := c.discovery.ServerGroups()
 	if err != nil {
 		return nil, err
@@ -164,7 +171,24 @@ func (c *certificateRequestApproval) apiResourceForGroupKind(groupKind schema.Gr
 		}
 	}
 
+	c.indexAPIResourceNotFound(groupKind)
+
 	return nil, errNoResourceExists
+}
+
+const missingAPITTL = time.Duration(30 * time.Second)
+
+func (c *certificateRequestApproval) checkAPIResourceNotFound(groupKind schema.GroupKind) bool {
+	c.mutex.RLock()
+	defer c.mutex.RUnlock()
+	lastTimeNotFound, ok := c.missingAPIs[groupKind]
+	return ok && lastTimeNotFound.Add(missingAPITTL).After(time.Now())
+}
+
+func (c *certificateRequestApproval) indexAPIResourceNotFound(groupKind schema.GroupKind) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.missingAPIs[groupKind] = time.Now()
 }
 
 func (c *certificateRequestApproval) readAPIResourceFromCache(groupKind schema.GroupKind) *resourceInfo {

--- a/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
+++ b/internal/webhook/admission/certificaterequest/approval/certificaterequest_approval_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/synctest"
+	"time"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	authnv1 "k8s.io/api/authentication/v1"
@@ -309,6 +311,112 @@ func TestValidate(t *testing.T) {
 			compareErrors(t, test.expErr, err)
 		})
 	}
+}
+
+func TestMissingKind(t *testing.T) {
+	synctest.Test(t, func(t *testing.T) {
+		// This copies the test in the TestValidate above, but delaying the set of ServerGroups until later,
+		// similar to a real cluster that installs the CRD later. We're copying this test:
+		// "if the CertificateRequest references a signer that the approver has permissions for the wildcard of, return nil"
+		authorizer := &fakeAuthorizer{
+			verb:        "approve",
+			allowedName: "issuers.example.io/*",
+			decision:    authorizer.DecisionAllow,
+			t:           t,
+		}
+		discoverClient := discoveryfake.NewDiscovery().
+			WithServerGroups(func() (*metav1.APIGroupList, error) {
+				return &metav1.APIGroupList{}, nil
+			})
+		// try to run function with crd that does not exist
+		a := NewPlugin(authorizer, discoverClient).(*certificateRequestApproval)
+
+		req := admissionv1.AdmissionRequest{
+			UserInfo: authnv1.UserInfo{
+				Username: "user-1",
+			},
+			Operation: admissionv1.Update,
+			RequestResource: &metav1.GroupVersionResource{
+				Group:    "cert-manager.io",
+				Resource: "certificaterequests",
+			},
+			RequestSubResource: "status",
+		}
+
+		baseCR := &certmanager.CertificateRequest{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "testns"},
+			Spec: certmanager.CertificateRequestSpec{
+				IssuerRef: meta.IssuerReference{
+					Name:  "my-issuer",
+					Kind:  "Issuer",
+					Group: "example.io",
+				},
+			},
+		}
+
+		approvedCR := baseCR.DeepCopy()
+		approvedCR.Status = certmanager.CertificateRequestStatus{
+			Conditions: []certmanager.CertificateRequestCondition{
+				{
+					Type:    certmanager.CertificateRequestConditionApproved,
+					Status:  meta.ConditionTrue,
+					Reason:  "cert-manager.io",
+					Message: "",
+				},
+			},
+		}
+
+		_, validateErr1 := a.Validate(t.Context(), req, baseCR, approvedCR)
+
+		if validateErr1 == nil {
+			t.Errorf("Expected errors from validate from missing crd, but there were no errors")
+		}
+		// wait for five seconds
+		time.Sleep(5 * time.Second)
+		// install the CRD
+		a.discovery = discoveryfake.NewDiscovery().
+			WithServerGroups(func() (*metav1.APIGroupList, error) {
+				return &metav1.APIGroupList{
+					Groups: []metav1.APIGroup{
+						{
+							Name: "example.io",
+							Versions: []metav1.GroupVersionForDiscovery{
+								{GroupVersion: "example.io/a-version", Version: "a-version"},
+							},
+						},
+					},
+				}, nil
+			}).
+			WithServerResourcesForGroupVersion(func(groupVersion string) (*metav1.APIResourceList, error) {
+				return &metav1.APIResourceList{
+					APIResources: []metav1.APIResource{
+						{
+							Name:       "issuers",
+							Namespaced: true,
+							Kind:       "Issuer",
+						},
+					},
+				}, nil
+			})
+		// Try again
+		_, validateErr2 := a.Validate(t.Context(), req, baseCR, approvedCR)
+
+		// Fail, because the missing crd is still in cache
+		if validateErr2 == nil {
+			t.Errorf("Expected errors from validate from crd cached as missing, but there were none")
+		}
+		// wait through the full TTL
+		time.Sleep(missingAPITTL)
+
+		// try one more time
+		_, validateErr3 := a.Validate(t.Context(), req, baseCR, approvedCR)
+
+		// Succeed
+		if validateErr3 != nil {
+			t.Errorf("Did not expect errors from validate from missing crd, we should have found them at this point")
+		}
+
+	})
 }
 
 type fakeAuthorizer struct {


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

Resolves #8644

Special thanks to @mircea-cosbuc who helped with pair programming and morale. This PR was created during KubeCon Amsterdam 2026 Contrib Fest. Hot Diggity!

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind feature
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
