### PR TITLE
Migrate upgrade e2e test to Helm OCI

### DIFF
--- a/hack/verify-upgrade.sh
+++ b/hack/verify-upgrade.sh
@@ -64,16 +64,9 @@ NAMESPACE="${NAMESPACE:-cert-manager}"
 # Release name to use with Helm
 RELEASE_NAME="${RELEASE_NAME:-cert-manager}"
 
-HELM_URL="https://charts.jetstack.io"
-
-# cert-manager Helm chart location
-HELM_CHART="cmupgradetest/cert-manager"
+HELM_URL="oci://quay.io/jetstack/charts/cert-manager"
 
 echo "+++ Testing upgrading from ${INITIAL_RELEASE} to commit ${KUBE_GIT_COMMIT} with Helm"
-
-# This will target the host's helm repository cache
-$helm repo add cmupgradetest $HELM_URL
-$helm repo update
 
 # 1. INSTALL THE INITIAL RELEASE'S PUBLISHED HELM CHART
 
@@ -89,7 +82,7 @@ $helm upgrade \
     --create-namespace \
     --version "${INITIAL_RELEASE}" \
     "$RELEASE_NAME" \
-    "$HELM_CHART"
+    "$HELM_URL"
 
 # Wait for the cert-manager api to be available
 $cmctl check api --wait=2m -v=5


### PR DESCRIPTION
<!--

Thanks for opening a pull request! Here are some tips to get everything merged smoothly:

1. Read our contributor guidelines: https://cert-manager.io/docs/contributing/

2. Make sure your commits are signed off: https://cert-manager.io/docs/contributing/sign-off/

3. If the PR is unfinished, raise it as a draft or prefix the title with "WIP:" so it's clear to everyone.

4. Be sure to allow edits from maintainers so it's easier for us to help: https://help.github.com/en/articles/allowing-changes-to-a-pull-request-branch-created-from-a-fork

-->

### Pull Request Motivation

<!-- Explain the motivation behind this PR. If there's a related issue or PR, link to it here! -->

After releasing cert-manager 1.20.2, which is not yet published to our legacy Helm chart repo (https://charts.jetstack.io), the upgrade e2e-test has been failing on all PRs. This change migrates the upgrade e2e-test to use Helm OCI.

### Kind

<!--
The kind(s) listed after "kind" after this comment will be used by a bot to add labels when the PR is opened.
If omitted at PR creation, someone will need to make a new comment with them later (editing the description after the fact will not trigger the bot).
-->
/kind cleanup
<!--

Pick the kind(s) which best describe your PR from the following list:

	<cleanup | bug | feature | documentation | design | flake>

If you're unsure which is best or if you're not sure what we mean by "kind",
just ignore this section and a maintainer will fill it in for you!
-->

### Release Note

<!--

Should we mention this PR in release notes? If so, replace "NONE" with a line of text explaining what changed!

For more details, see: https://git.k8s.io/community/contributors/guide/release-notes.md

-->

```release-note
NONE
```
