### PR TITLE
fix: honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -71,6 +71,13 @@ func AddFlags(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 	var allFlags flag.FlagSet
 	klog.InitFlags(&allFlags)
 
+	// Opt into the new klog behavior so that -stderrthreshold is honored even
+	// when -logtostderr=true (the default). Without this, all log levels are
+	// unconditionally sent to stderr and users cannot filter by severity.
+	// Requires klog v2.140.0+ (https://github.com/kubernetes/klog/issues/212).
+	_ = allFlags.Set("legacy_stderr_threshold_behavior", "false")
+	_ = allFlags.Set("stderrthreshold", "INFO")
+
 	allFlags.VisitAll(func(f *flag.Flag) {
 		switch f.Name {
 		case "add_dir_header", "alsologtostderr", "log_backtrace_at", "log_dir", "log_file", "log_file_max_size",


### PR DESCRIPTION
## Summary

Opt into the new klog v2.140.0 behavior so that `-stderrthreshold` is honored even when `-logtostderr=true` (the default). This fixes the long-standing klog bug (kubernetes/klog#212) where the stderrthreshold flag was silently ignored.

## Changes

- Set `legacy_stderr_threshold_behavior=false` and `stderrthreshold=INFO` programmatically in `AddFlags()`
- **No user-facing flag changes**: The deprecated+hidden CLI flags remain exactly as they are
- **No behavior change by default**: `stderrthreshold=INFO` means all logs still go to stderr (same as current behavior)

## Compatibility with KEP-2845

This change is fully compatible with [KEP-2845](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md):

1. KEP-2845 is [scoped to Kubernetes core components](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md#proposal), not third-party projects. "Remove flags from klog" is listed as a [Non-Goal](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md#non-goals).
2. This PR sets **internal programmatic defaults**, not new user-facing CLI flags.
3. `legacy_stderr_threshold_behavior` is a **new** flag (klog v2.140.0) not in the KEP's deprecation list.
4. Setting `stderrthreshold=INFO` aligns with KEP-2845's 12-factor app philosophy (logs as event streams to stderr).

## References

- https://github.com/kubernetes/klog/issues/212 — the underlying bug (open since 2020)
- https://github.com/kubernetes/klog/pull/432 — the fix in klog v2.140.0

```release-note
Honor stderrthreshold when logtostderr is enabled by opting into the fixed klog v2.140.0 behavior.
```