### PR TITLE
helm: add ttlSecondsAfterFinished to startupapicheck Job

### DIFF
--- a/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/cert-manager/templates/startupapicheck-job.yaml
@@ -16,6 +16,9 @@ metadata:
   {{- end }}
 spec:
   backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  {{- if hasKey .Values.startupapicheck "ttlSecondsAfterFinished" }}
+  ttlSecondsAfterFinished: {{ .Values.startupapicheck.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/deploy/charts/cert-manager/values.schema.json
+++ b/deploy/charts/cert-manager/values.schema.json
@@ -1537,6 +1537,9 @@
         "timeout": {
           "$ref": "#/$defs/helm-values.startupapicheck.timeout"
         },
+        "ttlSecondsAfterFinished": {
+          "$ref": "#/$defs/helm-values.startupapicheck.ttlSecondsAfterFinished"
+        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
         },
@@ -1761,6 +1764,11 @@
       "default": "1m",
       "description": "Timeout for 'kubectl check api' command.",
       "type": "string"
+    },
+    "helm-values.startupapicheck.ttlSecondsAfterFinished": {
+      "description": "TTL for cleaning up finished Jobs. If set, completed startupapicheck Jobs will be automatically deleted after the given number of seconds.",
+      "type": "integer",
+      "minimum": 0
     },
     "helm-values.startupapicheck.tolerations": {
       "default": [],

--- a/deploy/charts/cert-manager/values.yaml
+++ b/deploy/charts/cert-manager/values.yaml
@@ -1529,6 +1529,15 @@ startupapicheck:
   # Job backoffLimit
   backoffLimit: 4
 
+  # TTL for cleaning up finished Jobs. If set, completed startupapicheck Jobs
+  # will be automatically deleted after the given number of seconds. Note that
+  # the default Helm hook-delete-policy (before-hook-creation,hook-succeeded)
+  # already removes successful Jobs on the next install/upgrade; this field is
+  # useful when you customise hook-delete-policy or want the kubelet to handle
+  # cleanup independently.
+  # +docs:property
+  # ttlSecondsAfterFinished: 600
+
   # Optional additional annotations to add to the startupapicheck Job.
   # +docs:property
   jobAnnotations:


### PR DESCRIPTION
## Description

Add a configurable `ttlSecondsAfterFinished` field to the `cert-manager-startupapicheck` Job in the Helm chart. This addresses kube-linter warnings about completed Jobs lingering in the cluster.

### Changes
- **`templates/startupapicheck-job.yaml`** — Added conditional `ttlSecondsAfterFinished` rendering using `hasKey`, matching the existing `automountServiceAccountToken` pattern
- **`values.yaml`** — Added documented (commented-out) `ttlSecondsAfterFinished` field under `startupapicheck`, with context about the interaction with `hook-delete-policy`
- **`values.schema.json`** — Added schema definition with `type: integer` and `minimum: 0`

### Design Decisions
- **Optional by default** — field is only rendered when explicitly set, ensuring no behavior change for existing users
- **Uses `hasKey`** guard rather than a truthy check, so `ttlSecondsAfterFinished: 0` (immediate cleanup) works correctly
- **Integer type** in schema matches K8s API expectation (`int32`)

### Validation
- `helm template` with value=600: renders correctly
- `helm template` without value: field absent
- `helm template` with value=0: renders correctly
- Schema rejects negative values and non-integers
- `helm lint`: clean

Fixes #8363