### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -71,6 +71,10 @@ func AddFlags(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 	var allFlags flag.FlagSet
 	klog.InitFlags(&allFlags)
 
+	// Opt into fixed stderrthreshold behavior (kubernetes/klog#212).
+	_ = allFlags.Set("legacy_stderr_threshold_behavior", "false")
+	_ = allFlags.Set("stderrthreshold", "INFO")
+
 	allFlags.VisitAll(func(f *flag.Flag) {
 		switch f.Name {
 		case "add_dir_header", "alsologtostderr", "log_backtrace_at", "log_dir", "log_file", "log_file_max_size",


### PR DESCRIPTION
## Description

When `logtostderr` is `true` (the default), klog historically ignored
`stderrthreshold`, silently dropping log messages that should have been
written to stderr.

This was fixed in klog **v2.140.0** by introducing a new flag
`legacy_stderr_threshold_behavior`.  Setting it to `false` makes klog
honour `stderrthreshold` regardless of `logtostderr`.

This PR opts into the fixed behavior by calling:

```go
_ = allFlags.Set("legacy_stderr_threshold_behavior", "false")
_ = allFlags.Set("stderrthreshold", "INFO")
```

right after `klog.InitFlags()` in the `AddFlags` function.

## References

- kubernetes/klog#212
- kubernetes/klog#432

/cc @erikgb @thatsmrtalbot

```release-note
Honor stderrthreshold when logtostderr is enabled by opting into fixed klog behavior
```