### PR TITLE
Honor stderrthreshold when logtostderr is enabled

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -71,6 +71,13 @@ func AddFlags(opts *logsapi.LoggingConfiguration, fs *pflag.FlagSet) {
 	var allFlags flag.FlagSet
 	klog.InitFlags(&allFlags)
 
+	// Opt into the new klog behavior so that -stderrthreshold is honored even
+	// when -logtostderr=true (the default). Without this, all log levels are
+	// unconditionally sent to stderr and users cannot filter by severity.
+	// Requires klog v2.140.0+ (https://github.com/kubernetes/klog/issues/212).
+	_ = allFlags.Set("legacy_stderr_threshold_behavior", "false")
+	_ = allFlags.Set("stderrthreshold", "INFO")
+
 	allFlags.VisitAll(func(f *flag.Flag) {
 		switch f.Name {
 		case "add_dir_header", "alsologtostderr", "log_backtrace_at", "log_dir", "log_file", "log_file_max_size",


### PR DESCRIPTION
## Description

When `logtostderr` is `true` (the default), klog historically ignored
`stderrthreshold`, silently dropping the filtering that should have been
applied. This was fixed in klog **v2.140.0** by introducing
`legacy_stderr_threshold_behavior`. Setting it to `false` makes klog
honour `stderrthreshold` regardless of `logtostderr`.

This PR adds two lines after `klog.InitFlags()` in `AddFlags`:

```go
_ = allFlags.Set("legacy_stderr_threshold_behavior", "false")
_ = allFlags.Set("stderrthreshold", "INFO")
```

## Why this replaces #8653

I closed #8653 after @hjoshi123 raised a concern about [KEP-2845](https://github.com/kubernetes/enhancements/blob/master/keps/sig-instrumentation/2845-deprecate-klog-specific-flags-in-k8s-components/README.md) deprecating klog-specific flags. On closer review, I believe that concern does not apply here, for the reasons below.

### cert-manager already uses these flags internally

`pkg/logs/logs.go` already:

1. **Calls `klog.InitFlags(&allFlags)`** (line 72) — initializing the full klog flag set
2. **Registers `stderrthreshold`** as a deprecated-but-functional flag (lines 76-82) — users can pass `--stderrthreshold=ERROR` today
3. **Uses klog v2.140.0** (`go.mod`) — the exact version that ships the `legacy_stderr_threshold_behavior` fix

### KEP-2845 deprecates flags for future removal — it does not break them

KEP-2845 marks these flags as deprecated so they can be removed in a future release. cert-manager follows this by hiding the flags and adding a deprecation warning. But **deprecation ≠ broken**: a flag that is registered, accepted by the binary, and documented as deprecated should still function correctly until it is actually removed.

Today, a user who passes `--stderrthreshold=ERROR` to any cert-manager binary gets **zero effect** — the flag is silently a no-op because `logtostderr=true` (the default) overrides it. This is confusing and arguably worse than the KEP-2845 concern: the flag exists, is accepted without error, but does nothing.

### This change adds no new user-facing flags

The fix is purely internal configuration: it tells klog to use its corrected behavior so that the **already-registered** `stderrthreshold` flag works as expected. No new flags are added, no deprecated flags are un-deprecated, and the deprecation warning remains intact.

### Summary

| Aspect | Before this PR | After this PR |
|---|---|---|
| `stderrthreshold` registered? | Yes (deprecated) | Yes (deprecated) |
| `stderrthreshold` functional? | **No** — silently ignored | **Yes** — works correctly |
| New user-facing flags? | — | None |
| klog version required | v2.140.0 (already in go.mod) | v2.140.0 (already in go.mod) |

## References

- kubernetes/klog#212
- kubernetes/klog#432

/cc @erikgb @thatsmrtalbot @hjoshi123

```release-note
Honor stderrthreshold when logtostderr is enabled by opting into fixed klog behavior
```